### PR TITLE
Point GOPRIVATE to tanzu-framework repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ endif
 DOCKER_DIR := /app
 SWAGGER=docker run --rm -v ${PWD}:${DOCKER_DIR} quay.io/goswagger/swagger:v0.21.0
 
-PRIVATE_REPOS="github.com/vmware-tanzu"
+PRIVATE_REPOS="github.com/vmware-tanzu/tanzu-framework"
 GO := GOPRIVATE=${PRIVATE_REPOS} go
 
 # Add supported OS-ARCHITECTURE combinations here

--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -6,8 +6,7 @@ FROM harbor-repo.vmware.com/dockerhub-proxy-cache/library/golang:1.16 as builder
 
 WORKDIR /workspace
 
-ENV GOPRIVATE=github.com/vmware-tanzu/*
-ENV GONOSUMDB=github.com/vmware-tanzu/*
+ENV GOPRIVATE=github.com/vmware-tanzu/tanzu-framework
 
 ARG SSH_PRIVATE_KEY
 

--- a/pkg/v1/builder/template/plugintemplates/Makefile.tmpl
+++ b/pkg/v1/builder/template/plugintemplates/Makefile.tmpl
@@ -14,7 +14,7 @@ TOOLS_DIR := tools
 TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint
 
-PRIVATE_REPOS=github.com/vmware-tanzu
+PRIVATE_REPOS="github.com/vmware-tanzu/tanzu-framework"
 
 export GOPRIVATE := $(PRIVATE_REPOS)
 

--- a/pkg/v1/builder/template/plugintemplates/plugin_readme.md.tmpl
+++ b/pkg/v1/builder/template/plugintemplates/plugin_readme.md.tmpl
@@ -24,5 +24,5 @@ cmd/plugin/<plugin>/test: Plugins are required to have a test command defined
 ## Private Repos
 Until the repository is open sourced, you will have to set PRIVATE_REPOS for gomodules to work properly.
 ```
-export PRIVATE_REPOS="github.com/vmware-tanzu"
+export PRIVATE_REPOS="github.com/vmware-tanzu/tanzu-framework"
 ```

--- a/pkg/v1/sdk/capabilities/Dockerfile
+++ b/pkg/v1/sdk/capabilities/Dockerfile
@@ -7,7 +7,7 @@ FROM golang:1.16 as builder
 WORKDIR /workspace
 
 
-ENV GOPRIVATE=github.com/vmware-tanzu/*
+ENV GOPRIVATE=github.com/vmware-tanzu/tanzu-framework
 
 # Create the image's SSH directory.
 RUN mkdir -p /root/.ssh && chmod 0700 /root/.ssh

--- a/pkg/v1/sdk/capabilities/Makefile
+++ b/pkg/v1/sdk/capabilities/Makefile
@@ -12,7 +12,7 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-PRIVATE_REPOS="github.com/vmware-tanzu"
+PRIVATE_REPOS="github.com/vmware-tanzu/tanzu-framework"
 GO := GOPRIVATE=${PRIVATE_REPOS} go
 
 # ssh private key file name

--- a/pkg/v1/tkr/Dockerfile
+++ b/pkg/v1/tkr/Dockerfile
@@ -7,7 +7,7 @@ FROM golang:1.16 as builder
 WORKDIR /workspace
 
 
-ENV GOPRIVATE=github.com/vmware-tanzu/*
+ENV GOPRIVATE=github.com/vmware-tanzu/tanzu-framework
 
 # Create the image's SSH directory.
 RUN mkdir -p /root/.ssh && chmod 0700 /root/.ssh

--- a/pkg/v1/tkr/Makefile
+++ b/pkg/v1/tkr/Makefile
@@ -12,7 +12,7 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-PRIVATE_REPOS="github.com/vmware-tanzu"
+PRIVATE_REPOS="github.com/vmware-tanzu/tanzu-framework"
 GO := GOPRIVATE=${PRIVATE_REPOS} go
 
 # ssh private key file name


### PR DESCRIPTION
**What this PR does / why we need it**:

Dependencies from vmware-tanzu org are all public (except for this repo
itself). Pointing GOPRIVATE to all the repos in the org sometimes causes
docker builds to fail with "unknown revision" errors because go mod is
trying to access public repos in a private way.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:

`make docker-build` from `pkg/v1/sdk/{capabilities, features}`

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
