### PR TITLE
remove unneeded marker comments in codegen fake types

### DIFF
--- a/cmd/cli/plugin-admin/codegen/test/fakeData/mykind_types.go
+++ b/cmd/cli/plugin-admin/codegen/test/fakeData/mykind_types.go
@@ -14,8 +14,6 @@ type MyKindSpec struct {
 type MyKindStatus struct {
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
 //+tanzu:feature:name=foo,immutable=false,activated=false,discoverable=false,maturity=dev
 
 // MyKind is the Schema for the mykinds API

--- a/pkg/v1/codegen/generators/feature/fakeData/cronjob_types.go
+++ b/pkg/v1/codegen/generators/feature/fakeData/cronjob_types.go
@@ -14,8 +14,6 @@ type CronjobSpec struct {
 type CronjobStatus struct {
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
 //+tanzu:feature:name=bar,immutable=false,activated=false,discoverable=false,maturity=dev
 //+tanzu:feature:name=baz,immutable=false,activated=false,discoverable=false,maturity=dev
 

--- a/pkg/v1/codegen/generators/feature/fakeData/memcached_types.go
+++ b/pkg/v1/codegen/generators/feature/fakeData/memcached_types.go
@@ -14,9 +14,6 @@ type MemcachedSpec struct {
 type MemcachedStatus struct {
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
-
 // Memcached is the Schema for the memcacheds API
 type Memcached struct {
 	Status            MemcachedStatus `json:"status,omitempty"`

--- a/pkg/v1/codegen/generators/feature/fakeData/mykind_types.go
+++ b/pkg/v1/codegen/generators/feature/fakeData/mykind_types.go
@@ -14,8 +14,6 @@ type MyKindSpec struct {
 type MyKindStatus struct {
 }
 
-//+kubebuilder:object:root=true
-//+kubebuilder:subresource:status
 //+tanzu:feature:name=foo,immutable=false,activated=false,discoverable=false,maturity=dev
 
 // MyKind is the Schema for the mykinds API


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes unneeded marker comments in the codegen fake types. These marker comments were generating deepcopy funcs which are not needed. 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Run `make generate` in the project root and made sure deepcopy funcs are not generated

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
