### PR TITLE
Refactor Kind client to use Kind configuration types instead of string templating

### DIFF
--- a/addons/go.mod
+++ b/addons/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.13.0
 	github.com/pkg/errors v0.9.1
-	github.com/vmware-tanzu/tanzu-framework v0.0.0-20201211200158-5838874f2c38
 	github.com/vmware-tanzu/carvel-kapp-controller v0.20.0-rc.1
+	github.com/vmware-tanzu/tanzu-framework v0.0.0-20201211200158-5838874f2c38
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2

--- a/addons/go.sum
+++ b/addons/go.sum
@@ -797,6 +797,7 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bAOTRnLElKs=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
+github.com/pelletier/go-toml/v2 v2.0.0-beta.3/go.mod h1:aNseLYu/uKskg0zpr/kbr2z8yGuWtotWf/0BpGIAL2Y=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -927,8 +928,9 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942 h1:t0lM6y/M5IiUZyvbBTcngso8SZEZICH7is9B6g/obVU=
+github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=
 github.com/tdakkota/asciicheck v0.0.0-20200416200610-e657995f937b/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=

--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.13.0
 	github.com/otiai10/copy v1.4.2
+	github.com/pelletier/go-toml/v2 v2.0.0-beta.3
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/common v0.29.0 // indirect
 	github.com/rs/xid v1.2.1
@@ -81,7 +82,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942
 	github.com/vmware-tanzu/carvel-kapp-controller v0.20.0-rc.1
 	github.com/vmware-tanzu/carvel-vendir v0.19.0
 	github.com/vmware/govmomi v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -893,6 +893,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.8.0/go.mod h1:D6yutnOGMveHEPV7VQOuvI/gXY61bv+9bAOTRnLElKs=
 github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNCRM=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
+github.com/pelletier/go-toml/v2 v2.0.0-beta.3 h1:PNCTU4naEJ8mKal97P3A2qDU74QRQGlv4FXiL1XDqi4=
+github.com/pelletier/go-toml/v2 v2.0.0-beta.3/go.mod h1:aNseLYu/uKskg0zpr/kbr2z8yGuWtotWf/0BpGIAL2Y=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/checkstyle v0.0.0-20170904204023-bfd46e6a821d/go.mod h1:3OzsM7FXDQlpCiw2j81fOmAwQLnZnLGXVKUzeKQXIAw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -1041,8 +1043,9 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942 h1:t0lM6y/M5IiUZyvbBTcngso8SZEZICH7is9B6g/obVU=
+github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tdakkota/asciicheck v0.0.0-20200416190851-d7f85be797a2/go.mod h1:yHp0ai0Z9gUljN3o0xMhYJnH/IcvkdTBOX2fmJ93JEM=

--- a/pkg/v1/tkg/kind/client.go
+++ b/pkg/v1/tkg/kind/client.go
@@ -10,7 +10,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/rs/xid"
+	"gopkg.in/yaml.v2"
+	kindv1 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/errors"
 
