### PR TITLE
Fix ipFamily config for kind

### DIFF
--- a/pkg/v1/tkg/kind/client.go
+++ b/pkg/v1/tkg/kind/client.go
@@ -319,7 +319,9 @@ func (k *KindClusterProxy) getKindNetworkingConfig() string {
 	}
 	networkConfig := fmt.Sprintf(kindNetworking, podSubnet, serviceSubnet)
 	if ipFamilyConfig != "" {
-		networkConfig = fmt.Sprintf("%s\n%s", networkConfig, ipFamilyConfig)
+		// we need to nest ipFamilyConfig into networkConfig
+		const indentation = "  "
+		networkConfig = fmt.Sprintf("%s\n%s%s", networkConfig, indentation, ipFamilyConfig)
 	}
 	return networkConfig
 }

--- a/pkg/v1/tkg/kind/client_test.go
+++ b/pkg/v1/tkg/kind/client_test.go
@@ -206,6 +206,10 @@ var _ = Describe("Kind Client", func() {
 		It("generates a config with ipfamily set to ipv6", func() {
 			Expect(kindConfig).To(ContainSubstring("ipFamily: ipv6"))
 		})
+
+		It("nests ipFamilyConfig into networkConfig", func() {
+			Expect(kindConfig).To(MatchRegexp(`(?m)^  ipFamily: ipv6$`))
+		})
 	})
 
 	Context("When CLUSTER_CIDR and SERVICE_CIDR are not set", func() {


### PR DESCRIPTION
* ipFamily should be nested into networkConfig with indentation

Co-authored-by: Mikael Manukyan <mmanukyan@vmware.com>

**What this PR does / why we need it**:
This PR adds indentation to the `ipFamily` field of the kind configuration that we generate. Without this, if a user specifies `TKG_IP_FAMILY` in their config then the `management-cluster create` will fail when creating the bootstrap cluster.

**Describe testing done for PR**:
Wrote improved unit tests to verify the indentation on yaml rendering.

**Special notes for your reviewer**:

**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu-private/core/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
