### PR TITLE
Use image tags from the TKG BoM file while installing providers

### DIFF
--- a/pkg/v1/providers/bootstrap-kubeadm/v0.3.22/bootstrap-components.yaml
+++ b/pkg/v1/providers/bootstrap-kubeadm/v0.3.22/bootstrap-components.yaml
@@ -3924,7 +3924,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.8.0_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -3935,7 +3935,7 @@ spec:
         - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false}
         command:
         - /manager
-        image: registry.tkg.vmware.run/cluster-api/kubeadm-bootstrap-controller:v0.3.22_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/kubeadm-bootstrap-controller:${CABPK_CONTROLLER_IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         name: manager
       terminationGracePeriodSeconds: 10
@@ -3969,7 +3969,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.8.0_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -3980,7 +3980,7 @@ spec:
         - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false}
         command:
         - /manager
-        image: registry.tkg.vmware.run/cluster-api/kubeadm-bootstrap-controller:v0.3.22_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/kubeadm-bootstrap-controller:${CABPK_CONTROLLER_IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         name: manager
         ports:

--- a/pkg/v1/providers/cluster-api/v0.3.22/core-components.yaml
+++ b/pkg/v1/providers/cluster-api/v0.3.22/core-components.yaml
@@ -4834,7 +4834,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.8.0_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -4845,7 +4845,7 @@ spec:
         - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=true
         command:
         - /manager
-        image: registry.tkg.vmware.run/cluster-api/cluster-api-controller:v0.3.22_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/cluster-api-controller:${CAPI_CONTROLLER_IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -4891,7 +4891,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.8.0_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -4902,7 +4902,7 @@ spec:
         - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=true
         command:
         - /manager
-        image: registry.tkg.vmware.run/cluster-api/cluster-api-controller:v0.3.22_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/cluster-api-controller:${CAPI_CONTROLLER_IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/pkg/v1/providers/control-plane-kubeadm/v0.3.22/control-plane-components.yaml
+++ b/pkg/v1/providers/control-plane-kubeadm/v0.3.22/control-plane-components.yaml
@@ -1489,7 +1489,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.8.0_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -1499,7 +1499,7 @@ spec:
         - --enable-leader-election
         command:
         - /manager
-        image: registry.tkg.vmware.run/cluster-api/kubeadm-control-plane-controller:v0.3.22_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/kubeadm-control-plane-controller:${KCP_CONTROLLER_IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         name: manager
       terminationGracePeriodSeconds: 10
@@ -1533,7 +1533,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.8.0_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -1543,7 +1543,7 @@ spec:
         - --webhook-port=9443
         command:
         - /manager
-        image: registry.tkg.vmware.run/cluster-api/kubeadm-control-plane-controller:v0.3.22_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/kubeadm-control-plane-controller:${KCP_CONTROLLER_IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         name: manager
         ports:

--- a/pkg/v1/providers/infrastructure-aws/v0.6.6/infrastructure-components.yaml
+++ b/pkg/v1/providers/infrastructure-aws/v0.6.6/infrastructure-components.yaml
@@ -4501,7 +4501,7 @@ spec:
             - --metrics-addr=127.0.0.1:8080
             - --enable-leader-election
             - --feature-gates=EKS=${EXP_EKS:=false},EKSEnableIAM=${EXP_EKS_IAM:=false},MachinePool=${EXP_MACHINE_POOL:=false},EventBridgeInstanceState=${EVENT_BRIDGE_INSTANCE_STATE:=false},AutoControllerIdentityCreator=${AUTO_CONTROLLER_IDENTITY_CREATOR:=true}
-          image: registry.tkg.vmware.run/cluster-api-aws/cluster-api-aws-controller:v0.6.6_vmware.1
+          image: registry.tkg.vmware.run/cluster-api-aws/cluster-api-aws-controller:${CAPA_CONTROLLER_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -4533,7 +4533,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=10
-          image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.4.1_vmware.2
+          image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443
@@ -4578,7 +4578,7 @@ spec:
             - --metrics-addr=127.0.0.1:8080
             - --webhook-port=9443
             - --feature-gates=EKS=${EXP_EKS:=false},EKSEnableIAM=${EXP_EKS_IAM:=false},MachinePool=${EXP_MACHINE_POOL:=false},EventBridgeInstanceState=${EVENT_BRIDGE_INSTANCE_STATE:=false},AutoControllerIdentityCreator=${AUTO_CONTROLLER_IDENTITY_CREATOR:=true}
-          image: registry.tkg.vmware.run/cluster-api-aws/cluster-api-aws-controller:v0.6.6_vmware.1
+          image: registry.tkg.vmware.run/cluster-api-aws/cluster-api-aws-controller:${CAPA_CONTROLLER_IMAGE_TAG}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -4605,7 +4605,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=10
-          image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.4.1_vmware.2
+          image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/pkg/v1/providers/infrastructure-azure/v0.4.15/infrastructure-components.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v0.4.15/infrastructure-components.yaml
@@ -3611,7 +3611,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.4.1_vmware.2
+        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -3633,7 +3633,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: registry.tkg.vmware.run/cluster-api/cluster-api-azure-controller:v0.4.15_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/cluster-api-azure-controller:${CAPZ_CONTROLLER_IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -3692,7 +3692,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.4.1_vmware.2
+        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -3745,7 +3745,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: registry.tkg.vmware.run/cluster-api/cluster-api-azure-controller:v0.4.15_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/cluster-api-azure-controller:${CAPZ_CONTROLLER_IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -3802,7 +3802,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: registry.tkg.vmware.run/cluster-api/nmi:v1.6.3_vmware.2
+        image: registry.tkg.vmware.run/cluster-api/nmi:${NMI_IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/pkg/v1/providers/infrastructure-docker/v0.3.22/infrastructure-components.yaml
+++ b/pkg/v1/providers/infrastructure-docker/v0.3.22/infrastructure-components.yaml
@@ -904,7 +904,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.8.0_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -913,7 +913,7 @@ spec:
         - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false}
         - --metrics-addr=0
         - -v=4
-        image: registry.tkg.vmware.run/cluster-api/capd-manager:v0.3.22_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/capd-manager:${CAPD_CONTROLLER_IMAGE_TAG}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/pkg/v1/providers/infrastructure-vsphere/v0.7.10/infrastructure-components.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v0.7.10/infrastructure-components.yaml
@@ -3719,7 +3719,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.4.1_vmware.2
+        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -3728,7 +3728,7 @@ spec:
         - --metrics-addr=127.0.0.1:8080
         - --webhook-port=9443
         - --enable-leader-election=false
-        image: registry.tkg.vmware.run/cluster-api/cluster-api-vsphere-controller:v0.7.10_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/cluster-api-vsphere-controller:${CAPV_CONTROLLER_IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -3786,14 +3786,14 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.4.1_vmware.2
+        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
           name: https
       - args:
         - --metrics-addr=127.0.0.1:8080
-        image: registry.tkg.vmware.run/cluster-api/cluster-api-vsphere-controller:v0.7.10_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/cluster-api-vsphere-controller:${CAPV_CONTROLLER_IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/pkg/v1/providers/infrastructure-windows-vsphere/v0.7.8/infrastructure-components.yaml
+++ b/pkg/v1/providers/infrastructure-windows-vsphere/v0.7.8/infrastructure-components.yaml
@@ -3198,7 +3198,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.4.1_vmware.2
+        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -3207,7 +3207,7 @@ spec:
         - --metrics-addr=127.0.0.1:8080
         - --webhook-port=9443
         - --enable-leader-election=false
-        image: registry.tkg.vmware.run/cluster-api/cluster-api-vsphere-controller:v0.7.8_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/cluster-api-vsphere-controller:${CAPV_CONTROLLER_IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -3265,14 +3265,14 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.4.1_vmware.2
+        image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:${KUBE_RBAC_PROXY_IMAGE_TAG}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
           name: https
       - args:
         - --metrics-addr=127.0.0.1:8080
-        image: registry.tkg.vmware.run/cluster-api/cluster-api-vsphere-controller:v0.7.8_vmware.1
+        image: registry.tkg.vmware.run/cluster-api/cluster-api-vsphere-controller:${CAPV_CONTROLLER_IMAGE_TAG}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/pkg/v1/tkg/client/upgrade_region.go
+++ b/pkg/v1/tkg/client/upgrade_region.go
@@ -154,6 +154,16 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 }
 
 func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterClient clusterclient.Client) error {
+	err := c.configureImageTagsForProviderInstallation()
+	if err != nil {
+		return errors.Wrap(err, "failed to configure image tags for provider installation")
+	}
+
+	// If region client is not specified nothing to configure based on existing management cluster
+	if regionalClusterClient == nil {
+		return nil
+	}
+
 	infraProvider, err := regionalClusterClient.GetRegionalClusterDefaultProviderName(clusterctlv1.InfrastructureProviderType)
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster provider information.")

--- a/pkg/v1/tkg/constants/config_variables.go
+++ b/pkg/v1/tkg/constants/config_variables.go
@@ -154,4 +154,15 @@ const (
 	ConfigVariableAviPassword                      = "AVI_PASSWORD"
 	ConfigVariableLDAPBindPassword                 = "LDAP_BIND_PASSWORD"                   //nolint:gosec
 	ConfigVariableOIDCIdentiryProviderClientSecret = "OIDC_IDENTITY_PROVIDER_CLIENT_SECRET" //nolint:gosec
+
+	// Config variables for image tags used for provider installation
+	ConfigVariableInternalKubeRBACProxyImageTag   = "KUBE_RBAC_PROXY_IMAGE_TAG"
+	ConfigVariableInternalCABPKControllerImageTag = "CABPK_CONTROLLER_IMAGE_TAG"
+	ConfigVariableInternalCAPIControllerImageTag  = "CAPI_CONTROLLER_IMAGE_TAG"
+	ConfigVariableInternalKCPControllerImageTag   = "KCP_CONTROLLER_IMAGE_TAG"
+	ConfigVariableInternalCAPDManagerImageTag     = "CAPD_CONTROLLER_IMAGE_TAG"
+	ConfigVariableInternalCAPAManagerImageTag     = "CAPA_CONTROLLER_IMAGE_TAG"
+	ConfigVariableInternalCAPVManagerImageTag     = "CAPV_CONTROLLER_IMAGE_TAG"
+	ConfigVariableInternalCAPZManagerImageTag     = "CAPZ_CONTROLLER_IMAGE_TAG"
+	ConfigVariableInternalNMIImageTag             = "NMI_IMAGE_TAG"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
- Reads the BoM file and configures image tag for each image used for
  provider installation
- Fixes the potential issues where we have a mismatch of a provider
  the component version in BoM file and installed providers
- This change programmatically configures config variables needed for the
  provider image tags before we install or upgrade providers

Signed-off-by: Anuj Chaudhari <anujc@vmware.com>

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
- ✅  vSphere management and workload cluster creation
- ✅  vSphere management and workload cluster upgrade
- ✅  AWS management and workload cluster upgrade

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
