### PR TITLE
Allow ENVS make variable to be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ PRIVATE_REPOS="github.com/vmware-tanzu"
 GO := GOPRIVATE=${PRIVATE_REPOS} go
 
 # Add supported OS-ARCHITECTURE combinations here
-ENVS := linux-amd64 windows-amd64 darwin-amd64
+ENVS ?= linux-amd64 windows-amd64 darwin-amd64
 
 .DEFAULT_GOAL:=help
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When trying to build everything for a single architecture that may or
may not match the host's, the `make build-install-cli-all` target always
iterates over the same list of ENVS.

This change allows a user to pass in an override to change the subset of
architectures built.

**Which issue(s) this PR fixes**:
Fixes #

**Describe testing done for PR**:
```shell
% make build-cli-install-all
% ENVS=linux-amd64 make build-install-cli-all
% ENVS=linux-i386 make build-install-cli-all # This should fail since it is not a supported architecture.
```

**Special notes for your reviewer**:

This is an enabler for https://github.com/vmware-tanzu/tce/pull/1158, which provides similar behavior for TCE.

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.