### PR TITLE
Fixes minor issue in roadmap description section

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ This document provides an up to date description of items that are intended for 
 Discussion on the roadmap should take place in threads under Issues. Please comment on an issue if you want to provide suggestions and feedback to an item in the roadmap. Please review the roadmap to avoid potential duplicated efforts.
 
 ### How to add an item to the roadmap?
-Please open an issue to track any initiative on the roadmap of Framework. For smaller enhancements, you can just open an issue to track that initiative or feature request. We work with and rely on community feedback to focus our efforts to improve Contour and maintain a healthy roadmap.
+Please open an issue to track any initiative on the roadmap of Framework. For smaller enhancements, you can just open an issue to track that initiative or feature request. We work with and rely on community feedback to focus our efforts to improve Framework and maintain a healthy roadmap.
 
 ## Current Roadmap
 The following table includes the current roadmap for Framework.


### PR DESCRIPTION
Fixes minor issue in roadmap description section, removes "Contour" reference
Potential copy/paste issue from https://github.com/projectcontour/community/blob/main/ROADMAP.md, fixes by changing the same to "Framework"

**What this PR does / why we need it**:
Improves the roadmap readme
**Which issue(s) this PR fixes**:
Issue not raised
**Describe testing done for PR**:
Readme verified in branch, no explicit testing needed
**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
```release-note
NONE
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
