### PR TITLE
Add List Table output format

### DIFF
--- a/cmd/cli/plugin/package/main.go
+++ b/cmd/cli/plugin/package/main.go
@@ -10,6 +10,7 @@ import (
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
 )
 
 var descriptor = cliv1alpha1.PluginDescriptor{
@@ -40,4 +41,15 @@ func main() {
 	if err := p.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+// getOutputFormat gets the desired output format for package commands that need the ListTable format
+// for its output.
+func getOutputFormat() string {
+	format := outputFormat
+	if format != string(component.JSONOutputType) && format != string(component.YAMLOutputType) {
+		// For table output, we want to force the list table format for this part
+		format = string(component.ListTableOutputType)
+	}
+	return format
 }

--- a/cmd/cli/plugin/package/package_available_get.go
+++ b/cmd/cli/plugin/package/package_available_get.go
@@ -49,7 +49,7 @@ func validatePackage(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func packageAvailableGet(cmd *cobra.Command, args []string) error { //nolint:funlen,gocyclo
+func packageAvailableGet(cmd *cobra.Command, args []string) error { //nolint:gocyclo
 	kc, err := kappclient.NewKappClient(packageAvailableOp.KubeConfig)
 	if err != nil {
 		return err
@@ -98,7 +98,7 @@ func packageAvailableGet(cmd *cobra.Command, args []string) error { //nolint:fun
 		return nil
 	}
 
-	t, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat,
+	t, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), getOutputFormat(),
 		fmt.Sprintf("Retrieving package details for %s...", args[0]), true)
 	if err != nil {
 		return err
@@ -119,26 +119,17 @@ func packageAvailableGet(cmd *cobra.Command, args []string) error { //nolint:fun
 		if err != nil {
 			return err
 		}
-		t.AddRow("NAME:", pkg.Spec.RefName)
-		t.AddRow("VERSION:", pkg.Spec.Version)
-		t.AddRow("RELEASED-AT:", pkg.Spec.ReleasedAt)
-		t.AddRow("DISPLAY-NAME:", pkgMetadata.Spec.DisplayName)
-		t.AddRow("SHORT-DESCRIPTION:", pkgMetadata.Spec.ShortDescription)
-		t.AddRow("PACKAGE-PROVIDER:", pkgMetadata.Spec.ProviderName)
-		t.AddRow("MINIMUM-CAPACITY-REQUIREMENTS:", pkg.Spec.CapactiyRequirementsDescription)
-		t.AddRow("LONG-DESCRIPTION:", pkgMetadata.Spec.LongDescription)
-		t.AddRow("MAINTAINERS:", pkgMetadata.Spec.Maintainers)
-		t.AddRow("RELEASE-NOTES:", pkg.Spec.ReleaseNotes)
-		t.AddRow("LICENSE:", pkg.Spec.Licenses)
+		t.SetKeys("name", "version", "released-at", "display-name", "short-description", "package-provider", "minimum-capacity-requirements",
+			"long-description", "maintainers", "release-notes", "license")
+		t.AddRow(pkg.Spec.RefName, pkg.Spec.Version, pkg.Spec.ReleasedAt, pkgMetadata.Spec.DisplayName, pkgMetadata.Spec.ShortDescription,
+			pkgMetadata.Spec.ProviderName, pkg.Spec.CapactiyRequirementsDescription, pkgMetadata.Spec.LongDescription, pkgMetadata.Spec.Maintainers,
+			pkg.Spec.ReleaseNotes, pkg.Spec.Licenses)
 
 		t.RenderWithSpinner()
 	} else {
-		t.AddRow("NAME:", pkgMetadata.Name)
-		t.AddRow("DISPLAY-NAME:", pkgMetadata.Spec.DisplayName)
-		t.AddRow("SHORT-DESCRIPTION:", pkgMetadata.Spec.ShortDescription)
-		t.AddRow("PACKAGE-PROVIDER:", pkgMetadata.Spec.ProviderName)
-		t.AddRow("LONG-DESCRIPTION:", pkgMetadata.Spec.LongDescription)
-		t.AddRow("MAINTAINERS:", pkgMetadata.Spec.Maintainers)
+		t.SetKeys("name", "display-name", "short-description", "package-provider", "long-description", "maintainers")
+		t.AddRow(pkgMetadata.Name, pkgMetadata.Spec.DisplayName, pkgMetadata.Spec.ShortDescription,
+			pkgMetadata.Spec.ProviderName, pkgMetadata.Spec.LongDescription, pkgMetadata.Spec.Maintainers)
 
 		t.RenderWithSpinner()
 	}

--- a/cmd/cli/plugin/package/package_installed_get.go
+++ b/cmd/cli/plugin/package/package_installed_get.go
@@ -37,7 +37,7 @@ func packageInstalledGet(cmd *cobra.Command, args []string) error {
 
 	pkgName = args[0]
 	packageInstalledOp.PkgInstallName = pkgName
-	t, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat,
+	t, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), getOutputFormat(),
 		fmt.Sprintf("Retrieving installation details for %s...", pkgName), true)
 	if err != nil {
 		return err
@@ -53,12 +53,9 @@ func packageInstalledGet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	t.AddRow("NAME:", pkg.Name)
-	t.AddRow("PACKAGE-NAME:", pkg.Spec.PackageRef.RefName)
-	t.AddRow("PACKAGE-VERSION:", pkg.Spec.PackageRef.VersionSelection.Constraints)
-	t.AddRow("STATUS:", pkg.Status.FriendlyDescription)
-	t.AddRow("CONDITIONS:", pkg.Status.Conditions)
-	t.AddRow("USEFUL-ERROR-MESSAGE:", pkg.Status.UsefulErrorMessage)
+	t.SetKeys("name", "package-name", "package-version", "status", "conditions", "useful-error-message")
+	t.AddRow(pkg.Name, pkg.Spec.PackageRef.RefName, pkg.Spec.PackageRef.VersionSelection.Constraints,
+		pkg.Status.FriendlyDescription, pkg.Status.Conditions, pkg.Status.UsefulErrorMessage)
 
 	t.RenderWithSpinner()
 

--- a/cmd/cli/plugin/package/repository_get.go
+++ b/cmd/cli/plugin/package/repository_get.go
@@ -40,7 +40,7 @@ func repositoryGet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	t, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat,
+	t, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), getOutputFormat(),
 		fmt.Sprintf("Retrieving repository %s...", repoOp.RepositoryName), true)
 	if err != nil {
 		return err
@@ -56,11 +56,9 @@ func repositoryGet(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	t.AddRow("NAME:", packageRepository.Name)
-	t.AddRow("VERSION:", packageRepository.ResourceVersion)
-	t.AddRow("REPOSITORY:", packageRepository.Spec.Fetch.ImgpkgBundle.Image)
-	t.AddRow("STATUS:", packageRepository.Status.FriendlyDescription)
-	t.AddRow("REASON:", packageRepository.Status.UsefulErrorMessage)
+	t.SetKeys("name", "version", "repository", "status", "reason")
+	t.AddRow(packageRepository.Name, packageRepository.ResourceVersion, packageRepository.Spec.Fetch.ImgpkgBundle.Image,
+		packageRepository.Status.FriendlyDescription, packageRepository.Status.UsefulErrorMessage)
 
 	t.RenderWithSpinner()
 	return nil

--- a/pkg/v1/cli/component/output.go
+++ b/pkg/v1/cli/component/output.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
@@ -31,8 +32,10 @@ const (
 	TableOutputType OutputType = "table"
 	// YAMLOutputType specifies output should be in yaml format.
 	YAMLOutputType OutputType = "yaml"
-	// JSONOutputType sepcifies output should be in json format.
+	// JSONOutputType specifies output should be in json format.
 	JSONOutputType OutputType = "json"
+	// ListTableOutputType specified output should be in a list table format.
+	ListTableOutputType OutputType = "listtable"
 )
 
 // outputwriter is our internal implementation.
@@ -78,6 +81,8 @@ func (ow *outputwriter) Render() {
 		renderJSON(ow.out, ow.dataStruct())
 	case YAMLOutputType:
 		renderYAML(ow.out, ow.dataStruct())
+	case ListTableOutputType:
+		renderListTable(ow)
 	default:
 		renderTable(ow)
 	}
@@ -163,6 +168,27 @@ func renderYAML(out io.Writer, data interface{}) {
 	}
 
 	fmt.Fprintf(out, "%s", yamlInBytes)
+}
+
+// renderListTable prints output as a list table.
+func renderListTable(ow *outputwriter) {
+	headerLength := 10
+	for _, header := range ow.keys {
+		length := len(header) + 2
+		if length > headerLength {
+			headerLength = length
+		}
+	}
+
+	for i, header := range ow.keys {
+		row := []string{}
+		for _, data := range ow.values {
+			row = append(row, data[i])
+		}
+		headerLabel := strings.ToUpper(header) + ":"
+		values := strings.Join(row, ", ")
+		fmt.Fprintf(ow.out, "%-"+strconv.Itoa(headerLength)+"s   %s\n", headerLabel, values)
+	}
 }
 
 // renderTable prints output as a table

--- a/pkg/v1/cli/component/output_test.go
+++ b/pkg/v1/cli/component/output_test.go
@@ -33,7 +33,7 @@ func TestNewOutputWriterNewHeaders(t *testing.T) {
 	require.NotNil(t, output)
 
 	lines := strings.Split(output, "\n")
-	// Output should contain header row, data row, and a blank lines
+	// Output should contain header row, data row, and a blank line
 	require.Equal(t, 3, len(lines), "%v", lines)
 	require.Contains(t, lines[0], "D")
 	require.Contains(t, lines[0], "E")
@@ -64,15 +64,36 @@ func TestNewOutputWriterInvalid(t *testing.T) {
 
 func validateTableOutput(t *testing.T, output string) {
 	require.NotNil(t, output)
-	require.NotNil(t, output)
 	lines := strings.Split(output, "\n")
 
-	// Output should contain header row, data row, and a blank lines
+	// Output should contain header row, data row, and a blank line
 	require.Equal(t, 3, len(lines), "%v", lines)
 	require.Contains(t, lines[0], "A")
 	require.Contains(t, lines[0], "B")
 	require.Contains(t, lines[0], "C")
 	require.Equal(t, lines[1], "  1  2  3  ")
+}
+
+func TestNewOutputWriterListTable(t *testing.T) {
+	var b bytes.Buffer
+	tab := NewOutputWriter(&b, string(ListTableOutputType), "a", "b", "c")
+	require.NotNil(t, tab)
+	tab.AddRow("1", "2", "3")
+	tab.AddRow("4", "5", "6")
+	tab.Render()
+
+	output := b.String()
+	require.NotNil(t, output)
+	lines := strings.Split(output, "\n")
+
+	// Output should contain row per header and a blank line
+	require.Equal(t, 4, len(lines), "%v", lines)
+	require.Contains(t, lines[0], "A:")
+	require.Contains(t, lines[0], "1, 4")
+	require.Contains(t, lines[1], "B:")
+	require.Contains(t, lines[1], "2, 5")
+	require.Contains(t, lines[2], "C:")
+	require.Contains(t, lines[2], "3, 6")
 }
 
 func TestNewOutputWriterYAML(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Some of the package commands need to print out a table of the results,
but with the "keys" of the table being the first column and any values
being listed after the key.

This adds a ListTableOutputFormat option that pivots the default table
to be this list of results.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

Stepped through unit test output and verified format was as expected.

**Special notes for your reviewer**:

@ggpaue - please take a look.

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Added a ListTable output format that will print output in rows of "KEY: value1, value2, etc" format.
```
**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [X] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
