### PR TITLE
Add ability to copy carvel bundles for tkg standard and core packages

### DIFF
--- a/hack/gen-publish-images.sh
+++ b/hack/gen-publish-images.sh
@@ -35,41 +35,59 @@ if ! [ -x "$(command -v yq)" ]; then
   exit 3
 fi
 
+function imgpkg_copy() {
+    flags=$1
+    src=$2
+    dst=$3
+    echo ""
+    echo "imgpkg copy $flags $src $dst"
+}
+
 echo "set -euo pipefail"
 echodual "Note that yq must be version above or equal to version 4.5 and below version 5."
 
 actualImageRepository=""
 # Iterate through BoM file to read actual image repository
 for TKG_BOM_FILE in "$BOM_DIR"/*.yaml; do
-  echodual "Processing BOM file ${TKG_BOM_FILE}"
   # Get actual image repository from BoM file
   actualImageRepository=$(yq e '.imageConfig.imageRepository' "$TKG_BOM_FILE")
   break
 done
+
 # Iterate through TKG BoM file to create the complete Image name
 # and then pull, retag and push image to custom registry.
 list=$(imgpkg  tag  list -i "${actualImageRepository}"/tkg-bom)
 for imageTag in ${list}; do
   if [[ ${imageTag} == v* ]]; then 
     TKG_BOM_FILE="tkg-bom-${imageTag//_/+}.yaml"
+    imgpkg pull --image "${actualImageRepository}/tkg-bom:${imageTag}" --output "tmp" > /dev/null 2>&1
     echodual "Processing TKG BOM file ${TKG_BOM_FILE}"
 
     actualTKGImage=${actualImageRepository}/tkg-bom:${imageTag}
     customTKGImage=${TKG_CUSTOM_IMAGE_REPOSITORY}/tkg-bom:${imageTag}
-    echo ""
-    echo "docker pull $actualTKGImage"
-    echo "docker tag  $actualTKGImage $customTKGImage"
-    echo "docker push $customTKGImage"
-    imgpkg pull --image "${actualImageRepository}/tkg-bom:${imageTag}" --output "tmp" > /dev/null 2>&1
-    yq e '.. | select(has("images"))|.images[] | .imagePath + ":" + .tag ' "tmp/$TKG_BOM_FILE" |
-    while read -r image; do
-      actualImage=${actualImageRepository}/${image}
-      customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/${image}
-      echo "docker pull $actualImage"
-      echo "docker tag  $actualImage $customImage"
-      echo "docker push $customImage"
-      echo ""
+    imgpkg_copy "-i" $actualTKGImage $customTKGImage
+    
+    
+    # Get components in the tkg-bom.
+    # Remove the leading '[' and trailing ']' in the output of yq.
+    components=(`yq e '.components | keys | .. style="flow"' "tmp/$TKG_BOM_FILE" | sed 's/^.//;s/.$//'`)
+    for comp in "${components[@]}"
+    do
+    # remove: leading and trailing whitespace, and trailing comma
+    comp=`echo $comp | sed -e 's/^[[:space:]]*//' | sed 's/,*$//g'`
+    get_comp_images="yq e '.components[\"${comp}\"][]  | select(has(\"images\"))|.images[] | .imagePath + \":\" + .tag' "\"tmp/\"$TKG_BOM_FILE""
+
+    flags="-i"
+    if [ $comp = "tkg-standard-packages" ] || [ $comp = "tkg-core-packages" ]; then
+      flags="-b"
+    fi
+    eval $get_comp_images | while read -r image; do
+        actualImage=${actualImageRepository}/${image}
+        customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/${image}
+        imgpkg_copy $flags $actualImage $customImage
+      done
     done
+
     rm -rf tmp
     echodual "Finished processing TKG BOM file ${TKG_BOM_FILE}"
     echo ""
@@ -78,7 +96,7 @@ done
 
 # Iterate through TKR BoM file to create the complete Image name
 # and then pull, retag and push image to custom registry.
-list=$(imgpkg  tag  list -i "${actualImageRepository}"/tkr-bom)
+list=$(imgpkg  tag  list -i ${actualImageRepository}/tkr-bom)
 for imageTag in ${list}; do
   if [[ ${imageTag} == v* ]]; then 
     TKR_BOM_FILE="tkr-bom-${imageTag//_/+}.yaml"
@@ -86,18 +104,13 @@ for imageTag in ${list}; do
 
     actualTKRImage=${actualImageRepository}/tkr-bom:${imageTag}
     customTKRImage=${TKG_CUSTOM_IMAGE_REPOSITORY}/tkr-bom:${imageTag}
-    echo ""
-    echo "docker pull $actualTKRImage"
-    echo "docker tag  $actualTKRImage $customTKRImage"
-    echo "docker push $customTKRImage"
-    imgpkg pull --image "${actualImageRepository}/tkr-bom:${imageTag}" --output "tmp" > /dev/null 2>&1
+    imgpkg_copy "-i" $actualTKRImage $customTKRImage
+    imgpkg pull --image ${actualImageRepository}/tkr-bom:${imageTag} --output "tmp" > /dev/null 2>&1
     yq e '.. | select(has("images"))|.images[] | .imagePath + ":" + .tag ' "tmp/$TKR_BOM_FILE" |
     while read -r image; do
       actualImage=${actualImageRepository}/${image}
       customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/${image}
-      echo "docker pull $actualImage"
-      echo "docker tag  $actualImage $customImage"
-      echo "docker push $customImage"
+      imgpkg_copy "-i" $actualImage $customImage
       echo ""
     done
     rm -rf tmp
@@ -106,16 +119,13 @@ for imageTag in ${list}; do
   fi
 done
 
-list=$(imgpkg  tag  list -i "${actualImageRepository}"/tkr-compatibility)
+list=$(imgpkg  tag  list -i ${actualImageRepository}/tkr-compatibility)
 for imageTag in ${list}; do
   if [[ ${imageTag} == v* ]]; then
     echodual "Processing TKR compatibility image"
     actualImage=${actualImageRepository}/tkr-compatibility:${imageTag}
     customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/tkr-compatibility:${imageTag}
-    echo ""
-    echo "docker pull $actualImageRepository/tkr-compatibility:$imageTag"
-    echo "docker tag  $actualImage $customImage"
-    echo "docker push $customImage"
+    imgpkg_copy "-i" $actualImage $customImage
     echo ""
     echodual "Finished processing TKR compatibility image"
   fi
@@ -127,10 +137,7 @@ for imageTag in ${list}; do
     echodual "Processing TKG compatibility image"
     actualImage=${actualImageRepository}/tkg-compatibility:${imageTag}
     customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/tkg-compatibility:${imageTag}
-    echo ""
-    echo "docker pull $actualImageRepository/tkg-compatibility:$imageTag"
-    echo "docker tag  $actualImage $customImage"
-    echo "docker push $customImage"
+    imgpkg_copy "-i" $actualImage $customImage
     echo ""
     echodual "Finished processing TKG compatibility image"
   fi


### PR DESCRIPTION
Signed-off-by: Ashish Amarnath <ashisham@vmware.com>

**What this PR does / why we need it**:
This PR adds the ability to copy carvel bundles for tkg standard and core packages.
The changes to the script, once checked-in, will be used to update the documentation at https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.3/vmware-tanzu-kubernetes-grid-13/GUID-mgmt-clusters-airgapped-environments.html?hWord=N4IghgNiBcIMIFUDKAVA8gWRAXyA

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Verified commands are generated to copy all the images and bundles from a TKG release.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
