### PR TITLE
add serviceaccount to capability API type

### DIFF
--- a/apis/run/v1alpha1/capability_types.go
+++ b/apis/run/v1alpha1/capability_types.go
@@ -10,6 +10,12 @@ import (
 
 // CapabilitySpec defines the desired state of Capability.
 type CapabilitySpec struct {
+	// ServiceAccountName is the name of the service account with which requests
+	// are made to the API server for evaluating queries.
+	// Service account should exist in the same namespace as this resource.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength:=1
+	ServiceAccountName string `json:"serviceAccountName"`
 	// Queries specifies set of queries that are evaluated.
 	// +listType=map
 	// +listMapKey=name

--- a/apis/run/v1alpha1/capability_types.go
+++ b/apis/run/v1alpha1/capability_types.go
@@ -13,8 +13,9 @@ type CapabilitySpec struct {
 	// ServiceAccountName is the name of the service account with which requests
 	// are made to the API server for evaluating queries.
 	// Service account should exist in the same namespace as this resource.
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinLength:=1
+	// When this field is not specified, a default service account with only the
+	// ability to execute GVR queries is used.
+	// +optional
 	ServiceAccountName string `json:"serviceAccountName"`
 	// Queries specifies set of queries that are evaluated.
 	// +listType=map

--- a/config/crd/bases/run.tanzu.vmware.com_capabilities.yaml
+++ b/config/crd/bases/run.tanzu.vmware.com_capabilities.yaml
@@ -183,8 +183,15 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
+              serviceAccountName:
+                description: ServiceAccountName is the name of the service account
+                  with which requests are made to the API server for evaluating queries.
+                  Service account should exist in the same namespace as this resource.
+                minLength: 1
+                type: string
             required:
             - queries
+            - serviceAccountName
             type: object
           status:
             description: Status is the capability status that has results of cluster

--- a/config/crd/bases/run.tanzu.vmware.com_capabilities.yaml
+++ b/config/crd/bases/run.tanzu.vmware.com_capabilities.yaml
@@ -187,11 +187,11 @@ spec:
                 description: ServiceAccountName is the name of the service account
                   with which requests are made to the API server for evaluating queries.
                   Service account should exist in the same namespace as this resource.
-                minLength: 1
+                  When this field is not specified, a default service account with
+                  only the ability to execute GVR queries is used.
                 type: string
             required:
             - queries
-            - serviceAccountName
             type: object
           status:
             description: Status is the capability status that has results of cluster

--- a/docs/api-machinery/capability-discovery.md
+++ b/docs/api-machinery/capability-discovery.md
@@ -142,6 +142,7 @@ kind: Capability
 metadata:
   name: tkg-capabilities
 spec:
+  serviceAccountName: my-service-account
   queries:
     - name: "tanzu-cluster-with-feature-gating"
       groupVersionResources:
@@ -163,6 +164,10 @@ spec:
             name: "vmware-system-nsx"
             apiVersion: "v1"
 ```
+
+To execute the queries with the above CR, a serviceAccountName needs to be specified to give capabilities controller 
+enough privileges to query for resources. Refer to [Security model](#security-model) to understand how a ServiceAccount 
+is used to query for resources.
 
 The capabilities controller:
 
@@ -195,4 +200,68 @@ status:
     objects:
     - found: false
       name: nsx-namespace
+```
+
+### Security Model
+
+Capabilities controller container runs with a service account that has access to all service accounts and secrets in the
+cluster. This service account is not used for querying resources, each Capbilities CR must specify a service account to
+allow the Capabilities CR owner to query for only resources they have access to. This avoids the problem of privilege 
+escalation by not relying on the shared service account to query for resources.
+
+Example use case:
+If you as a user want to query for a particular resource, for example a pod named `nginx` in `foo` namespace, create a 
+Role, RoleBinding and add the ServiceAccount as a subject in the RoleBinding and specify the ServiceAccount in the 
+Capability CR.
+
+Create RBAC rules:
+```
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: my-sa
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: foo
+  name: pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: my-role-binding
+  namespace: foo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-reader
+subjects:
+  - kind: ServiceAccount
+    name: my-sa
+    namespace: default
+```
+
+Create a Capability CR in the same namespace as the ServiceAccount(in this case `default` namespace).
+```
+apiVersion: run.tanzu.vmware.com/v1alpha1
+kind: Capability
+metadata:
+  name: nginx-capability
+spec:
+  serviceAccountName: my-sa
+  queries:
+    - name: "Query for nginx pod"
+      objects:
+        - name: "query nginx"
+          objectReference:
+            kind: "Pod"
+            name: "nginx"
+            apiVersion: "v1"
+            namespace: "foo"
 ```

--- a/pkg/v1/providers/ytt/03_customizations/capabilities/add_capabilities.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/capabilities/add_capabilities.yaml
@@ -193,6 +193,13 @@ spec:
                   x-kubernetes-list-map-keys:
                     - name
                   x-kubernetes-list-type: map
+                serviceAccountName:
+                  description: ServiceAccountName is the name of the service account
+                    with which requests are made to the API server for evaluating queries.
+                    Service account should exist in the same namespace as this resource.
+                    When this field is not specified, a default service account with
+                    only the ability to execute GVR queries is used.
+                  type: string
               required:
                 - queries
               type: object
@@ -372,38 +379,10 @@ rules:
       - patch
       - update
   - apiGroups:
-      - run.tanzu.vmware.com
-    resources:
-      - tanzukubernetesreleases
-      - tanzukubernetesreleases/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - run.tanzu.vmware.com
-    resources:
-      - tanzukubernetesclusters
-      - tanzukubernetesclusters/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - clusterctl.cluster.x-k8s.io
-    resources:
-      - providers
-      - providers/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - ""
     resources:
-      - configmaps
-      - namespaces
-      - nodes
+      - serviceaccounts
+      - secrets
     verbs:
       - get
       - list
@@ -423,6 +402,16 @@ subjects:
   - kind: ServiceAccount
     name: tanzu-capabilities-manager-sa
     namespace: tkg-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tanzu-capabilities-manager
+  name: tanzu-capabilities-manager-default-sa
+  namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: "capabilities/capabilities-controller"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/pkg/v1/sdk/capabilities/config/rbac.yaml
+++ b/pkg/v1/sdk/capabilities/config/rbac.yaml
@@ -32,38 +32,10 @@ rules:
       - patch
       - update
   - apiGroups:
-      - run.tanzu.vmware.com
-    resources:
-      - tanzukubernetesreleases
-      - tanzukubernetesreleases/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - run.tanzu.vmware.com
-    resources:
-      - tanzukubernetesclusters
-      - tanzukubernetesclusters/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - clusterctl.cluster.x-k8s.io
-    resources:
-      - providers
-      - providers/status
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - ""
     resources:
-      - configmaps
-      - namespaces
-      - nodes
+      - serviceaccounts
+      - secrets
     verbs:
       - get
       - list

--- a/pkg/v1/sdk/capabilities/config/rbac.yaml
+++ b/pkg/v1/sdk/capabilities/config/rbac.yaml
@@ -53,3 +53,11 @@ subjects:
   - kind: ServiceAccount
     name: tanzu-capabilities-manager-sa
     namespace: tkg-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tanzu-capabilities-manager
+  name: tanzu-capabilities-manager-default-sa
+  namespace: tkg-system

--- a/pkg/v1/sdk/capabilities/controllers/capability_controller.go
+++ b/pkg/v1/sdk/capabilities/controllers/capability_controller.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -21,9 +22,9 @@ const contextTimeout = 60 * time.Second
 // CapabilityReconciler reconciles a Capability object.
 type CapabilityReconciler struct {
 	client.Client
-	Log                logr.Logger
-	Scheme             *runtime.Scheme
-	ClusterQueryClient *discovery.ClusterQueryClient
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+	Host   string
 }
 
 //+kubebuilder:rbac:groups=run.tanzu.vmware.com,resources=capabilities,verbs=get;list;watch;create;update;patch;delete
@@ -42,6 +43,15 @@ func (r *CapabilityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	config, err := GetConfigForServiceAccount(ctx, req.Namespace, capability.Spec.ServiceAccountName, r.Client, r.Host)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to get config for ClusterQueryClient creation: %w", err)
+	}
+	clusterQueryClient, err := discovery.NewClusterQueryClientForConfig(config)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("unable to create ClusterQueryClient: %w", err)
+	}
+
 	capability.Status.Results = make([]runv1alpha1.Result, len(capability.Spec.Queries))
 
 	for i, query := range capability.Spec.Queries {
@@ -49,11 +59,11 @@ func (r *CapabilityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 		capability.Status.Results[i].Name = query.Name
 		// Query GVRs.
-		capability.Status.Results[i].GroupVersionResources = r.queryGVRs(l, query.GroupVersionResources)
+		capability.Status.Results[i].GroupVersionResources = r.queryGVRs(l, clusterQueryClient, query.GroupVersionResources)
 		// Query Objects.
-		capability.Status.Results[i].Objects = r.queryObjects(l, query.Objects)
+		capability.Status.Results[i].Objects = r.queryObjects(l, clusterQueryClient, query.Objects)
 		// Query PartialSchemas.
-		capability.Status.Results[i].PartialSchemas = r.queryPartialSchemas(l, query.PartialSchemas)
+		capability.Status.Results[i].PartialSchemas = r.queryPartialSchemas(l, clusterQueryClient, query.PartialSchemas)
 	}
 
 	log.Info("Successfully reconciled")
@@ -61,8 +71,8 @@ func (r *CapabilityReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 }
 
 // queryGVRs executes GVR queries and returns results.
-func (r *CapabilityReconciler) queryGVRs(log logr.Logger, queries []runv1alpha1.QueryGVR) []runv1alpha1.QueryResult {
-	return r.executeQueries(log.WithValues("queryType", "GVR"), func() map[string]discovery.QueryTarget {
+func (r *CapabilityReconciler) queryGVRs(log logr.Logger, clusterQueryClient *discovery.ClusterQueryClient, queries []runv1alpha1.QueryGVR) []runv1alpha1.QueryResult {
+	return r.executeQueries(log.WithValues("queryType", "GVR"), clusterQueryClient, func() map[string]discovery.QueryTarget {
 		queryTargets := make(map[string]discovery.QueryTarget)
 		for i := range queries {
 			q := queries[i]
@@ -74,8 +84,8 @@ func (r *CapabilityReconciler) queryGVRs(log logr.Logger, queries []runv1alpha1.
 }
 
 // queryObjects executes Object queries and returns results.
-func (r *CapabilityReconciler) queryObjects(log logr.Logger, queries []runv1alpha1.QueryObject) []runv1alpha1.QueryResult {
-	return r.executeQueries(log.WithValues("queryType", "Object"), func() map[string]discovery.QueryTarget {
+func (r *CapabilityReconciler) queryObjects(log logr.Logger, clusterQueryClient *discovery.ClusterQueryClient, queries []runv1alpha1.QueryObject) []runv1alpha1.QueryResult {
+	return r.executeQueries(log.WithValues("queryType", "Object"), clusterQueryClient, func() map[string]discovery.QueryTarget {
 		queryTargets := make(map[string]discovery.QueryTarget)
 		for i := range queries {
 			q := queries[i]
@@ -87,8 +97,8 @@ func (r *CapabilityReconciler) queryObjects(log logr.Logger, queries []runv1alph
 }
 
 // queryPartialSchemas executes PartialSchema queries and returns results.
-func (r *CapabilityReconciler) queryPartialSchemas(log logr.Logger, queries []runv1alpha1.QueryPartialSchema) []runv1alpha1.QueryResult {
-	return r.executeQueries(log.WithValues("queryType", "PartialSchema"), func() map[string]discovery.QueryTarget {
+func (r *CapabilityReconciler) queryPartialSchemas(log logr.Logger, clusterQueryClient *discovery.ClusterQueryClient, queries []runv1alpha1.QueryPartialSchema) []runv1alpha1.QueryResult {
+	return r.executeQueries(log.WithValues("queryType", "PartialSchema"), clusterQueryClient, func() map[string]discovery.QueryTarget {
 		queryTargets := make(map[string]discovery.QueryTarget)
 		for i := range queries {
 			q := queries[i]
@@ -100,12 +110,12 @@ func (r *CapabilityReconciler) queryPartialSchemas(log logr.Logger, queries []ru
 }
 
 // executeQueries executes queries using the discovery client and stores results.
-func (r *CapabilityReconciler) executeQueries(log logr.Logger, specToQueryTargetFn func() map[string]discovery.QueryTarget) []runv1alpha1.QueryResult {
+func (r *CapabilityReconciler) executeQueries(log logr.Logger, clusterQueryClient *discovery.ClusterQueryClient, specToQueryTargetFn func() map[string]discovery.QueryTarget) []runv1alpha1.QueryResult {
 	var results []runv1alpha1.QueryResult
 	queryTargetsMap := specToQueryTargetFn()
 	for name, queryTarget := range queryTargetsMap {
 		result := runv1alpha1.QueryResult{Name: name}
-		c := r.ClusterQueryClient.Query(queryTarget)
+		c := clusterQueryClient.Query(queryTarget)
 		found, err := c.Execute()
 		if err != nil {
 			result.Error = true

--- a/pkg/v1/sdk/capabilities/controllers/config.go
+++ b/pkg/v1/sdk/capabilities/controllers/config.go
@@ -13,7 +13,7 @@ import (
 )
 
 // GetConfigForServiceAccount returns a *rest.Config which uses the service account for talking to a Kubernetes API server.
-func GetConfigForServiceAccount(ctx context.Context, nsName, saName string, coreClient client.Client, host string) (*rest.Config, error) {
+func GetConfigForServiceAccount(ctx context.Context, coreClient client.Client, nsName, saName, host string) (*rest.Config, error) {
 	serviceAccount := &corev1.ServiceAccount{}
 	if err := coreClient.Get(ctx, client.ObjectKey{
 		Namespace: nsName,

--- a/pkg/v1/sdk/capabilities/controllers/config.go
+++ b/pkg/v1/sdk/capabilities/controllers/config.go
@@ -1,0 +1,65 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetConfigForServiceAccount returns a *rest.Config which uses the service account for talking to a Kubernetes API server.
+func GetConfigForServiceAccount(ctx context.Context, nsName, saName string, coreClient client.Client, host string) (*rest.Config, error) {
+	serviceAccount := &corev1.ServiceAccount{}
+	if err := coreClient.Get(ctx, client.ObjectKey{
+		Namespace: nsName,
+		Name:      saName,
+	}, serviceAccount); err != nil {
+		return nil, fmt.Errorf("couldn't get service account: %w", err)
+	}
+
+	for _, secretRef := range serviceAccount.Secrets {
+		secret := &corev1.Secret{}
+		if err := coreClient.Get(ctx, client.ObjectKey{
+			Namespace: nsName,
+			Name:      secretRef.Name,
+		}, secret); err != nil {
+			return nil, fmt.Errorf("couldn't get service account secret: %w", err)
+		}
+
+		if secret.Type != corev1.SecretTypeServiceAccountToken {
+			continue
+		}
+
+		return buildConfig(secret, host)
+	}
+
+	return nil, fmt.Errorf("expected to find one service account token secret, but found none")
+}
+
+// buildConfig builds a *rest.Config from the service account secret
+func buildConfig(secret *corev1.Secret, host string) (*rest.Config, error) {
+	caBytes, found := secret.Data[corev1.ServiceAccountRootCAKey]
+	if !found {
+		return nil, fmt.Errorf("couldn't find service account token ca")
+	}
+
+	tokenBytes, found := secret.Data[corev1.ServiceAccountTokenKey]
+	if !found {
+		return nil, fmt.Errorf("couldn't find service account token value")
+	}
+
+	tlsClientConfig := rest.TLSClientConfig{
+		CAData: caBytes,
+	}
+
+	return &rest.Config{
+		Host:            host,
+		TLSClientConfig: tlsClientConfig,
+		BearerToken:     string(tokenBytes),
+	}, nil
+}

--- a/pkg/v1/sdk/capabilities/controllers/config_test.go
+++ b/pkg/v1/sdk/capabilities/controllers/config_test.go
@@ -13,12 +13,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestGetConfigForServiceAccount(t *testing.T) {
 	objs, secrets := getTestObjects()
-	cl := fake.NewFakeClientWithScheme(scheme.Scheme, objs...)
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(objs...).Build()
 	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
 	defer cancel()
 	testCases := []struct {
@@ -57,7 +57,7 @@ func TestGetConfigForServiceAccount(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			config, err := GetConfigForServiceAccount(ctx, tc.namespaceName, tc.serviceAccountName, cl, tc.host)
+			config, err := GetConfigForServiceAccount(ctx, cl, tc.namespaceName, tc.serviceAccountName, tc.host)
 			if err != nil {
 				if !tc.returnErr {
 					t.Errorf("error not expected, but got error: %v", err)

--- a/pkg/v1/sdk/capabilities/controllers/config_test.go
+++ b/pkg/v1/sdk/capabilities/controllers/config_test.go
@@ -1,0 +1,139 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck
+)
+
+func TestGetConfigForServiceAccount(t *testing.T) {
+	objs, secrets := getTestObjects()
+	cl := fake.NewFakeClientWithScheme(scheme.Scheme, objs...)
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+	testCases := []struct {
+		description        string
+		serviceAccountName string
+		namespaceName      string
+		client             client.Client
+		host               string
+		returnErr          bool
+	}{
+		{
+			description:        "should successfully return config",
+			serviceAccountName: "foo",
+			namespaceName:      "default",
+			client:             cl,
+			host:               "localhost:31145",
+			returnErr:          false,
+		},
+		{
+			description:        "pass invalid service account",
+			serviceAccountName: "bar",
+			namespaceName:      "default",
+			client:             cl,
+			host:               "localhost:31146",
+			returnErr:          true,
+		},
+		{
+			description:        "pass service account name that doesn't exist",
+			serviceAccountName: "baz",
+			namespaceName:      "default",
+			client:             cl,
+			host:               "localhost:31147",
+			returnErr:          true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			config, err := GetConfigForServiceAccount(ctx, tc.namespaceName, tc.serviceAccountName, cl, tc.host)
+			if err != nil {
+				if !tc.returnErr {
+					t.Errorf("error not expected, but got error: %v", err)
+				}
+			} else if tc.returnErr {
+				if err == nil {
+					t.Errorf("error expected, but got nothing")
+				}
+			} else {
+				if config.BearerToken != string(secrets[tc.serviceAccountName].Data[corev1.ServiceAccountTokenKey]) {
+					t.Errorf("config object is not constructed properly")
+				}
+				res := bytes.Compare(config.TLSClientConfig.CAData, secrets[tc.serviceAccountName].Data[corev1.ServiceAccountRootCAKey])
+				if res != 0 {
+					t.Errorf("config object is not constructed properly")
+				}
+			}
+		})
+	}
+}
+
+func getTestObjects() ([]runtime.Object, map[string]*corev1.Secret) {
+	fooSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"token":     []byte("eyJhbGciOiJSUzI1NiIsImtpZCI6InlSV3V1T3RFWDJvUDN0MGtGQ3BiUVRNUkd0SFotX0hvUHJaMEFuNGF4ZTAifQ.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJkZWZhdWx0Iiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZWNyZXQubmFtZSI6Im15LXNhLXRva2VuLWxuY3FwIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQubmFtZSI6Im15LXNhIiwia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9zZXJ2aWNlLWFjY291bnQudWlkIjoiOGIxMWUwZWMtYTE5Ny00YWMyLWFjNDQtODczZGJjNTMwNGJlIiwic3ViIjoic3lzdGVtOnNlcnZpY2VhY2NvdW50OmRlZmF1bHQ6bXktc2EifQ.je34lgxiMKgwD1Paac_T1FMXwWXCBfhcqXP0A6UEvOAzzOqXhiQGF7jhctRxXfQQITK4CkdVftanRR3OEDNMLU1PW5ulWxmU6SbC3vfJOz3-RO_pNVCfUo-eDinSuZnwn3s23ceOJ3r3bM8rpk0vYdX2EYPDb-2wxr23gTqR5qeNT-muq-jbKWTO0btXV_pTscNqWRFHW2AU5GaPincVUx5mq1-stHWN8kcLoz8_zKdgRrFa_vrQcosVg6BEnLHKv5m_THZGp2mO0bkHWruClDP7KsKL8UZeloL3xcwPkM4VPAoetl9y39oR-JmhwEIHq-a_psiXyXODAN8I72lFiQ%"),
+			"namespace": []byte("default"),
+			"ca.crt":    []byte("-----BEGIN CERTIFICATE-----\nMIIC5zCCAc+gAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl\ncm5ldGVzMB4XDTIxMDgxNzE4NTg1MVoXDTMxMDgxNTE4NTg1MVowFTETMBEGA1UE\nAxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKbD\ndordCz868nGBmvu+IxsyFE4N8xFMm3k8K85omiqsKgr+z2GhiWaO1WHv+EjQFv9k\n1HSJ/jcoh1G7wtc0d1pZbsZWWscR2I50REKcTI55kES12NJg/oGK2fjSN4eQm3Ag\nFQTj0x+9FvB7ydJCZ9xGyMHh8yhGBc2JgU/aR8aeY2yrxnyCTLS1QxU0E1LxBpLg\nHV/JjSWFxULeDQtufP4lNl/Fmi9UFoEKgE5xwgLzTF3UpkCodKwdlVVcsc2VStof\n9peuA5nFXoA6dyHuG+PEDCKH72oYtN3I3NzFFn4ecCRVt2tWQOhsGI1lrEeg1KSS\n0eexH6a2uTv9jxfXG2sCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB\n/wQFMAMBAf8wHQYDVR0OBBYEFAK8hmyS1mlR3ipnSRc/oz07QluJMA0GCSqGSIb3\nDQEBCwUAA4IBAQAfMmX+sPye95+wQAVglnwG8BEFboGb7Jbqd9Lm9i+AWjhVnrqX\nZdnnSh1o8xbuAqVv4etbZruh5wXJw57yMCoGg/K8jJwoGiFDFFHuzzotLt9gkrQv\n2tSazl1yUEDCZcwaymXiJIoqMIjr1bHaAp92ycgx++hSNszwyT3uKbuScYTODTFg\ntbFQy5UTbfvLOBF7DM5sRqpWGSu6fZw6yEgYPAYTmwLN9Cb08onohTouNF71Mobr\n7jdXWv2CLtq7VC3rqpWAO81idsrbx2kxL7UEAONaGNqPfmoZgi1S2jAxBygQrcMV\nsZAZ38xYxkCcxsBIKW+/kL6jramz7IJJYvg4\n-----END CERTIFICATE-----"),
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+
+	fooServiceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Secrets: []corev1.ObjectReference{
+			corev1.ObjectReference{
+				Name: "foo",
+			},
+		},
+	}
+
+	barSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar",
+			Namespace: "default",
+		},
+		Data: map[string][]byte{
+			"namespace": []byte("default"),
+			"ca.crt":    []byte("-----BEGIN CERTIFICATE-----\nMIIC5zCCAc+gAwIBAgIBADANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwprdWJl\ncm5ldGVzMB4XDTIxMDgxNzE4NTg1MVoXDTMxMDgxNTE4NTg1MVowFTETMBEGA1UE\nAxMKa3ViZXJuZXRlczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKbD\ndordCz868nGBmvu+IxsyFE4N8xFMm3k8K85omiqsKgr+z2GhiWaO1WHv+EjQFv9k\n1HSJ/jcoh1G7wtc0d1pZbsZWWscR2I50REKcTI55kES12NJg/oGK2fjSN4eQm3Ag\nFQTj0x+9FvB7ydJCZ9xGyMHh8yhGBc2JgU/aR8aeY2yrxnyCTLS1QxU0E1LxBpLg\nHV/JjSWFxULeDQtufP4lNl/Fmi9UFoEKgE5xwgLzTF3UpkCodKwdlVVcsc2VStof\n9peuA5nFXoA6dyHuG+PEDCKH72oYtN3I3NzFFn4ecCRVt2tWQOhsGI1lrEeg1KSS\n0eexH6a2uTv9jxfXG2sCAwEAAaNCMEAwDgYDVR0PAQH/BAQDAgKkMA8GA1UdEwEB\n/wQFMAMBAf8wHQYDVR0OBBYEFAK8hmyS1mlR3ipnSRc/oz07QluJMA0GCSqGSIb3\nDQEBCwUAA4IBAQAfMmX+sPye95+wQAVglnwG8BEFboGb7Jbqd9Lm9i+AWjhVnrqX\nZdnnSh1o8xbuAqVv4etbZruh5wXJw57yMCoGg/K8jJwoGiFDFFHuzzotLt9gkrQv\n2tSazl1yUEDCZcwaymXiJIoqMIjr1bHaAp92ycgx++hSNszwyT3uKbuScYTODTFg\ntbFQy5UTbfvLOBF7DM5sRqpWGSu6fZw6yEgYPAYTmwLN9Cb08onohTouNF71Mobr\n7jdXWv2CLtq7VC3rqpWAO81idsrbx2kxL7UEAONaGNqPfmoZgi1S2jAxBygQrcMV\nsZAZ38xYxkCcxsBIKW+/kL6jramz7IJJYvg4\n-----END CERTIFICATE-----"),
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+	}
+
+	barServiceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar",
+			Namespace: "default",
+		},
+		Secrets: []corev1.ObjectReference{
+			corev1.ObjectReference{
+				Name: "bar",
+			},
+		},
+	}
+
+	secrets := map[string]*corev1.Secret{
+		"foo": fooSecret,
+		"bar": barSecret,
+	}
+
+	// Objects to track in the fake client.
+	return []runtime.Object{fooServiceAccount, fooSecret, barServiceAccount, barSecret}, secrets
+}


### PR DESCRIPTION
Signed-off-by: yharish991 <yharish991@gmail.com>

**What this PR does / why we need it**:
This PR adds serviceAccountName field to Capability API, allowing users to query for resources only they have access to. RIght now we only let query a few resources that capabilities controller has access to, but if the user A wants to query for other resources they will have to update the RBAC rule used by the controller, this can result in privilege escalation as we are letting users other than A also access resources which they may not have access to.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/535

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

Run the controller by
1. make install - to install CRDs
2. make run - to run the controller
3. Now test the controller behavior:
 

- Apply the below rbac rule with initial access to only namespaces

```
apiVersion: v1
kind: ServiceAccount
metadata:
  name: my-sa
  namespace: default
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: my-clusterrole
rules:
  - apiGroups:
      - config.tanzu.vmware.com
    resources:
      - featuregates
    verbs:
      - create
      - delete
      - get
      - list
      - patch
      - update
      - watch
  - apiGroups:
      - ""
    resources:
      - namespaces
    verbs:
      - create
      - delete
      - get
      - list
      - patch
      - watch
      - update
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: my-clusterrolebinding
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: my-clusterrole
subjects:
  - kind: ServiceAccount
    name: my-sa
    namespace: default
```

- Create nginx pod in default namespace

```
apiVersion: v1
 kind: Pod
 metadata:
   name: nginx
 spec:
   containers:
     - name: front-end
       image: nginx
       ports:
         - containerPort: 80
 ```

- Query for resource


```
apiVersion: run.tanzu.vmware.com/v1alpha1
kind: Capability
metadata:
  name: tkg-capabilities
spec:
  serviceAccountName: my-sa
  queries:
    - name: "tanzu-cluster-with-feature-gating"
      groupVersionResources:
        - name: "tanzu-resource1"
          group: "run.tanzu.vmware.com"
          versions:
            - v1alpha1
          resource: "tanzukubernetesreleases"
        - name: "featuregate-resource"
          group: "config.tanzu.vmware.com"
          versions:
            - v1alpha1
    - name: "nsx-support"
      objects:
        - name: "nsx-namespace"
          objectReference:
            kind: "Namespace"
            name: "tkg-system"
            apiVersion: "v1"
        - name: "nginx pods"
          objectReference:
            kind: "Pod"
            name: "nginx"
            apiVersion: "v1"
            namespace: "default"
```
 

- Observe the status of the CR you created for `nginx pods` query, it should say access to pods is forbidden
-  Update the RBAC rule to include access to pods

```
---
apiVersion: v1
kind: ServiceAccount
metadata:
  name: my-sa
  namespace: default
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: my-clusterrole
rules:
  - apiGroups:
      - config.tanzu.vmware.com
    resources:
      - featuregates
    verbs:
      - create
      - delete
      - get
      - list
      - patch
      - update
      - watch
  - apiGroups:
      - ""
    resources:
      - namespaces
      - pods
    verbs:
      - create
      - delete
      - get
      - list
      - patch
      - watch
      - update
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: my-clusterrolebinding
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: my-clusterrole
subjects:
  - kind: ServiceAccount
    name: my-sa
    namespace: default
```
-   Observe the status of the CR, your `nginx pods` query should be successfully executed

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Introduced serviceAccountName field to Capability API to allow users to only query for resources they have access to.
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
