### PR TITLE
Support custom nameservers on cluster nodes

### DIFF
--- a/pkg/v1/providers/config_default.yaml
+++ b/pkg/v1/providers/config_default.yaml
@@ -398,6 +398,10 @@ TKG_NO_PROXY: ""
 #! IP Family setting
 TKG_IP_FAMILY:
 
+#! Node Nameservers (currently only supports the vSphere provider)
+CONTROL_PLANE_NODE_NAMESERVERS:
+WORKER_NODE_NAMESERVERS:
+
 #! Audit Logging settings
 ENABLE_AUDIT_LOGGING: false
 

--- a/pkg/v1/providers/infrastructure-vsphere/v0.7.10/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v0.7.10/ytt/overlay.yaml
@@ -130,23 +130,20 @@ spec:
       memoryMiB: #@ data.values.VSPHERE_CONTROL_PLANE_MEM_MIB
       network:
         devices:
-        #@ if data.values.TKG_IP_FAMILY == "ipv6":
         #@overlay/match by=overlay.index(0)
         #@overlay/replace
-        - dhcp6: true
-          networkName: #@ data.values.VSPHERE_NETWORK
-        #@ elif data.values.TKG_IP_FAMILY in ["ipv4,ipv6", "ipv6,ipv4"]:
-        #@overlay/match by=overlay.index(0)
-        #@overlay/replace
-        - dhcp4: true
+        - networkName: #@ data.values.VSPHERE_NETWORK
+          #@ if data.values.CONTROL_PLANE_NODE_NAMESERVERS:
+          nameservers: #@ data.values.CONTROL_PLANE_NODE_NAMESERVERS.replace(" ", "").split(",")
+          #@ end
+          #@ if data.values.TKG_IP_FAMILY == "ipv6":
           dhcp6: true
-          networkName: #@ data.values.VSPHERE_NETWORK
-        #@ else:
-        #@overlay/match by=overlay.index(0)
-        #@overlay/replace
-        - dhcp4: true
-          networkName: #@ data.values.VSPHERE_NETWORK
-        #@ end
+          #@ elif data.values.TKG_IP_FAMILY in ["ipv4,ipv6", "ipv6,ipv4"]:
+          dhcp4: true
+          dhcp6: true
+          #@ else:
+          dhcp4: true
+          #@ end
       numCPUs: #@ data.values.VSPHERE_CONTROL_PLANE_NUM_CPUS
       resourcePool: #@ data.values.VSPHERE_RESOURCE_POOL
       server: #@ data.values.VSPHERE_SERVER
@@ -170,23 +167,20 @@ spec:
       memoryMiB: #@ data.values.VSPHERE_WORKER_MEM_MIB
       network:
         devices:
-        #@ if data.values.TKG_IP_FAMILY == "ipv6":
         #@overlay/match by=overlay.index(0)
         #@overlay/replace
-        - dhcp6: true
-          networkName: #@ data.values.VSPHERE_NETWORK
-        #@ elif data.values.TKG_IP_FAMILY in ["ipv4,ipv6", "ipv6,ipv4"]:
-        #@overlay/match by=overlay.index(0)
-        #@overlay/replace
-        - dhcp4: true
+        - networkName: #@ data.values.VSPHERE_NETWORK
+          #@ if data.values.WORKER_NODE_NAMESERVERS:
+          nameservers: #@ data.values.WORKER_NODE_NAMESERVERS.replace(" ", "").split(",")
+          #@ end
+          #@ if data.values.TKG_IP_FAMILY == "ipv6":
           dhcp6: true
-          networkName: #@ data.values.VSPHERE_NETWORK
-        #@ else:
-        #@overlay/match by=overlay.index(0)
-        #@overlay/replace
-        - dhcp4: true
-          networkName: #@ data.values.VSPHERE_NETWORK
-        #@ end
+          #@ elif data.values.TKG_IP_FAMILY in ["ipv4,ipv6", "ipv6,ipv4"]:
+          dhcp4: true
+          dhcp6: true
+          #@ else:
+          dhcp4: true
+          #@ end
       numCPUs: #@ data.values.VSPHERE_WORKER_NUM_CPUS
       resourcePool: #@ data.values.VSPHERE_RESOURCE_POOL
       server: #@ data.values.VSPHERE_SERVER

