### PR TITLE
Relaxes kube-vip leader election parameters

### DIFF
--- a/pkg/v1/providers/infrastructure-vsphere/v0.7.10/ytt/base-template.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v0.7.10/ytt/base-template.yaml
@@ -145,11 +145,11 @@ spec:
             - name: vip_interface
               value: '${ VIP_NETWORK_INTERFACE }'
             - name: vip_leaseduration
-              value: "15"
+              value: "30"
             - name: vip_renewdeadline
-              value: "10"
+              value: "20"
             - name: vip_retryperiod
-              value: "2"
+              value: "4"
             image: '${ _TKG_KUBE_VIP_IMAGE }'
             imagePullPolicy: IfNotPresent
             name: kube-vip


### PR DESCRIPTION
**What this PR does / why we need it**:
There's a [known issue](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.3.1/rn/VMware-Tanzu-Kubernetes-Grid-131-Release-Notes.html#vsphere-issues-known) with deploying multiple control plane nodes while using kube-vip. The current workaround is to relax the leader election parameters for kube-vip. 

This PR introduces those updated parameters as the new default.

**Which issue(s) this PR fixes**:
Fixes #

**Describe testing done for PR**:
**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.