### PR TITLE
Fix panic when using endpoint without scheme in URL with login command

### DIFF
--- a/cmd/cli/plugin/login/main.go
+++ b/cmd/cli/plugin/login/main.go
@@ -336,7 +336,7 @@ func createServerWithEndpoint() (server *configv1alpha1.Server, err error) {
 	} else {
 		kubeConfig, kubecontext, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, nil)
 		if err != nil {
-			log.Fatalf("Error creating kubeconfig with tanzu pinniped-auth login plugin: err-%v", err)
+			log.Fatalf("Error creating kubeconfig with tanzu pinniped-auth login plugin: %v", err)
 			return nil, err
 		}
 		server = &configv1alpha1.Server{
@@ -435,7 +435,7 @@ func managementClusterLogin(s *configv1alpha1.Server) error {
 	if s.ManagementClusterOpts.Path != "" && s.ManagementClusterOpts.Context != "" {
 		_, err := tkgauth.GetServerKubernetesVersion(s.ManagementClusterOpts.Path, s.ManagementClusterOpts.Context)
 		if err != nil {
-			log.Fatalf("failed to login to the management cluster %s, err-%v", s.Name, err)
+			log.Fatalf("failed to login to the management cluster %s, %v", s.Name, err)
 			return err
 		}
 		err = config.PutServer(s, true)

--- a/pkg/v1/tkg/utils/kubeconfig.go
+++ b/pkg/v1/tkg/utils/kubeconfig.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -82,6 +83,15 @@ func GetClusterServerFromKubeconfigAndContext(kubeConfigPath, context string) (s
 
 // GetClusterInfoFromCluster gets the cluster Info by accessing the cluster-info configMap in kube-public namespace
 func GetClusterInfoFromCluster(clusterAPIServerURL string) (*clientcmdapi.Cluster, error) {
+	clusterAPIServerURL = strings.TrimSpace(clusterAPIServerURL)
+	if !strings.HasPrefix(clusterAPIServerURL, "https://") && !strings.HasPrefix(clusterAPIServerURL, "http://") {
+		clusterAPIServerURL = "https://" + clusterAPIServerURL
+	}
+	_, err := url.Parse(clusterAPIServerURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse endpoint URL")
+	}
+
 	clusterAPIServerURL = strings.TrimRight(clusterAPIServerURL, " /")
 	clusterInfoURL := clusterAPIServerURL + "/api/v1/namespaces/kube-public/configmaps/cluster-info"
 	//nolint:noctx


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix panic when using endpoint without scheme in URL with login command

When using `tanzu login --endpoint 192.168.7.16:6443 --name test` without `https://` scheme in the endpoint URL, CLI panics and throws nil pointer dereference error.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested `tanzu login` command with some sample inputs.
**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
