### PR TITLE
Improve post-install failure log on plugin installation

### DIFF
--- a/pkg/v1/cli/catalog.go
+++ b/pkg/v1/cli/catalog.go
@@ -590,8 +590,8 @@ func InitializePlugin(name string) error {
 	// Note: If user is installing old version of plugin than it is possible that
 	// the plugin does not implement post-install command. Ignoring the
 	// errors if the command does not exist for a particular plugin.
-	if err != nil && !strings.Contains(err.Error(), "unknown command") {
-		log.Warningf("error while initializing plugin '%q'. Error: %v", name, string(b))
+	if err != nil && !strings.Contains(string(b), "unknown command") {
+		log.Warningf("Warning: Failed to initialize plugin '%q' after installation. %v", name, string(b))
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve the failure log message if the old plugin version is used with the new tanzu cli and the plugin does not implement `post-install` command.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Run the plugin build and install command and if the plugin is old, it should not return the "unknown command" error. But just skip the log message.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
