### PR TITLE
Fix `TKG_CUSTOM_IMAGE_REPOSITORY` not respected during mc delete

### DIFF
--- a/pkg/v1/tkg/client/upgrade_addon.go
+++ b/pkg/v1/tkg/client/upgrade_addon.go
@@ -304,13 +304,19 @@ func (c *TkgClient) setCustomImageRepositoryConfiguration(regionalClusterClient 
 		return nil
 	}
 
-	if customImageRepository := configmap.Data["imageRepository"]; customImageRepository != "" {
-		c.TKGConfigReaderWriter().Set(constants.ConfigVariableCustomImageRepository, customImageRepository)
+	// Read TKG_CUSTOM_IMAGE_REPOSITORY from configuration first to allow user to provide different image repository during cluster deletion
+	if customImageRepository, err := c.TKGConfigReaderWriter().Get(constants.ConfigVariableCustomImageRepository); err != nil || customImageRepository == "" {
+		if customImageRepository := configmap.Data["imageRepository"]; customImageRepository != "" {
+			c.TKGConfigReaderWriter().Set(constants.ConfigVariableCustomImageRepository, customImageRepository)
+		}
 	}
 
-	if customImageRepositoryCaCertificate := configmap.Data["caCerts"]; customImageRepositoryCaCertificate != "" {
-		customImageRepositoryCaCertificateEncoded := base64.StdEncoding.EncodeToString([]byte(customImageRepositoryCaCertificate))
-		c.TKGConfigReaderWriter().Set(constants.ConfigVariableCustomImageRepositoryCaCertificate, customImageRepositoryCaCertificateEncoded)
+	// Read TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE from configuration first to allow user to provide different image repository during cluster deletion
+	if customImageRepositoryCaCertificate, err := c.TKGConfigReaderWriter().Get(constants.ConfigVariableCustomImageRepositoryCaCertificate); err != nil || customImageRepositoryCaCertificate == "" {
+		if customImageRepositoryCaCertificate := configmap.Data["caCerts"]; customImageRepositoryCaCertificate != "" {
+			customImageRepositoryCaCertificateEncoded := base64.StdEncoding.EncodeToString([]byte(customImageRepositoryCaCertificate))
+			c.TKGConfigReaderWriter().Set(constants.ConfigVariableCustomImageRepositoryCaCertificate, customImageRepositoryCaCertificateEncoded)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix `TKG_CUSTOM_IMAGE_REPOSITORY` not respected during mc delete

We are seeing issue when we switch the custom image repository during
upgrade or deleting management cluster using `TKG_CUSTOM_IMAGE_REPOSITORY`
it still tries to use the image repository with which management cluster
was created.

This leads to errors when using different image repository for testing
upgrade and deleting management cluster because it tries to fetch images
from the old registry.

This fix takes TKG_CUSTOM_IMAGE_REPOSITORY config variable into account
if specified. If not it uses image repository from management cluster

Changes were done in this PR: https://github.com/vmware-tanzu/tanzu-framework/pull/214

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
