### PR TITLE
fix bootstrap cluster avi node_network_list format error when using avi to provide control plane vip

### DIFF
--- a/pkg/v1/providers/ytt/02_addons/avi/spec.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/avi/spec.lib.yaml
@@ -100,9 +100,6 @@ spec:
 #@ if data.values.AVI_INGRESS_SERVICE_TYPE != "":
       serviceType: #@ data.values.AVI_INGRESS_SERVICE_TYPE
 #@ end
-#@ if data.values.AVI_INGRESS_NODE_NETWORK_LIST != []:
-      nodeNetworkList: #@ data.values.AVI_INGRESS_NODE_NETWORK_LIST
-#@ end
 #@ end
 
 #@ def avi_credentials():


### PR DESCRIPTION
**What this PR does / why we need it**:

When using AVI to provide control plane VIP, we need to deploy AKOO and AKO in bootstrap cluster, recently we modified the `AVI_LABELS` and `AVI_INGRESS_NODE_NETWORK_LIST` passing format, refer to here:  https://github.com/vmware-tanzu/tanzu-framework/pull/263/, so we need to modify the way we receive value correspondingly.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

Manually verified on a local vsphere testbed, create a management cluster using AVI to provide control plane VIP, it created successfully.

- ✅ empty  `AVI_INGRESS_NODE_NETWORK_LIST`
- ✅ configured `AVI_INGRESS_NODE_NETWORK_LIST`

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
