### PR TITLE
Prevent BOMs from downloading twice, improve existing BOM detection and increase visibility on BOM downloads

### DIFF
--- a/cmd/cli/plugin/managementcluster/create.go
+++ b/cmd/cli/plugin/managementcluster/create.go
@@ -21,6 +21,7 @@ type initRegionOptions struct {
 	deployTKGonVsphere7         bool
 	unattended                  bool
 	dryRun                      bool
+	forceConfigUpdate           bool
 	clusterConfigFile           string
 	plan                        string
 	clusterName                 string
@@ -128,6 +129,8 @@ func init() {
 	createCmd.Flags().StringToStringVarP(&iro.featureFlags, "feature-flags", "", nil, "Activate and deactivate hidden features in the form 'feature1=true,feature2=false'")
 	createCmd.Flags().MarkHidden("feature-flags") //nolint
 
+	createCmd.Flags().BoolVar(&iro.forceConfigUpdate, "force-config-update", false, "Force an update of all configuration files in ${HOME}/.config/tanzu/tkg/bom and ${HOME}/.tanzu/tkg/compatibility")
+
 	createCmd.Flags().SetNormalizeFunc(aliasNormalizeFunc)
 }
 
@@ -139,7 +142,7 @@ func aliasNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
 }
 
 func runInit() error {
-	forceUpdateTKGCompatibilityImage := true
+	forceUpdateTKGCompatibilityImage := iro.forceConfigUpdate
 	tkgClient, err := newTKGCtlClient(forceUpdateTKGCompatibilityImage)
 	if err != nil {
 		return err

--- a/pkg/v1/tkg/tkgconfigbom/bom.go
+++ b/pkg/v1/tkg/tkgconfigbom/bom.go
@@ -408,7 +408,7 @@ func (c *client) DownloadDefaultBOMFilesFromRegistry(bomRegistry registry.Regist
 		return err
 	}
 
-	log.V(4).Infof("Downloading the TKG BOM file from Image name '%s", fmt.Sprintf("%s:%s", tkgBOMImagePath, tkgBOMImageTag))
+	log.Infof("Downloading the TKG Bill of Materials (BOM) file from '%s'", fmt.Sprintf("%s:%s", tkgBOMImagePath, tkgBOMImageTag))
 	tkgBOMContent, err := bomRegistry.GetFile(tkgBOMImagePath, tkgBOMImageTag, "")
 	if err != nil {
 		return errors.Errorf(errorDownloadingDefaultBOMFiles, fmt.Sprintf("%s:%s", tkgBOMImagePath, tkgBOMImageTag), err, tkgconfigpath)
@@ -445,7 +445,7 @@ func (c *client) DownloadDefaultBOMFilesFromRegistry(bomRegistry registry.Regist
 	}
 	defaultTKRImagePath := tkrBOMImageRepo + "/" + bomConfiguration.TKRBOM.ImagePath
 
-	log.V(4).Infof("Downloading the TKr BOM file from Image name '%s", fmt.Sprintf("%s:%s", defaultTKRImagePath, tkrBOMTagName))
+	log.Infof("Downloading the TKr Bill of Materials (BOM) file from '%s'", fmt.Sprintf("%s:%s", defaultTKRImagePath, tkrBOMTagName))
 	tkrBOMContent, err := bomRegistry.GetFile(defaultTKRImagePath, tkrBOMTagName, "")
 	if err != nil {
 		return errors.Errorf(errorDownloadingDefaultBOMFiles, fmt.Sprintf("%s:%s", defaultTKRImagePath, tkrBOMTagName), err, tkgconfigpath)
@@ -478,6 +478,7 @@ func (c *client) DownloadTKGCompatibilityFileFromRegistry(bomRegistry registry.R
 		tkgCompatibilityImagePath = compatibilityImageRepo + "/" + customTKGCompatibilityImagePath
 	}
 
+	log.Infof("Downloading TKG compatibility file from '%s'", tkgCompatibilityImagePath)
 	tags, err := bomRegistry.ListImageTags(tkgCompatibilityImagePath)
 	if err != nil || len(tags) == 0 {
 		return errors.Wrap(err, "failed to list TKG compatibility image tags")
@@ -503,7 +504,6 @@ func (c *client) DownloadTKGCompatibilityFileFromRegistry(bomRegistry registry.R
 		return err
 	}
 
-	log.V(4).Infof("Downloading the TKG Compatibility file from Image name '%s", fmt.Sprintf("%s:%s", tkgCompatibilityImagePath, tagName))
 	tkgCompatibilityContent, err := bomRegistry.GetFile(tkgCompatibilityImagePath, tagName, "")
 	if err != nil {
 		return errors.Errorf(errorDownloadingTKGCompatibilityFile, fmt.Sprintf("%s:%s", tkgCompatibilityImagePath, tagName), err, tkgconfigpath)

--- a/pkg/v1/tkg/tkgconfigupdater/ensure.go
+++ b/pkg/v1/tkg/tkgconfigupdater/ensure.go
@@ -92,7 +92,8 @@ func (c *client) DecodeCredentialsInViper() error {
 	return nil
 }
 
-// EnsureTKGCompatibilityFile ensures the TKG compatibility file. If forceUpdate option is set,TKG compatibility would fetched
+// EnsureTKGCompatibilityFile ensures the TKG compatibility file. If forceUpdate option is set,
+// the TKG compatibility file is fetched.
 // TKG compatibility file would fetched from the registry though local copy exists
 func (c *client) EnsureTKGCompatibilityFile(forceUpdate bool) error {
 	compatibilityDir, err := c.tkgConfigPathsClient.GetTKGCompatibilityDirectory()
@@ -116,6 +117,7 @@ func (c *client) EnsureTKGCompatibilityFile(forceUpdate bool) error {
 	}
 
 	if compatibilityFileExists && !forceUpdate {
+		log.V(4).Infof("compatibility file (%s) already exists, skipping download", compatabilityFilePath)
 		return nil
 	}
 
@@ -160,6 +162,7 @@ func (c *client) EnsureBOMFiles(forceUpdate bool) error {
 
 	// If there are existing BOM files and doesn't need update then do nothing
 	if !isBOMDirectoryEmpty && !bomsNeedUpdate && !forceUpdate {
+		log.V(4).Infof("BOM files inside %s already exists, skipping download", bomDir)
 		return nil
 	}
 

--- a/pkg/v1/tkg/tkgconfigupdater/tkgconfigupdater_test.go
+++ b/pkg/v1/tkg/tkgconfigupdater/tkgconfigupdater_test.go
@@ -540,6 +540,65 @@ var _ = Describe("EnsureImages", func() {
 	})
 })
 
+var _ = Describe("Ensuring TKG compatibility file", func() {
+	var (
+		clusterConfigPath     string
+		client                Client
+		tkgConfigReaderWriter tkgconfigreaderwriter.TKGConfigReaderWriter
+		err                   error
+	)
+
+	BeforeEach(func() {
+		createTempDirectory("reader_test")
+	})
+
+	JustBeforeEach(func() {
+		tkgConfigReaderWriter, err = tkgconfigreaderwriter.NewReaderWriterFromConfigFile(clusterConfigPath, filepath.Join(testingDir, "config.yaml"))
+		Expect(err).NotTo(HaveOccurred())
+		client = New(testingDir, NewProviderTest(), tkgConfigReaderWriter)
+		tkgConfigNode := loadTKGNode(clusterConfigPath)
+
+		client.EnsureCredEncoding(tkgConfigNode)
+		writeYaml(clusterConfigPath, tkgConfigNode)
+
+		_, err = tkgconfigreaderwriter.New(clusterConfigPath)
+		Expect(err).ToNot(HaveOccurred())
+		err = client.DecodeCredentialsInViper()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("When the tkg-compatibility.yaml pre-exists", func() {
+		BeforeEach(func() {
+			clusterConfigPath = getConfigFilePath("config4.yaml")
+		})
+
+		It("should not re-download the file", func() {
+			compatibilityConfigFile, err := tkgconfigpaths.New(testingDir).GetTKGCompatibilityConfigPath()
+			Expect(err).ToNot(HaveOccurred())
+
+			// capture modified time of existing compatibility file
+			f1, err := os.Stat(compatibilityConfigFile)
+			Expect(err).ToNot(HaveOccurred())
+			f1ModTime := f1.ModTime()
+
+			// EnsureTKGCompatabilityFile will go out to a registry to retrieve a file if the
+			// compatibility is not present. Causing the test to fail and it to return a slow test
+			// warning.
+			err = client.EnsureTKGCompatibilityFile(false)
+			Expect(err).ToNot(HaveOccurred())
+
+			// capture modified time of final compatibility file
+			f2, err := os.Stat(compatibilityConfigFile)
+			Expect(err).ToNot(HaveOccurred())
+			f2ModTime := f2.ModTime()
+
+			// true when the modified times are the same
+			modTimesAreSame := f1ModTime.Equal(f2ModTime)
+			Expect(modTimesAreSame).To(Equal(true))
+		})
+	})
+})
+
 func getNodeIndex(node []*yaml.Node, key string) int {
 	appIdx := -1
 	for i, k := range node {

--- a/pkg/v1/tkg/tkgctl/client.go
+++ b/pkg/v1/tkg/tkgctl/client.go
@@ -266,19 +266,3 @@ func ensureConfigImages(configDir string, tkgConfigUpdater tkgconfigupdater.Clie
 
 	return tkgConfigUpdater.EnsureConfigImages()
 }
-
-func ensureTKGCompatibilityAndBOMFiles(configDir string, tkgConfigUpdaterClient tkgconfigupdater.Client, forceUpdate bool) error {
-	var err error
-	lock, err := utils.GetFileLockWithTimeOut(filepath.Join(configDir, constants.LocalTanzuFileLock), utils.DefaultLockTimeout)
-	if err != nil {
-		return errors.Wrap(err, "cannot acquire lock for ensuring local files")
-	}
-
-	defer func() {
-		if err := lock.Unlock(); err != nil {
-			log.Warningf("cannot release lock for ensuring local files, reason: %v", err)
-		}
-	}()
-	// EnsureBOMFiles() would also ensure TKGCompatibility file
-	return tkgConfigUpdaterClient.EnsureBOMFiles(forceUpdate)
-}

--- a/pkg/v1/tkg/tkgctl/init.go
+++ b/pkg/v1/tkg/tkgctl/init.go
@@ -61,12 +61,6 @@ func (t *tkgctl) Init(options InitRegionOptions) error {
 	if err != nil {
 		return err
 	}
-	// Update the tkg-compatibility file and BOM files
-	forceUpdateTKGCompatibilityFile := true
-	err = ensureTKGCompatibilityAndBOMFiles(t.configDir, t.tkgConfigUpdaterClient, forceUpdateTKGCompatibilityFile)
-	if err != nil {
-		return err
-	}
 	options.CoreProvider, options.BootstrapProvider, options.ControlPlaneProvider, err = t.tkgBomClient.GetDefaultClusterAPIProviders()
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR has the following changes.

**What this PR does / why we need it**:

* [x] BOM, Compatibility, and Provider downloads are now done exclusively when a tkgctl
  client is created. Previously this was done at tkgctl creation
  and management-cluster init. Due to this, the BOM files were
  downloaded twice.
* [x] Introduce `--force-config-update` flag. Previously this was always set
      to 'true'. This caused compatibility, tkg-bom, and tkr-bom files to be
      downloaded every time.
* [x] Change the default for forceably downloading compatibility, tkg-bom, and tkr-bom to false.
* [x] Increased logging to the user. These logs inform the user when BOMs
  are being downloaded.
* [x] Detect existing TKG BOM and if present, do not re-download
* [x] Detect existing TKR BOM and if present, do not re-download
* [x] Detect existing TKG Compatibility file and if present, do not re-download
* [x] Write unit tests to validate BOM detection logic

**Which issue(s) this PR fixes**:

* Resolves: https://github.com/vmware-tanzu/tanzu-framework/issues/254
* Resolves: https://github.com/vmware-tanzu/tanzu-framework/issues/273

**Describe testing done for PR**:

Original Behavior

```sh
$ tanzu management-cluster create --ui

< 30 seconds - 1 min elapse with no feedback >

the old providers folder /home/tce/.config/tanzu/tkg/providers is backed up to /home/tce/.config/tanzu/tkg/providers-20210726174523-jn4a6z03

< boms and config files are downloaded twice >

Validating the pre-requisites...
Serving kickstart UI at http://127.0.0.1:8080
```

New Behavior: Fresh Install; default logging

```sh
$ tanzu management-cluster create --ui
Downloading TKG compatability file from 'projects-stg.registry.vmware.com/tkg/v1.4.0-zshippable/tkg-compatibility'
Downloading the TKG Bill of Materials (BOM) file from 'projects-stg.registry.vmware.com/tkg/tkg-bom:v1.4.0-zshippable'
Downloading the TKR Bill of Materials (BOM) file from 'projects-stg.registry.vmware.com/tkg/tkr-bom:v1.21.2_vmware.1-tkg.1-zshippable'

Validating the pre-requisites...
Serving kickstart UI at http://127.0.0.1:8080
```

New Behavior: Subsequent create (pre-existing config); default logging

```sh
$ tanzu management-cluster create --ui

Validating the pre-requisites...
Serving kickstart UI at http://127.0.0.1:8080
```

New Behavior: TKG Config file missing (`rm -v 
~/.config/tanzu/tkg/compatibility/tkg-compatibility.yaml) boms are present); default logging

```sh
$ tanzu management-cluster create --ui
Downloading TKG compatability file from 'projects-stg.registry.vmware.com/tkg/v1.4.0-zshippable/tkg-compatibility'

Validating the pre-requisites...
Serving kickstart UI at http://127.0.0.1:8080
```

New Behavior: TKG BOM and/or TKR BOM missing

```sh
$ tanzu management-cluster create --ui
Downloading the TKG Bill of Materials (BOM) file from 'projects-stg.registry.vmware.com/tkg/tkg-bom:v1.4.0-zshippable'
Downloading the TKR Bill of Materials (BOM) file from 'projects-stg.registry.vmware.com/tkg/tkr-bom:v1.21.2_vmware.1-tkg.1-zshippable'

Validating the pre-requisites...
Serving kickstart UI at http://127.0.0.1:8080
```

New Behavior: Force update triggered when config is already present; default logging

```sh
$ tanzu management-cluster create --ui --force-config-update
Downloading TKG compatability file from 'projects-stg.registry.vmware.com/tkg/v1.4.0-zshippable/tkg-compatibility'
Downloading the TKG Bill of Materials (BOM) file from 'projects-stg.registry.vmware.com/tkg/tkg-bom:v1.4.0-zshippable'
Downloading the TKR Bill of Materials (BOM) file from 'projects-stg.registry.vmware.com/tkg/tkr-bom:v1.21.2_vmware.1-tkg.1-zshippable'

Validating the pre-requisites...
Serving kickstart UI at http://127.0.0.1:8080
```


**Special notes for your reviewer**:

Please review the above section and validate the behavior.


**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
yes

```release-note
* Improved logging on management-cluster plugin to notify user that BOM and/or compatibility files are being downloaded.
* Introduced --force-config-update flag on management-cluster plugin. Allows users to force download compatibility files and BOMs.
* Defaulted force config download to false. When BOM and compatibility files are present, they are no longer downloaded.
* New flag `--force-config-update` is added to management-cluster create command to force update the tkg-compatibility, tkg-bom and tkr-bom files.
```

**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
