### PR TITLE
Add standards for considering CLI words changes

### DIFF
--- a/docs/dev/merging_standards.md
+++ b/docs/dev/merging_standards.md
@@ -1,0 +1,31 @@
+# Merging Standards
+
+Many aspects of Framework are intended to be standardized - things like CLI flags, log output and terminology are all intended to be standard to ensure cohesion across the product.
+
+This document intends to layout steps on how to consider Pull Requests which may alter these areas.
+
+## CLI Words
+
+We have standard [CLI words](../../pkg/v1/cli/command/plugin/lint/cli-wordlist.yml) defined in this repo to make it simple to keep our CLI words intact and allow our CLI plugins to vet themselves.
+
+The easiest way to check if a command aligns with our CLI nouns and verbs standards is to run the plugins hidden `lint` comand. Every plugin offered by Tanzu CLI can lint itself against our standard words list. For any plugin, simply run:
+
+`tanzu <plugin> lint`
+
+Alternatively, the list can always just [be referenced directly](https://github.com/vmware-tanzu/tanzu-framework/blob/main/hack/linter/cli-wordlist.yml).
+
+### Format
+
+The [CLI style-guide](docs/cli/style_guide.md) provides guidance on how CLI nouns and verbs should be structured, please make sure to consult this while evaluating CLI word changes.
+
+In short, words meet the following criteria:
+
+* English, using US spelling
+* Clear and unambiguous
+* Concise without using acronyms that are not an industry standard (URL is good, MC is not)
+
+Ideally, words will be the appropriate part of speech; nouns should be nouns, verbs should be verbs.
+
+Ideally, merge requests proposing new words will define those terms.
+
+Any additions that contradict existing terms should be adjusted and changes which do not conform to this list always require input from *Product*. This list is parsed and used to enforce standardization so it is important to treat changes here deliberately, like changing a model.


### PR DESCRIPTION
**What this PR does / why we need it**:

We have [standard cli words](https://github.com/vmware-tanzu/tanzu-framework/blob/main/hack/linter/cli-wordlist.yml), and we need some guidance on how to evaluate changes to them since changes to the list can be quite destructive and have an immediate effect on our product cohesion.

**Describe testing done for PR**:
I executed the lint command for a few plugins to ensure the steps work.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Add docs for guidance on updating CLI words.
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
