### PR TITLE
Delete existing providers zip file during building CLI with embed providers

### DIFF
--- a/pkg/v1/providers/Makefile
+++ b/pkg/v1/providers/Makefile
@@ -56,6 +56,7 @@ lint: ## Run YAML linter
 .PHONY: clean-providers
 clean-providers: ## cleans provider-bundle
 	# cleanup old provider bundles
+	@rm -rf client/manifest/providers.zip
 	@rm -rf provider-bundle || true
 	@mkdir -p ${PROVIDER_BUNDLE_DIR}
 

--- a/pkg/v1/tkg/tkgconfigupdater/helper.go
+++ b/pkg/v1/tkg/tkgconfigupdater/helper.go
@@ -96,7 +96,14 @@ func (c *client) saveEmbeddedProviderTemplates(providerPath string) error {
 	if err != nil {
 		return errors.Wrap(err, "cannot find the provider bundle")
 	}
-	providerZipPath := filepath.Join(providerPath, constants.LocalProvidersZipFileName)
+
+	// Remove existing provider files under directory
+	err = os.RemoveAll(providerPath)
+	if err != nil {
+		return errors.Wrap(err, "error while deleting providers directory")
+	}
+
+	providerZipPath := filepath.Join(providerPath, "..", constants.LocalProvidersZipFileName)
 	if err := os.WriteFile(providerZipPath, providersZipBytes, 0o644); err != nil {
 		return errors.Wrap(err, "error while writing provider zip file")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
- When building the CLI with embedded providers, make sure we delete the
zip file while building the providers zip again.
- Also delete the local providers zip directory before extracting the
zip file to the providers directory

Signed-off-by: Anuj Chaudhari <anujc@vmware.com>

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