--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
@@ -98,6 +98,10 @@ TKG_NO_PROXY: "NA", "10.0.200.1/24", "10.184.90.80"
 # ip family
 TKG_IP_FAMILY: "NA", "", "ipv4", "ipv6", "ipv4<comma>ipv6", "ipv6<comma>ipv4"
 
+# nameservers
+CONTROL_PLANE_NODE_NAMESERVERS: "NA", "", "8.8.8.8", "2001:4860:4860::8888"
+WORKER_NODE_NAMESERVERS: "NA", "", "8.8.8.8", "2001:4860:4860::8888"
+
 # audit logging
 ENABLE_AUDIT_LOGGING: "true", "false"
 OS_NAME: "photon", "ubuntu", "amazon"
@@ -135,6 +139,8 @@ IF [_INFRA] = "\"vsphere:v0.7.8\"" THEN [--VSPHERE-CONTROLPLANE-ENDPOINT] = "\"1
 IF [_INFRA] <> "\"vsphere:v0.7.8\"" THEN [--VSPHERE-CONTROLPLANE-ENDPOINT] = "\"NOTPROVIDED\"";
 
 IF [_INFRA] <> "\"vsphere:v0.7.8\"" THEN [OS_NAME] <> "\"photon\"";
+IF [_INFRA] <> "\"vsphere:v0.7.8\"" THEN [CONTROL_PLANE_NODE_NAMESERVERS] = "\"NOTPROVIDED\"";
+IF [_INFRA] <> "\"vsphere:v0.7.8\"" THEN [WORKER_NODE_NAMESERVERS] = "\"NOTPROVIDED\"";
 
 IF [TKG_HTTP_PROXY] = "\"http://10.0.200.100\"" THEN [TKG_HTTPS_PROXY] = "\"http://10.0.200.100\"";
 IF [TKG_HTTP_PROXY] LIKE "\"http://[fc00*" THEN [TKG_HTTPS_PROXY] <> "\"http://10.0.200.100\"";

