### PR TITLE
Add helper functions to determine feature activation state

### DIFF
--- a/pkg/v1/sdk/capabilities/controllers/capability_controller.go
+++ b/pkg/v1/sdk/capabilities/controllers/capability_controller.go
@@ -35,6 +35,7 @@ func (r *CapabilityReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 	defer cancel()
 
 	log := r.Log.WithValues("capability", req.NamespacedName)
+	log.Info("Starting reconcile")
 
 	capability := &runv1alpha1.Capability{}
 	if err := r.Get(ctx, req.NamespacedName, capability); err != nil {
@@ -55,6 +56,7 @@ func (r *CapabilityReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) 
 		capability.Status.Results[i].PartialSchemas = r.queryPartialSchemas(l, query.PartialSchemas)
 	}
 
+	log.Info("Successfully reconciled")
 	return ctrl.Result{}, r.Status().Update(ctx, capability)
 }
 

--- a/pkg/v1/sdk/features/controllers/featuregate_controller.go
+++ b/pkg/v1/sdk/features/controllers/featuregate_controller.go
@@ -38,7 +38,8 @@ func (r *FeatureGateReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 	defer cancel()
 
-	_ = r.Log.WithValues("featuregate", req.NamespacedName)
+	log := r.Log.WithValues("featuregate", req.NamespacedName)
+	log.Info("Starting reconcile")
 
 	featureGate := &configv1alpha1.FeatureGate{}
 	if err := r.Client.Get(ctx, req.NamespacedName, featureGate); err != nil {
@@ -64,6 +65,7 @@ func (r *FeatureGateReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 	featureGate.Status.DeactivatedFeatures = deactivated
 	featureGate.Status.UnavailableFeatures = unavailable
 
+	log.Info("Successfully reconciled")
 	return ctrl.Result{}, r.Client.Status().Update(ctx, featureGate)
 }
 

--- a/pkg/v1/sdk/features/featuregate/featuregate.go
+++ b/pkg/v1/sdk/features/featuregate/featuregate.go
@@ -4,10 +4,27 @@
 package featuregate
 
 import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
+	featureutil "github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/features/util"
 )
+
+const (
+	// TKGSystemFeatureGate is the FeatureGate resource for gating TKG features.
+	TKGSystemFeatureGate = "tkg-system"
+)
+
+// TKGNamespaceSelector is a label selector which matches TKG-related namespaces.
+var TKGNamespaceSelector = metav1.LabelSelector{
+	MatchExpressions: []metav1.LabelSelectorRequirement{
+		{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"tkg-system-public"}},
+	},
+}
 
 // ComputeFeatureStates takes a FeatureGate spec and computes the actual state (activated, deactivated or unavailable)
 // of the features in the gate by referring to a list of Feature resources.
@@ -64,4 +81,54 @@ func ComputeFeatureStates(featureGateSpec configv1alpha1.FeatureGateSpec, featur
 	unavailable = allFeaturesInSpec.Difference(discovered).List()
 
 	return activated, deactivated, unavailable
+}
+
+// FeatureActivatedInNamespace returns true only if all of the features specified are activated in the namespace.
+func FeatureActivatedInNamespace(ctx context.Context, c client.Client, namespace, feature string) (bool, error) {
+	selector := metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{namespace}},
+		},
+	}
+	return FeaturesActivatedInNamespacesMatchingSelector(ctx, c, selector, []string{feature})
+}
+
+// FeaturesActivatedInNamespacesMatchingSelector returns true only if all the features specified are activated in every namespace matched by the selector.
+func FeaturesActivatedInNamespacesMatchingSelector(ctx context.Context, c client.Client, namespaceSelector metav1.LabelSelector, features []string) (bool, error) {
+	namespaces, err := featureutil.NamespacesMatchingSelector(ctx, c, &namespaceSelector)
+	if err != nil {
+		return false, err
+	}
+
+	// If no namespaces are matched or no features specified, return false.
+	if len(namespaces) == 0 || len(features) == 0 {
+		return false, nil
+	}
+
+	featureGatesList := &configv1alpha1.FeatureGateList{}
+	if err := c.List(ctx, featureGatesList); err != nil {
+		return false, err
+	}
+
+	// Map of namespace to a set of features activated in that namespace.
+	namespaceToActivatedFeatures := make(map[string]sets.String)
+	for i := range featureGatesList.Items {
+		fg := featureGatesList.Items[i]
+		for _, namespace := range fg.Status.Namespaces {
+			namespaceToActivatedFeatures[namespace] = sets.NewString(fg.Status.ActivatedFeatures...)
+		}
+	}
+
+	for _, ns := range namespaces {
+		activatedFeatures, found := namespaceToActivatedFeatures[ns]
+		if !found {
+			// Namespace has no features gated.
+			return false, nil
+		}
+		// Feature is not activated in this namespace.
+		if !activatedFeatures.HasAll(features...) {
+			return false, nil
+		}
+	}
+	return true, nil
 }

