### PR TITLE
Addon controller waits for CRDs

### DIFF
--- a/addons/Makefile
+++ b/addons/Makefile
@@ -9,7 +9,7 @@ ROOT_DIR	:= $(dir $(shell pwd))
 export GO111MODULE := on
 
 # Image URL to use all building/pushing image targets
-IMG ?= addons-controller:latest
+IMG ?= addons-controller:$(shell git describe --always --dirty --tags)
 
 # Directories
 BIN_DIR       := bin

--- a/addons/controllers/addon_controller.go
+++ b/addons/controllers/addon_controller.go
@@ -6,14 +6,19 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/pointer"
 	clusterapiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	controlplanev1alpha3 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
@@ -27,6 +32,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	kappctrl "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
+	kapppkg "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
+	kappdatapkg "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
 
 	addonconfig "github.com/vmware-tanzu/tanzu-framework/addons/pkg/config"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
@@ -131,6 +140,74 @@ func (r *AddonReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ct
 	}
 
 	return result, nil
+}
+
+// WaitForCRDs checks if CRDs are available by polling for resources that addon controller depends on.
+func (r *AddonReconciler) WaitForCRDs(mgr ctrl.Manager) error {
+	// add all the CRDs the controller is watching and is dependent on
+	var crds = map[schema.GroupVersion]*sets.String{}
+	// cluster-api
+	clusterapiv1alpha3Resources := sets.NewString("clusters", "kubeadmcontrolplanes")
+	crds[runtanzuv1alpha1.GroupVersion] = &clusterapiv1alpha3Resources
+
+	// tkr
+	runtanzuv1alpha1Resources := sets.NewString("tanzukubernetesreleases")
+	crds[runtanzuv1alpha1.GroupVersion] = &runtanzuv1alpha1Resources
+
+	// kapp-controller APIs
+	kappctrlv1alpha1Resources := sets.NewString("apps")
+	crds[kappctrl.SchemeGroupVersion] = &kappctrlv1alpha1Resources
+
+	kapppkgv1alpha1Resources := sets.NewString("packageinstalls", "packagerepositories")
+	crds[kapppkg.SchemeGroupVersion] = &kapppkgv1alpha1Resources
+
+	kappdatapkgv1alpha1Resources := sets.NewString("packagemetadatas", "packages")
+	crds[kappdatapkg.SchemeGroupVersion] = &kappdatapkgv1alpha1Resources
+
+	addonPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: os.Getenv("POD_NAME"), Namespace: os.Getenv("POD_NAMESPACE")}}
+
+	poller := func() (done bool, err error) {
+		// Create new clientset for every invocation to avoid caching of resources
+		cs, err := clientset.NewForConfig(mgr.GetConfig())
+		if err != nil {
+			return false, err
+		}
+
+		allFound := true
+		for gv, resources := range crds {
+			// All resources found, do nothing
+			if resources.Len() == 0 {
+				delete(crds, gv)
+				continue
+			}
+
+			// Get the Resources for this GroupVersion
+			groupVersion := gv.String()
+			resourceList, err := cs.Discovery().ServerResourcesForGroupVersion(groupVersion)
+			if err != nil {
+				r.Log.Error(err, "error retrieving GroupVersion", "GroupVersion", groupVersion)
+				mgr.GetEventRecorderFor(constants.AddonControllerName).Eventf(addonPod, corev1.EventTypeWarning,
+					"Polling for GroupVersion", "The GroupVersion '%s' is not available yet", groupVersion)
+				return false, nil
+			}
+
+			// Remove each found resource from the resources set that we are waiting for
+			for i := 0; i < len(resourceList.APIResources); i++ {
+				resources.Delete(resourceList.APIResources[i].Name)
+			}
+
+			// Still waiting on some resources in this group version
+			if resources.Len() != 0 {
+				allFound = false
+				r.Log.Info("resources are not available yet", "api-resources", resources, "GroupVersion", groupVersion)
+				mgr.GetEventRecorderFor(constants.AddonControllerName).Eventf(addonPod, corev1.EventTypeWarning,
+					"Polling for api-resources", "The api-resources '%s' in GroupVersion '%s' are not available yet", resources, groupVersion)
+			}
+		}
+		return allFound, nil
+	}
+
+	return wait.PollImmediate(constants.CRDWaitPollInterval, constants.CRDWaitPollTimeout, poller)
 }
 
 // reconcileDelete deletes the addon secrets that belong to the cluster

