### PR TITLE
CI: Add label checker to gate merges

### DIFF
--- a/.github/workflows/verify-label.yaml
+++ b/.github/workflows/verify-label.yaml
@@ -1,0 +1,22 @@
+---
+name: Merge Checker
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+
+  check_labels:
+    name: Check labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://agilepathway/pull-request-label-checker:latest
+        with:
+          none_of: do-not-merge/hold
+          one_of: ok-to-merge
+          repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The action introduced will block PRs unless

- it is labeled with ok-to-merge
- it it NOT labeled with do-not-merge/hold

This is to make explicity any decision made on whether to accept or hold
a PR close to release time.

Signed-off-by: Vui Lam <vui@vmware.com>

**Which issue(s) this PR fixes**:
Fixes #123

**Describe testing done for PR**:
Tested on a test repo, verified PR and label updates triggers the recheck, and action does what it is supposed to.

**Special notes for your reviewer**:

None

**New PR Checklist**

- x Ensure PR contains only public links or terms
- x Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- x Squash the commits in this branch before merge to preserve our git history
- x Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
