### PR TITLE
Refactor capability query results

### DIFF
--- a/apis/run/v1alpha1/capability_types.go
+++ b/apis/run/v1alpha1/capability_types.go
@@ -103,15 +103,19 @@ type QueryResult struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength:=1
 	Name string `json:"name"`
-	// Found is a boolean which represents if the query condition succeeded.
+	// Found is a boolean which indicates if the query condition succeeded.
 	// +optional
 	Found bool `json:"found"`
 	// Error indicates if an error occurred while processing the query.
 	// +optional
-	Error bool `json:"error"`
+	Error bool `json:"error,omitempty"`
 	// ErrorDetail represents the error detail, if an error occurred.
 	// +optional
-	ErrorDetail string `json:"errorDetail"`
+	ErrorDetail string `json:"errorDetail,omitempty"`
+	// NotFoundReason provides the reason if the query condition fails.
+	// This is non-empty when Found is false.
+	// +optional
+	NotFoundReason string `json:"notFoundReason,omitempty"`
 }
 
 // Result represents the results of queries in Query.

--- a/config/crd/bases/run.tanzu.vmware.com_capabilities.yaml
+++ b/config/crd/bases/run.tanzu.vmware.com_capabilities.yaml
@@ -210,13 +210,17 @@ spec:
                             an error occurred.
                           type: string
                         found:
-                          description: Found is a boolean which represents if the
-                            query condition succeeded.
+                          description: Found is a boolean which indicates if the query
+                            condition succeeded.
                           type: boolean
                         name:
                           description: Name is the name of the query in spec whose
                             result this struct represents.
                           minLength: 1
+                          type: string
+                        notFoundReason:
+                          description: NotFoundReason provides the reason if the query
+                            condition fails. This is non-empty when Found is false.
                           type: string
                       required:
                       - name
@@ -243,13 +247,17 @@ spec:
                             an error occurred.
                           type: string
                         found:
-                          description: Found is a boolean which represents if the
-                            query condition succeeded.
+                          description: Found is a boolean which indicates if the query
+                            condition succeeded.
                           type: boolean
                         name:
                           description: Name is the name of the query in spec whose
                             result this struct represents.
                           minLength: 1
+                          type: string
+                        notFoundReason:
+                          description: NotFoundReason provides the reason if the query
+                            condition fails. This is non-empty when Found is false.
                           type: string
                       required:
                       - name
@@ -273,13 +281,17 @@ spec:
                             an error occurred.
                           type: string
                         found:
-                          description: Found is a boolean which represents if the
-                            query condition succeeded.
+                          description: Found is a boolean which indicates if the query
+                            condition succeeded.
                           type: boolean
                         name:
                           description: Name is the name of the query in spec whose
                             result this struct represents.
                           minLength: 1
+                          type: string
+                        notFoundReason:
+                          description: NotFoundReason provides the reason if the query
+                            condition fails. This is non-empty when Found is false.
                           type: string
                       required:
                       - name

--- a/pkg/v1/sdk/capabilities/discovery/cluster_gvr.go
+++ b/pkg/v1/sdk/capabilities/discovery/cluster_gvr.go
@@ -13,18 +13,25 @@ import (
 )
 
 // Group represents any API group that may exist on a cluster, with ability to specify versions and resource to check for GVR.
