### PR TITLE
Add --values-file flag for package update

### DIFF
--- a/pkg/v1/tkg/fakes/kappclient.go
+++ b/pkg/v1/tkg/fakes/kappclient.go
@@ -181,10 +181,11 @@ type KappClient struct {
 		result1 *v1alpha1b.PackageList
 		result2 error
 	}
-	UpdatePackageInstallStub        func(*v1alpha1.PackageInstall) error
+	UpdatePackageInstallStub        func(*v1alpha1.PackageInstall, bool) error
 	updatePackageInstallMutex       sync.RWMutex
 	updatePackageInstallArgsForCall []struct {
 		arg1 *v1alpha1.PackageInstall
+		arg2 bool
 	}
 	updatePackageInstallReturns struct {
 		result1 error
@@ -1027,18 +1028,19 @@ func (fake *KappClient) ListPackagesReturnsOnCall(i int, result1 *v1alpha1b.Pack
 	}{result1, result2}
 }
 
-func (fake *KappClient) UpdatePackageInstall(arg1 *v1alpha1.PackageInstall) error {
+func (fake *KappClient) UpdatePackageInstall(arg1 *v1alpha1.PackageInstall, arg2 bool) error {
 	fake.updatePackageInstallMutex.Lock()
 	ret, specificReturn := fake.updatePackageInstallReturnsOnCall[len(fake.updatePackageInstallArgsForCall)]
 	fake.updatePackageInstallArgsForCall = append(fake.updatePackageInstallArgsForCall, struct {
 		arg1 *v1alpha1.PackageInstall
-	}{arg1})
+		arg2 bool
+	}{arg1, arg2})
 	stub := fake.UpdatePackageInstallStub
 	fakeReturns := fake.updatePackageInstallReturns
-	fake.recordInvocation("UpdatePackageInstall", []interface{}{arg1})
+	fake.recordInvocation("UpdatePackageInstall", []interface{}{arg1, arg2})
 	fake.updatePackageInstallMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -1052,17 +1054,17 @@ func (fake *KappClient) UpdatePackageInstallCallCount() int {
 	return len(fake.updatePackageInstallArgsForCall)
 }
 
