### PR TITLE
add ClusterResourceSet resource for capabilities

### DIFF
--- a/pkg/v1/providers/ytt/03_customizations/capabilities/add_capabilities.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/capabilities/add_capabilities.yaml
@@ -1,4 +1,482 @@
 #@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("/lib/helpers.star", "get_default_tkg_bom_data", "get_image_repo_for_component")
+
+#@ bomData = get_default_tkg_bom_data()
+
+#@ def capabilityDefinitions():
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+  creationTimestamp: null
+  name: capabilities.run.tanzu.vmware.com
+spec:
+  group: run.tanzu.vmware.com
+  names:
+    kind: Capability
+    listKind: CapabilityList
+    plural: capabilities
+    singular: capability
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Capability is the Schema for the capabilities API
+      properties:
+        apiVersion:
+          description:
+            "APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources"
+          type: string
+        kind:
+          description:
+            "Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec is the capability spec that has cluster queries.
+          properties:
+            queries:
+              description: Queries specifies set of queries that are evaluated.
+              items:
+                description:
+                  Query is a logical grouping of GVR, Object and PartialSchema
+                  queries.
+                properties:
+                  groupVersionResources:
+                    description: GroupVersionResources evaluates a slice of GVR queries.
+                    items:
+                      description:
+                        QueryGVR queries for an API group with the optional
+                        ability to check for API versions and resource.
+                      properties:
+                        group:
+                          description:
+                            Group is the API group to check for in the
+                            cluster.
+                          minLength: 1
+                          type: string
+                        name:
+                          description: Name is the unique name of the query.
+                          minLength: 1
+                          type: string
+                        resource:
+                          description:
+                            Resource is the API resource to check for given
+                            an API group and a slice of versions. Specifying a Resource
+                            requires at least one version to be specified in Versions.
+                          type: string
+                        versions:
+                          description:
+                            Versions is the slice of versions to check
+                            for in the specified API group.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - group
+                        - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                      - name
+                    x-kubernetes-list-type: map
+                  name:
+                    description: Name is the unique name of the query.
+                    minLength: 1
+                    type: string
+                  objects:
+                    description: Objects evaluates a slice of Object queries.
+                    items:
+                      description:
+                        QueryObject represents any runtime.Object that
+                        could exist in a cluster with the ability to check for annotations.
+                      properties:
+                        name:
+                          description: Name is the unique name of the query.
+                          minLength: 1
+                          type: string
+                        objectReference:
+                          description:
+                            ObjectReference is the ObjectReference to check
+                            for in the cluster.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description:
+                                'If referring to a piece of an object instead
+                                of an entire object, this string should contain a
+                                valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                For example, if the object reference is to a container
+                                within a pod, this would take on a value like: "spec.containers{name}"
+                                (where "name" refers to the name of the container
+                                that triggered the event) or if no container name
+                                is specified "spec.containers[2]" (container with
+                                index 2 in this pod). This syntax is chosen only to
+                                have some well-defined way of referencing a part of
+                                an object. TODO: this design is not final and this
+                                field is subject to change in the future.'
+                              type: string
+                            kind:
+                              description: "Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
+                              type: string
+                            name:
+                              description: "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names"
+                              type: string
+                            namespace:
+                              description:
+                                "Namespace of the referent. More info:
+                                https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+                              type: string
+                            resourceVersion:
+                              description:
+                                "Specific resourceVersion to which this
+                                reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency"
+                              type: string
+                            uid:
+                              description: "UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids"
+                              type: string
+                          type: object
+                        withAnnotations:
+                          additionalProperties:
+                            type: string
+                          description:
+                            WithAnnotations are the annotations whose presence
+                            is checked in the object. The query succeeds only if all
+                            the annotations specified exists.
+                          type: object
+                        withoutAnnotations:
+                          additionalProperties:
+                            type: string
+                          description:
+                            WithAnnotations are the annotations whose absence
+                            is checked in the object. The query succeeds only if all
+                            the annotations specified do not exist.
+                          type: object
+                      required:
+                        - name
+                        - objectReference
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                      - name
+                    x-kubernetes-list-type: map
+                  partialSchemas:
+                    description:
+                      PartialSchemas evaluates a slice of PartialSchema
+                      queries.
+                    items:
+                      description:
+                        QueryPartialSchema queries for any OpenAPI schema
+                        that may exist on a cluster.
+                      properties:
+                        name:
+                          description: Name is the unique name of the query.
+                          minLength: 1
+                          type: string
+                        partialSchema:
+                          description:
+                            PartialSchema is the partial OpenAPI schema
+                            that will be matched in a cluster.
+                          minLength: 1
+                          type: string
+                      required:
+                        - name
+                        - partialSchema
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                      - name
+                    x-kubernetes-list-type: map
+                required:
+                  - name
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+                - name
+              x-kubernetes-list-type: map
+          required:
+            - queries
+          type: object
+        status:
+          description:
+            Status is the capability status that has results of cluster
+            queries.
+          properties:
+            results:
+              description:
+                Results represents the results of all the queries specified
+                in the spec.
+              items:
+                description: Result represents the results of queries in Query.
+                properties:
+                  groupVersionResources:
+                    description:
+                      GroupVersionResources represents results of GVR queries
+                      in spec.
+                    items:
+                      description: QueryResult represents the result of a single query.
+                      properties:
+                        error:
+                          description:
+                            Error indicates if an error occurred while
+                            processing the query.
+                          type: boolean
+                        errorDetail:
+                          description:
+                            ErrorDetail represents the error detail, if
+                            an error occurred.
+                          type: string
+                        found:
+                          description:
+                            Found is a boolean which indicates if the query
+                            condition succeeded.
+                          type: boolean
+                        name:
+                          description:
+                            Name is the name of the query in spec whose
+                            result this struct represents.
+                          minLength: 1
+                          type: string
+                        notFoundReason:
+                          description:
+                            NotFoundReason provides the reason if the query
+                            condition fails. This is non-empty when Found is false.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                      - name
+                    x-kubernetes-list-type: map
+                  name:
+                    description: Name is the unique name of the query.
+                    minLength: 1
+                    type: string
+                  objects:
+                    description: Objects represents results of Object queries in spec.
+                    items:
+                      description: QueryResult represents the result of a single query.
+                      properties:
+                        error:
+                          description:
+                            Error indicates if an error occurred while
+                            processing the query.
+                          type: boolean
+                        errorDetail:
+                          description:
+                            ErrorDetail represents the error detail, if
+                            an error occurred.
+                          type: string
+                        found:
+                          description:
+                            Found is a boolean which indicates if the query
+                            condition succeeded.
+                          type: boolean
+                        name:
+                          description:
+                            Name is the name of the query in spec whose
+                            result this struct represents.
+                          minLength: 1
+                          type: string
+                        notFoundReason:
+                          description:
+                            NotFoundReason provides the reason if the query
+                            condition fails. This is non-empty when Found is false.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                      - name
+                    x-kubernetes-list-type: map
+                  partialSchemas:
+                    description:
+                      PartialSchemas represents results of PartialSchema
+                      queries in spec.
+                    items:
+                      description: QueryResult represents the result of a single query.
+                      properties:
+                        error:
+                          description:
+                            Error indicates if an error occurred while
+                            processing the query.
+                          type: boolean
+                        errorDetail:
+                          description:
+                            ErrorDetail represents the error detail, if
+                            an error occurred.
+                          type: string
+                        found:
+                          description:
+                            Found is a boolean which indicates if the query
+                            condition succeeded.
+                          type: boolean
+                        name:
+                          description:
+                            Name is the name of the query in spec whose
+                            result this struct represents.
+                          minLength: 1
+                          type: string
+                        notFoundReason:
+                          description:
+                            NotFoundReason provides the reason if the query
+                            condition fails. This is non-empty when Found is false.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                      - name
+                    x-kubernetes-list-type: map
+                required:
+                  - name
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+                - name
+              x-kubernetes-list-type: map
+          required:
+            - results
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tanzu-capabilities-manager
+  name: tanzu-capabilities-manager-sa
+  namespace: tkg-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tanzu-capabilities-manager-clusterrole
+rules:
+  - apiGroups:
+      - run.tanzu.vmware.com
+    resources:
+      - capabilities
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - run.tanzu.vmware.com
+    resources:
+      - capabilities/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - run.tanzu.vmware.com
+    resources:
+      - tanzukubernetesreleases
+      - tanzukubernetesreleases/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - run.tanzu.vmware.com
+    resources:
+      - tanzukubernetesclusters
+      - tanzukubernetesclusters/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - clusterctl.cluster.x-k8s.io
+    resources:
+      - providers
+      - providers/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - namespaces
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tanzu-capabilities-manager-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tanzu-capabilities-manager-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: tanzu-capabilities-manager-sa
+    namespace: tkg-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tanzu-capabilities-manager
+  name: tanzu-capabilities-controller-manager
+  namespace: tkg-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tanzu-capabilities-manager
+  template:
+    metadata:
+      labels:
+        app: tanzu-capabilities-manager
+    spec:
+      containers:
+        - image: #@ "{}/{}:{}".format(get_image_repo_for_component(bomData.components["tanzu-framework"][0].images.capabilitiesImage), bomData.components["tanzu-framework"][0].images.capabilitiesImage.imagePath, bomData.components["tanzu-framework"][0].images.capabilitiesImage.tag)
+          imagePullPolicy: IfNotPresent
+          name: manager
+          resources:
+            limits:
+              cpu: 100m
+              memory: 30Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi
+      serviceAccount: tanzu-capabilities-manager-sa
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+#@ end
 ---
 apiVersion: addons.cluster.x-k8s.io/v1alpha3
 kind: ClusterResourceSet
