### PR TITLE
Add nil check to avoid panic when setting unstable-versions in CLI

### DIFF
--- a/apis/config/v1alpha1/clientconfig.go
+++ b/apis/config/v1alpha1/clientconfig.go
@@ -47,6 +47,12 @@ func (c *ClientConfig) GetCurrentServer() (*Server, error) {
 // experimental: all pre-release versions without +build semver data
 // all: return all unstable versions.
 func (c *ClientConfig) SetUnstableVersionSelector(f VersionSelectorLevel) {
+	if c.ClientOptions == nil {
+		c.ClientOptions = &ClientOptions{}
+	}
+	if c.ClientOptions.CLI == nil {
+		c.ClientOptions.CLI = &CLIOptions{}
+	}
 	switch f {
 	case AllUnstableVersions, AlphaUnstableVersions, ExperimentalUnstableVersions, NoUnstableVersions:
 		c.ClientOptions.CLI.UnstableVersionSelector = f


### PR DESCRIPTION
**What this PR does / why we need it**:

`tanzu config set unstable-versions` can panic when `ClientOptions` is
removed from the config file. This change adds nil check and initializes
the parent objects appropriately before setting unstable-versions.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #144 

**Describe testing done for PR**:

`tanzu config init` and manually remove `clientOptions` key from `~/.config/tanzu/config.yaml` to simulate user change to the config. Then run `make set-unstable-versions` and verify no panic occurs.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