--- a/pkg/v1/providers/tests/unit/custom_nameservers_test.go
+++ b/pkg/v1/providers/tests/unit/custom_nameservers_test.go
@@ -1,0 +1,156 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package unit
+
+import (
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/providers/tests/unit/matchers"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/providers/tests/unit/ytt"
+)
+
+var _ = Describe("Control Plane/Workload Node Nameserver Ytt Templating", func() {
+	var paths []string
+	BeforeEach(func() {
+		paths = []string{
+			filepath.Join("fixtures", "yttmocks"),
+			filepath.Join("..", "..", "infrastructure-vsphere", "v0.7.10", "ytt", "overlay.yaml"),
+			filepath.Join("..", "..", "infrastructure-vsphere", "v0.7.10", "ytt", "base-template.yaml"),
+			filepath.Join("..", "..", "config_default.yaml"),
+		}
+	})
+
+	When("TKG_IP_FAMILY is ipv4", func() {
+		var values string
+		BeforeEach(func() {
+			values = createDataValues(map[string]string{
+				"CLUSTER_NAME":                   "foo",
+				"TKG_CLUSTER_ROLE":               "workload",
+				"TKG_IP_FAMILY":                  "ipv4",
+				"CONTROL_PLANE_NODE_NAMESERVERS": "1.1.1.1,2.2.2.2",
+				"WORKER_NODE_NAMESERVERS":        "3.3.3.3,4.4.4.4",
+			})
+		})
+
+		It("renders the control plane VSphereMachineTemplate with the custom control plane node nameservers", func() {
+			output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+			Expect(err).NotTo(HaveOccurred())
+
+			vsphereMachineTemplate, err := FindDocsMatchingYAMLPath(output, map[string]string{
+				"$.kind":          "VSphereMachineTemplate",
+				"$.metadata.name": "foo-control-plane",
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vsphereMachineTemplate).To(HaveLen(1))
+			Expect(vsphereMachineTemplate[0]).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].nameservers[0]", "1.1.1.1"))
+			Expect(vsphereMachineTemplate[0]).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].nameservers[1]", "2.2.2.2"))
+		})
+
+		It("renders the worker VSphereMachineTemplate with the custom worker node nameservers", func() {
+			output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+			Expect(err).NotTo(HaveOccurred())
+
+			vsphereMachineTemplate, err := FindDocsMatchingYAMLPath(output, map[string]string{
+				"$.kind":          "VSphereMachineTemplate",
+				"$.metadata.name": "foo-worker",
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vsphereMachineTemplate).To(HaveLen(1))
+			Expect(vsphereMachineTemplate[0]).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].nameservers[0]", "3.3.3.3"))
+			Expect(vsphereMachineTemplate[0]).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].nameservers[1]", "4.4.4.4"))
+		})
+	})
+
+	When("TKG_IP_FAMILY is ipv6", func() {
+		var values string
+		BeforeEach(func() {
+			values = createDataValues(map[string]string{
+				"CLUSTER_NAME":                   "foo",
+				"TKG_CLUSTER_ROLE":               "workload",
+				"TKG_IP_FAMILY":                  "ipv6",
+				"CONTROL_PLANE_NODE_NAMESERVERS": "fd00::1,fd00::2",
+				"WORKER_NODE_NAMESERVERS":        "fd00::3,fd00::4",
+			})
+		})
+
+		It("renders the control plane VSphereMachineTemplate with the custom control plane node nameservers", func() {
+			output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+			Expect(err).NotTo(HaveOccurred())
+
+			vsphereMachineTemplate, err := FindDocsMatchingYAMLPath(output, map[string]string{
+				"$.kind":          "VSphereMachineTemplate",
+				"$.metadata.name": "foo-control-plane",
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vsphereMachineTemplate).To(HaveLen(1))
+			Expect(vsphereMachineTemplate[0]).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].nameservers[0]", "fd00::1"))
+			Expect(vsphereMachineTemplate[0]).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].nameservers[1]", "fd00::2"))
+		})
+
+		It("renders the worker VSphereMachineTemplate with the custom worker node nameservers", func() {
+			output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+			Expect(err).NotTo(HaveOccurred())
+
+			vsphereMachineTemplate, err := FindDocsMatchingYAMLPath(output, map[string]string{
+				"$.kind":          "VSphereMachineTemplate",
+				"$.metadata.name": "foo-worker",
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vsphereMachineTemplate).To(HaveLen(1))
+			Expect(vsphereMachineTemplate[0]).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].nameservers[0]", "fd00::3"))
+			Expect(vsphereMachineTemplate[0]).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].nameservers[1]", "fd00::4"))
+		})
+	})
+
+	When("TKG_IP_FAMILY is ipv4,ipv6", func() {
+		var values string
+		BeforeEach(func() {
+			values = createDataValues(map[string]string{
+				"CLUSTER_NAME":                   "foo",
+				"TKG_CLUSTER_ROLE":               "workload",
+				"TKG_IP_FAMILY":                  "ipv4,ipv6",
+				"CONTROL_PLANE_NODE_NAMESERVERS": "1.1.1.1,fd00::2",
+				"WORKER_NODE_NAMESERVERS":        "3.3.3.3,fd00::4",
+			})
+		})
+
+		It("renders the control plane VSphereMachineTemplate with the custom control plane node nameservers", func() {
+			output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+			Expect(err).NotTo(HaveOccurred())
+
+			vsphereMachineTemplate, err := FindDocsMatchingYAMLPath(output, map[string]string{
+				"$.kind":          "VSphereMachineTemplate",
+				"$.metadata.name": "foo-control-plane",
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vsphereMachineTemplate).To(HaveLen(1))
+			Expect(vsphereMachineTemplate[0]).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].nameservers[0]", "1.1.1.1"))
+			Expect(vsphereMachineTemplate[0]).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].nameservers[1]", "fd00::2"))
+		})
+
+		It("renders the worker VSphereMachineTemplate with the custom worker node nameservers", func() {
+			output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+			Expect(err).NotTo(HaveOccurred())
+
+			vsphereMachineTemplate, err := FindDocsMatchingYAMLPath(output, map[string]string{
+				"$.kind":          "VSphereMachineTemplate",
+				"$.metadata.name": "foo-worker",
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vsphereMachineTemplate).To(HaveLen(1))
+			Expect(vsphereMachineTemplate[0]).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].nameservers[0]", "3.3.3.3"))
+			Expect(vsphereMachineTemplate[0]).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].nameservers[1]", "fd00::4"))
+		})
+	})
+})

