### PR TITLE
Add tanzu-addons-manager package

### DIFF
--- a/addons/packages/addons-manager/1.4.0/bundle/.imgpkg/images.yml
+++ b/addons/packages/addons-manager/1.4.0/bundle/.imgpkg/images.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: imgpkg.carvel.dev/v1alpha1
+images:
+- annotations:
+    kbld.carvel.dev/id: projects-stg.registry.vmware.com/tkg/sandbox/tanzu_core_addons/tanzu-addons-manager:v1.4.0_vmware.1
+  image: projects-stg.registry.vmware.com/tkg/tanzu_core/addons/tanzu-addons-manager@sha256:71c2244514dc2b0df7d177d6f70d0d802a6be5ff822f8caebfdd66f135773c61
+kind: ImagesLock

--- a/addons/packages/addons-manager/1.4.0/bundle/config/overlays/overlay-addons-manager.yaml
+++ b/addons/packages/addons-manager/1.4.0/bundle/config/overlays/overlay-addons-manager.yaml
@@ -1,0 +1,57 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@ if data.values.tanzuAddonsManager.createNamespace:
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: #@ data.values.tanzuAddonsManager.namespace
+#@ end
+
+#@overlay/match by=overlay.subset({"kind":"ServiceAccount", "metadata": {"name": "tanzu-addons-manager-sa"}})
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: #@ data.values.tanzuAddonsManager.namespace
+
+#@overlay/match by=overlay.subset({"kind":"ClusterRoleBinding", "metadata": {"name": "tanzu-addons-manager-clusterrolebinding"}})
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+subjects:
+#@overlay/match by=overlay.subset({"kind":"ServiceAccount", "name": "tanzu-addons-manager-sa"})
+- kind: ServiceAccount
+  name: tanzu-addons-manager-sa
+  namespace: #@ data.values.tanzuAddonsManager.namespace
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata": {"name": "tanzu-addons-controller-manager"}})
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: #@ data.values.tanzuAddonsManager.namespace
+spec:
+  template:
+    spec:
+      containers:
+      #@overlay/match by=overlay.subset({"name": "tanzu-addons-controller"})
+      - args:
+        #@overlay/match by=lambda index, left, right: "--health-addr=" in left, expects=1
+        - #@ "--health-addr=:{}".format(data.values.tanzuAddonsManager.deployment.healthzPort)
+        ports:
+          #@overlay/match by="name"
+          - name: healthz
+            containerPort: #@ data.values.tanzuAddonsManager.deployment.healthzPort
+      #@ if/end data.values.tanzuAddonsManager.deployment.hostNetwork:
+      #@overlay/match missing_ok=True
+      hostNetwork: true
+      #@ if/end data.values.tanzuAddonsManager.deployment.priorityClassName:
+      #@overlay/match missing_ok=True
+      priorityClassName: #@ data.values.tanzuAddonsManager.deployment.priorityClassName
+      #@ if hasattr(data.values.tanzuAddonsManager.deployment, 'tolerations') and data.values.tanzuAddonsManager.deployment.tolerations:
+      #@overlay/match missing_ok=True
+      tolerations: #@ data.values.tanzuAddonsManager.deployment.tolerations
+      #@ end
+

--- a/addons/packages/addons-manager/1.4.0/bundle/config/upstream/addons-manager.yaml
+++ b/addons/packages/addons-manager/1.4.0/bundle/config/upstream/addons-manager.yaml
@@ -1,0 +1,172 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tanzu-addons-manager
+  name: tanzu-addons-manager-sa
+  namespace: tanzu-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tanzu-addons-manager-clusterrole
+rules:
+- apiGroups:
+  - run.tanzu.vmware.com
+  resources:
+  - tanzukubernetesreleases
+  - tanzukubernetesreleases/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - kubeadmcontrolplanes
+  - kubeadmcontrolplanes/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kappctrl.k14s.io
+  resources:
+  - apps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - packaging.carvel.dev
+  resources:
+  - packagerepositories
+  - packagerepositories/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - packaging.carvel.dev
+  resources:
+  - packageinstalls
+  - packageinstalls/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tanzu-addons-manager-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tanzu-addons-manager-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: tanzu-addons-manager-sa
+  namespace: tanzu-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tanzu-addons-manager
+  name: tanzu-addons-controller-manager
+  namespace: tanzu-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tanzu-addons-manager
+  template:
+    metadata:
+      labels:
+        app: tanzu-addons-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-addr=0
+        - --enable-leader-election=false
+        - --health-addr=:18316
+        image:  projects-stg.registry.vmware.com/tkg/sandbox/tanzu_core_addons/tanzu-addons-manager:v1.3.1_vmware.1
+        imagePullPolicy: IfNotPresent
+        name: tanzu-addons-controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 500Mi
+          requests:
+            cpu: 100m
+            memory: 40Mi
+        ports:
+          - containerPort: 18316
+            name: healthz
+            protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          failureThreshold: 60
+          periodSeconds: 10
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      serviceAccount: tanzu-addons-manager-sa
+      terminationGracePeriodSeconds: 10

--- a/addons/packages/addons-manager/1.4.0/bundle/config/values.yaml
+++ b/addons/packages/addons-manager/1.4.0/bundle/config/values.yaml
@@ -1,0 +1,12 @@
+#@data/values
+#@overlay/match-child-defaults missing_ok=True
+
+---
+tanzuAddonsManager:
+  namespace: tanzu-system
+  createNamespace: true
+  deployment:
+    hostNetwork: false
+    priorityClassName: null
+    tolerations: []
+    healthzPort: 18316

--- a/addons/packages/addons-manager/1.4.0/package.yaml
+++ b/addons/packages/addons-manager/1.4.0/package.yaml
@@ -1,0 +1,26 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: addons-manager.tanzu.vmware.com.1.4.0
+  namespace: addons-manager
+spec:
+  refName: addons-manager.tanzu.vmware.com
+  version: 1.4.0
+  releaseNotes: "addons-manager 1.4.0"
+  licenses:
+    - "UNKNOWN"
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects.registry.vmware.com/tkg/packages/core/addons-manager@sha256:31c3f27350b693fec042ddead8906c119870ec8a876b9ee3e698a8d5d9c6d8b7
+      template:
+        - ytt:
+            paths:
+              - config/
+        - kbld:
+            paths:
+              - "-"
+              - .imgpkg/images.yml
+      deploy:
+        - kapp: {}

--- a/addons/packages/addons-manager/metadata.yaml
+++ b/addons/packages/addons-manager/metadata.yaml
@@ -1,0 +1,14 @@
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: PackageMetadata
+metadata:
+  name: addons-manager.tanzu.vmware.com
+  namespace: addons-manager
+spec:
+  displayName: "tanzu-addons-manager"
+  longDescription: "This package provides TKG addons lifecycle management capabilities."
+  shortDescription: "This package provides TKG addons lifecycle management capabilities."
+  providerName: VMware
+  maintainers:
+  - name: Lucheng Bao 
+  categories:
+    - "addons-lifecycle-management"


### PR DESCRIPTION
Signed-off-by: Shyaam Nagarajan <nagarajans@vmware.com>

**What this PR does / why we need it**:
Tanzu Addons Manager is a controller in the tanzu-framework repo that manages the lifecycle of core tanzu addons like CNI, CSI, CPI etc. This PR is adding tanzu-addons-manager as a Carvel Package so that it can be deployed on a tanzu management cluster using Carvel Packaging API's.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
ytt --ignore-unknown-comments -f 1.4.0/bundle/config

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
