### PR TITLE
Update management to standalone for SA clusters

### DIFF
--- a/pkg/v1/tkg/client/delete_standalone.go
+++ b/pkg/v1/tkg/client/delete_standalone.go
@@ -134,9 +134,9 @@ func (c *TkgClient) DeleteStandalone(options DeleteRegionOptions) error {
 	isStartedRegionalClusterDeletion = true
 
 	// Move all Cluster API objects from files to cleanup cluster for all namespaces
-	log.Info("Moving all Cluster API objects from bootstrap cluster to management cluster...")
+	log.Info("Moving all Cluster API objects from bootstrap cluster to standalone cluster...")
 	if err = c.RestoreObjects(cleanupClusterKubeconfigPath, regionalClusterNamespace, options.ClusterName); err != nil {
-		return errors.Wrap(err, "unable to move Cluster API objects from bootstrap cluster to management cluster")
+		return errors.Wrap(err, "unable to move Cluster API objects from bootstrap cluster to standalone cluster")
 	}
 
 	log.Info("Waiting for the Cluster API objects to be ready after restore ...")

--- a/pkg/v1/tkg/tkgctl/init_standalone.go
+++ b/pkg/v1/tkg/tkgctl/init_standalone.go
@@ -59,7 +59,6 @@ import (
 
 // InitStandalone initializes standalone cluster
 func (t *tkgctl) InitStandalone(options InitRegionOptions) error {
-	log.Infof("\nSTANDALONE INIT YO YO YO...")
 	var err error
 
 	log.Infof("\nloading cluster config file at %s", options.ClusterConfigFile)
@@ -192,7 +191,7 @@ func (t *tkgctl) InitStandalone(options InitRegionOptions) error {
 		log.Infof("\nSetting up standalone cluster...\n")
 		err = t.tkgClient.InitStandaloneRegion(&optionsIR)
 		if err != nil {
-			return errors.Wrap(err, "unable to set up management cluster")
+			return errors.Wrap(err, "unable to set up standalone cluster")
 		}
 
 		log.Infof("\nStandalone cluster created!\n\n")


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

The standalone cluster creation and deletion code had several references
to management clusters in the output. Some is coming from the UI, but
there were a few cases within the init and delete logic. This tries to
address most of those cases.

Related https://github.com/vmware-tanzu/tce/issues/845

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
