### PR TITLE
Updated worker count for mgmt clusters (#304)

### DIFF
--- a/pkg/v1/tkg/client/init.go
+++ b/pkg/v1/tkg/client/init.go
@@ -599,6 +599,7 @@ func (c *TkgClient) getMachineCountForMC(plan string) (int, int) {
 	case constants.PlanProd:
 		// update controlplane count for prod plan
 		controlPlaneMachineCount = constants.DefaultProdControlPlaneMachineCount
+		workerMachineCount = constants.DefaultProdWorkerMachineCountForManagementCluster
 	default:
 		// For custom plan use config variables to determine the count
 		// Verify there is no error in retrieving this and controlplane count is odd number

--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -584,9 +584,17 @@ func (c *TkgClient) ConfigureAndValidateManagementClusterConfiguration(options *
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
+	isProdPlan := options.Plan == constants.PlanProd
+	var workerCount int64
+	if isProdPlan {
+		workerCount = constants.DefaultProdWorkerMachineCountForManagementCluster
+	} else {
+		workerCount = constants.DefaultWorkerMachineCountForManagementCluster
+	}
+
 	switch name {
 	case AWSProviderName:
-		err = c.ConfigureAndValidateAWSConfig(tkrVersion, options.NodeSizeOptions, skipValidation, options.Plan == constants.PlanProd, constants.DefaultWorkerMachineCountForManagementCluster, nil, true)
+		err = c.ConfigureAndValidateAWSConfig(tkrVersion, options.NodeSizeOptions, skipValidation, isProdPlan, workerCount, nil, true)
 	case VSphereProviderName:
 		err := c.ConfigureAndValidateVsphereConfig(tkrVersion, options.NodeSizeOptions, options.VsphereControlPlaneEndpoint, skipValidation, nil)
 		if err != nil {
@@ -597,7 +605,7 @@ func (c *TkgClient) ConfigureAndValidateManagementClusterConfiguration(options *
 			log.Warningf("WARNING: The control plane endpoint '%s' might already used by other cluster. This might affect the deployment of the cluster", options.VsphereControlPlaneEndpoint)
 		}
 	case AzureProviderName:
-		err = c.ConfigureAndValidateAzureConfig(tkrVersion, options.NodeSizeOptions, skipValidation, options.Plan == constants.PlanProd, constants.DefaultWorkerMachineCountForManagementCluster, nil, true)
+		err = c.ConfigureAndValidateAzureConfig(tkrVersion, options.NodeSizeOptions, skipValidation, isProdPlan, workerCount, nil, true)
 	case DockerProviderName:
 		err = c.ConfigureAndValidateDockerConfig(tkrVersion, options.NodeSizeOptions, skipValidation)
 	case WindowsVSphereProviderName:
@@ -1347,6 +1355,7 @@ func (c *TkgClient) ConfigureAndValidateCNIType(cniType string) error {
 
 // DistributeMachineDeploymentWorkers distributes machine deployment for worker nodes
 func (c *TkgClient) DistributeMachineDeploymentWorkers(workerMachineCount int64, isProdConfig, isManagementCluster bool, infraProviderName string) ([]int, error) { // nolint:gocyclo
+	log.V(4).Infof("Worker Machine Count %d", workerMachineCount)
 	workerCounts := make([]int, 3)
 	if infraProviderName != "aws" && infraProviderName != "azure" {
 		workerCounts[0] = int(workerMachineCount)

--- a/pkg/v1/tkg/constants/defaults.go
+++ b/pkg/v1/tkg/constants/defaults.go
@@ -11,11 +11,12 @@ import (
 const (
 	DefaultCNIType = "antrea"
 
-	DefaultDevControlPlaneMachineCount              = 1
-	DefaultProdControlPlaneMachineCount             = 3
-	DefaultWorkerMachineCountForManagementCluster   = 1
-	DefaultDevWorkerMachineCountForWorkloadCluster  = 1
-	DefaultProdWorkerMachineCountForWorkloadCluster = 3
+	DefaultDevControlPlaneMachineCount                = 1
+	DefaultProdControlPlaneMachineCount               = 3
+	DefaultWorkerMachineCountForManagementCluster     = 1
+	DefaultProdWorkerMachineCountForManagementCluster = 3
+	DefaultDevWorkerMachineCountForWorkloadCluster    = 1
+	DefaultProdWorkerMachineCountForWorkloadCluster   = 3
 
 	DefaultOperationTimeout            = 30 * time.Second
 	DefaultLongRunningOperationTimeout = 30 * time.Minute


### PR DESCRIPTION
**What this PR does / why we need it**:
Recreating the PR from https://github.com/vmware-tanzu/tanzu-framework/pull/304

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
