### PR TITLE
[AVI] Use VIP network by default

### DIFF
--- a/pkg/v1/providers/ytt/02_addons/avi/ako_operator_secret.yaml
+++ b/pkg/v1/providers/ytt/02_addons/avi/ako_operator_secret.yaml
@@ -28,8 +28,13 @@ akoOperator:
     avi_disable_static_route_sync: #@ data.values.AVI_DISABLE_STATIC_ROUTE_SYNC
     avi_cni_plugin: #@ data.values.CNI
     avi_control_plane_ha_provider: #@ data.values.AVI_CONTROL_PLANE_HA_PROVIDER
+#@ if data.values.AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_NAME and data.values.AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_CIDR: 
     avi_management_cluster_vip_network_name: #@ data.values.AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_NAME
     avi_management_cluster_vip_network_cidr: #@ data.values.AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_CIDR
+#@ else:
+    avi_management_cluster_vip_network_name: #@ data.values.AVI_DATA_NETWORK
+    avi_management_cluster_vip_network_cidr: #@ data.values.AVI_DATA_NETWORK_CIDR
+#@ end
     avi_control_plane_endpoint_port: #@ data.values.VSPHERE_CONTROL_PLANE_ENDPOINT_PORT
 #@ end
 

--- a/pkg/v1/providers/ytt/03_customizations/add_akoo.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/add_akoo.yaml
@@ -38,8 +38,13 @@ certificateAuthorityRef:
 #@overlay/match missing_ok=True
 dataNetwork:
   #@overlay/replace
+#@ if data.values.AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_NAME and data.values.AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_CIDR: 
   name: #@ data.values.AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_NAME
   cidr: #@ data.values.AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_CIDR 
+#@ else:
+  name: #@ data.values.AVI_DATA_NETWORK
+  cidr: #@ data.values.AVI_DATA_NETWORK_CIDR
+#@ end
 #@ end
 
 --- #@ crd()


### PR DESCRIPTION
**What this PR does / why we need it**:

We added support to separate the management cluster VIP network from workload clusters' VIP network in Dakar.

But `AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_NAME` and `AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_CIDR` should be the optional fields for customers and when they are missed, use `AVI_DATA_NETWORK` and `AVI_DATA_NETWORK_CIDR` as the default values for forward compatibility.


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu-private/core/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu-private/core/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
