### PR TITLE
Removes polling and timeout when looking for cluster credentials

### DIFF
--- a/pkg/v1/tkg/clusterclient/credentials.go
+++ b/pkg/v1/tkg/clusterclient/credentials.go
@@ -104,8 +104,7 @@ func (c *client) GetVCCredentialsFromSecret(clusterName string) (string, string,
 func (c *client) UpdateVsphereIdentityRefSecret(clusterName, namespace, username, password string) error {
 	secret := &corev1.Secret{}
 
-	pollOptions := &PollOptions{Interval: CheckResourceInterval, Timeout: c.operationTimeout}
-	err := c.GetResource(secret, clusterName, namespace, nil, pollOptions)
+	err := c.GetResource(secret, clusterName, namespace, nil, nil)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			log.Info("Cluster identityRef secret not present. Skipping update...")
@@ -141,6 +140,7 @@ func (c *client) UpdateVsphereIdentityRefSecret(clusterName, namespace, username
 		}
 	]`, string(usernameBytesB64), string(passwordBytesB64))
 
+	pollOptions := &PollOptions{Interval: CheckResourceInterval, Timeout: c.operationTimeout}
 	if err := c.PatchResource(secret, clusterName, namespace, patchString, types.JSONPatchType, pollOptions); err != nil {
 		return errors.Wrap(err, "unable to save cluster identityRef secret")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
When updating credentials for a cluster, we look for credentials used by the cluster via a secret. With older clusters provisioned before 1.4, the secret with credentials wouldn't exist. While the code had logic to workaround that, it still polled for the non-existent secret every 5 seconds with a 30 minute timeout. This PR removes that polling. 

**Describe testing done for PR**:
No tests changes needed, the branch of logic is already covered with tests

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
