### PR TITLE
Remove internal links from the codebase

### DIFF
--- a/addons/pinniped/post-deploy/go.mod
+++ b/addons/pinniped/post-deploy/go.mod
@@ -24,6 +24,5 @@ require (
 )
 
 // Import an nested go modules have some known issues. The following replace temporarily fixes it
-// https://vmware.slack.com/archives/C0158N04WDD/p1602106922371100
 // https://github.com/golang/go/issues/34055
 replace go.pinniped.dev/generated/1.19/apis => go.pinniped.dev/generated/1.19/apis v0.0.0-20201219022151-546b8b5d25c6

--- a/addons/pinniped/post-deploy/pkg/configure/configure.go
+++ b/addons/pinniped/post-deploy/pkg/configure/configure.go
@@ -272,7 +272,7 @@ func Pinniped(ctx context.Context, c Clients, inspector inspect.Inspector, p *Pa
 		var supervisorSvcEndpoint string
 		if p.SupervisorSvcEndpoint != "" {
 			// If the endpoint is passed in, then use it for management cluster otherwise construct the correct one
-			// TODO: file a JIRA to track the issue being discussed under https://vmware.slack.com/archives/G01HFK90QE8/p1610051838070300?thread_ts=1610051580.069400&cid=G01HFK90QE8
+			// Workaround some picky behavior in the Pinniped HTTP router, perhaps this will be fixed in the future?
 			supervisorSvcEndpoint = utils.RemoveDefaultTLSPort(p.SupervisorSvcEndpoint)
 		} else if supervisorSvcEndpoint, err = inspector.GetServiceEndpoint(p.SupervisorSvcNamespace, p.SupervisorSvcName); err != nil {
 			zap.S().Error(err)
@@ -314,7 +314,6 @@ func Pinniped(ctx context.Context, c Clients, inspector inspect.Inspector, p *Pa
 
 	zap.S().Infof("Restarting Pinniped supervisor pods to reload the configmap that contains custom TLS secret names...")
 	// restart the Pinniped pod to refresh the config
-	// Discussed in: https://vmware.slack.com/archives/G01HFK90QE8/p1611970411157300
 	// After the user specifies a custom Pinniped secret name, we need to update the default Pinniped TLS secret name stored in a config map.
 	// This info can't be refreshed unless the Pinniped supervisor pods are restarted.
 	var podList *corev1.PodList

--- a/addons/pinniped/post-deploy/pkg/inspect/inspect.go
+++ b/addons/pinniped/post-deploy/pkg/inspect/inspect.go
@@ -194,7 +194,7 @@ func (i *Inspector) GetServiceEndpoint(namespace, name string) (string, error) {
 		}
 		serviceEndpoint = fmt.Sprintf("https://%s", net.JoinHostPort(host, fmt.Sprint(service.Spec.Ports[0].Port)))
 	}
-	// TODO: file a JIRA to track the issue being discussed under https://vmware.slack.com/archives/G01HFK90QE8/p1610051838070300?thread_ts=1610051580.069400&cid=G01HFK90QE8
+	// Workaround some picky behavior in the Pinniped HTTP router, perhaps this will be fixed in the future?
 	serviceEndpoint = utils.RemoveDefaultTLSPort(serviceEndpoint)
 	zap.S().Infof("The external endpoint of Service %s/%s is %s", namespace, name, serviceEndpoint)
 	return serviceEndpoint, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

- This PR removes internal links from the codebase
- We need it because we are gonna be a public repo in a couple months and my current understanding is that we do not want these internal links to be visible

**Which issue(s) this PR fixes**:

None

**Describe testing done for PR**:

`make test` passed on my machine

**Special notes for your reviewer**:

None

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```

**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [X] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.