### PR TITLE
Fix Bootstrap cluster reuse issue

### DIFF
--- a/pkg/v1/tkg/client/delete_region.go
+++ b/pkg/v1/tkg/client/delete_region.go
@@ -144,6 +144,12 @@ func (c *TkgClient) DeleteRegion(options DeleteRegionOptions) error { //nolint:f
 
 		isStartedRegionalClusterDeletion = true
 
+		// delete ClusterResourceSet objects if present.
+		if err = deleteCRSObjectsIfPresent(regionalClusterClient, options.ClusterName, regionalClusterNamespace); err != nil {
+			// do not fail. these resources only need to be deleted for tkg workload bootstrap clusters
+			log.Warning("Failed to delete ClusterResourceSet resources from management cluster")
+		}
+
 		log.Info("Moving Cluster API objects from management cluster to cleanup cluster...")
 		regionalClusterKubeConfigPath, err := regionalClusterClient.ExportCurrentKubeconfigToFile()
 		if err != nil {


### PR DESCRIPTION
This change removes ClusterResourceSet objects from a management cluster
before deleting the management cluster. This is necessary when using a
tkg workload cluster as bootstrap cluster. In this scenario the
ClusterResourceSet objects cannot be removed once moved to the bootstrap
cluster and this results in future cluster creations failing on this
workload cluster.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Created TKG workload cluster. Used that cluster to create an additional management cluster. Verified the creation of the management cluster using the workload as a bootstrapper. Deleted the second management cluster, again using the workload cluster as a bootstrapper. Finally recreated the second management cluster, again just the same workload cluster. Each step was successful.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
