### PR TITLE
Pull only required TKG-BOM files

### DIFF
--- a/hack/gen-publish-images.sh
+++ b/hack/gen-publish-images.sh
@@ -141,3 +141,15 @@ for imageTag in ${list}; do
     echodual "Finished processing TKR compatibility image"
   fi
 done
+
+list=$(imgpkg  tag  list -i ${actualImageRepository}/tkg-compatibility)
+for imageTag in ${list}; do
+  if [[ ${imageTag} == v* ]]; then 
+    echodual "Processing TKG compatibility image"
+    actualImage=${actualImageRepository}/tkg-compatibility:${imageTag}
+    customImage=$TKG_CUSTOM_IMAGE_REPOSITORY/tkg-compatibility
+    imgpkg_copy "-i" $actualImage $customImage
+    echo ""
+    echodual "Finished processing TKG compatibility image"
+  fi
+done


### PR DESCRIPTION
Signed-off-by: Meghana Jangi <mjangi@vmware.com>

**What this PR does / why we need it**:
The current version of script pulls all TKG-BOM files present in the source repository. This change has been made so that only the TKG-BOM files which match the tanzu cli version are retrieved. This will reduce the time taken by the script to copy images for all BOM files.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
This has been tested in an internet restricted environment on AWS.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
