### PR TITLE
Pinniped post-deploy job is IPv6 compatible

### DIFF
--- a/addons/pinniped/post-deploy/pkg/inspect/inspect.go
+++ b/addons/pinniped/post-deploy/pkg/inspect/inspect.go
@@ -7,6 +7,7 @@ package inspect
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/url"
 	"time"
 
@@ -180,7 +181,7 @@ func (i *Inspector) GetServiceEndpoint(namespace, name string) (string, error) {
 			zap.S().Error(err)
 			return "", err
 		}
-		serviceEndpoint = fmt.Sprintf("%s://%s:%d", "https", host, service.Spec.Ports[0].NodePort)
+		serviceEndpoint = fmt.Sprintf("https://%s", net.JoinHostPort(host, fmt.Sprint(service.Spec.Ports[0].NodePort)))
 	} else if service.Spec.Type == corev1.ServiceTypeLoadBalancer {
 		hostname := service.Status.LoadBalancer.Ingress[0].Hostname
 		ip := service.Status.LoadBalancer.Ingress[0].IP
@@ -191,7 +192,7 @@ func (i *Inspector) GetServiceEndpoint(namespace, name string) (string, error) {
 			// on gce or openstack it usually is set to be IP
 			host = ip
 		}
-		serviceEndpoint = fmt.Sprintf("%s://%s:%d", "https", host, service.Spec.Ports[0].Port)
+		serviceEndpoint = fmt.Sprintf("https://%s", net.JoinHostPort(host, fmt.Sprint(service.Spec.Ports[0].Port)))
 	}
 	// TODO: file a JIRA to track the issue being discussed under https://vmware.slack.com/archives/G01HFK90QE8/p1610051838070300?thread_ts=1610051580.069400&cid=G01HFK90QE8
 	serviceEndpoint = utils.RemoveDefaultTLSPort(serviceEndpoint)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the way the `tanzu management-cluster kubeconfig get` generates kubeconfigs so that the issuer and audience flags are IPv6 compatible. This PR ensures the audience and issuer flags are surrounded by brackets when the host is an IPv6 address.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
TKG was deployed on an IPv6 environment. The addon image was built and pushed to a test harbor repo. The pinniped post deploy job was copied and deployed to the testbed pointing to the updated image. With these changes, it was seen that the ipv6 address in the issuer and audience in the retrieved kubeconfig contained properly formatted urls.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu-private/core/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
```release-note
NONE
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu-private/core/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.

cc @christianang 