### PR TITLE
Configure TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE even if TKG_CUST…

### DIFF
--- a/pkg/v1/providers/ytt/02_addons/kapp-controller/kapp-controller_addon_data.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/kapp-controller/kapp-controller_addon_data.lib.yaml
@@ -36,7 +36,7 @@ kappController:
       value: "true"
 #@ end
   config:
-    #@ if tkg_image_repo_customized() and tkg_image_repo_ca_cert():
+    #@ if tkg_image_repo_ca_cert():
     caCerts: #@ base64.decode(tkg_image_repo_ca_cert())
     #@ end
     #@ if data.values.TKG_HTTP_PROXY:

--- a/pkg/v1/providers/ytt/03_customizations/registry_ca_cert.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/registry_ca_cert.yaml
@@ -2,7 +2,7 @@
 #@ load("@ytt:data", "data")
 #@ load("/lib/helpers.star", "tkg_image_repo_customized", "tkg_image_repo_hostname", "tkg_image_repo_ca_cert", "tkg_image_repo_skip_tls_verify")
 
-#@ if tkg_image_repo_customized() and tkg_image_repo_ca_cert() and not tkg_image_repo_skip_tls_verify():
+#@ if tkg_image_repo_ca_cert() and not tkg_image_repo_skip_tls_verify():
 #@overlay/match by=overlay.subset({"kind":"KubeadmControlPlane"})
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1alpha3


### PR DESCRIPTION
…OM_IMAGE_REPOSITORY is unset

**What this PR does / why we need it**:

- Allows configuring caCert data based on
  TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE variable even if
  TKG_CUSTOM_IMAGE_REPOSITORY is not provided
- Above usecase is applicable for proxy configuration where user need to
  provide CA certificate of the registry even if not using custom image
  repository

Signed-off-by: Anuj Chaudhari <anujc@vmware.com>

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
