### PR TITLE
Remove provider checksum and bindata references and validation from Makefile

### DIFF
--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -35,10 +35,6 @@ jobs:
       run: |
         git config --global url."https://git:$GH_ACCESS_TOKEN@github.com".insteadOf "https://github.com"
 
-    - name: Basic checks
-      run: |
-        make providers
-
     - name: Extract PR Info
       shell: bash
       run: |

--- a/Makefile
+++ b/Makefile
@@ -454,11 +454,6 @@ generate-ui-swagger-api: ## Generate swagger files for UI backend
 ## Provider templates/overlays
 ## --------------------------------------
 
-.PHONY: providers
-providers: $(GOBINDATA)
-	make -C pkg/v1/providers -f Makefile ci
-	$(MAKE) fmt
-
 .PHONY: clustergen
 clustergen:
 	CLUSTERGEN_BASE=${CLUSTERGEN_BASE} make -C pkg/v1/providers -f Makefile cluster-generation-diffs

--- a/hack/verify-dirty.sh
+++ b/hack/verify-dirty.sh
@@ -32,18 +32,3 @@ if ! (git diff --quiet HEAD -- .); then
 else
   echo "OK"
 fi
-
-echo
-echo "#############################"
-echo "Verify make providers..."
-echo "#############################"
-make providers > /dev/null
-if ! (git diff --quiet HEAD -- .); then
-  git diff --stat
-  echo "FAIL"
-  echo "'make providers' detected changes to provider files but checksum/bindata have not been updated."
-  echo "Please verify if provider changes are intended and commit the generated files if so."
-  exit 1
-else
-  echo "OK"
-fi

--- a/pkg/v1/providers/Makefile
+++ b/pkg/v1/providers/Makefile
@@ -35,17 +35,7 @@ help:  ## Display this help
 
 verify-build:  ## verify-build verifies the changes with generated files
 
-all: lint checksum verify ## run all target
-
-ci: checksum verify ## run ci target
-
-.PHONY: checksum
-checksum: ## Generate checksum of provider files
-	find . -type f | grep -v ${FILES_TO_IGNORE} | sort | xargs shasum -a 256 | shasum -a 256 | cut -d" " -f1 > providers.sha256sum
-
-.PHONY: verify
-verify: ## verify that checksum and generated bindata file match
-	git diff --exit-code providers.sha256sum client/manifest/zz_generated.bindata.go || (echo "Run make vendir-sync and ensure diff is added to your changeset")
+all: lint ## run all target
 
 .PHONY: build-cli ## build tkg cli with existing provider changes
 build-cli:


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes provider checksum and bindata references and validation from Makefile.

As part of the previous PR, we removed checksum and bindata file dependency.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
