### PR TITLE
Add logic to validate the known proxy issue in vsphere provider

### DIFF
--- a/pkg/v1/providers/ytt/lib/helpers.star
+++ b/pkg/v1/providers/ytt/lib/helpers.star
@@ -293,3 +293,20 @@ def get_no_proxy():
   end
   return ""
 end
+
+def validate_proxy_bypass_vsphere_host():
+  if data.values.PROVIDER_TYPE != "vsphere":
+    return
+  end
+  if not data.values.VSPHERE_INSECURE:
+    return
+  end
+
+  no_proxy_list = []
+  if data.values.TKG_NO_PROXY != "":
+    no_proxy_list = data.values.TKG_NO_PROXY.split(",")
+  end
+  if data.values.VSPHERE_SERVER not in no_proxy_list:
+    assert.fail("unable to proxy traffic to vSphere host in security connection, either set VSPHERE_INSECURE to true or add VSPHERE_SERVER to TKG_NO_PROXY")
+  end
+end

--- a/pkg/v1/providers/ytt/lib/validate.star
+++ b/pkg/v1/providers/ytt/lib/validate.star
@@ -1,5 +1,6 @@
 load("@ytt:data", "data")
 load("@ytt:assert", "assert")
+load("/lib/helpers.star", "validate_proxy_bypass_vsphere_host")
 
 required_variable_list_vsphere = [
   "VSPHERE_USERNAME",
@@ -42,6 +43,11 @@ def validate_configuration(provider):
     flag_missing_variable_error(required_variable_list_vsphere)
     if data.values.NSXT_POD_ROUTING_ENABLED == True:
       validate_nsxt_config()
+    end
+    #! known issue for govc: https://github.com/vmware/govmomi/issues/2494
+    #! TODO: remove the validation once the issue is resolved
+    if not data.values.VSPHERE_INSECURE:
+      validate_proxy_bypass_vsphere_host()
     end
   elif provider == "aws":
     flag_missing_variable_error(required_variable_list_aws)


### PR DESCRIPTION
There's a known issue that if govc client is using http proxy, then its
connection need to be insecure.
Here's the known issue: https://github.com/vmware/govmomi/issues/2494

Signed-off-by: Hanlin Shi <shihanlin9@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Add parameter validation for proxy. In vSphere, proxy is not working if the connection to vCenter is mTLS. Govc client can't validate server's thumbprint if the traffic is proxied (more context in https://github.com/vmware/govmomi/issues/2494). This change will detect the configuration conflict and fail user's request before the deployment.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Added configuration validation for proxy when used with vSphere. Users need to ensure traffic to vCenter is not proxied if they want to validate vCenter server.
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
