### PR TITLE
Remove k8s version hardcoding from clustergen scripts

### DIFF
--- a/pkg/v1/providers/tests/clustergen/gen_duplicate_bom_azure.py
+++ b/pkg/v1/providers/tests/clustergen/gen_duplicate_bom_azure.py
@@ -27,19 +27,15 @@ import sys
 def get_bom_dir():
     return os.path.join(sys.argv[1], "bom")
 
-def get_bom_filename(k8sVersion):
+def get_default_tkr_bom():
     bomDir = get_bom_dir()
     for bomFile in os.listdir(bomDir):
-        bomFilePath = os.path.join(bomDir, bomFile)
-        with open(bomFilePath) as file:
-            bom = yaml.safe_load(file)
-            if(bom["release"]["version"] == k8sVersion):
-                return bomFile
+        if(bomFile.startswith("tkr-bom")):
+            return bomFile
     return None
 
 def main():
-    k8sVersion = "v1.21.1+vmware.4-tkg.1-zshippable"
-    bomFile = get_bom_filename(k8sVersion)
+    bomFile = get_default_tkr_bom()
     bomDir = get_bom_dir()
     bomFilePath = os.path.join(bomDir, bomFile)
     with open(bomFilePath) as file:


### PR DESCRIPTION
**What this PR does / why we need it**:
Clustergen tests are failing with the following error.
```
~/work/tanzu-framework/tanzu-framework/pkg/v1/providers
cd tests/clustergen && TKG=/home/runner/work/tanzu-framework/tanzu-framework/bin/tkg-linux-amd64 ./run_tests.sh old
  MANAGEMENT-CLUSTER-NAME  CONTEXT-NAME  STATUS  
Traceback (most recent call last):
  File "./gen_duplicate_bom_azure.py", line 94, in <module>
    main()
  File "./gen_duplicate_bom_azure.py", line 44, in main
    bomFilePath = os.path.join(bomDir, bomFile)
  File "/usr/lib/python3.7/posixpath.py", line 94, in join
    genericpath._check_arg_types('join', a, *p)
  File "/usr/lib/python3.7/genericpath.py", line 153, in _check_arg_types
    (funcname, s.__class__.__name__)) from None
```

This is due to the recent changes introduced to decouple bom and clustergen tests no longer rely on the hardcoded boms checked in for clustergen tests.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
Generated the clustergen tests locally.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