-func Group(group string) *QueryGVR {
+func Group(queryName, group string) *QueryGVR {
 	return &QueryGVR{
+		name:  queryName,
 		group: group,
 	}
 }
 
 // QueryGVR provides insight to the clusters GVRs
 type QueryGVR struct {
+	name          string
 	group         string
 	resource      string
 	versions      []string
 	unmatchedGVRs []string
+}
+
+// Name returns the name of the query.
+func (q *QueryGVR) Name() string {
+	return q.name
 }
 
 // WithVersions checks if an API group with all the specified versions exist.

--- a/pkg/v1/sdk/capabilities/discovery/cluster_object.go
+++ b/pkg/v1/sdk/capabilities/discovery/cluster_object.go
@@ -20,8 +20,9 @@ import (
 // WithAnnotations()
 // WithLabels()
 // WithConditions()
-func Object(obj *corev1.ObjectReference) *QueryObject {
+func Object(queryName string, obj *corev1.ObjectReference) *QueryObject {
 	return &QueryObject{
+		name:     queryName,
 		object:   obj,
 		presence: true,
 	}
@@ -29,10 +30,16 @@ func Object(obj *corev1.ObjectReference) *QueryObject {
 
 // QueryObject allows for resource querying
 type QueryObject struct {
+	name        string
 	object      *corev1.ObjectReference
 	annotations []resourceAnnotation
 	presence    bool
 	//	conditions []resourceCondition
+}
+
+// Name is the name of the query.
+func (q *QueryObject) Name() string {
+	return q.name
 }
 
 // WithoutAnnotations ensures lack of presence annotations on a resource

--- a/pkg/v1/sdk/capabilities/discovery/cluster_schema.go
+++ b/pkg/v1/sdk/capabilities/discovery/cluster_schema.go
@@ -25,6 +25,11 @@ type QueryPartialSchema struct {
 	presence bool
 }
 
+// Name is the name of the query.
+func (q *QueryPartialSchema) Name() string {
+	return q.name
+}
+
 // Run the partial query match
 func (q *QueryPartialSchema) Run(config *clusterQueryClientConfig) (bool, error) {
 	doc, err := config.discoveryClientset.OpenAPISchema()

--- a/pkg/v1/sdk/capabilities/discovery/cluster_test.go
+++ b/pkg/v1/sdk/capabilities/discovery/cluster_test.go
@@ -25,9 +25,9 @@ var testAnnotations = map[string]string{
 	"cluster.x-k8s.io/provider": "infrastructure-fake",
 }
 
-var testObject = Object(&carp).WithAnnotations(testAnnotations) // .WithConditions(field)
+var testObject = Object("carpObj", &carp).WithAnnotations(testAnnotations) // .WithConditions(field)
 
-var testGVR = Group(testapigroup.SchemeGroupVersion.Group).WithVersions(testapigroup.SchemeGroupVersion.Version).WithResource("carps")
+var testGVR = Group("carpResource", testapigroup.SchemeGroupVersion.Group).WithVersions(testapigroup.SchemeGroupVersion.Version).WithResource("carps")
 
 var testObjects = []runtime.Object{
 	&testapigroup.Carp{
@@ -99,6 +99,13 @@ func TestClusterQueries(t *testing.T) {
 			queryTargets:      []QueryTarget{},
 			want:              true,
 			err:               "",
+		},
+		{
+			description:       "query target names contain duplicates",
+			discoveryClientFn: queryClientWithResourcesAndObjects,
+			queryTargets:      []QueryTarget{testGVR, testObject, Object("carpObj", &carp)},
+			want:              false,
+			err:               "query target names must be unique",
 		},
 	}
 

--- a/pkg/v1/sdk/capabilities/discovery/discovery.go
+++ b/pkg/v1/sdk/capabilities/discovery/discovery.go
@@ -4,6 +4,8 @@
 package discovery
 
 import (
+	"fmt"
+
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -49,6 +51,7 @@ func (c *ClusterQueryClient) Query(targets ...QueryTarget) *ClusterQuery {
 	return &ClusterQuery{
 		targets: targets,
 		config:  c.config,
+		results: Results{},
 	}
 }
 
@@ -57,38 +60,73 @@ func (c *ClusterQueryClient) PreparedQuery(targets ...QueryTarget) func() (bool,
 	q := &ClusterQuery{
 		targets: targets,
 		config:  c.config,
+		results: Results{},
 	}
 	return q.Prepare()
 }
 
 // QueryTarget implementations: Resource, GVK, Schema
 type QueryTarget interface {
+	Name() string
 	Run(config *clusterQueryClientConfig) (bool, error)
 	Reason() string
 }
 
-// ClusterQuery provides a means of executing a queries targets to determine results
-type ClusterQuery struct {
-	queryFailures []string
-	targets       []QueryTarget
-	config        *clusterQueryClientConfig
+// QueryResult is a result of a single query.
+type QueryResult struct {
+	// Found indicates whether the entity being checked in the query exists.
+	Found bool
+	// NotFoundReason indicates the reason why Found was false.
+	NotFoundReason string
 }
 
-// Execute actually executes the function
+// Results is a map of query names to their corresponding QueryResult.
+type Results map[string]*QueryResult
+
+// ForQuery returns the QueryResult for a given query name.
+// Return value is nil if the query target with the given name does not exist.
+func (r Results) ForQuery(queryName string) *QueryResult {
+	return r[queryName]
+}
+
+// ClusterQuery provides a means of executing a queries targets to determine results
+type ClusterQuery struct {
+	targets []QueryTarget
+	config  *clusterQueryClientConfig
+	results Results
+}
+
+// Execute runs all the query targets and returns true only if *all* of them succeed.
+// For granular results of each query, use the Results() method after calling this method.
 // Normally this function is returned by Prepare() and stored as a constant to re-use
 func (c *ClusterQuery) Execute() (bool, error) {
+	// Check for duplicate query names.
+	m := make(map[string]struct{})
+	for _, t := range c.targets {
+		if _, ok := m[t.Name()]; ok {
+			return false, fmt.Errorf("query target names must be unique")
+		}
+		m[t.Name()] = struct{}{}
+	}
+
+	success := true
 	for _, t := range c.targets {
 		ok, err := t.Run(c.config)
 		if err != nil {
 			return false, err
 		}
+		queryResult := &QueryResult{}
 		if !ok {
-			c.queryFailures = append(c.queryFailures, t.Reason())
+			queryResult.Found = false
+			queryResult.NotFoundReason = t.Reason()
+			c.results[t.Name()] = queryResult
+			success = false
 			continue
 		}
+		queryResult.Found = true
+		c.results[t.Name()] = queryResult
 	}
-
-	return len(c.queryFailures) == 0, nil
+	return success, nil
 }
 
 // Prepare queries for the discovery API on the resources, GVKs and/or partial schema a cluster has.
@@ -96,7 +134,7 @@ func (c *ClusterQuery) Prepare() func() (bool, error) {
 	return c.Execute
 }
 
-// QueryFailures returns all of the queries failures
-func (c *ClusterQuery) QueryFailures() []string {
-	return c.queryFailures
+// Results returns all of the queries failures
+func (c *ClusterQuery) Results() Results {
+	return c.results
 }

--- a/pkg/v1/sdk/capabilities/discovery/tkg/capabilities.go
+++ b/pkg/v1/sdk/capabilities/discovery/tkg/capabilities.go
@@ -93,6 +93,6 @@ func (dc *DiscoveryClient) HasNSX(ctx context.Context) (bool, error) {
 		Name:       namespaceNSX,
 		APIVersion: corev1.SchemeGroupVersion.Version,
 	}
-	query := discovery.Object(nsx)
+	query := discovery.Object("nsx", nsx)
 	return dc.clusterQueryClient.PreparedQuery(query)()
 }

--- a/pkg/v1/sdk/capabilities/discovery/tkg/resource.go
+++ b/pkg/v1/sdk/capabilities/discovery/tkg/resource.go
@@ -12,13 +12,13 @@ import (
 
 // HasTanzuRunGroup checks if run.tanzu.vmware.com API group exists and optionally checks versions.
 func (dc *DiscoveryClient) HasTanzuRunGroup(ctx context.Context, versions ...string) (bool, error) {
-	query := discovery.Group(runv1alpha1.GroupVersion.Group).WithVersions(versions...)
+	query := discovery.Group("rungroup", runv1alpha1.GroupVersion.Group).WithVersions(versions...)
 	return dc.clusterQueryClient.PreparedQuery(query)()
 }
 
 // HasTanzuKubernetesClusterV1alpha1 checks if the cluster has TanzuKubernetesCluster v1alpha1 resource.
 func (dc *DiscoveryClient) HasTanzuKubernetesClusterV1alpha1(ctx context.Context) (bool, error) {
-	query := discovery.Group(runv1alpha1.GroupVersion.Group).
+	query := discovery.Group("tkc", runv1alpha1.GroupVersion.Group).
 		WithVersions(runv1alpha1.GroupVersion.Version).
 		WithResource("tanzukubernetesclusters")
 	return dc.clusterQueryClient.PreparedQuery(query)()
@@ -26,7 +26,7 @@ func (dc *DiscoveryClient) HasTanzuKubernetesClusterV1alpha1(ctx context.Context
 
 // HasTanzuKubernetesReleaseV1alpha1 checks if the cluster has TanzuKubernetesRelease v1alpha1 resource.
 func (dc *DiscoveryClient) HasTanzuKubernetesReleaseV1alpha1(ctx context.Context) (bool, error) {
-	query := discovery.Group(runv1alpha1.GroupVersion.Group).
+	query := discovery.Group("tkr", runv1alpha1.GroupVersion.Group).
 		WithVersions(runv1alpha1.GroupVersion.Version).
 		WithResource("tanzukubernetesreleases")
 	return dc.clusterQueryClient.PreparedQuery(query)()


### PR DESCRIPTION
**What this PR does / why we need it**:
Query package returns a `Results` type instead of a list of failure
strings. The type makes it easy to programmatically consume the results.

Also adds a corresponding `NotFoundReason` field to the results in CRD
status.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Describe testing done for PR**:
`go test` and running capabilities controller locally with resources and observing reconciled state.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Adds Results method to capability query client and NotFoundReason field to Capability CRD status results for better query result inspection.
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
