### PR TITLE
Add a script to help manage GitHub labels

### DIFF
--- a/hack/update-github-labels.sh
+++ b/hack/update-github-labels.sh
@@ -228,16 +228,16 @@ merge-areas () {
     # The array is passed by name at the end of this function
     # shellcheck disable=SC2034
     areas=(
-            ["api machinery"]=""
+            [api-machinery]=""
             [bootstrap]=""
-            ["cli machinery"]=""
-            ["cli plugin"]=""
-            ["cluster lifecycle"]=""
+            [cli-machinery]=""
+            [cli-plugins]=""
+            [cluster-lifecycle]=""
             [docs]=""
             [iam]=""
             [packages]=""
             [release]=""
-            ["repo maintenance"]=""
+            [repo-maintenance]=""
             [security]=""
             [testing]=""
     )


### PR DESCRIPTION
**What this PR does / why we need it**:

To help create a review/approval process for changes to GitHub labels, introduce a script (based on one from [another VMware project][1]) which uses the GitHub API to create and update labels.

This allows changes to GitHub labels and their descriptions to be proposed using pull requests. Once merged, a maintainer can use an API token to apply the change. The history of the script can be used to understand the reason a GitHub label was introduced.

This does not prevent direct manipulation of GitHub labels by users with the permissions to do so.

[1]:https://github.com/vmware/vic-tools

**Which issue(s) this PR fixes**:

Towards #321

(But is not a complete fix)

**Describe testing done for PR**:

* Ran `shellcheck`
* Used the `REPO` variable to run this script against a test repository

Screenshots:

![Screenshot 2021-08-05 at 22-24-22 Labels · zjs label-test](https://user-images.githubusercontent.com/408880/128429206-68ac5cf5-4255-493f-9f41-cbb9752a6472.png)
![Screenshot 2021-08-05 at 22-24-30 Labels · zjs label-test](https://user-images.githubusercontent.com/408880/128429202-417a9fd2-1edd-4ecf-b723-34e8a80ae025.png)

**Special notes for your reviewer**:

1. The biggest change proposed here is to the way we communicate the importance of issues. This switches from labels like `priority/critical-urgent` to `severity/1-critical`. The new labels are sortable, have concrete definitions, and focus on the severity of the issue (which should be relatively intrinsic to the issue) rather than its priority (which inherently evolves over time).
2. If this change is approved, I'll rename some of the existing labels to match the new names before running the script.
3. If this change is approved, I'll bulk adjust issue labels as needed to de-duplicate labels (e.g., we have both `bug` and `kind/bug`).
4. I did not attempt to describe each of the existing area labels, but I think this would be good to do. Feel free to suggest descriptions. Otherwise, I may handle that as a follow-up change.

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
```release-note
NONE
```

**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