--- a/pkg/v1/providers/ytt/03_customizations/nameservers.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/nameservers.yaml
@@ -1,0 +1,16 @@
+#@ load("@ytt:assert", "assert")
+#@ load("@ytt:data", "data")
+
+#! Validate CONTROL_PLANE_NODE_NAMESERVERS and WORKER_NODE_NAMESERVERS values
+
+#@ if data.values.CONTROL_PLANE_NODE_NAMESERVERS not in ["", None]:
+#@ if data.values.PROVIDER_TYPE != "vsphere":
+#@ assert.fail("CONTROL_PLANE_NODE_NAMESERVERS is only compatible with PROVIDER_TYPE \"vsphere\". Please set INFRASTRUCTURE_PROVIDER to a compatible value.")
+#@ end
+#@ end
+
+#@ if data.values.WORKER_NODE_NAMESERVERS not in ["", None]:
+#@ if data.values.PROVIDER_TYPE != "vsphere":
+#@ assert.fail("WORKER_NODE_NAMESERVERS is only compatible with PROVIDER_TYPE \"vsphere\". Please set INFRASTRUCTURE_PROVIDER to a compatible value.")
+#@ end
+#@ end

--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -584,6 +584,10 @@ func (c *TkgClient) ConfigureAndValidateManagementClusterConfiguration(options *
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
+	if err = c.ConfigureAndValidateNameserverConfiguration(); err != nil {
+		return NewValidationError(ValidationErrorCode, err.Error())
+	}
+
 	switch name {
 	case AWSProviderName:
 		err = c.ConfigureAndValidateAWSConfig(tkrVersion, options.NodeSizeOptions, skipValidation, options.Plan == constants.PlanProd, constants.DefaultWorkerMachineCountForManagementCluster, nil, true)
@@ -1706,4 +1710,44 @@ func getDockerBridgeNetworkCidr() (string, error) {
 	networkCidr = strings.Trim(networkCidr, "'")
 
 	return networkCidr, nil
+}
+
+// ConfigureAndValidateNameserverConfiguration validates the configuration of the control plane node and workload node nameservers
+func (c *TkgClient) ConfigureAndValidateNameserverConfiguration() error {
+	err := c.validateNameservers(constants.ConfigVariableControlPlaneNodeNameservers)
+	if err != nil {
+		return err
+	}
+
+	return c.validateNameservers(constants.ConfigVariableWorkerNodeNameservers)
+}
+
+func (c *TkgClient) validateNameservers(nameserverConfigVariable string) error {
+	// ignoring error because IPFamily is an optional configuration
+	// if not set Get will return an empty string
+	ipFamily, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableIPFamily)
+	if ipFamily == "" {
+		ipFamily = constants.IPv4Family
+	}
+
+	nameservers, err := c.TKGConfigReaderWriter().Get(nameserverConfigVariable)
+	if err != nil {
+		return nil
+	}
+
+	invalidNameservers := []string{}
+	for _, nameserver := range strings.Split(nameservers, ",") {
+		nameserver = strings.TrimSpace(nameserver)
+		ip := net.ParseIP(nameserver)
+		if ip == nil ||
+			ipFamily == constants.IPv4Family && ip.To4() == nil ||
+			ipFamily == constants.IPv6Family && ip.To4() != nil {
+			invalidNameservers = append(invalidNameservers, nameserver)
+		}
+	}
+
+	if len(invalidNameservers) > 0 {
+		return fmt.Errorf("invalid %s %q, expected to be IP addresses that match TKG_IP_FAMILY %q", nameserverConfigVariable, strings.Join(invalidNameservers, ","), ipFamily)
+	}
+	return nil
 }

--- a/pkg/v1/tkg/client/validate_test.go
+++ b/pkg/v1/tkg/client/validate_test.go
@@ -714,5 +714,160 @@ var _ = Describe("Validate", func() {
 				Entry("Primary IPv6: Garbage", dualStackIPv6Primary, "asdf,fasd"),
 			)
 		})
