### PR TITLE
Fix CNI and CPI addons registration

### DIFF
--- a/pkg/v1/providers/ytt/02_addons/cni/add_cni.yaml
+++ b/pkg/v1/providers/ytt/02_addons/cni/add_cni.yaml
@@ -11,9 +11,14 @@
 #@ end
 
 #! skip generation of CNI for TKGs and on cluster upgrade
-#@ if data.values.PROVIDER_TYPE != "tkg-service-vsphere" and not data.values.FILTER_BY_ADDON_TYPE:
+#@ if data.values.PROVIDER_TYPE != "tkg-service-vsphere":
 
-#@ if data.values.CNI == "calico":
+#! FILTER_BY_ADDON_TYPE is used to indicate INSTALL or UPGRADE case.
+#! FILTER_BY_ADDON_TYPE is empty during INSTALL and set to "kapp-controller, tanzu-addons-manager, tkr-controller" during UPGRADE.
+#! The below check ensures this ytt template is run during INSTALL or when "cni/calico" is set in FILTER_BY_ADDON_TYPE.
+#! "cni/calico" is never set by tanzu cli code and only set manually if anyone wants to register calico addon.
+
+#@ if data.values.CNI == "calico" and (not data.values.FILTER_BY_ADDON_TYPE or "cni/calico" in data.values.FILTER_BY_ADDON_TYPE):
 #@ load("/vendir/cni/cni.lib.yaml", "cni_calico_lib")
 
 #@ load("calico/calico_addon_data.lib.yaml", "calicodatavalues")
@@ -68,7 +73,12 @@ stringData:
 
 #@ end
 
-#@ if data.values.CNI == "antrea":
+#! FILTER_BY_ADDON_TYPE is used to indicate INSTALL or UPGRADE case.
+#! FILTER_BY_ADDON_TYPE is empty during INSTALL and set to "kapp-controller, tanzu-addons-manager, tkr-controller" during UPGRADE.
+#! The below check ensures this ytt template is run during INSTALL or when "cni/antrea" is set in FILTER_BY_ADDON_TYPE.
+#! "cni/antrea" is never set by tanzu cli code and only set manually if anyone wants to register antrea addon.
+
+#@ if data.values.CNI == "antrea" and (not data.values.FILTER_BY_ADDON_TYPE or "cni/antrea" in data.values.FILTER_BY_ADDON_TYPE):
 #@ load("/vendir/cni/cni.lib.yaml", "cni_antrea_lib")
 #@ load("antrea/antrea_addon_data.lib.yaml", "antreadatavalues")
 #@ load("antrea/antrea_overlay.lib.yaml", "updateantreaimage")

--- a/pkg/v1/providers/ytt/02_addons/cpi/cpi_secret_crs.yaml
+++ b/pkg/v1/providers/ytt/02_addons/cpi/cpi_secret_crs.yaml
@@ -8,8 +8,12 @@
 #@ load("cpi_overlay.lib.yaml", "update_vsphere_cpi_image", "remove_versioned_annotation")
 #@ load("/vendir/vsphere_cpi/vsphere_cpi.lib.yaml", "vsphere_cpi_lib")
 
-#! skip generation of CPI on cluster upgrade
-#@ if data.values.PROVIDER_TYPE == "vsphere" and data.values.TKG_CLUSTER_ROLE != "workload" and not data.values.FILTER_BY_ADDON_TYPE:
+#! FILTER_BY_ADDON_TYPE is used to indicate INSTALL or UPGRADE case.
+#! FILTER_BY_ADDON_TYPE is empty during INSTALL and set to "kapp-controller, tanzu-addons-manager, tkr-controller" during UPGRADE.
+#! The below check ensures this ytt template is run during INSTALL or when "cloud-provider/vsphere-cpi" is set in FILTER_BY_ADDON_TYPE.
+#! "cloud-provider/vsphere-cpi" is never set by tanzu cli code and only set manually if anyone wants to register vsphere-cpi addon.
+
+#@ if data.values.PROVIDER_TYPE == "vsphere" and data.values.TKG_CLUSTER_ROLE != "workload" and (not data.values.FILTER_BY_ADDON_TYPE or "cloud-provider/vsphere-cpi" in data.values.FILTER_BY_ADDON_TYPE):
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Signed-off-by: Shyaam Nagarajan <nagarajans@vmware.com>

**What this PR does / why we need it**:
Fixes FILTER_BY_ADDONS check in CNI and CPI templates to also run if user explicitly sets cni or cpi as addon type.

**Which issue(s) this PR fixes**:
Addons can be registered with management-cluster for older clusters that are upgraded and dont have the addons in the previous versions. But this wasnt working because the CNI and CPI ytt templates were executed only for install case due to the presence of `not data.values.FILTER_BY_ADDONS` check. 

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
