### PR TITLE
fix l7 bootstrap cluster ako service type error

### DIFF
--- a/pkg/v1/providers/ytt/03_customizations/add_akoo.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/add_akoo.yaml
@@ -45,6 +45,11 @@ dataNetwork:
   name: #@ data.values.AVI_DATA_NETWORK
   cidr: #@ data.values.AVI_DATA_NETWORK_CIDR
 #@ end
+#@overlay/match missing_ok=True
+extraConfigs:
+  ingress:
+    #@overlay/match missing_ok=True
+    serviceType: NodePort
 #@ end
 
 --- #@ crd()


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

**What this PR does / why we need it**:

We support L7 ingress using AKO in Dakar, and when we also use AVI to provide control plane VIPs, it hits an issue that we don't  need L7 ingress in bootstrap cluster and we should enforce the service type to `NodePort`, otherwise, ako in bootstrap cluster will crash.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