+		Context("Nameserver configuration and validation", func() {
+			It("should allow empty nameserver configurations", func() {
+				validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+				Expect(validationError).NotTo(HaveOccurred())
+			})
+
+			Context("Control Plane Node Nameservers", func() {
+				Context("when CONTROL_PLANE_NODE_NAMESERVERS is a valid set of IPv4 address", func() {
+					It("should pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableControlPlaneNodeNameservers, "8.8.8.8,8.8.4.4")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+				Context("when CONTROL_PLANE_NODE_NAMESERVERS is a valid set of IPv6 address and TKG_IP_FAMILY is ipv6", func() {
+					It("should pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv6")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableControlPlaneNodeNameservers, "2001:DB8::1, 2001:DB8::2")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+				Context("when CONTROL_PLANE_NODE_NAMESERVERS only contains IPv6 addresses and TKG_IP_FAMILY is ipv4,ipv6", func() {
+					It("should pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv4,ipv6")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableControlPlaneNodeNameservers, "2001:DB8::1,2001:DB8::2")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+				Context("when CONTROL_PLANE_NODE_NAMESERVERS only contains IPv4 addresses and TKG_IP_FAMILY is ipv4,ipv6", func() {
+					It("should pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv4,ipv6")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableControlPlaneNodeNameservers, "8.8.8.8,8.8.4.4")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+				Context("when CONTROL_PLANE_NODE_NAMESERVERS is a valid set of IPv4,IPv6 address and TKG_IP_FAMILY is ipv4,ipv6", func() {
+					It("should pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv4,ipv6")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableControlPlaneNodeNameservers, "8.8.8.8,2001:DB8::2,8.8.4.4,2001:DB8::4")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+				Context("when CONTROL_PLANE_NODE_NAMESERVERS contains multiple invalid entries", func() {
+					It("should return an error", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableControlPlaneNodeNameservers, "google.dns,1.2.3.4,foo.bar")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("invalid CONTROL_PLANE_NODE_NAMESERVERS \"google.dns,foo.bar\", expected to be IP addresses that match TKG_IP_FAMILY \"ipv4\""))
+					})
+				})
+				Context("when CONTROL_PLANE_NODE_NAMESERVERS is a IPv6, but the TKG_IP_FAMILY is ipv4", func() {
+					It("should return an error", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableControlPlaneNodeNameservers, "2001:DB8::1")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("invalid CONTROL_PLANE_NODE_NAMESERVERS \"2001:DB8::1\", expected to be IP addresses that match TKG_IP_FAMILY \"ipv4\""))
+					})
+				})
+				Context("when CONTROL_PLANE_NODE_NAMESERVERS is a IPv4, but the TKG_IP_FAMILY is ipv6", func() {
+					It("should return an error", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv6")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableControlPlaneNodeNameservers, "8.8.8.8")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("invalid CONTROL_PLANE_NODE_NAMESERVERS \"8.8.8.8\", expected to be IP addresses that match TKG_IP_FAMILY \"ipv6\""))
+					})
+				})
+			})
+			Context("Worker Node Nameservers", func() {
+				Context("when WORKER_NODE_NAMESERVERS is a valid set of IPv4 address", func() {
+					It("should pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableWorkerNodeNameservers, "8.8.8.8,8.8.4.4")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+				Context("when WORKER_NODE_NAMESERVERS is a valid set of IPv6 address and TKG_IP_FAMILY is ipv6", func() {
+					It("should pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv6")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableWorkerNodeNameservers, "2001:DB8::1, 2001:DB8::2")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+				Context("when WORKER_NODE_NAMESERVERS only contains IPv6 addresses and TKG_IP_FAMILY is ipv4,ipv6", func() {
+					It("should pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv4,ipv6")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableWorkerNodeNameservers, "2001:DB8::1,2001:DB8::2")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+				Context("when WORKER_NODE_NAMESERVERS only contains IPv4 addresses and TKG_IP_FAMILY is ipv4,ipv6", func() {
+					It("should pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv4,ipv6")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableWorkerNodeNameservers, "8.8.8.8,8.8.4.4")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+				Context("when WORKER_NODE_NAMESERVERS is a valid set of IPv4,IPv6 address and TKG_IP_FAMILY is ipv4,ipv6", func() {
+					It("should pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv4,ipv6")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableWorkerNodeNameservers, "8.8.8.8,2001:DB8::2,8.8.4.4,2001:DB8::4")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+				Context("when WORKER_NODE_NAMESERVERS contains multiple invalid entries", func() {
+					It("should return an error", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableWorkerNodeNameservers, "google.dns,1.2.3.4,foo.bar")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("invalid WORKER_NODE_NAMESERVERS \"google.dns,foo.bar\", expected to be IP addresses that match TKG_IP_FAMILY \"ipv4\""))
+					})
+				})
+				Context("when WORKER_NODE_NAMESERVERS is a IPv6, but the TKG_IP_FAMILY is ipv4", func() {
+					It("should return an error", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableWorkerNodeNameservers, "2001:DB8::1")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("invalid WORKER_NODE_NAMESERVERS \"2001:DB8::1\", expected to be IP addresses that match TKG_IP_FAMILY \"ipv4\""))
+					})
+				})
+				Context("when WORKER_NODE_NAMESERVERS is a IPv4, but the TKG_IP_FAMILY is ipv6", func() {
+					It("should return an error", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv6")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableWorkerNodeNameservers, "8.8.8.8")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("invalid WORKER_NODE_NAMESERVERS \"8.8.8.8\", expected to be IP addresses that match TKG_IP_FAMILY \"ipv6\""))
+					})
+				})
+			})
+		})
 	})
 })

