### PR TITLE
Improve the error messages around missing VM Template for vSphere

### DIFF
--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -428,7 +428,7 @@ func (c *TkgClient) ConfigureAndValidateVSphereTemplate(vcClient vc.Client, tkrV
 
 	vsphereVM, err := vcClient.GetAndValidateVirtualMachineTemplate(tkrBom.GetOVAVersions(), tkrVersion, templateName, dc, c.TKGConfigReaderWriter())
 	if err != nil || vsphereVM == nil {
-		return errors.Wrapf(err, "unable to get or validate %s for given Tanzu Kubernetes release", constants.ConfigVariableVsphereTemplate)
+		return errors.Wrap(err, "unable to get or validate VM Template for given Tanzu Kubernetes release")
 	}
 
 	c.TKGConfigReaderWriter().Set(constants.ConfigVariableVsphereTemplate, vsphereVM.Name)

--- a/pkg/v1/tkg/vc/helpers.go
+++ b/pkg/v1/tkg/vc/helpers.go
@@ -81,7 +81,7 @@ func (c *DefaultClient) GetAndValidateVirtualMachineTemplate(
 		return nil, errors.Errorf("unable to find VM Template associated with TanzuKubernetesRelease %s, but found these VM(s) [%s] that can be used once converted to a VM Template", tkrVersion, strings.Join(nonTemplateVMs, ","))
 	}
 
-	return nil, errors.Errorf("unable to find VM Template associated with TanzuKubernetesRelease %s. Please upload VM Template for this TanzuKubernetesRelease to continue", tkrVersion)
+	return nil, errors.Errorf("unable to find VM Template associated with TanzuKubernetesRelease %s. Please upload at least one VM Template from versions [%v] to continue", tkrVersion, strings.Join(ovaVersions, ","))
 }
 
 // FindMatchingVirtualMachineTemplate finds a virtual machine template that matches the ova versions


### PR DESCRIPTION
**What this PR does / why we need it**:

Improve the log and error messages that are returned when VM Template is not present on provided vSphere environment

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:

Run the create management cluster command to force this error and verified the error message is as expected.
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
