### PR TITLE
Add ensureConfigImages to InitStandalone for standalone clusters

### DIFF
--- a/pkg/v1/tkg/tkgctl/init_standalone.go
+++ b/pkg/v1/tkg/tkgctl/init_standalone.go
@@ -68,6 +68,11 @@ func (t *tkgctl) InitStandalone(options InitRegionOptions) error {
 		return err
 	}
 
+	err = ensureConfigImages(t.configDir, t.tkgConfigUpdaterClient)
+	if err != nil {
+		return err
+	}
+
 	options.CoreProvider, options.BootstrapProvider, options.ControlPlaneProvider, err = t.tkgBomClient.GetDefaultClusterAPIProviders()
 	if err != nil {
 		return err


### PR DESCRIPTION
### Description
Adds the `ensureConfigImages` call to the `InitStandalone` tkgclt client function.

This is in parity to what `InitRegion` is doing and resolves an issue where standalone clusters could not get the clusterctl template file from the Github repo:

```
Setting up standalone cluster...
Validating configuration...
Using infrastructure provider docker:v0.3.22
Generating cluster configuration...
Error: failed to initialize standalone cluster.
Cause: unable to set up management cluster:
  unable to build standalone cluster configuration:
  unable to get template: 
  failed to read "cluster-template-definition-dev.yaml" from provider's repository "infrastructure-docker": 
  failed to download files from GitHub release v0.3.22: failed to get file "cluster-template-definition-dev.yaml" from "v0.3.22" release

```

`ensureConfigImages` is needed since it sets the default providers in the tkg config file. So, for a brand new install of TCE and attempting to instantiate a new standalone cluster, the call to this method will correctly populate the tkg config with the any default providers, primarily CAPD. One workaround that was observed was running a management cluster installation before running the `standalone cluster create`. Since the management cluster init would run this method, we would have a correctly populated tkg config with the CAPD providers.

### Which issue(s) this PR fixes
Related to #348

### Describe testing done for PR
* Built TCE using this branch locally
* `scp` standalone binary to fresh vm`
* `./standalone-cluster create test -i docker`
  * observed cluster being created correctly without error
  * Deleted cluster using `./standalone-cluster delete test`
