### PR TITLE
Fixing syntax errors in hack/gen-publish-images.sh for imgpkg copy

### DIFF
--- a/hack/gen-publish-images.sh
+++ b/hack/gen-publish-images.sh
@@ -41,7 +41,7 @@ function imgpkg_copy() {
     src=$2
     dst=$3
     echo ""
-    echo "imgpkg copy $flags $src $dst"
+    echo "imgpkg copy $flags $src --to-repo $dst"
 }
 
 echo "set -euo pipefail"
@@ -59,7 +59,7 @@ for imageTag in ${list}; do
     echodual "Processing TKG BOM file ${TKG_BOM_FILE}"
 
     actualTKGImage=${actualImageRepository}/tkg-bom:${imageTag}
-    customTKGImage=${TKG_CUSTOM_IMAGE_REPOSITORY}/tkg-bom:${imageTag}
+    customTKGImage=${TKG_CUSTOM_IMAGE_REPOSITORY}/tkg-bom
     imgpkg_copy "-i" $actualTKGImage $customTKGImage
     
     # Get components in the tkg-bom.
@@ -77,7 +77,8 @@ for imageTag in ${list}; do
     fi
     eval $get_comp_images | while read -r image; do
         actualImage=${actualImageRepository}/${image}
-        customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/${image}
+        image2=$(echo "$image" | cut -f1 -d":")
+        customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/${image2}
         imgpkg_copy $flags $actualImage $customImage
       done
     done
@@ -97,7 +98,7 @@ for imageTag in ${list}; do
     echodual "Processing TKR BOM file ${TKR_BOM_FILE}"
 
     actualTKRImage=${actualImageRepository}/tkr-bom:${imageTag}
-    customTKRImage=${TKG_CUSTOM_IMAGE_REPOSITORY}/tkr-bom:${imageTag}
+    customTKRImage=${TKG_CUSTOM_IMAGE_REPOSITORY}/tkr-bom
     imgpkg_copy "-i" $actualTKRImage $customTKRImage
     imgpkg pull --image ${actualImageRepository}/tkr-bom:${imageTag} --output "tmp" > /dev/null 2>&1
 
@@ -116,7 +117,8 @@ for imageTag in ${list}; do
     fi
     eval $get_comp_images | while read -r image; do
         actualImage=${actualImageRepository}/${image}
-        customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/${image}
+        image2=$(echo "$image" | cut -f1 -d":")
+        customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/${image2}
         imgpkg_copy $flags $actualImage $customImage
       done
     done
@@ -132,7 +134,7 @@ for imageTag in ${list}; do
   if [[ ${imageTag} == v* ]]; then
     echodual "Processing TKR compatibility image"
     actualImage=${actualImageRepository}/tkr-compatibility:${imageTag}
-    customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/tkr-compatibility:${imageTag}
+    customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/tkr-compatibility
     imgpkg_copy "-i" $actualImage $customImage
     echo ""
     echodual "Finished processing TKR compatibility image"
@@ -144,7 +146,7 @@ for imageTag in ${list}; do
   if [[ ${imageTag} == v* ]]; then 
     echodual "Processing TKG compatibility image"
     actualImage=${actualImageRepository}/tkg-compatibility:${imageTag}
-    customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/tkg-compatibility:${imageTag}
+    customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/tkg-compatibility
     imgpkg_copy "-i" $actualImage $customImage
     echo ""
     echodual "Finished processing TKG compatibility image"


### PR DESCRIPTION
Signed-off-by: Meghana Jangi <mjangi@vmware.com>

**What this PR does / why we need it**:
Fixes syntax issues for imgpkg copy commands in gen-publish-images.sh script which is used to copy images.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested in internet restricted environment on AWS to copy images.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