--- a/pkg/v1/sdk/features/featuregate/featuregate_test.go
+++ b/pkg/v1/sdk/features/featuregate/featuregate_test.go
@@ -4,12 +4,18 @@
 package featuregate
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck
 
 	configv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/test/cmp/strings"
+	stringcmp "github.com/vmware-tanzu/tanzu-framework/pkg/v1/test/cmp/strings"
 )
 
 func TestComputeFeatureStates(t *testing.T) {
@@ -57,16 +63,245 @@ func TestComputeFeatureStates(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			activated, deactivated, unavailable := ComputeFeatureStates(tc.spec, tc.features)
 
-			if diff := strings.SliceDiffIgnoreOrder(activated, tc.expectedActivated); diff != "" {
+			if diff := stringcmp.SliceDiffIgnoreOrder(activated, tc.expectedActivated); diff != "" {
 				t.Errorf("got activated features %v, want %v, diff: %s", activated, tc.expectedActivated, diff)
 			}
 
-			if diff := strings.SliceDiffIgnoreOrder(deactivated, tc.expectedDeactivated); diff != "" {
+			if diff := stringcmp.SliceDiffIgnoreOrder(deactivated, tc.expectedDeactivated); diff != "" {
 				t.Errorf("got deactivated features %v, want %v, diff: %s", deactivated, tc.expectedDeactivated, diff)
 			}
 
-			if diff := strings.SliceDiffIgnoreOrder(unavailable, tc.expectedUnavailable); diff != "" {
+			if diff := stringcmp.SliceDiffIgnoreOrder(unavailable, tc.expectedUnavailable); diff != "" {
 				t.Errorf("got unavailable features %v, want %v, diff: %s", unavailable, tc.expectedUnavailable, diff)
+			}
+		})
+	}
+}
+
+//nolint:funlen
+func TestFeaturesActivatedInNamespacesMatchingSelector(t *testing.T) {
+	scheme, err := configv1alpha1.SchemeBuilder.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := k8sscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	newNamespace := func(name string) *corev1.Namespace {
+		return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{"kubernetes.io/metadata.name": name}}}
+	}
+
+	newFeatureGate := func(name string, namespaces, activated, deactivated, unavailable []string) *configv1alpha1.FeatureGate {
+		return &configv1alpha1.FeatureGate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Status: configv1alpha1.FeatureGateStatus{
+				Namespaces:          namespaces,
+				ActivatedFeatures:   activated,
+				DeactivatedFeatures: deactivated,
+				UnavailableFeatures: unavailable,
+			}}
+	}
+
+	testCases := []struct {
+		description     string
+		existingObjects []runtime.Object
+		selector        metav1.LabelSelector
+		features        []string
+		want            bool
+		err             string
+	}{
+		{
+			description: "Namespace matched by selector is gated and all features are activated",
+			existingObjects: []runtime.Object{
+				newNamespace("kube-system"),
+				newNamespace("kube-public"),
+				newNamespace("tkg-system"),
+				newFeatureGate("tkg", []string{"kube-system", "tkg-system"}, []string{"one", "two"}, []string{"three", "four"}, []string{"five", "six"}),
+			},
+			selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"tkg-system"}},
+			}},
+			features: []string{"one", "two"},
+			want:     true,
+			err:      "",
+		},
+		{
+			description: "Namespace matched by selector is gated and one feature is deactivated",
+			existingObjects: []runtime.Object{
+				newNamespace("kube-system"),
+				newNamespace("ns-no-feature-gates"),
+				newNamespace("tkg-system"),
+				newFeatureGate("tkg", []string{"kube-system", "tkg-system"}, []string{"one", "two"}, []string{"three", "four"}, []string{"five", "six"}),
+			},
+			selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"tkg-system"}},
+			}},
+			features: []string{"one", "three"},
+			want:     false,
+			err:      "",
+		},
+		{
+			description: "Namespaces matched by selector are gated and all features are activated",
+			existingObjects: []runtime.Object{
+				newNamespace("kube-system"),
+				newNamespace("ns-no-feature-gates"),
+				newNamespace("tkg-system"),
+				newFeatureGate("tkg", []string{"kube-system", "tkg-system"}, []string{"one", "two"}, []string{"three", "four"}, []string{"five", "six"}),
+			},
+			selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"tkg-system", "kube-system"}},
+			}},
+			features: []string{"one", "two"},
+			want:     true,
+			err:      "",
+		},
+		{
+			description: "Namespaces matched by selector are gated and all features are activated across multiple feature gates",
+			existingObjects: []runtime.Object{
+				newNamespace("kube-system"),
+				newNamespace("ns-no-feature-gates"),
+				newNamespace("tkg-system"),
+				newFeatureGate("tkg", []string{"kube-system", "tkg-system"}, []string{"one", "two"}, []string{"three", "four"}, []string{"five", "six"}),
+				newFeatureGate("dev", []string{"kube-public"}, []string{"one", "two"}, []string{"three"}, []string{}),
+			},
+			selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"tkg-system", "kube-system", "kube-public"}},
+			}},
+			features: []string{"one", "two"},
+			want:     true,
+			err:      "",
+		},
+		{
+			description: "Namespaces are gated and all features are either deactivated or unavailable",
+			existingObjects: []runtime.Object{
+				newNamespace("kube-system"),
+				newNamespace("kube-public"),
+				newNamespace("tkg-system"),
+				newFeatureGate("tkg", []string{"kube-system", "tkg-system"}, []string{"one", "two"}, []string{"three", "four"}, []string{"five", "six"}),
+			},
+			selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"tkg-system"}},
+			}},
+			features: []string{"five", "three"},
+			want:     false,
+			err:      "",
+		},
+		{
+			description: "Label selector matches only one namespace with all features activated",
+			existingObjects: []runtime.Object{
+				newNamespace("kube-system"),
+				newNamespace("kube-public"),
+				newNamespace("tkg-system"),
+				newFeatureGate("tkg", []string{"kube-system", "tkg-system"}, []string{"one", "two"}, []string{"three", "four"}, []string{"five", "six"}),
+			},
+			selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"tkg-system", "ns-no-feature-gates"}},
+			}},
+			features: []string{"one", "two"},
+			want:     true,
+			err:      "",
+		},
+		{
+			description: "Label selector matches two namespaces where a feature is in different activation states",
+			existingObjects: []runtime.Object{
+				newNamespace("kube-system"),
+				newNamespace("kube-public"),
+				newNamespace("tkg-system"),
+				newFeatureGate("tkg", []string{"kube-system", "tkg-system"}, []string{"one"}, []string{}, []string{}),
+				newFeatureGate("dev", []string{"kube-public"}, []string{}, []string{"one"}, []string{}),
+			},
+			selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"tkg-system", "kube-public"}},
+			}},
+			features: []string{"one"},
+			want:     false,
+			err:      "",
+		},
+		{
+			description: "Label selector matches no namespaces",
+			existingObjects: []runtime.Object{
+				newNamespace("kube-system"),
+				newNamespace("kube-public"),
+				newNamespace("tkg-system"),
+				newFeatureGate("tkg", []string{"kube-system", "tkg-system"}, []string{"one", "two"}, []string{"three", "four"}, []string{"five", "six"}),
+			},
+			selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				// LabelSelectorRequirement are ANDed.
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"tkg-system"}},
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"ns-no-feature-gates"}},
+			}},
+			features: []string{"one", "two"},
+			want:     false,
+			err:      "",
+		},
+		{
+			description: "Features are not gated in any of the namespaces",
+			existingObjects: []runtime.Object{
+				newNamespace("kube-system"),
+				newNamespace("kube-public"),
+				newNamespace("tkg-system"),
+				newFeatureGate("tkg", []string{"kube-system", "tkg-system"}, []string{"one", "two"}, []string{"three", "four"}, []string{"five", "six"}),
+			},
+			selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"ns-no-feature-gates"}},
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"kube-public"}},
+			}},
+			features: []string{"one", "two"},
+			want:     false,
+			err:      "",
+		},
+		{
+			description: "No features specified",
+			existingObjects: []runtime.Object{
+				newNamespace("kube-system"),
+				newNamespace("kube-public"),
+				newNamespace("tkg-system"),
+				newFeatureGate("tkg", []string{"kube-system", "tkg-system"}, []string{"one", "two"}, []string{"three", "four"}, []string{"five", "six"}),
+			},
+			selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"ns-no-feature-gates"}},
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpIn, Values: []string{"kube-public"}},
+			}},
+			features: []string{},
+			want:     false,
+			err:      "",
+		},
+		{
+			description: "Error due to bad namespace selector",
+			existingObjects: []runtime.Object{
+				newNamespace("kube-system"),
+				newNamespace("kube-public"),
+				newNamespace("tkg-system"),
+				newFeatureGate("tkg", []string{"kube-system", "tkg-system"}, []string{"one", "two"}, []string{"three", "four"}, []string{"five", "six"}),
+			},
+			selector: metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+				{Key: "kubernetes.io/metadata.name", Operator: metav1.LabelSelectorOpExists, Values: []string{"bad-value"}},
+			}},
+			features: []string{},
+			want:     false,
+			err:      "failed to get namespaces from NamespaceSelector",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			fakeClient := fake.NewFakeClientWithScheme(scheme, tc.existingObjects...)
+			got, err := FeaturesActivatedInNamespacesMatchingSelector(context.Background(), fakeClient, tc.selector, tc.features)
+			if err != nil {
+				if tc.err == "" {
+					t.Errorf("no error string specified, but got error: %v", err)
+				}
+				if !strings.Contains(err.Error(), tc.err) {
+					t.Errorf("error string=%q doesn't match partial=%q", tc.err, err)
+				}
+			} else if tc.err != "" {
+				t.Errorf("error string=%q specified but error not found", tc.err)
+			}
+			if got != tc.want {
+				t.Errorf("feature activation: got %t, want %t", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

These helper functions are intended to be used by consumers (mostly
controllers) to check if feature(s) are activated.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
