### PR TITLE
fix tanzu cli --dry-run does not work for windows-vsphere provider

### DIFF
--- a/pkg/v1/tkg/constants/cluster_internal.go
+++ b/pkg/v1/tkg/constants/cluster_internal.go
@@ -57,10 +57,11 @@ const (
 
 // infrastructure provider name constants
 const (
-	InfrastructureProviderVSphere = "vsphere"
-	InfrastructureProviderAWS     = "aws"
-	InfrastructureProviderAzure   = "azure"
-	InfrastructureProviderDocker  = "docker"
+	InfrastructureProviderVSphere        = "vsphere"
+	InfrastructureProviderAWS            = "aws"
+	InfrastructureProviderAzure          = "azure"
+	InfrastructureProviderDocker         = "docker"
+	InfrastructureProviderWindowsVSphere = "windows-vsphere"
 )
 
 // machine template name constants

--- a/pkg/v1/tkg/tkgctl/create_cluster.go
+++ b/pkg/v1/tkg/tkgctl/create_cluster.go
@@ -181,7 +181,7 @@ func (t *tkgctl) configureCreateClusterOptionsFromConfigFile(cc *CreateClusterOp
 			cc.InfrastructureProvider = infraProvider
 		}
 		// CheckInfrastructureVersion needs to be directly called for windows because we have a separate windows plan
-		if cc.InfrastructureProvider == "windows-vsphere" {
+		if cc.InfrastructureProvider == constants.InfrastructureProviderWindowsVSphere {
 			cc.InfrastructureProvider, err = t.tkgConfigUpdaterClient.CheckInfrastructureVersion(cc.InfrastructureProvider)
 			if err != nil {
 				return errors.Wrap(err, "unable to check infrastructure provider version")

--- a/pkg/v1/tkg/tkgctl/create_cluster_test.go
+++ b/pkg/v1/tkg/tkgctl/create_cluster_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Unit tests for create cluster", func() {
 			err = tkgctlClient.CreateCluster(options)
 			Expect(err).NotTo(HaveOccurred())
 		})
-		It("InfrastructureProvider is windows vsphere when GenerateOnly is true", func() {
+		It("InfrastructureProvider is windows-vsphere when GenerateOnly is true", func() {
 			kubeConfigPath := getConfigFilePath()
 			regionContext := region.RegionContext{
 				ContextName:    "queen-anne-context",
@@ -108,7 +108,7 @@ var _ = Describe("Unit tests for create cluster", func() {
 				tkgConfigUpdaterClient: tkgconfigupdater.New(testingDir, nil, tkgConfigReaderWriter),
 			}
 
-			options.InfrastructureProvider = "windows-vsphere"
+			options.InfrastructureProvider = constants.InfrastructureProviderWindowsVSphere
 			options.GenerateOnly = true
 			err = tkgctlClient.CreateCluster(options)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fix tanzu cli --dry-run parameter does not work for windows-vsphere provider

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Following the issue description, run --dry-run for windows cluster and work as expected.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [ X ] Ensure PR contains only public links or terms
- [ X ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ X ] Squash the commits in this branch before merge to preserve our git history
- [ X ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ X ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
