### PR TITLE
Automatically provision IPv6 cleanup clusters for IPv6 management clusters

### DIFF
--- a/pkg/v1/tkg/client/delete_region.go
+++ b/pkg/v1/tkg/client/delete_region.go
@@ -88,7 +88,7 @@ func (c *TkgClient) DeleteRegion(options DeleteRegionOptions) error { //nolint:f
 		return err
 	}
 
-	err = c.retriveRegionalClusterConfiguration(regionalClusterClient)
+	err = c.retriveRegionalClusterConfiguration(regionalClusterClient, regionalClusterNamespace)
 	if err != nil {
 		return errors.Wrap(err, "failed to set configurations for deletion")
 	}
@@ -105,7 +105,7 @@ func (c *TkgClient) DeleteRegion(options DeleteRegionOptions) error { //nolint:f
 		}
 
 		// configure variables required to deploy providers
-		if err := c.configureVariablesForProvidersInstallation(regionalClusterClient); err != nil {
+		if err := c.configureVariablesForProvidersInstallation(regionalClusterClient, regionalClusterNamespace); err != nil {
 			return errors.Wrap(err, "unable to configure variables for provider installation")
 		}
 

--- a/pkg/v1/tkg/client/upgrade_addon_test.go
+++ b/pkg/v1/tkg/client/upgrade_addon_test.go
@@ -10,7 +10,10 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+
 	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
 )
@@ -45,13 +48,40 @@ var _ = Describe("Unit tests for addons upgrade", func() {
 	})
 
 	Describe("When upgrading addons", func() {
+		const (
+			clusterName = "tkg-mgmt"
+		)
+		var (
+			serviceCIDRs []string
+			podCIDRs     []string
+		)
 		BeforeEach(func() {
+			serviceCIDRs = []string{"1.2.3.4/16"}
+			podCIDRs = []string{"2.3.4.5/16"}
+
 			setupBomFile("../fakes/config/bom/tkr-bom-v1.18.0+vmware.1-tkg.2.yaml", testingDir)
 			setupBomFile("../fakes/config/bom/tkg-bom-v1.3.1.yaml", testingDir)
 			regionalClusterClient.PatchResourceReturns(nil)
 			regionalClusterClient.GetKCPObjectForClusterReturns(getDummyKCP(constants.DockerMachineTemplate), nil)
-			regionalClusterClient.GetResourceReturns(nil)
 			currentClusterClient.GetKubernetesVersionReturns(currentK8sVersion, nil)
+			regionalClusterClient.GetCurrentKubeContextReturns("context", nil)
+			regionalClusterClient.GetCurrentClusterNameReturns(clusterName, nil)
+			regionalClusterClient.GetResourceCalls(func(cluster interface{}, resourceName, namespace string, postVerify clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+				if cluster, ok := cluster.(*capi.Cluster); ok && resourceName == clusterName && namespace == upgradeAddonOptions.Namespace {
+					cluster.Spec = capi.ClusterSpec{
+						ClusterNetwork: &capi.ClusterNetwork{
+							Services: &capi.NetworkRanges{
+								CIDRBlocks: serviceCIDRs,
+							},
+							Pods: &capi.NetworkRanges{
+								CIDRBlocks: podCIDRs,
+							},
+						},
+					}
+					return nil
+				}
+				return nil
+			})
 			isRegionalCluster = true
 
 			clusterConfigGetter = func(*CreateClusterOptions) ([]byte, error) {
@@ -153,6 +183,37 @@ var _ = Describe("Unit tests for addons upgrade", func() {
 			It("should returns an error", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("upgrade of 'tkr/tkr-controller' component is only supported on management cluster"))
+			})
+		})
+
+		Describe("When setting networking configuration", func() {
+			It("sets the cluster CIDR in the TKGConfig", func() {
+				clusterCIDR, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterCIDR)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(clusterCIDR).To(Equal("2.3.4.5/16"))
+			})
+			It("sets the service CIDR in the TKGConfig", func() {
+				serviceCIDR, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableServiceCIDR)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(serviceCIDR).To(Equal("1.2.3.4/16"))
+			})
+			When("the cluster is ipv4", func() {
+				It("sets the IPFamily to ipv4", func() {
+					ipFamily, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableIPFamily)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ipFamily).To(Equal("ipv4"))
+				})
+			})
+			When("the cluster is ipv6", func() {
+				BeforeEach(func() {
+					serviceCIDRs = []string{"fd00::/32"}
+					podCIDRs = []string{"fd01::/32"}
+				})
+				It("sets the IPFamily to ipv6", func() {
+					ipFamily, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableIPFamily)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(ipFamily).To(Equal("ipv6"))
+				})
 			})
 		})
 	})

--- a/pkg/v1/tkg/client/upgrade_region.go
+++ b/pkg/v1/tkg/client/upgrade_region.go
@@ -100,7 +100,7 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 		return errors.New("upgrading 'Tanzu Kubernetes Cluster service for vSphere' management cluster is not yet supported")
 	}
 
-	if err := c.configureVariablesForProvidersInstallation(regionalClusterClient); err != nil {
+	if err := c.configureVariablesForProvidersInstallation(regionalClusterClient, options.Namespace); err != nil {
 		return errors.Wrap(err, "unable to configure variables for provider installation")
 	}
 
@@ -153,7 +153,7 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 	return nil
 }
 