@@ -25,42 +28,37 @@ import (
 const (
 	kindClusterNamePrefix       = "tkg-kind-"
 	kindClusterWaitForReadyTime = 2 * time.Minute
-
-	defaultKindExtraMounts = `
-nodes:
-- role: control-plane
-  extraMounts:
-    - hostPath: /var/run/docker.sock
-      containerPath: /var/run/docker.sock`
-
-	kindExtraMounts = `
-nodes:
-- role: control-plane
-  extraMounts:
-    - hostPath: /var/run/docker.sock
-      containerPath: /var/run/docker.sock
-    - hostPath: %s
-      containerPath: /etc/containerd/tkg-registry-ca.crt`
-
-	KindRegistryConfigSkipTLSVerify = `
-containerdConfigPatches:
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.configs."%s".tls]
-    insecure_skip_verify = true
-`
-
-	KindRegistryConfigCaCert = `
-containerdConfigPatches:
-- |-
-  [plugins."io.containerd.grpc.v1.cri".registry.configs."%s".tls]
-    insecure_skip_verify = false
-    ca_file = "/etc/containerd/tkg-registry-ca.crt"`
-
-	kindNetworking = `
-networking:
-  podSubnet: %s
-  serviceSubnet: %s`
+	kindRegistryCAPath          = "/etc/containerd/tkg-registry-ca.crt"
 )
+
+var (
+	dockerMount = kindv1.Mount{
+		HostPath:      "/var/run/docker.sock",
+		ContainerPath: "/var/run/docker.sock",
+	}
+)
+
+type newKindNodeInput struct {
+	role   kindv1.NodeRole
+	caPath string
+}
+
+func newKindNode(input newKindNodeInput) kindv1.Node {
+	node := kindv1.Node{}
+	if input.role != "" {
+		node.Role = input.role
+	}
+	node.ExtraMounts = []kindv1.Mount{dockerMount}
+	if input.caPath != "" {
+		node.ExtraMounts = append(node.ExtraMounts,
+			kindv1.Mount{
+				HostPath:      input.caPath,
+				ContainerPath: kindRegistryCAPath,
+			},
+		)
+	}
+	return node
+}
 
 // Client is used to create/delete kubernetes-in-docker cluster
 type Client interface {
@@ -74,7 +72,7 @@ type Client interface {
 	GetKindClusterName() string
 
 	// GetKindNodeImageAndConfig returns the kind node image and kind config
-	GetKindNodeImageAndConfig() (string, []byte, error)
+	GetKindNodeImageAndConfig() (string, *kindv1.Cluster, error)
 }
 
 //go:generate counterfeiter -o ../fakes/kindprovider.go --fake-name KindProvider . KindClusterProvider
@@ -98,7 +96,8 @@ type KindClusterOptions struct { //nolint:golint
 
 // KindClusterProxy return the Proxy used for operating kubernetes-in-docker clusters
 type KindClusterProxy struct { //nolint:golint
-	options *KindClusterOptions
+	options    *KindClusterOptions
+	caCertPath string
 }
 
 // ensure clusterConfig implements Client interface
@@ -117,15 +116,14 @@ func New(options *KindClusterOptions) Client {
 
 // CreateKindCluster creates new kind cluster
 func (k *KindClusterProxy) CreateKindCluster() (string, error) {
-	var err error
-	var configBytes []byte
-
 	if k.options.ClusterName == "" {
 		k.options.ClusterName = kindClusterNamePrefix + xid.New().String()
 	}
 
 	log.V(3).Infof("Fetching configuration for kind node image...")
-	k.options.NodeImage, configBytes, err = k.GetKindNodeImageAndConfig()
+	var config *kindv1.Cluster
+	var err error
+	k.options.NodeImage, config, err = k.GetKindNodeImageAndConfig()
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get kind node image and configuration from BoM file")
 	}
@@ -159,7 +157,7 @@ func (k *KindClusterProxy) CreateKindCluster() (string, error) {
 		cluster.CreateWithKubeconfigPath(k.options.KubeConfigPath),
 		cluster.CreateWithDisplayUsage(false),
 		cluster.CreateWithDisplaySalutation(false),
-		cluster.CreateWithRawConfig(configBytes),
+		cluster.CreateWithV1Alpha4Config(config),
 	); err != nil {
 		return "", errors.Wrapf(err, "failed to create kind cluster %s", k.options.ClusterName)
 	}
@@ -190,7 +188,7 @@ func (k *KindClusterProxy) GetKindClusterName() string {
 }
 
 // GetKindNodeImageAndConfig return the Kind node Image full path and configuration details
-func (k *KindClusterProxy) GetKindNodeImageAndConfig() (string, []byte, error) {
+func (k *KindClusterProxy) GetKindNodeImageAndConfig() (string, *kindv1.Cluster, error) {
 	bomConfiguration, err := tkgconfigbom.New(k.options.TKGConfigDir, k.options.Readerwriter).GetDefaultTkgBOMConfiguration()
 	if err != nil {
 		return "", nil, errors.Wrap(err, "unable to get default BoM file")
@@ -205,26 +203,39 @@ func (k *KindClusterProxy) GetKindNodeImageAndConfig() (string, []byte, error) {
 		return "", nil, errors.New("unable to read kind configuration")
 	}
 
-	kindConfig := strings.Join(bomConfiguration.KindKubeadmConfigSpec, "\n")
+	kindConfigData := []byte(strings.Join(bomConfiguration.KindKubeadmConfigSpec, "\n"))
+	kindConfig := &kindv1.Cluster{}
+	err = yaml.Unmarshal(kindConfigData, kindConfig)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "unable to parse kind configuration")
+	}
+
 	kindNodeImageString := tkgconfigbom.GetFullImagePath(kindNodeImage, bomConfiguration.ImageConfig.ImageRepository) + ":" + kindNodeImage.Tag
 
-	kindExtraMounts, err := k.getKindExtraMounts()
+	caCertFilePath, err := k.getDockerRegistryCACertFilePath()
 	if err != nil {
-		return "", nil, errors.Wrap(err, "unable to generate kind extraMounts")
+		return "", nil, errors.Wrap(err, "unable to generate CA cert file")
 	}
-	kindConfig += kindExtraMounts
+
+	defaultNode := newKindNode(newKindNodeInput{
+		caPath: caCertFilePath,
+	})
+
+	kindConfig.Nodes = []kindv1.Node{defaultNode}
 
 	kindRegistryConfig, err := k.getKindRegistryConfig()
 	if err != nil {
 		return "", nil, errors.Wrap(err, "unable to generate kind containerdConfigPatches")
 	}
-	kindConfig += kindRegistryConfig
 
-	kindNetworkingConfig := k.getKindNetworkingConfig()
-	kindConfig += kindNetworkingConfig
+	kindConfig.Networking = k.getKindNetworkingConfig()
 
-	log.V(3).Infof("kindConfig: \n" + kindConfig)
-	return kindNodeImageString, []byte(kindConfig), nil
+	if kindRegistryConfig != "" {
+		kindConfig.ContainerdConfigPatches = []string{kindRegistryConfig}
+	}
+
+	log.V(3).Infof("kindConfig: \n %v", kindConfig)
+	return kindNodeImageString, kindConfig, nil
 }
 
 // Return the containerdConfigPatches field for kind Cluster object
@@ -239,19 +250,39 @@ func (k *KindClusterProxy) getKindRegistryConfig() (string, error) {
 	}
 	hostname := strings.Split(customRepository, "/")[0]
 
-	if tkgconfigClient.IsCustomRepositorySkipTLSVerify() {
-		return fmt.Sprintf(KindRegistryConfigSkipTLSVerify, hostname), nil
-	}
-
-	customRepositoryCaCert, err := tkgconfigClient.GetCustomRepositoryCaCertificate()
+	customRepositoryCaCert, err := k.getDockerRegistryCACertFilePath()
 	if err != nil {
 		return "", err
 	}
-	if len(customRepositoryCaCert) > 0 {
-		return fmt.Sprintf(KindRegistryConfigCaCert, hostname), nil
+
+	registryTLSConfig := criRegistryTLSConfig{
+		InsecureSkipVerify: tkgconfigClient.IsCustomRepositorySkipTLSVerify(),
 	}
 
-	return "", nil
+	if customRepositoryCaCert != "" {
+		registryTLSConfig.CAFile = kindRegistryCAPath
+	}
+
+	config := containerDConfig{
+		Plugins: map[string]interface{}{
+			"io.containerd.grpc.v1.cri": criConfig{
+				Registry: criRegistry{
+					Configs: map[string]criRegistryConfig{
+						hostname: {
+							TLS: registryTLSConfig,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	configData, err := toml.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+
+	return string(configData), nil
 }
 
 // Create the CA certificate file for the private Docker Registry on local machine
@@ -269,38 +300,52 @@ func (k *KindClusterProxy) createDockerRegistryCACertFile(customRepositoryCaCert
 	return tempCACertFilePath, nil
 }
 
-func (k *KindClusterProxy) getKindExtraMounts() (string, error) {
+func (k *KindClusterProxy) getDockerRegistryCACertFilePath() (string, error) {
+	if k.caCertPath != "" {
+		return k.caCertPath, nil
+	}
 	tkgconfigClient := tkgconfigbom.New(k.options.TKGConfigDir, k.options.Readerwriter)
 	customRepositoryCaCert, err := tkgconfigClient.GetCustomRepositoryCaCertificate()
 	if err != nil {
 		return "", err
 	}
-
 	if len(customRepositoryCaCert) > 0 {
 		// Create a temp file with the content of customRepositoryCaCert when the CA cert is specified
-		caCertFilePath, err := k.createDockerRegistryCACertFile(customRepositoryCaCert)
+		k.caCertPath, err = k.createDockerRegistryCACertFile(customRepositoryCaCert)
 		if err != nil {
 			return "", err
 		}
-		if utils.IsOnWindows() {
-			// On Windows the '\' in hostPath must be replaced with '\\'.
-			caCertFilePath = strings.ReplaceAll(caCertFilePath, "\\", "\\\\")
-		}
-		return fmt.Sprintf(kindExtraMounts, caCertFilePath), nil
 	}
 
-	return defaultKindExtraMounts, nil
+	return k.caCertPath, nil
+}
+
+type containerDConfig struct {
+	Plugins map[string]interface{} `toml:"plugins"`
+}
+
+type criConfig struct {
+	Registry criRegistry `toml:"registry"`
+}
+
+type criRegistry struct {
+	Configs map[string]criRegistryConfig `toml:"configs"`
+}
+
+type criRegistryConfig struct {
+	TLS criRegistryTLSConfig `toml:"tls"`
+}
+
+type criRegistryTLSConfig struct {
+	InsecureSkipVerify bool   `toml:"insecure_skip_verify"`
+	CAFile             string `toml:"ca_file"`
 }
 
 // Return the networking field for kind Cluster object
 // set the podSubnet and serviceSubnet fields
 // if TKG_IP_FAMILY is set then set the ipFamily field
-func (k *KindClusterProxy) getKindNetworkingConfig() string {
-	ipFamilyConfig := ""
-	ipFamily, err := k.options.Readerwriter.Get(constants.ConfigVariableIPFamily)
-	if err == nil || ipFamily != "" {
-		ipFamilyConfig = fmt.Sprintf("ipFamily: %s", ipFamily)
-	}
+func (k *KindClusterProxy) getKindNetworkingConfig() kindv1.Networking {
+	ipFamily, _ := k.getIPFamily()
 	podSubnet, err := k.options.Readerwriter.Get(constants.ConfigVariableClusterCIDR)
 	if err != nil {
 		if ipFamily == constants.IPv6Family {
@@ -317,9 +362,28 @@ func (k *KindClusterProxy) getKindNetworkingConfig() string {
 			serviceSubnet = constants.DefaultIPv4ServiceCIDR
 		}
 	}
-	networkConfig := fmt.Sprintf(kindNetworking, podSubnet, serviceSubnet)
-	if ipFamilyConfig != "" {
-		networkConfig = fmt.Sprintf("%s\n%s", networkConfig, ipFamilyConfig)
+
+	networkConfig := kindv1.Networking{
+		PodSubnet:     podSubnet,
+		ServiceSubnet: serviceSubnet,
+		IPFamily:      ipFamily,
 	}
+
 	return networkConfig
+}
+
+// if TKG_IP_FAMILY is set then set the networking field
+func (k *KindClusterProxy) getIPFamily() (kindv1.ClusterIPFamily, error) {
+	ipFamily, err := k.options.Readerwriter.Get(constants.ConfigVariableIPFamily)
+	if err != nil {
+		// ignore this error as TKG_IP_FAMILY is optional
+		ipFamily = ""
+	}
+	normalisedIPFamily := kindv1.ClusterIPFamily(strings.ToLower(ipFamily))
+	switch normalisedIPFamily {
+	case kindv1.IPv4Family, kindv1.IPv6Family, kindv1.DualStackFamily, kindv1.ClusterIPFamily(""):
+		return normalisedIPFamily, nil
+	default:
+		return "", fmt.Errorf("TKG_IP_FAMILY should be one of %s, %s, %s, got %s", kindv1.IPv4Family, kindv1.IPv6Family, kindv1.DualStackFamily, normalisedIPFamily)
+	}
 }

--- a/pkg/v1/tkg/kind/client_test.go
+++ b/pkg/v1/tkg/kind/client_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	kindv1 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
@@ -44,7 +45,7 @@ var (
 	kindProvider *fakes.KindProvider
 	err          error
 	clusterName  string
-	kindConfig   string
+	kindConfig   *kindv1.Cluster
 )
 
 var _ = Describe("Kind Client", func() {
@@ -131,17 +132,16 @@ var _ = Describe("Kind Client", func() {
 			BeforeEach(func() {
 				setupTestingFiles(configPathCustomRegistrySkipTLSVerify, testingDir, defaultBoMFileForTesting)
 				kindClient = buildKindClient()
-				_, kindConfigBytes, err := kindClient.GetKindNodeImageAndConfig()
+				_, kindConfig, err = kindClient.GetKindNodeImageAndConfig()
 				Expect(err).NotTo(HaveOccurred())
-				kindConfig = string(kindConfigBytes)
 			})
 
 			Describe("Generate kind cluster config", func() {
 				It("generates 'insecure_skip_verify = true' in containerdConfigPatches", func() {
-					Expect(kindConfig).Should(ContainSubstring(fmt.Sprintf(kind.KindRegistryConfigSkipTLSVerify, registryHostname)))
-					Expect(kindConfig).Should(ContainSubstring("insecure_skip_verify = true"))
-					Expect(kindConfig).ShouldNot(ContainSubstring("ca_file = \"/etc/containerd/tkg-registry-ca.crt\""))
-					Expect(kindConfig).ShouldNot(ContainSubstring("containerPath: /etc/containerd/tkg-registry-ca.crt"))
+					Expect(kindConfig.ContainerdConfigPatches[0]).Should(ContainSubstring(fmt.Sprintf("plugins.'io.containerd.grpc.v1.cri'.registry.configs.'%s'.tls", registryHostname)))
+					Expect(kindConfig.ContainerdConfigPatches[0]).Should(ContainSubstring("insecure_skip_verify = true"))
+					Expect(kindConfig.ContainerdConfigPatches[0]).ShouldNot(ContainSubstring("ca_file = '/etc/containerd/tkg-registry-ca.crt'"))
+					Expect(len(kindConfig.Nodes[0].ExtraMounts)).To(Equal(1))
 				})
 			})
 		})
@@ -150,17 +150,16 @@ var _ = Describe("Kind Client", func() {
 			BeforeEach(func() {
 				setupTestingFiles(configPathCustomRegistryCaCert, testingDir, defaultBoMFileForTesting)
 				kindClient = buildKindClient()
-				_, kindConfigBytes, err := kindClient.GetKindNodeImageAndConfig()
+				_, kindConfig, err = kindClient.GetKindNodeImageAndConfig()
 				Expect(err).NotTo(HaveOccurred())
-				kindConfig = string(kindConfigBytes)
 			})
 
 			Describe("Generate kind cluster config", func() {
 				It("generates ca_file config in containerdConfigPatches", func() {
-					Expect(kindConfig).Should(ContainSubstring(fmt.Sprintf(kind.KindRegistryConfigCaCert, registryHostname)))
-					Expect(kindConfig).Should(ContainSubstring("insecure_skip_verify = false"))
-					Expect(kindConfig).Should(ContainSubstring("ca_file = \"/etc/containerd/tkg-registry-ca.crt\""))
-					Expect(kindConfig).Should(ContainSubstring("containerPath: /etc/containerd/tkg-registry-ca.crt"))
+					Expect(kindConfig.ContainerdConfigPatches[0]).Should(ContainSubstring(fmt.Sprintf("plugins.'io.containerd.grpc.v1.cri'.registry.configs.'%s'.tls", registryHostname)))
+					Expect(kindConfig.ContainerdConfigPatches[0]).Should(ContainSubstring("insecure_skip_verify = false"))
+					Expect(kindConfig.ContainerdConfigPatches[0]).Should(ContainSubstring("ca_file = '/etc/containerd/tkg-registry-ca.crt'"))
+					Expect(kindConfig.Nodes[0].ExtraMounts[1].ContainerPath).Should(ContainSubstring("/etc/containerd/tkg-registry-ca.crt"))
 				})
 			})
 		})
@@ -170,13 +169,12 @@ var _ = Describe("Kind Client", func() {
 		BeforeEach(func() {
 			setupTestingFiles(configPath, testingDir, defaultBoMFileForTesting)
 			kindClient = buildKindClient()
-			_, kindConfigBytes, err := kindClient.GetKindNodeImageAndConfig()
+			_, kindConfig, err = kindClient.GetKindNodeImageAndConfig()
 			Expect(err).NotTo(HaveOccurred())
-			kindConfig = string(kindConfigBytes)
 		})
 
 		It("generates a config with ipfamily omitted", func() {
-			Expect(kindConfig).NotTo(ContainSubstring("ipFamily:"))
+			Expect(string(kindConfig.Networking.IPFamily)).To(Equal(""))
 		})
 	})
 
@@ -184,13 +182,12 @@ var _ = Describe("Kind Client", func() {
 		BeforeEach(func() {
 			setupTestingFiles(configPathIPv4, testingDir, defaultBoMFileForTesting)
 			kindClient = buildKindClient()
-			_, kindConfigBytes, err := kindClient.GetKindNodeImageAndConfig()
+			_, kindConfig, err = kindClient.GetKindNodeImageAndConfig()
 			Expect(err).NotTo(HaveOccurred())
-			kindConfig = string(kindConfigBytes)
 		})
 
 		It("generates a config with ipfamily set to ipv4", func() {
-			Expect(kindConfig).To(ContainSubstring("ipFamily: ipv4"))
+			Expect(kindConfig.Networking.IPFamily).To(Equal(kindv1.IPv4Family))
 		})
 	})
 
@@ -198,13 +195,12 @@ var _ = Describe("Kind Client", func() {
 		BeforeEach(func() {
 			setupTestingFiles(configPathIPv6, testingDir, defaultBoMFileForTesting)
 			kindClient = buildKindClient()
-			_, kindConfigBytes, err := kindClient.GetKindNodeImageAndConfig()
+			_, kindConfig, err = kindClient.GetKindNodeImageAndConfig()
 			Expect(err).NotTo(HaveOccurred())
-			kindConfig = string(kindConfigBytes)
 		})
 
 		It("generates a config with ipfamily set to ipv6", func() {
-			Expect(kindConfig).To(ContainSubstring("ipFamily: ipv6"))
+			Expect(kindConfig.Networking.IPFamily).To(Equal(kindv1.IPv6Family))
 		})
 	})
 
@@ -212,14 +208,13 @@ var _ = Describe("Kind Client", func() {
 		BeforeEach(func() {
 			setupTestingFiles(configPath, testingDir, defaultBoMFileForTesting)
 			kindClient = buildKindClient()
-			_, kindConfigBytes, err := kindClient.GetKindNodeImageAndConfig()
+			_, kindConfig, err = kindClient.GetKindNodeImageAndConfig()
 			Expect(err).NotTo(HaveOccurred())
-			kindConfig = string(kindConfigBytes)
 		})
 
 		It("generates a config with default pod and service subnet", func() {
-			Expect(kindConfig).To(ContainSubstring("podSubnet: 100.96.0.0/11"))
-			Expect(kindConfig).To(ContainSubstring("serviceSubnet: 100.64.0.0/13"))
+			Expect(kindConfig.Networking.PodSubnet).To(Equal("100.96.0.0/11"))
+			Expect(kindConfig.Networking.ServiceSubnet).To(Equal("100.64.0.0/13"))
 		})
 	})
 
@@ -227,14 +222,13 @@ var _ = Describe("Kind Client", func() {
 		BeforeEach(func() {
 			setupTestingFiles(configPathCIDR, testingDir, defaultBoMFileForTesting)
 			kindClient = buildKindClient()
-			_, kindConfigBytes, err := kindClient.GetKindNodeImageAndConfig()
+			_, kindConfig, err = kindClient.GetKindNodeImageAndConfig()
 			Expect(err).NotTo(HaveOccurred())
-			kindConfig = string(kindConfigBytes)
 		})
 
 		It("generates a config with specified pod and service subnet", func() {
-			Expect(kindConfig).To(ContainSubstring("podSubnet: 200.200.200.0/24"))
-			Expect(kindConfig).To(ContainSubstring("serviceSubnet: 250.250.250.0/24"))
+			Expect(kindConfig.Networking.PodSubnet).To(Equal("200.200.200.0/24"))
+			Expect(kindConfig.Networking.ServiceSubnet).To(Equal("250.250.250.0/24"))
 		})
 	})
 })


### PR DESCRIPTION


Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
Testing using the mgmt-cluster plugin

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
