### PR TITLE
Read akoo rbac image from BoM in bootstrap cluster

### DIFF
--- a/pkg/v1/providers/ytt/02_addons/avi/spec.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/avi/spec.lib.yaml
@@ -1,9 +1,10 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:base64", "base64")
-#@ load("/lib/helpers.star", "get_default_tkr_bom_data", "tkg_image_repo")
+#@ load("/lib/helpers.star", "get_default_tkr_bom_data", "get_default_tkg_bom_data", "tkg_image_repo")
 
 #@ akooRepo = get_default_tkr_bom_data().components["ako-operator"][0]
 #@ akoRepo = get_default_tkr_bom_data().components["load-balancer-and-ingress-service"][0]
+#@ rbacRepo = get_default_tkg_bom_data().components["kube_rbac_proxy"][0]
 
 #@ def labels():
 app: tanzu-ako-operator
@@ -15,6 +16,10 @@ app: tanzu-ako-operator
 
 #@ def ako_repo():
 #@  return "{}/{}".format(tkg_image_repo(), akoRepo.images.loadBalancerAndIngressServiceImage.imagePath)
+#@ end
+
+#@ def rbac_image():
+#@  return "{}/{}:{}".format(tkg_image_repo(), rbacRepo.images.kubeRbacProxyControllerImageCapi.imagePath, rbacRepo.images.kubeRbacProxyControllerImageCapi.tag)
 #@ end
 
 #@ def akoo_deployment():
@@ -38,7 +43,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=10
-          image: registry.tkg.vmware.run/cluster-api/kube-rbac-proxy:v0.4.1_vmware.2
+          image: #@ rbac_image() 
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the rbac image akoo is used in bootstrap cluster is hardcoded and it will not going to work in air-gapped environments. So we use tkg_image_repo() and read the rbac image from the BoM file.

**Describe testing done for PR**:
tested locally by creating mgmt cluster and workload cluster. Lb svc works fine.