### PR TITLE
Allow plugin native completion to propagate ShellCompDirective

### DIFF
--- a/pkg/v1/cli/catalog.go
+++ b/pkg/v1/cli/catalog.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -97,23 +98,21 @@ func GetCmd(p *cliv1alpha1.PluginDescriptor) *cobra.Command {
 			ctx := context.Background()
 			output, _, err := runner.RunOutput(ctx)
 			if err != nil {
-				return nil, cobra.ShellCompDirectiveNoFileComp
+				return nil, cobra.ShellCompDirectiveError
 			}
 
 			lines := strings.Split(strings.Trim(output, "\n"), "\n")
-			valid := false
 			var results []string
 			for _, line := range lines {
 				if strings.HasPrefix(line, ":") {
 					// Special marker in output to indicate the end
-					valid = true
-					break
+					directive, err := strconv.Atoi(line[1:])
+					if err != nil {
+						return results, cobra.ShellCompDirectiveError
+					}
+					return results, cobra.ShellCompDirective(directive)
 				}
 				results = append(results, line)
-			}
-
-			if valid {
-				return results, cobra.ShellCompDirectiveNoFileComp
 			}
 
 			return []string{}, cobra.ShellCompDirectiveError


### PR DESCRIPTION
**What this PR does / why we need it**:

Cobra completion commands pass a directive as the last line of the
output that indicates how the completion script should interpret the
completion values. For example, the value of an argument or flag may be
a file path.

The native completion handler for plugins is currently hard coded to
return `ShellCompDirectiveNoFileComp` for all sets of completion,
regardless of what value the plugin returned. Now the directive returned
from plugins is propagated to the tanzu completion script. If an error
occurs, `ShellCompDirectiveError` is returned.

**Describe testing done for PR**:

There are no existing unit tests that cover shell completion, tested the behavior locally with completion for a plugin I am developing.

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Plugin native shell completion now propagates ShellCompDirective value from plugin
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