--- a/addons/go.mod
+++ b/addons/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework v0.0.0-20201211200158-5838874f2c38
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.21.2
+	k8s.io/apiextensions-apiserver v0.21.2
 	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v0.21.2
 	k8s.io/klog v1.0.0

--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -4,6 +4,8 @@
 // Package constants defines various constants used in the code.
 package constants
 
+import "time"
+
 const (
 	/* Addon constants section */
 
@@ -86,4 +88,13 @@ const (
 
 	// PackageRepositoryLogKey is the log key for "core-package-repository"
 	PackageRepositoryLogKey = "core-package-repository"
+
+	// AddonControllerName is name of addon-controller
+	AddonControllerName = "addon-controller"
+
+	// CRDWaitPollInterval is poll interval for checking server resources
+	CRDWaitPollInterval = time.Second * 5
+
+	// CRDWaitPollTimeout is poll timeout for checking server resources
+	CRDWaitPollTimeout = time.Minute * 10
 )


### PR DESCRIPTION
* Wait for cluster-api and kapp-controller resources
* Add health, ready and startup probes
* Emit events for pod to help diagnose startup issues.

**What this PR does / why we need it**:
Wait for CRDs so that controller does not crash when watches are set.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #42 

**Describe testing done for PR**:
1. Deploy on a cluster without CRDs and observe that the pod is not ready.
2. Observe that events are being emitted for pod.
```
k get event -n tanzu-system --field-selector involvedObject.name=tanzu-addons-controller-manager-7c98c97f59-xbwrx
LAST SEEN   TYPE      REASON                     OBJECT                                                 MESSAGE
45m         Normal    Scheduled                  pod/tanzu-addons-controller-manager-7c98c97f59-xbwrx   Successfully assigned tanzu-system/tanzu-addons-controller-manager-7c98c97f59-xbwrx to docker-desktop
15m         Normal    Pulled                     pod/tanzu-addons-controller-manager-7c98c97f59-xbwrx   Container image "projects-stg.registry.vmware.com/tkg/vkatam/addons-controller:v1.4.0-pre-alpha-2-29-ged4c177" already present on machine
45m         Normal    Created                    pod/tanzu-addons-controller-manager-7c98c97f59-xbwrx   Created container tanzu-addons-controller
45m         Normal    Started                    pod/tanzu-addons-controller-manager-7c98c97f59-xbwrx   Started container tanzu-addons-controller
40m         Warning   Polling for GroupVersion   pod/tanzu-addons-controller-manager-7c98c97f59-xbwrx   The GroupVersion 'run.tanzu.vmware.com/v1alpha1' is not available yet
10m         Warning   Unhealthy                  pod/tanzu-addons-controller-manager-7c98c97f59-xbwrx   Startup probe failed: Get "http://10.1.0.14:18316/healthz": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
43m         Warning   Polling for GroupVersion   pod/tanzu-addons-controller-manager-7c98c97f59-xbwrx   The GroupVersion 'data.packaging.carvel.dev/v1alpha1' is not available yet
35m         Warning   Polling for GroupVersion   pod/tanzu-addons-controller-manager-7c98c97f59-xbwrx   The GroupVersion 'kappctrl.k14s.io/v1alpha1' is not available yet
30m         Warning   Polling for GroupVersion   pod/tanzu-addons-controller-manager-7c98c97f59-xbwrx   The GroupVersion 'run.tanzu.vmware.com/v1alpha1' is not available yet
25m         Warning   Polling for GroupVersion   pod/tanzu-addons-controller-manager-7c98c97f59-xbwrx   The GroupVersion 'data.packaging.carvel.dev/v1alpha1' is not available yet
20m         Warning   Polling for GroupVersion   pod/tanzu-addons-controller-manager-7c98c97f59-xbwrx   The GroupVersion 'data.packaging.carvel.dev/v1alpha1' is not available yet
10m         Warning   Polling for GroupVersion   pod/tanzu-addons-controller-manager-7c98c97f59-xbwrx   The GroupVersion 'data.packaging.carvel.dev/v1alpha1' is not available yet
```
3. Install cluster-api CRD's and kapp-controller and pod starts up and becomes ready.
```
 k get pods -n tanzu-system
NAME                                               READY   STATUS    RESTARTS   AGE
tanzu-addons-controller-manager-7c98c97f59-xbwrx   1/1     Running   3          46m
```

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
