### PR TITLE
Restore posting of clustergen results via a different workflow.

### DIFF
--- a/.github/workflows/recv_providers.yaml
+++ b/.github/workflows/recv_providers.yaml
@@ -1,0 +1,86 @@
+name: Post Cluster Generation Results As Comment
+
+# Adapted from https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+on:
+  workflow_run:
+    workflows: ["Provider Template Tests"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      ${{ github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@v3.1.0
+        with:
+          script: |
+            var artifacts = await github.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            var download = await github.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+
+      - name: Read artifact info
+        shell: bash
+        run: |
+          unzip pr.zip
+          echo "##[set-output name=diffstatus;]$(cat ./clustergen.status)"
+          echo "##[set-output name=prnum;]$(cat ./prnum)"
+        id: read_artifact
+
+      - name: Get Time
+        id: time
+        uses: nanzm/get-time-action@v1.1
+        with:
+          format: 'YYYYMMDDHHmmss'
+
+      - id: upload-clustergen-results
+        if: ${{ steps.clustergen.outputs.diffstatus == 0 }}
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: ./clustergen.diff.txt
+          destination: tkg-clustergen/${{ steps.read_artifact.outputs.prnum }}/${{ steps.time.outputs.time }}
+          credentials: ${{ secrets.GCP_BUCKET_SA }}
+
+      - id: upload-clustergen-results2
+        if: ${{ steps.clustergen.outputs.diffstatus == 0 }}
+        uses: google-github-actions/upload-cloud-storage@main
+        with:
+          path: ./clustergen.html
+          destination: tkg-clustergen/${{ steps.read_artifact.outputs.prnum }}/${{ steps.time.outputs.time }}
+          credentials: ${{ secrets.GCP_BUCKET_SA }}
+
+      - name: Create comment with diffs
+        if: ${{ steps.clustergen.outputs.diffstatus == 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ steps.read_artifact.outputs.prnum }}
+          body: |
+            Cluster Generation A/B Results:
+            https://storage.googleapis.com/tkg-clustergen/${{ steps.read_artifact.outputs.prnum }}/${{ steps.time.outputs.time }}/clustergen.diff.txt
+            Author/reviewers:
+            Please review to verify that the effects on the generated cluster configurations are exactly what the PR intended, and give a thumbs-up if so.
+
+      - name: Create comment indicating no changes detected
+        if: ${{ steps.clustergen.outputs.diffstatus != 0 }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ steps.read_artifact.outputs.prnum }}
+          body: |
+            Cluster Generation A/B Results: (no changes detected)
+


### PR DESCRIPTION
This workflow, triggered on workflow_run, runs with access to main repo
secrets, and takes advantage of it to repost artifacts published by the
less privileged providers workflow as PR comment links for review by
author and reviewers.


Signed-off-by: Vui Lam <vui@vmware.com>

**What this PR does / why we need it**:
The providers workflow was refactored so that steps requiring main repo privileges are removed.
This change restores those steps in a workflow with access to main repo secrets used in a more 
controllable fashion.
This follows the model described in
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

**Which issue(s) this PR fixes**:
Partially fixes: #17

**Describe testing done for PR**:
Unfortunately the effect of this change can only be exercised when it is checked into main.
Monitoring and verifying the change as we go.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- x Ensure PR contains only public links or terms
- x Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- x Squash the commits in this branch before merge to preserve our git history
- x If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- x Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