@@ -8,6 +486,7 @@ metadata:
     cluster.x-k8s.io/cluster-name: #@ data.values.CLUSTER_NAME
   annotations:
     tkg.tanzu.vmware.com/addon-type: "capabilities/capabilities-controller"
+  namespace: tkg-system
 spec:
   strategy: "ApplyOnce"
   clusterSelector:
@@ -15,447 +494,13 @@ spec:
       tkg.tanzu.vmware.com/cluster-name: #@ data.values.CLUSTER_NAME
   resources:
     - name: #@ "{}-capabilities".format(data.values.CLUSTER_NAME)
-      kind: ConfigMap
+      kind: Secret
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: #@ "{}-capabilities".format(data.values.CLUSTER_NAME)
-data:
-  data: |
-    apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        controller-gen.kubebuilder.io/version: v0.2.5
-      creationTimestamp: null
-      name: capabilities.run.tanzu.vmware.com
-    spec:
-      group: run.tanzu.vmware.com
-      names:
-        kind: Capability
-        listKind: CapabilityList
-        plural: capabilities
-        singular: capability
-      scope: Namespaced
-      subresources:
-        status: {}
-      validation:
-        openAPIV3Schema:
-          description: Capability is the Schema for the capabilities API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-                of an object. Servers should convert recognized schemas to the latest
-                internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
-                object represents. Servers may infer this from the endpoint the client
-                submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: Spec is the capability spec that has cluster queries.
-              properties:
-                queries:
-                  description: Queries specifies set of queries that are evaluated.
-                  items:
-                    description: Query is a logical grouping of GVR, Object and PartialSchema
-                      queries.
-                    properties:
-                      groupVersionResources:
-                        description: GroupVersionResources evaluates a slice of GVR queries.
-                        items:
-                          description: QueryGVR queries for an API group with the optional
-                            ability to check for API versions and resource.
-                          properties:
-                            group:
-                              description: Group is the API group to check for in the
-                                cluster.
-                              minLength: 1
-                              type: string
-                            name:
-                              description: Name is the unique name of the query.
-                              minLength: 1
-                              type: string
-                            resource:
-                              description: Resource is the API resource to check for given
-                                an API group and a slice of versions. Specifying a Resource
-                                requires at least one version to be specified in Versions.
-                              type: string
-                            versions:
-                              description: Versions is the slice of versions to check
-                                for in the specified API group.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - group
-                          - name
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - name
-                        x-kubernetes-list-type: map
-                      name:
-                        description: Name is the unique name of the query.
-                        minLength: 1
-                        type: string
-                      objects:
-                        description: Objects evaluates a slice of Object queries.
-                        items:
-                          description: QueryObject represents any runtime.Object that
-                            could exist in a cluster with the ability to check for annotations.
-                          properties:
-                            name:
-                              description: Name is the unique name of the query.
-                              minLength: 1
-                              type: string
-                            objectReference:
-                              description: ObjectReference is the ObjectReference to check
-                                for in the cluster.
-                              properties:
-                                apiVersion:
-                                  description: API version of the referent.
-                                  type: string
-                                fieldPath:
-                                  description: 'If referring to a piece of an object instead
-                                    of an entire object, this string should contain a
-                                    valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                                    For example, if the object reference is to a container
-                                    within a pod, this would take on a value like: "spec.containers{name}"
-                                    (where "name" refers to the name of the container
-                                    that triggered the event) or if no container name
-                                    is specified "spec.containers[2]" (container with
-                                    index 2 in this pod). This syntax is chosen only to
-                                    have some well-defined way of referencing a part of
-                                    an object. TODO: this design is not final and this
-                                    field is subject to change in the future.'
-                                  type: string
-                                kind:
-                                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                                  type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                  type: string
-                                namespace:
-                                  description: 'Namespace of the referent. More info:
-                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                                  type: string
-                                resourceVersion:
-                                  description: 'Specific resourceVersion to which this
-                                    reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                                  type: string
-                                uid:
-                                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                                  type: string
-                              type: object
-                            withAnnotations:
-                              additionalProperties:
-                                type: string
-                              description: WithAnnotations are the annotations whose presence
-                                is checked in the object. The query succeeds only if all
-                                the annotations specified exists.
-                              type: object
-                            withoutAnnotations:
-                              additionalProperties:
-                                type: string
-                              description: WithAnnotations are the annotations whose absence
-                                is checked in the object. The query succeeds only if all
-                                the annotations specified do not exist.
-                              type: object
-                          required:
-                          - name
-                          - objectReference
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - name
-                        x-kubernetes-list-type: map
-                      partialSchemas:
-                        description: PartialSchemas evaluates a slice of PartialSchema
-                          queries.
-                        items:
-                          description: QueryPartialSchema queries for any OpenAPI schema
-                            that may exist on a cluster.
-                          properties:
-                            name:
-                              description: Name is the unique name of the query.
-                              minLength: 1
-                              type: string
-                            partialSchema:
-                              description: PartialSchema is the partial OpenAPI schema
-                                that will be matched in a cluster.
-                              minLength: 1
-                              type: string
-                          required:
-                          - name
-                          - partialSchema
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - name
-                        x-kubernetes-list-type: map
-                    required:
-                    - name
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                  - name
-                  x-kubernetes-list-type: map
-              required:
-              - queries
-              type: object
-            status:
-              description: Status is the capability status that has results of cluster
-                queries.
-              properties:
-                results:
-                  description: Results represents the results of all the queries specified
-                    in the spec.
-                  items:
-                    description: Result represents the results of queries in Query.
-                    properties:
-                      groupVersionResources:
-                        description: GroupVersionResources represents results of GVR queries
-                          in spec.
-                        items:
-                          description: QueryResult represents the result of a single query.
-                          properties:
-                            error:
-                              description: Error indicates if an error occurred while
-                                processing the query.
-                              type: boolean
-                            errorDetail:
-                              description: ErrorDetail represents the error detail, if
-                                an error occurred.
-                              type: string
-                            found:
-                              description: Found is a boolean which indicates if the query
-                                condition succeeded.
-                              type: boolean
-                            name:
-                              description: Name is the name of the query in spec whose
-                                result this struct represents.
-                              minLength: 1
-                              type: string
-                            notFoundReason:
-                              description: NotFoundReason provides the reason if the query
-                                condition fails. This is non-empty when Found is false.
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - name
-                        x-kubernetes-list-type: map
-                      name:
-                        description: Name is the unique name of the query.
-                        minLength: 1
-                        type: string
-                      objects:
-                        description: Objects represents results of Object queries in spec.
-                        items:
-                          description: QueryResult represents the result of a single query.
-                          properties:
-                            error:
-                              description: Error indicates if an error occurred while
-                                processing the query.
-                              type: boolean
-                            errorDetail:
-                              description: ErrorDetail represents the error detail, if
-                                an error occurred.
-                              type: string
-                            found:
-                              description: Found is a boolean which indicates if the query
-                                condition succeeded.
-                              type: boolean
-                            name:
-                              description: Name is the name of the query in spec whose
-                                result this struct represents.
-                              minLength: 1
-                              type: string
-                            notFoundReason:
-                              description: NotFoundReason provides the reason if the query
-                                condition fails. This is non-empty when Found is false.
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - name
-                        x-kubernetes-list-type: map
-                      partialSchemas:
-                        description: PartialSchemas represents results of PartialSchema
-                          queries in spec.
-                        items:
-                          description: QueryResult represents the result of a single query.
-                          properties:
-                            error:
-                              description: Error indicates if an error occurred while
-                                processing the query.
-                              type: boolean
-                            errorDetail:
-                              description: ErrorDetail represents the error detail, if
-                                an error occurred.
-                              type: string
-                            found:
-                              description: Found is a boolean which indicates if the query
-                                condition succeeded.
-                              type: boolean
-                            name:
-                              description: Name is the name of the query in spec whose
-                                result this struct represents.
-                              minLength: 1
-                              type: string
-                            notFoundReason:
-                              description: NotFoundReason provides the reason if the query
-                                condition fails. This is non-empty when Found is false.
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                        - name
-                        x-kubernetes-list-type: map
-                    required:
-                    - name
-                    type: object
-                  type: array
-                  x-kubernetes-list-map-keys:
-                  - name
-                  x-kubernetes-list-type: map
-              required:
-              - results
-              type: object
-          type: object
-      version: v1alpha1
-      versions:
-      - name: v1alpha1
-        served: true
-        storage: true
-    ---
-    apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      labels:
-        app: tanzu-capabilities-manager
-      name: tanzu-capabilities-manager-sa
-      namespace: tkg-system
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRole
-    metadata:
-      name: tanzu-capabilities-manager-clusterrole
-    rules:
-      - apiGroups:
-          - run.tanzu.vmware.com
-        resources:
-          - capabilities
-        verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - update
-          - watch
-      - apiGroups:
-          - run.tanzu.vmware.com
-        resources:
-          - capabilities/status
-        verbs:
-          - get
-          - patch
-          - update
-      - apiGroups:
-          - run.tanzu.vmware.com
-        resources:
-          - tanzukubernetesreleases
-          - tanzukubernetesreleases/status
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - run.tanzu.vmware.com
-        resources:
-          - tanzukubernetesclusters
-          - tanzukubernetesclusters/status
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - clusterctl.cluster.x-k8s.io
-        resources:
-          - providers
-          - providers/status
-        verbs:
-          - get
-          - list
-          - watch
-      - apiGroups:
-          - ""
-        resources:
-          - configmaps
-          - namespaces
-          - nodes
-        verbs:
-          - get
-          - list
-          - watch
-    ---
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: tanzu-capabilities-manager-clusterrolebinding
-    roleRef:
-      apiGroup: rbac.authorization.k8s.io
-      kind: ClusterRole
-      name: tanzu-capabilities-manager-clusterrole
-    subjects:
-      - kind: ServiceAccount
-        name: tanzu-capabilities-manager-sa
-        namespace: tkg-system
-    ---
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      labels:
-        app: tanzu-capabilities-manager
-      name: tanzu-capabilities-controller-manager
-      namespace: tkg-system
-    spec:
-      replicas: 1
-      selector:
-        matchLabels:
-          app: tanzu-capabilities-manager
-      template:
-        metadata:
-          labels:
-            app: tanzu-capabilities-manager
-        spec:
-          containers:
-            - image:  #@ "{}/{}:{}".format(get_image_repo_for_component(bomData.components["tanzu-framework"][0].images.capabilitiesImage), bomData.components["tanzu-framework"][0].images.capabilitiesImage.imagePath, bomData.components["tanzu-framework"][0].images.capabilitiesImage.tag)
-              imagePullPolicy: IfNotPresent
-              name: manager
-              resources:
-                limits:
-                  cpu: 100m
-                  memory: 30Mi
-                requests:
-                  cpu: 100m
-                  memory: 20Mi
-          serviceAccount: tanzu-capabilities-manager-sa
-          terminationGracePeriodSeconds: 10
-          tolerations:
-            - effect: NoSchedule
-              key: node-role.kubernetes.io/master
-
-
+  namespace: tkg-system
+type: addons.cluster.x-k8s.io/resource-set
+stringData:
+  value: #@ yaml.encode(capabilityDefinitions())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds ClusterResourceSet CR for capabilities in providers template. I still need to add other resources for deploying the controller(waiting for resources to be added in the actual capabilities PR)
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes Partially https://github.com/vmware-tanzu/tanzu-framework/issues/89

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu-private/core/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu-private/core/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
