### PR TITLE
Update displayed package metadata with additional fields

### DIFF
--- a/cmd/cli/plugin/package/package_available_get.go
+++ b/cmd/cli/plugin/package/package_available_get.go
@@ -115,9 +115,9 @@ func packageAvailableGet(cmd *cobra.Command, args []string) error {
 
 		t.RenderWithSpinner()
 	} else {
-		t.SetKeys("name", "display-name", "short-description", "package-provider", "long-description", "maintainers")
+		t.SetKeys("name", "display-name", "short-description", "package-provider", "long-description", "maintainers", "support", "category")
 		t.AddRow(pkgMetadata.Name, pkgMetadata.Spec.DisplayName, pkgMetadata.Spec.ShortDescription,
-			pkgMetadata.Spec.ProviderName, pkgMetadata.Spec.LongDescription, pkgMetadata.Spec.Maintainers)
+			pkgMetadata.Spec.ProviderName, pkgMetadata.Spec.LongDescription, pkgMetadata.Spec.Maintainers, pkgMetadata.Spec.SupportDescription, pkgMetadata.Spec.Categories)
 
 		t.RenderWithSpinner()
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

- Update package metadata 
- Add fields support and category

Output:
`
>tanzu package available get contour.tanzu.vmware.com/1.15.1+vmware.1-tkg.1-zshippable --namespace tanzu-standard
/ Retrieving package details for contour.tanzu.vmware.com/1.15.1+vmware.1-tkg.1-zshippable... 
NAME:                             contour.tanzu.vmware.com
VERSION:                          1.15.1+vmware.1-tkg.1-zshippable
RELEASED-AT:                      
DISPLAY-NAME:                     contour
SHORT-DESCRIPTION:                This package provides ingress functionality.
PACKAGE-PROVIDER:                 
MINIMUM-CAPACITY-REQUIREMENTS:    
LONG-DESCRIPTION:                 This package provides ingress functionality.
MAINTAINERS:                      []
RELEASE-NOTES:                    
LICENSE:                          []
SUPPORT:                          
CATEGORY:                         [ingress]`

**Describe testing done for PR**:
Tested on local cluster


**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