-func (fake *KappClient) UpdatePackageInstallCalls(stub func(*v1alpha1.PackageInstall) error) {
+func (fake *KappClient) UpdatePackageInstallCalls(stub func(*v1alpha1.PackageInstall, bool) error) {
 	fake.updatePackageInstallMutex.Lock()
 	defer fake.updatePackageInstallMutex.Unlock()
 	fake.UpdatePackageInstallStub = stub
 }
 
-func (fake *KappClient) UpdatePackageInstallArgsForCall(i int) *v1alpha1.PackageInstall {
+func (fake *KappClient) UpdatePackageInstallArgsForCall(i int) (*v1alpha1.PackageInstall, bool) {
 	fake.updatePackageInstallMutex.RLock()
 	defer fake.updatePackageInstallMutex.RUnlock()
 	argsForCall := fake.updatePackageInstallArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *KappClient) UpdatePackageInstallReturns(result1 error) {

--- a/pkg/v1/tkg/kappclient/client.go
+++ b/pkg/v1/tkg/kappclient/client.go
@@ -234,8 +234,11 @@ func (c *client) ListPackages(packageName, namespace string) (*kapppkg.PackageLi
 }
 
 // UpdatePackageInstall updates the PackageInstall CR
-func (c *client) UpdatePackageInstall(installedPackage *kappipkg.PackageInstall) error {
-	if err := c.client.Update(context.Background(), installedPackage); err != nil {
+func (c *client) UpdatePackageInstall(packageInstall *kappipkg.PackageInstall, isPkgPluginCreatedSecret bool) error {
+	installedPkg := packageInstall.DeepCopy()
+	c.addAnnotations(&installedPkg.ObjectMeta, false, isPkgPluginCreatedSecret)
+
+	if err := c.client.Update(context.Background(), installedPkg); err != nil {
 		return err
 	}
 

--- a/pkg/v1/tkg/kappclient/interface.go
+++ b/pkg/v1/tkg/kappclient/interface.go
@@ -29,6 +29,6 @@ type Client interface {
 	ListPackageMetadata(namespace string) (*kapppkg.PackageMetadataList, error)
 	ListPackages(packageName string, namespace string) (*kapppkg.PackageList, error)
 	ListPackageRepositories(namespace string) (*kappipkg.PackageRepositoryList, error)
-	UpdatePackageInstall(installedPackage *kappipkg.PackageInstall) error
+	UpdatePackageInstall(packageInstall *kappipkg.PackageInstall, isPkgPluginCreatedSecret bool) error
 	UpdatePackageRepository(repository *kappipkg.PackageRepository) error
 }

--- a/pkg/v1/tkg/tkgpackageclient/package_update.go
+++ b/pkg/v1/tkg/tkgpackageclient/package_update.go
@@ -4,10 +4,15 @@
 package tkgpackageclient
 
 import (
+	"context"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kappipkg "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 
@@ -45,24 +50,66 @@ func (p *pkgClient) UpdatePackage(o *tkgpackagedatamodel.PackageOptions, progres
 		}
 		progress.ProgressMsg <- fmt.Sprintf("Installing package '%s'", o.PkgInstallName)
 		p.InstallPackage(o, progress, true)
-	} else if pkgInstall != nil && o.Version != pkgInstall.Status.Version {
-		if pkgInstall.Spec.PackageRef == nil || pkgInstall.Spec.PackageRef.VersionSelection == nil {
+		progress.Success <- true
+		return
+	}
+
+	pkgInstallToUpdate := pkgInstall.DeepCopy()
+	if o.Version != pkgInstallToUpdate.Status.Version {
+		if pkgInstallToUpdate.Spec.PackageRef == nil || pkgInstallToUpdate.Spec.PackageRef.VersionSelection == nil {
 			err = errors.New(fmt.Sprintf("failed to update package '%s'", o.PkgInstallName))
 			return
 		}
-		progress.ProgressMsg <- fmt.Sprintf("Getting package metadata for '%s'", pkgInstall.Spec.PackageRef.RefName)
-		o.PackageName = pkgInstall.Spec.PackageRef.RefName
+		progress.ProgressMsg <- fmt.Sprintf("Getting package metadata for '%s'", pkgInstallToUpdate.Spec.PackageRef.RefName)
+		o.PackageName = pkgInstallToUpdate.Spec.PackageRef.RefName
 		if _, _, err = p.GetPackage(o); err != nil {
 			return
 		}
-		pkgInstallToUpdate := pkgInstall.DeepCopy()
 		pkgInstallToUpdate.Spec.PackageRef.VersionSelection.Constraints = o.Version
-		progress.ProgressMsg <- fmt.Sprintf("Updating package install for '%s'", o.PkgInstallName)
-		if err = p.kappClient.UpdatePackageInstall(pkgInstallToUpdate); err != nil {
-			err = errors.Wrap(err, fmt.Sprintf("failed to update package '%s'", o.PkgInstallName))
-			return
+	}
+
+	if o.ValuesFile != "" {
+		o.SecretName = fmt.Sprintf(tkgpackagedatamodel.SecretName, o.PkgInstallName, o.Namespace)
+
+		if o.SecretName == pkgInstallToUpdate.GetAnnotations()[tkgpackagedatamodel.TanzuPkgPluginAnnotation+"-Secret"] {
+			progress.ProgressMsg <- fmt.Sprintf("Updating secret '%s'", o.SecretName)
+			if err = p.updateDataValuesSecret(o); err != nil {
+				err = errors.Wrap(err, "failed to update secret based on values file")
+				return
+			}
+		} else {
+			progress.ProgressMsg <- fmt.Sprintf("Creating secret '%s'", o.SecretName)
+			if err = p.createDataValuesSecret(o); err != nil {
+				err = errors.Wrap(err, "failed to create secret based on values file")
+				return
+			}
 		}
 	}
 
+	progress.ProgressMsg <- fmt.Sprintf("Updating package install for '%s'", o.PkgInstallName)
+	if err = p.kappClient.UpdatePackageInstall(pkgInstallToUpdate, o.CreateSecret); err != nil {
+		err = errors.Wrap(err, fmt.Sprintf("failed to update package '%s'", o.PkgInstallName))
+		return
+	}
+
 	progress.Success <- true
+}
+
+// updateDataValuesSecret update a secret object containing the user-provided configuration.
+func (p *pkgClient) updateDataValuesSecret(o *tkgpackagedatamodel.PackageOptions) error {
+	var err error
+	dataValues := make(map[string][]byte)
+
+	if dataValues[filepath.Base(o.ValuesFile)], err = ioutil.ReadFile(o.ValuesFile); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to read from data values file '%s'", o.ValuesFile))
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: o.SecretName, Namespace: o.Namespace}, Data: dataValues,
+	}
+
+	if err := p.kappClient.GetClient().Update(context.Background(), secret); err != nil {
+		return errors.Wrap(err, "failed to update Secret resource")
+	}
+
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Add --values-file flag for package update

**Describe testing done for PR**:
manually testing

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu-private/core/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
tanzu package installed update myfb --version 1.7.5+vmware.1-tkg.1 -n test-ns --values-file values.yaml
| Updating package 'myfb'
| Getting package install for 'myfb'
/ Updating secret 'myfb-test-ns-values'

 Updated package install 'myfb' in namespace 'test-ns'

original values.yaml
---
fluent_bit:
  outputs: |
    [OUTPUT]
      Name     stdout
      Match    *

updated values.yaml
---
fluent_bit:
  outputs: |
    [OUTPUT]
      Name     stdout
      Match    /

Verified secret has been updated by using kubectl cmd:
kubectl get secret myfb-test-ns-values -o jsonpath='{.data}' -n test-ns
echo xxxxxxxx | base64 --decode
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu-private/core/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
