### PR TITLE
Increased memory limits for the tkr-controller

### DIFF
--- a/pkg/v1/providers/ytt/03_customizations/01_tkr/tkr.lib.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/01_tkr/tkr.lib.yaml
@@ -338,13 +338,14 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: gcr.io/eminent-nation-87317/ruiw0721/tkr-controller:latest
+#!       The prod registry does not use a latest tag, but the image tag will be overlayed based on the BoM file being used
+        image: projects.registry.vmware.com/tkg/tanzu_core/tkr/tkr-controller-manager:latest
         imagePullPolicy: Always
         name: manager
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
Increased memory limit for the tkr-controller, and updated the default image path

**What this PR does / why we need it**:
Tests were failing because, memory constraints were causing CrashLoopBackOff errors.. This PR is to add additional memory limits to alleviate the issue.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
