### PR TITLE
fix regression on cluster upgrade

### DIFF
--- a/pkg/v1/tkg/client/delete_region.go
+++ b/pkg/v1/tkg/client/delete_region.go
@@ -94,7 +94,7 @@ func (c *TkgClient) DeleteRegion(options DeleteRegionOptions) error { //nolint:f
 		return err
 	}
 
-	err = c.retriveRegionalClusterConfiguration(regionalClusterClient, regionalClusterNamespace)
+	err = c.retriveRegionalClusterConfiguration(regionalClusterClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to set configurations for deletion")
 	}
@@ -111,7 +111,7 @@ func (c *TkgClient) DeleteRegion(options DeleteRegionOptions) error { //nolint:f
 		}
 
 		// configure variables required to deploy providers
-		if err := c.configureVariablesForProvidersInstallation(regionalClusterClient, regionalClusterNamespace); err != nil {
+		if err := c.configureVariablesForProvidersInstallation(regionalClusterClient); err != nil {
 			return errors.Wrap(err, "unable to configure variables for provider installation")
 		}
 

--- a/pkg/v1/tkg/client/upgrade_region.go
+++ b/pkg/v1/tkg/client/upgrade_region.go
@@ -100,7 +100,7 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 		return errors.New("upgrading 'Tanzu Kubernetes Cluster service for vSphere' management cluster is not yet supported")
 	}
 
-	if err := c.configureVariablesForProvidersInstallation(regionalClusterClient, options.Namespace); err != nil {
+	if err := c.configureVariablesForProvidersInstallation(regionalClusterClient); err != nil {
 		return errors.Wrap(err, "unable to configure variables for provider installation")
 	}
 
@@ -153,7 +153,7 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 	return nil
 }
 
-func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterClient clusterclient.Client, regionalClusterNamespace string) error {
+func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterClient clusterclient.Client) error {
 	infraProvider, err := regionalClusterClient.GetRegionalClusterDefaultProviderName(clusterctlv1.InfrastructureProviderType)
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster provider information.")
@@ -164,7 +164,7 @@ func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterCl
 	}
 	// retrieve required variables required for infrastructure component spec rendering
 	// set them to default values if they don't exist.
-	err = c.retriveRegionalClusterConfiguration(regionalClusterClient, regionalClusterNamespace)
+	err = c.retriveRegionalClusterConfiguration(regionalClusterClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to set configurations for upgrade")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
A regression was introduced in #120 that caused failures when an invalid
value for options.Namespace is passed in to retriveRegionalClusterConfiguration.

We now get the cluster name from the current context. Then we use the
name to fetch a list of all clusters and use the cluster name to discover
the namespace.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
All tests passing locally.
I am currently building the CLI to test the upgrade path.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
