### PR TITLE
addons: don't use internal docker cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Build from publicly reachable source by default, but allow people to re-build images on
+# top of their own trusted images.
+ARG BUILDER_BASE_IMAGE=mirror.gcr.io/library/golang:1.16
+
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM $BUILDER_BASE_IMAGE as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -1,8 +1,12 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Build from publicly reachable source by default, but allow people to re-build images on
+# top of their own trusted images.
+ARG BUILDER_BASE_IMAGE=mirror.gcr.io/library/golang:1.16
+
 # Build the manager binary
-FROM harbor-repo.vmware.com/dockerhub-proxy-cache/library/golang:1.16 as builder
+FROM $BUILDER_BASE_IMAGE as builder
 
 WORKDIR /workspace
 

--- a/addons/pinniped/post-deploy/Dockerfile
+++ b/addons/pinniped/post-deploy/Dockerfile
@@ -1,7 +1,12 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM harbor-repo.vmware.com/dockerhub-proxy-cache/library/golang:1.14.4 as builder
+# Build from publicly reachable source by default, but allow people to re-build images on
+# top of their own trusted images.
+ARG BUILDER_BASE_IMAGE=mirror.gcr.io/library/golang:1.16
+
+# Build the post-deploy binary
+FROM $BUILDER_BASE_IMAGE as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/pkg/v1/sdk/capabilities/Dockerfile
+++ b/pkg/v1/sdk/capabilities/Dockerfile
@@ -1,8 +1,12 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Build from publicly reachable source by default, but allow people to re-build images on
+# top of their own trusted images.
+ARG BUILDER_BASE_IMAGE=mirror.gcr.io/library/golang:1.16
+
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM $BUILDER_BASE_IMAGE as builder
 
 WORKDIR /workspace
 

--- a/pkg/v1/sdk/features/Dockerfile
+++ b/pkg/v1/sdk/features/Dockerfile
@@ -1,8 +1,12 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Build from publicly reachable source by default, but allow people to re-build images on
+# top of their own trusted images.
+ARG BUILDER_BASE_IMAGE=mirror.gcr.io/library/golang:1.16
+
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM $BUILDER_BASE_IMAGE as builder
 
 WORKDIR /workspace
 

--- a/pkg/v1/tkr/Dockerfile
+++ b/pkg/v1/tkr/Dockerfile
@@ -1,8 +1,12 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+# Build from publicly reachable source by default, but allow people to re-build images on
+# top of their own trusted images.
+ARG BUILDER_BASE_IMAGE=mirror.gcr.io/library/golang:1.16
+
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM $BUILDER_BASE_IMAGE as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- This removes the use of an internal docker cache to build addons images.
- Also bump pinniped post-deploy job to use the same (supported) version of Go that all other framework container images are built on.
- We need this change because we are gonna be a public repo in a couple months and my current understanding is that we do not want to use these internal systems.

**Which issue(s) this PR fixes**:

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/316

**Describe testing done for PR**:

- Built pinniped post-deploy job image with `make -C addons/pinniped/post-deploy/ build-images`
- Deployed newly built pinniped post-deploy on existing TKG instance (vsphere) and saw it succeed
- Built addons controller image with `make -C addons/ docker-build`

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [X] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
- ^^^ NOTE! I don't think I have the permissions necessary to add a label to this PR ^^^
