### PR TITLE
Fix configuration precidence during mgmt cluster upgrade and deletion

### DIFF
--- a/pkg/v1/tkg/client/upgrade_addon.go
+++ b/pkg/v1/tkg/client/upgrade_addon.go
@@ -271,22 +271,16 @@ func (c *TkgClient) setProxyConfiguration(regionalClusterClient clusterclient.Cl
 		return nil
 	}
 
-	if httpProxy, err := c.TKGConfigReaderWriter().Get(constants.HTTPProxy); err != nil || httpProxy == "" {
-		if httpProxy := configmap.Data["httpProxy"]; httpProxy != "" {
-			c.TKGConfigReaderWriter().Set(constants.TKGHTTPProxy, httpProxy)
-		}
+	if httpProxy := configmap.Data["httpProxy"]; httpProxy != "" {
+		c.TKGConfigReaderWriter().Set(constants.TKGHTTPProxy, httpProxy)
 	}
 
-	if httpsProxy, err := c.TKGConfigReaderWriter().Get(constants.TKGHTTPSProxy); err != nil || httpsProxy == "" {
-		if httpsProxy := configmap.Data["httpsProxy"]; httpsProxy != "" {
-			c.TKGConfigReaderWriter().Set(constants.TKGHTTPSProxy, httpsProxy)
-		}
+	if httpsProxy := configmap.Data["httpsProxy"]; httpsProxy != "" {
+		c.TKGConfigReaderWriter().Set(constants.TKGHTTPSProxy, httpsProxy)
 	}
 
-	if noProxy, err := c.TKGConfigReaderWriter().Get(constants.TKGNoProxy); err != nil || noProxy == "" {
-		if noProxy := configmap.Data["noProxy"]; noProxy != "" {
-			c.TKGConfigReaderWriter().Set(constants.TKGNoProxy, noProxy)
-		}
+	if noProxy := configmap.Data["noProxy"]; noProxy != "" {
+		c.TKGConfigReaderWriter().Set(constants.TKGNoProxy, noProxy)
 	}
 
 	return nil
@@ -305,17 +299,13 @@ func (c *TkgClient) setCustomImageRepositoryConfiguration(regionalClusterClient 
 		return nil
 	}
 
-	if customImageRepository, err := c.TKGConfigReaderWriter().Get(constants.ConfigVariableCustomImageRepository); err != nil || customImageRepository == "" {
-		if customImageRepository := configmap.Data["imageRepository"]; customImageRepository != "" {
-			c.TKGConfigReaderWriter().Set(constants.ConfigVariableCustomImageRepository, customImageRepository)
-		}
+	if customImageRepository := configmap.Data["imageRepository"]; customImageRepository != "" {
+		c.TKGConfigReaderWriter().Set(constants.ConfigVariableCustomImageRepository, customImageRepository)
 	}
 
-	if customImageRepositoryCaCertificate, err := c.TKGConfigReaderWriter().Get(constants.ConfigVariableCustomImageRepositoryCaCertificate); err != nil || customImageRepositoryCaCertificate == "" {
-		if customImageRepositoryCaCertificate := configmap.Data["caCerts"]; customImageRepositoryCaCertificate != "" {
-			customImageRepositoryCaCertificateEncoded := base64.StdEncoding.EncodeToString([]byte(customImageRepositoryCaCertificate))
-			c.TKGConfigReaderWriter().Set(constants.ConfigVariableCustomImageRepositoryCaCertificate, customImageRepositoryCaCertificateEncoded)
-		}
+	if customImageRepositoryCaCertificate := configmap.Data["caCerts"]; customImageRepositoryCaCertificate != "" {
+		customImageRepositoryCaCertificateEncoded := base64.StdEncoding.EncodeToString([]byte(customImageRepositoryCaCertificate))
+		c.TKGConfigReaderWriter().Set(constants.ConfigVariableCustomImageRepositoryCaCertificate, customImageRepositoryCaCertificateEncoded)
 	}
 
 	return nil


### PR DESCRIPTION
Consume the configs persisted during cluster creation instead of the
local configuration.

Signed-off-by: Hanlin Shi <shihanlin9@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #213

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
