### PR TITLE
kind: Add TKG_KIND_AUDITING variable to enable kind audit logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,6 +106,7 @@ require (
 	k8s.io/api v0.21.2
 	k8s.io/apiextensions-apiserver v0.21.2
 	k8s.io/apimachinery v0.21.2
+	k8s.io/apiserver v0.21.2
 	k8s.io/client-go v0.21.2
 	k8s.io/cluster-bootstrap v0.21.2 // indirect
 	k8s.io/klog/v2 v2.8.0

--- a/pkg/v1/tkg/constants/config_variables.go
+++ b/pkg/v1/tkg/constants/config_variables.go
@@ -132,6 +132,8 @@ const (
 
 	ConfigVariableIPFamily = "TKG_IP_FAMILY"
 
+	ConfigVariableKindAuditing = "TKG_KIND_AUDITING"
+
 	// Below config variables are added based on init and create command flags
 
 	ConfigVariableClusterPlan             = "CLUSTER_PLAN"

--- a/pkg/v1/tkg/fakes/config/config_kind_audit.yaml
+++ b/pkg/v1/tkg/fakes/config/config_kind_audit.yaml
@@ -1,0 +1,20 @@
+TKG_KIND_AUDITING: true
+providers:
+  - name: cluster-api
+    url: providers/cluster-api/v0.0.0/core-components.yaml
+    type: CoreProvider
+  - name: aws
+    url: providers/infrastructure-aws/v0.5.1/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere
+    url: providers/infrastructure-vsphere/v0.6.2/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere-pacific
+    url: providers/infrastructure-tkg-service-vsphere/v1.0.0/unused.yaml
+    type: InfrastructureProvider
+  - name: kubeadm
+    url: providers/bootstrap-kubeadm/v0.3.2/bootstrap-components.yaml
+    type: BootstrapProvider
+  - name: kubeadm
+    url: providers/control-plane-kubeadm/v0.3.2/control-plane-components.yaml
+    type: ControlPlaneProvider

--- a/pkg/v1/tkg/fakes/config/config_kind_audit_false.yaml
+++ b/pkg/v1/tkg/fakes/config/config_kind_audit_false.yaml
@@ -1,0 +1,20 @@
+TKG_KIND_AUDITING: false
+providers:
+  - name: cluster-api
+    url: providers/cluster-api/v0.0.0/core-components.yaml
+    type: CoreProvider
+  - name: aws
+    url: providers/infrastructure-aws/v0.5.1/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere
+    url: providers/infrastructure-vsphere/v0.6.2/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere-pacific
+    url: providers/infrastructure-tkg-service-vsphere/v1.0.0/unused.yaml
+    type: InfrastructureProvider
+  - name: kubeadm
+    url: providers/bootstrap-kubeadm/v0.3.2/bootstrap-components.yaml
+    type: BootstrapProvider
+  - name: kubeadm
+    url: providers/control-plane-kubeadm/v0.3.2/control-plane-components.yaml
+    type: ControlPlaneProvider

--- a/pkg/v1/tkg/kind/client_test.go
+++ b/pkg/v1/tkg/kind/client_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -31,6 +32,8 @@ var (
 	configPathCustomRegistryCaCert        = "../fakes/config/config_custom_registry_ca_cert.yaml"
 	configPathIPv6                        = "../fakes/config/config_ipv6.yaml"
 	configPathIPv4                        = "../fakes/config/config_ipv4.yaml"
+	configPathKindAuditing                = "../fakes/config/config_kind_audit.yaml"
+	configPathKindAuditingFalse           = "../fakes/config/config_kind_audit_false.yaml"
 	configPathCIDR                        = "../fakes/config/config_cluster_service_cidr.yaml"
 	registryHostname                      = "registry.mydomain.com"
 )
@@ -231,7 +234,56 @@ var _ = Describe("Kind Client", func() {
 			Expect(kindConfig.Networking.ServiceSubnet).To(Equal("250.250.250.0/24"))
 		})
 	})
+
+	Context("When TKG_KIND_AUDITING is unset", func() {
+		BeforeEach(func() {
+			setupTestingFiles(configPath, testingDir, defaultBoMFileForTesting)
+			kindClient = buildKindClient()
+			_, kindConfig, err = kindClient.GetKindNodeImageAndConfig()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("does not append audit log configuration as a patch", func() {
+			Expect(configHasAuditPatch(kindConfig)).To(BeFalse())
+		})
+	})
+
+	Context("When TKG_KIND_AUDITING is explicitly set", func() {
+		BeforeEach(func() {
+			setupTestingFiles(configPathKindAuditing, testingDir, defaultBoMFileForTesting)
+			kindClient = buildKindClient()
+			_, kindConfig, err = kindClient.GetKindNodeImageAndConfig()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("appends audit log configuration as a patch", func() {
+			Expect(configHasAuditPatch(kindConfig)).To(BeTrue())
+		})
+	})
+
+	Context("When TKG_KIND_AUDITING is explicitly set to false", func() {
+		BeforeEach(func() {
+			setupTestingFiles(configPathKindAuditingFalse, testingDir, defaultBoMFileForTesting)
+			kindClient = buildKindClient()
+			_, kindConfig, err = kindClient.GetKindNodeImageAndConfig()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("does not append audit log configuration as a patch", func() {
+			Expect(configHasAuditPatch(kindConfig)).To(BeFalse())
+		})
+	})
 })
+
+func configHasAuditPatch(kindConfig *kindv1.Cluster) bool {
+	var hasAuditPatch bool
+	for _, patch := range kindConfig.KubeadmConfigPatches {
+		if strings.Contains(patch, "audit-log-path") {
+			hasAuditPatch = true
+		}
+	}
+	return hasAuditPatch
+}
 
 func buildKindClient() kind.Client {
 	tkgConfigReaderWriter, err := tkgconfigreaderwriter.NewReaderWriterFromConfigFile(configPath, filepath.Join(testingDir, "config.yaml"))


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable audit logging on the kind cluster when the `TKG_KIND_AUDITING=true`, so as to help debug issues with bootstrapping with cert-manager or other eventualities.


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
Logging successfully set up

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Setting TKG_KIND_AUDITING=true will enable audit logging for the kind bootstrap cluster
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