-func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterClient clusterclient.Client) error {
+func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterClient clusterclient.Client, regionalClusterNamespace string) error {
 	infraProvider, err := regionalClusterClient.GetRegionalClusterDefaultProviderName(clusterctlv1.InfrastructureProviderType)
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster provider information.")
@@ -164,7 +164,7 @@ func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterCl
 	}
 	// retrieve required variables required for infrastructure component spec rendering
 	// set them to default values if they don't exist.
-	err = c.retriveRegionalClusterConfiguration(regionalClusterClient)
+	err = c.retriveRegionalClusterConfiguration(regionalClusterClient, regionalClusterNamespace)
 	if err != nil {
 		return errors.Wrap(err, "failed to set configurations for upgrade")
 	}

--- a/pkg/v1/tkg/client/utils.go
+++ b/pkg/v1/tkg/client/utils.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -14,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
@@ -233,4 +235,92 @@ func TimedExecution(command func() error) (time.Duration, error) {
 	start := time.Now()
 	err := command()
 	return time.Since(start), err
+}
+
+// Once #164 is resolved we can upgrade to the v1alpha4 Cluster types and
+// remove type ClusterIPFamily, func GetIPFamily, and func ipFamilyForCIDRStrings
+// https://github.com/kubernetes-sigs/cluster-api/blob/c6803793164abe26b61dae2f1b9b375d4acbecf9/api/v1alpha4/cluster_types.go#L224-L291
+
+// ClusterIPFamily defines the types of supported IP families.
+type ClusterIPFamily int
+
+// Define the ClusterIPFamily constants.
+const (
+	InvalidIPFamily ClusterIPFamily = iota
+	IPv4IPFamily
+	IPv6IPFamily
+	DualStackIPFamily
+)
+
+func (f ClusterIPFamily) String() string {
+	return [...]string{"InvalidIPFamily", "IPv4IPFamily", "IPv6IPFamily", "DualStackIPFamily"}[f]
+}
+
+// GetIPFamily returns a ClusterIPFamily from the configuration provided.
+func GetIPFamily(c *capi.Cluster) (ClusterIPFamily, error) {
+	var podCIDRs, serviceCIDRs []string
+	if c.Spec.ClusterNetwork != nil {
+		if c.Spec.ClusterNetwork.Pods != nil {
+			podCIDRs = c.Spec.ClusterNetwork.Pods.CIDRBlocks
+		}
+		if c.Spec.ClusterNetwork.Services != nil {
+			serviceCIDRs = c.Spec.ClusterNetwork.Services.CIDRBlocks
+		}
+	}
+	if len(podCIDRs) == 0 && len(serviceCIDRs) == 0 {
+		return IPv4IPFamily, nil
+	}
+
+	podsIPFamily, err := ipFamilyForCIDRStrings(podCIDRs)
+	if err != nil {
+		return InvalidIPFamily, fmt.Errorf("pods: %s", err)
+	}
+	if len(serviceCIDRs) == 0 {
+		return podsIPFamily, nil
+	}
+
+	servicesIPFamily, err := ipFamilyForCIDRStrings(serviceCIDRs)
+	if err != nil {
+		return InvalidIPFamily, fmt.Errorf("services: %s", err)
+	}
+	if len(podCIDRs) == 0 {
+		return servicesIPFamily, nil
+	}
+
+	if podsIPFamily == DualStackIPFamily {
+		return DualStackIPFamily, nil
+	} else if podsIPFamily != servicesIPFamily {
+		return InvalidIPFamily, errors.New("pods and services IP family mismatch")
+	}
+
+	return podsIPFamily, nil
+}
+
+func ipFamilyForCIDRStrings(cidrs []string) (ClusterIPFamily, error) {
+	if len(cidrs) > 2 {
+		return InvalidIPFamily, errors.New("too many CIDRs specified")
+	}
+	var foundIPv4 bool
+	var foundIPv6 bool
+	for _, cidr := range cidrs {
+		ip, _, err := net.ParseCIDR(cidr)
+		if err != nil {
+			return InvalidIPFamily, fmt.Errorf("could not parse CIDR: %s", err)
+		}
+		if ip.To4() != nil {
+			foundIPv4 = true
+		} else {
+			foundIPv6 = true
+		}
+	}
+	switch {
+	case foundIPv4 && foundIPv6:
+		return DualStackIPFamily, nil
+	case foundIPv4:
+		return IPv4IPFamily, nil
+	case foundIPv6:
+		return IPv6IPFamily, nil
+	default:
+		return InvalidIPFamily, nil
+	}
 }

--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -553,11 +553,11 @@ func (c *TkgClient) ConfigureAndValidateManagementClusterConfiguration(options *
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
-	if err = c.ConfigureAndValidateHTTPProxyConfiguration(name); err != nil {
+	if err = c.configureAndValidateIPFamilyConfiguration(); err != nil {
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
-	if err = c.configureAndValidateIPFamilyConfiguration(); err != nil {
+	if err = c.ConfigureAndValidateHTTPProxyConfiguration(name); err != nil {
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 


### PR DESCRIPTION
* set service and pods cidr to TKG config so they are
correctly picked up by proxy configurations
* set ipFamily to TKG config so kind creates a cluster with set ipfamily

Co-authored-by: Mikael Manukyan <mmanukyan@vmware.com>
Signed-off-by: Aidan Obley <aobley@vmware.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #99 

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Created and deleted vSphere IPv6 management clusters successfully.

**Special notes for your reviewer**:
This PR is based on #121 to get the kind IPFamily config fix for tests to run

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu-private/core/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
- IPv6 cleanup clusters are provisioned automatically by the Tanzu CLI
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu-private/core/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
