### PR TITLE
Standalone cluster - use `~/.config/tanzu` config dir

### DIFF
--- a/pkg/v1/tkg/client/delete_standalone.go
+++ b/pkg/v1/tkg/client/delete_standalone.go
@@ -177,12 +177,12 @@ func (c *TkgClient) DeleteStandalone(options DeleteRegionOptions) error {
 
 // RestoreObjects restores all the Cluster API objects from all the namespaces to files
 func (c *TkgClient) RestoreObjects(toKubeconfigPath string, namespace string, standaloneName string) error {
-	homeDir, err := os.UserHomeDir()
+	tceConfigDir, err := getTCEConfigDir()
 	if err != nil {
 		return err
 	}
 
-	directoryBin := filepath.Join(homeDir, ".tanzu", "tce", "objects")
+	directoryBin := filepath.Join(tceConfigDir, "objects")
 	err = os.MkdirAll(directoryBin, 0755)
 	if err != nil {
 		return err
@@ -199,12 +199,12 @@ func (c *TkgClient) RestoreObjects(toKubeconfigPath string, namespace string, st
 }
 
 func RestoreInitOptions(clusterName string) (*InitRegionOptions, error) {
-	homeDir, err := os.UserHomeDir()
+	tceConfigDir, err := getTCEConfigDir()
 	if err != nil {
 		return nil, err
 	}
 
-	initFile := filepath.Join(homeDir, ".tanzu", "tce", "init", clusterName)
+	initFile := filepath.Join(tceConfigDir, "init", clusterName)
 	byObj, err := ioutil.ReadFile(initFile)
 	if err != nil {
 		return nil, err

--- a/pkg/v1/tkg/client/init_standalone.go
+++ b/pkg/v1/tkg/client/init_standalone.go
@@ -27,6 +27,7 @@ import (
 
 	clusterctl "sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
@@ -210,14 +211,22 @@ func (c *TkgClient) InitStandaloneRegion(options *InitRegionOptions) error { //n
 	return nil
 }
 
+func getTCEConfigDir() (string, error) {
+	tanzuConfigDir, err := config.LocalDir()
+	if err != nil {
+		return "", errors.Wrap(err, "unable to get home directory")
+	}
+	return filepath.Join(tanzuConfigDir, "tce"), nil
+}
+
 // SaveObjects saves all the Cluster API objects from all the namespaces to files
 func (c *TkgClient) SaveObjects(fromKubeconfigPath, namespace string) error {
-	homeDir, err := os.UserHomeDir()
+	tceConfigDir, err := getTCEConfigDir()
 	if err != nil {
 		return err
 	}
 
-	directoryBin := filepath.Join(homeDir, ".tanzu", "tce", "objects")
+	directoryBin := filepath.Join(tceConfigDir, "objects")
 	err = os.MkdirAll(directoryBin, 0755)
 	if err != nil {
 		return err
@@ -233,12 +242,12 @@ func (c *TkgClient) SaveObjects(fromKubeconfigPath, namespace string) error {
 }
 
 func SaveInitOptions(options *InitRegionOptions) error {
-	homeDir, err := os.UserHomeDir()
+	tceConfigDir, err := getTCEConfigDir()
 	if err != nil {
 		return err
 	}
 
-	directoryBin := filepath.Join(homeDir, ".tanzu", "tce", "init")
+	directoryBin := filepath.Join(tceConfigDir, "init")
 	err = os.MkdirAll(directoryBin, 0755)
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
Standalone clusters were still using the `~/.tanzu` config folder. This PR updates the standalone logic to use the `~/.config/tanzu` directory

**Which issue(s) this PR fixes**:
N/a

**Describe testing done for PR**:
Built TCE, created and deleted a CAPD standalone cluster

**Special notes for your reviewer**:
Needed for TCE

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-
N/a 

**New PR Checklist**

- [ x ] Ensure PR contains only public links or terms
- [ x ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ x ] Squash the commits in this branch before merge to preserve our git history
- [ x ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ x ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
