### PR TITLE
Configure proxy settings for kind cluster

### DIFF
--- a/pkg/v1/tkg/client/delete_region.go
+++ b/pkg/v1/tkg/client/delete_region.go
@@ -88,6 +88,11 @@ func (c *TkgClient) DeleteRegion(options DeleteRegionOptions) error { //nolint:f
 		return err
 	}
 
+	err = c.retriveRegionalClusterConfiguration(regionalClusterClient)
+	if err != nil {
+		return errors.Wrap(err, "failed to set configurations for deletion")
+	}
+
 	isFailure, err := c.IsManagementClusterAKindCluster(options.ClusterName)
 	if err != nil {
 		return err

--- a/pkg/v1/tkg/client/upgrade_addon.go
+++ b/pkg/v1/tkg/client/upgrade_addon.go
@@ -205,7 +205,7 @@ func (c *TkgClient) DoUpgradeAddon(regionalClusterClient clusterclient.Client, /
 			c.TKGConfigReaderWriter().Set(constants.ConfigVaraibleDisableCRSForAddonType, addonName)
 		}
 
-		if err := c.setConfigurationForUpgrade(regionalClusterClient); err != nil {
+		if err := c.retriveRegionalClusterConfiguration(regionalClusterClient); err != nil {
 			return errors.Wrap(err, "unable to set cluster configuration")
 		}
 
@@ -231,7 +231,9 @@ func (c *TkgClient) DoUpgradeAddon(regionalClusterClient clusterclient.Client, /
 	return nil
 }
 
-func (c *TkgClient) setConfigurationForUpgrade(regionalClusterClient clusterclient.Client) error {
+// retriveRegionalClusterConfiguration gets TKG configurations from regional cluster and sets the TKGConfigReaderWriter.
+// this is required when we want to mutate the existing regional cluster.
+func (c *TkgClient) retriveRegionalClusterConfiguration(regionalClusterClient clusterclient.Client) error {
 	if err := c.setProxyConfiguration(regionalClusterClient); err != nil {
 		return errors.Wrapf(err, "error while getting proxy configuration from cluster and setting it")
 	}

--- a/pkg/v1/tkg/client/upgrade_region.go
+++ b/pkg/v1/tkg/client/upgrade_region.go
@@ -162,8 +162,9 @@ func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterCl
 	if err != nil {
 		return errors.Wrap(err, "failed to parse provider name")
 	}
-	// set default values for variables required for infrastructure component spec rendering
-	err = c.setConfigurationForUpgrade(regionalClusterClient)
+	// retrieve required variables required for infrastructure component spec rendering
+	// set them to default values if they don't exist.
+	err = c.retriveRegionalClusterConfiguration(regionalClusterClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to set configurations for upgrade")
 	}


### PR DESCRIPTION
Currently kind cluster is not configured for proxy settings during management cluster deletion. Now set the corresponding env vars so that the cluster-api provider components in bootstrap cluster will be configured with proper NO_PROXY settings.

Signed-off-by: Hanlin Shi <shihanlin9@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
