### PR TITLE
Fix delete of IPv6 management clusters

### DIFF
--- a/pkg/v1/tkg/client/delete_region.go
+++ b/pkg/v1/tkg/client/delete_region.go
@@ -100,7 +100,7 @@ func (c *TkgClient) DeleteRegion(options DeleteRegionOptions) error { //nolint:f
 		}
 
 		// configure variables required to deploy providers
-		if err := c.configureVariablesForProvidersInstallation(regionalClusterClient); err != nil {
+		if err := c.configureVariablesForProvidersInstallation(regionalClusterClient, regionalClusterNamespace); err != nil {
 			return errors.Wrap(err, "unable to configure variables for provider installation")
 		}
 

--- a/pkg/v1/tkg/client/upgrade_addon.go
+++ b/pkg/v1/tkg/client/upgrade_addon.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/jinzhu/copier"
 	"github.com/pkg/errors"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	clusterctl "sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 
 	"github.com/vmware-tanzu-private/core/pkg/v1/tkg/clusterclient"
@@ -200,7 +201,7 @@ func (c *TkgClient) DoUpgradeAddon(regionalClusterClient clusterclient.Client, /
 			c.TKGConfigReaderWriter().Set(constants.ConfigVaraibleDisableCRSForAddonType, addonName)
 		}
 
-		if err := c.setConfigurationForUpgrade(regionalClusterClient); err != nil {
+		if err := c.setConfigurationForUpgrade(regionalClusterClient, options.Namespace); err != nil {
 			return errors.Wrap(err, "unable to set cluster configuration")
 		}
 
@@ -226,13 +227,17 @@ func (c *TkgClient) DoUpgradeAddon(regionalClusterClient clusterclient.Client, /
 	return nil
 }
 
-func (c *TkgClient) setConfigurationForUpgrade(regionalClusterClient clusterclient.Client) error {
+func (c *TkgClient) setConfigurationForUpgrade(regionalClusterClient clusterclient.Client, regionalClusterNamespace string) error {
 	if err := c.setProxyConfiguration(regionalClusterClient); err != nil {
 		return errors.Wrapf(err, "error while getting proxy configuration from cluster and setting it")
 	}
 
 	if err := c.setCustomImageRepositoryConfiguration(regionalClusterClient); err != nil {
 		return errors.Wrapf(err, "error while getting custom image repository configuration from cluster and setting it")
+	}
+
+	if err := c.setNetworkingConfiguration(regionalClusterClient, regionalClusterNamespace); err != nil {
+		return errors.Wrap(err, "error while initializing networking configuration")
 	}
 
 	return nil
@@ -302,6 +307,38 @@ func (c *TkgClient) setCustomImageRepositoryConfiguration(regionalClusterClient 
 			customImageRepositoryCaCertificateEncoded := base64.StdEncoding.EncodeToString([]byte(customImageRepositoryCaCertificate))
 			c.TKGConfigReaderWriter().Set(constants.ConfigVariableCustomImageRepositoryCaCertificate, customImageRepositoryCaCertificateEncoded)
 		}
+	}
+
+	return nil
+}
+
+func (c *TkgClient) setNetworkingConfiguration(regionalClusterClient clusterclient.Client, regionalClusterNamespace string) error {
+	context, err := regionalClusterClient.GetCurrentKubeContext()
+	if err != nil {
+		return errors.Wrap(err, "unable to get current kube context")
+	}
+	clusterName, err := regionalClusterClient.GetCurrentClusterName(context)
+	if err != nil {
+		return errors.Wrapf(err, "unable to get current cluster name for context %q", context)
+	}
+	cluster := &capi.Cluster{}
+	err = regionalClusterClient.GetResource(cluster, clusterName, regionalClusterNamespace, nil, nil)
+	if err != nil {
+		return errors.Wrapf(err, "unable to get cluster %q from namespace %q", clusterName, regionalClusterNamespace)
+	}
+
+	if cluster.Spec.ClusterNetwork != nil {
+		if cluster.Spec.ClusterNetwork.Pods != nil && len(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks) > 0 {
+			c.TKGConfigReaderWriter().Set(constants.ConfigVariableClusterCIDR, cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0])
+		}
+		if cluster.Spec.ClusterNetwork.Services != nil && len(cluster.Spec.ClusterNetwork.Services.CIDRBlocks) > 0 {
+			c.TKGConfigReaderWriter().Set(constants.ConfigVariableServiceCIDR, cluster.Spec.ClusterNetwork.Services.CIDRBlocks[0])
+		}
+		ipFamily, err := getIPFamily(cluster)
+		if err != nil {
+			return errors.Wrapf(err, "unable to get IPFamily of %q", clusterName)
+		}
+		c.TKGConfigReaderWriter().Set(constants.ConfigVariableIPFamily, ipFamily)
 	}
 
 	return nil

--- a/pkg/v1/tkg/client/upgrade_region.go
+++ b/pkg/v1/tkg/client/upgrade_region.go
@@ -100,7 +100,7 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 		return errors.New("upgrading 'Tanzu Kubernetes Cluster service for vSphere' management cluster is not yet supported")
 	}
 
-	if err := c.configureVariablesForProvidersInstallation(regionalClusterClient); err != nil {
+	if err := c.configureVariablesForProvidersInstallation(regionalClusterClient, options.Namespace); err != nil {
 		return errors.Wrap(err, "unable to configure variables for provider installation")
 	}
 
@@ -153,7 +153,7 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 	return nil
 }
 
-func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterClient clusterclient.Client) error {
+func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterClient clusterclient.Client, regionalClusterNamespace string) error {
 	infraProvider, err := regionalClusterClient.GetRegionalClusterDefaultProviderName(clusterctlv1.InfrastructureProviderType)
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster provider information.")
@@ -163,7 +163,7 @@ func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterCl
 		return errors.Wrap(err, "failed to parse provider name")
 	}
 	// set default values for variables required for infrastructure component spec rendering
-	err = c.setConfigurationForUpgrade(regionalClusterClient)
+	err = c.setConfigurationForUpgrade(regionalClusterClient, regionalClusterNamespace)
 	if err != nil {
 		return errors.Wrap(err, "failed to set configurations for upgrade")
 	}

--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -556,11 +556,11 @@ func (c *TkgClient) ConfigureAndValidateManagementClusterConfiguration(options *
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
-	if err = c.ConfigureAndValidateHTTPProxyConfiguration(name); err != nil {
+	if err = c.configureAndValidateIPFamilyConfiguration(); err != nil {
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
-	if err = c.configureAndValidateIPFamilyConfiguration(); err != nil {
+	if err = c.ConfigureAndValidateHTTPProxyConfiguration(name); err != nil {
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 


### PR DESCRIPTION
* set service and pods cidr to TKG config so they are
correctly picked up by proxy configurations
* set ipFamily to TKG config so kind creates a cluster with set ipfamily

Co-authored-by: Mikael Manukyan <mmanukyan@vmware.com>
Signed-off-by: Aidan Obley <aobley@vmware.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #99 

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Created and deleted vSphere IPv6 management clusters successfully.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu-private/core/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
- IPv6 cleanup clusters are provisioned automatically by the Tanzu CLI
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu-private/core/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