--- a/pkg/v1/tkg/constants/config_variables.go
+++ b/pkg/v1/tkg/constants/config_variables.go
@@ -136,6 +136,9 @@ const (
 
 	ConfigVariableIPFamily = "TKG_IP_FAMILY"
 
+	ConfigVariableControlPlaneNodeNameservers = "CONTROL_PLANE_NODE_NAMESERVERS"
+	ConfigVariableWorkerNodeNameservers       = "WORKER_NODE_NAMESERVERS"
+
 	// Below config variables are added based on init and create command flags
 
 	ConfigVariableClusterPlan             = "CLUSTER_PLAN"


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows a user to customize dns servers for cluster nodes at cluster creation time.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #238

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

* Ran `make clustergen` locally with the additional of `WORKER_NODE_NAMESERVERS` and `CONTROL_PLANE_NODE_NAMESERVERS` in the model.
  * Note: The clustergen tests do not test setting multiple values for the nameserver fields because commas are used as separators for the model file. We didn't find a way to tell pict that `"8.8.8.8,8.8.4.4"` should be treated as a single value to pass into the test.
  * Tested setting multiple nameservers on the field manually: e.g `8.8.8.8,8.8.4.4` and observing the `nameservers` field get set to an array of those values.
* Ran `tanzu management-cluster create ./config.yaml --dry-run` with the above config vars set in my config yaml and observed the `nameservers` being set in the `VSphereMachineTemplate` resources.
* Run `tanzu management-cluster create ./config.yaml` with the above config vars set and observed the `resolvectl status` return the proper IPs on the cluster node VMs.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Added CONTROL_PLANE_NODE_NAMESERVERS and WORKER_NODE_NAMESERVERS cluster configuration variable. This allows the user to specify a comma-delimited list of DNS servers to be configured on the control plane and worker node VMs respectively. This is currently supported on vSphere only.
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
