### PR TITLE
Use PROVIDER_TYPE to validate infra for ipv6

### DIFF
--- a/pkg/v1/providers/ytt/03_customizations/ipfamily.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/ipfamily.yaml
@@ -8,6 +8,6 @@
 #@ assert.fail("TKG_IP_FAMILY value must be \"ipv6\", \"ipv4\", or unset")
 #@ end
 
-#@ if data.values.TKG_IP_FAMILY == "ipv6" and data.values.INFRASTRUCTURE_PROVIDER != "vsphere":
-#@ assert.fail("TKG_IP_FAMILY value of \"ipv6\" is only compatible with INFRASTRUCTURE_PROVIDER \"vsphere\"")
+#@ if data.values.TKG_IP_FAMILY == "ipv6" and data.values.PROVIDER_TYPE != "vsphere":
+#@ assert.fail("TKG_IP_FAMILY value of \"ipv6\" is only compatible with PROVIDER_TYPE \"vsphere\". Please set INFRASTRUCTURE_PROVIDER to a compatible value.")
 #@ end


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the infrastructure validation for `TKG_IP_FAMILY: ipv6` uses `INFRASTRUCTURE_PROVIDER`, which may not always work because it may have a version attached or the user may use the `-i` flag. Using the `PROVIDER_TYPE` field fixes both of these problems.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #281

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran the clustergen tests and observed the `-i vsphere:v0.7.10` flag return a successful manifest.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
