### PR TITLE
package repository stop spinner on error

### DIFF
--- a/cmd/cli/plugin/package/repository_get.go
+++ b/cmd/cli/plugin/package/repository_get.go
@@ -46,6 +46,7 @@ func repositoryGet(cmd *cobra.Command, args []string) error {
 
 	packageRepository, err := pkgClient.GetRepository(repoOp)
 	if err != nil || packageRepository == nil {
+		t.StopSpinner()
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it:**
This PR is to stop spinner on error for package repository get

**Describe testing done for PR:**
Existing unit tests & manual testing in the cluster

**Does this PR introduce a user-facing change?:**
None

**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
