### PR TITLE
Split TKR source controller into separate reconciliation loops

### DIFF
--- a/pkg/v1/tkr/controllers/source/helper.go
+++ b/pkg/v1/tkr/controllers/source/helper.go
@@ -5,10 +5,9 @@ package source
 
 import (
 	"context"
+	"regexp"
 	"strconv"
 	"strings"
-
-	"regexp"
 	"time"
 
 	"github.com/pkg/errors"
@@ -19,12 +18,10 @@ import (
 
 	runv1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/constants"
-	types "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/types"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/types"
 )
 
 const (
-	// VMwareVersionSeparator is the separator to use
-	VMwareVersionSeparator = "+vmware."
 	// InitialDiscoveryRetry is the number of retries for the initial TKR sync-up
 	InitialDiscoveryRetry = 10
 	// GetManagementClusterInfoFailedError is the error message for not getting management cluster info
@@ -220,10 +217,6 @@ func (r *reconciler) GetManagementClusterVersion(ctx context.Context) (string, e
 	return "", errors.New(GetManagementClusterInfoFailedError)
 }
 
-func isManagementClusterNotReadyError(err error) bool {
-	return strings.Contains(err.Error(), GetManagementClusterInfoFailedError)
-}
-
 func hasDeprecateUpgradeAvailableCondition(conditions []clusterv1.Condition) bool {
 	for _, c := range conditions {
 		if c.Type == runv1.ConditionUpgradeAvailable {
@@ -231,4 +224,20 @@ func hasDeprecateUpgradeAvailableCondition(conditions []clusterv1.Condition) boo
 		}
 	}
 	return false
+}
+
+type errorSlice []error
+
+func (e errorSlice) Error() string {
+	if len(e) == 0 {
+		return ""
+	}
+	sb := &strings.Builder{}
+	for i, err := range e {
+		if i != 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(err.Error())
+	}
+	return sb.String()
 }

--- a/pkg/v1/tkr/controllers/source/suite_test.go
+++ b/pkg/v1/tkr/controllers/source/suite_test.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	// The fake package is deprecated, though there is talk of undeprecating it
@@ -44,7 +46,6 @@ var bomContent17 []byte
 var bomContent18 []byte
 var bomContent193 []byte
 var bomContent191 []byte
-var badBom []byte
 var metadataContent []byte
 
 func TestAPIs(t *testing.T) {
@@ -64,7 +65,6 @@ var _ = BeforeSuite(func() {
 	bomContent18, _ = os.ReadFile("../../fakes/boms/bom-v1.18.10+vmware.1.yaml")
 	bomContent193, _ = os.ReadFile("../../fakes/boms/bom-v1.19.3+vmware.1.yaml")
 	bomContent191, _ = os.ReadFile("../../fakes/boms/bom-v1.19.1+vmware.1.yaml")
-	badBom, _ = os.ReadFile("../../fakes/boms/bad-bom.yaml")
 	metadataContent, _ = os.ReadFile("../../fakes/boms/metadata.yaml")
 })
 
@@ -76,8 +76,6 @@ var _ = Describe("SyncRelease", func() {
 		objects      []runtime.Object
 		r            reconciler
 		err          error
-		added        []runv1.TanzuKubernetesRelease
-		existing     []runv1.TanzuKubernetesRelease
 	)
 
 	JustBeforeEach(func() {
@@ -92,27 +90,40 @@ var _ = Describe("SyncRelease", func() {
 			bomImage: "my-registry.io/tkrs",
 		}
 
-		added, existing, err = r.SyncRelease(context.Background())
+		err = r.SyncRelease(context.Background())
 	})
 
-	Context("When BOM images with proper content are published, and no TKR has been created", func() {
+	Context("When BOM images with proper content are published", func() {
 
 		BeforeEach(func() {
 			fakeRegistry = &fakes.Registry{}
 			fakeRegistry.ListImageTagsReturns([]string{"bom-v1.17.13+vmware.1", "bom-v1.18.10+vmware.1", "bom-v1.19.3+vmware.1"}, nil)
 
-			fakeRegistry.GetFileReturnsOnCall(0, bomContent17, nil)
-			fakeRegistry.GetFileReturnsOnCall(1, bomContent18, nil)
-			fakeRegistry.GetFileReturnsOnCall(2, bomContent193, nil)
+			// we'll fetch BOM metadata image first
+			fakeRegistry.ListImageTagsReturnsOnCall(0, []string{"v1"}, nil)
+			fakeRegistry.GetFileReturnsOnCall(0, metadataContent, nil)
+
+			fakeRegistry.GetFileReturnsOnCall(1, bomContent17, nil)
+			fakeRegistry.GetFileReturnsOnCall(2, bomContent18, nil)
+			fakeRegistry.GetFileReturnsOnCall(3, bomContent193, nil)
 			objects = []runtime.Object{}
 
 		})
 
-		It("should create TKRs and BOM ConfigMap", func() {
+		It("should create BOM ConfigMaps", func() {
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(added)).To(Equal(3))
-			Expect(len(existing)).To(Equal(0))
-			Expect(fakeRegistry.GetFileCallCount()).To(Equal(3))
+
+			metadata, err := r.compatibilityMetadata(r.ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metadata).ToNot(BeNil())
+
+			cmList := &corev1.ConfigMapList{}
+			opts := []client.ListOption{
+				client.InNamespace(constants.TKRNamespace),
+				client.HasLabels{constants.BomConfigMapTKRLabel},
+			}
+			Expect(fakeClient.List(context.Background(), cmList, opts...)).To(Succeed())
+			Expect(len(cmList.Items)).To(Equal(3))
 		})
 
 	})
@@ -121,42 +132,29 @@ var _ = Describe("SyncRelease", func() {
 
 		BeforeEach(func() {
 			fakeRegistry = &fakes.Registry{}
-			fakeRegistry.ListImageTagsReturns([]string{"bom-v1.17.13+vmware.1", "bom-v1.18.10+vmware.1", "bom-v1.19.3+vmware."}, nil)
-			fakeRegistry.GetFileReturnsOnCall(0, bomContent193, nil)
+			fakeRegistry.ListImageTagsReturns([]string{"bom-v1.17.13+vmware.1", "bom-v1.18.10+vmware.1", "bom-v1.19.3+vmware.1"}, nil)
+
+			// we'll fetch BOM metadata image first
+			fakeRegistry.ListImageTagsReturnsOnCall(0, []string{"v1"}, nil)
+			fakeRegistry.GetFileReturnsOnCall(0, metadataContent, nil)
+
+			fakeRegistry.GetFileReturnsOnCall(1, bomContent193, nil)
 
 			cm1 := newConfigMap(version11713, map[string]string{constants.BomConfigMapTKRLabel: version11713}, map[string]string{constants.BomConfigMapImageTagAnnotation: "bom-v1.17.13+vmware.1"}, bomContent17)
 			cm2 := newConfigMap(version11810, map[string]string{constants.BomConfigMapTKRLabel: version11810}, map[string]string{constants.BomConfigMapImageTagAnnotation: "bom-v1.18.10+vmware.1"}, bomContent18)
 
-			tkr1, _ := NewTkrFromBom(version11713, bomContent17)
-			tkr2, _ := NewTkrFromBom(version11810, bomContent18)
-			objects = []runtime.Object{cm1, cm2, &tkr1, &tkr2}
+			objects = []runtime.Object{cm1, cm2}
 		})
 
-		It("should create a new TKR based on the new BOM", func() {
+		It("should create a new ConfigMap based on the new BOM", func() {
 			Expect(err).ToNot(HaveOccurred())
-			Expect(fakeRegistry.GetFileCallCount()).To(Equal(1))
-			Expect(len(added)).To(Equal(1))
-			Expect(len(existing)).To(Equal(2))
-		})
-	})
-
-	Context("When the BOM ConfigMap exists, but the corresponding TKR is missing", func() {
-
-		BeforeEach(func() {
-			fakeRegistry = &fakes.Registry{}
-			fakeRegistry.ListImageTagsReturns([]string{"bom-v1.17.13+vmware.1", "bom-v1.18.10+vmware.1"}, nil)
-			cm1 := newConfigMap(version11713, map[string]string{constants.BomConfigMapTKRLabel: version11713}, map[string]string{constants.BomConfigMapImageTagAnnotation: "bom-v1.17.13+vmware.1"}, bomContent17)
-			cm2 := newConfigMap(version11810, map[string]string{constants.BomConfigMapTKRLabel: version11810}, map[string]string{constants.BomConfigMapImageTagAnnotation: "bom-v1.18.10+vmware.1"}, bomContent18)
-			tkr1, _ := NewTkrFromBom(version11713, bomContent17)
-			objects = []runtime.Object{cm1, cm2, &tkr1}
-		})
-
-		It("should generate the TKR from the BOM ConfigMap", func() {
-			Expect(err).ToNot(HaveOccurred())
-			Expect(fakeRegistry.GetFileCallCount()).To(Equal(0))
-			Expect(len(added)).To(Equal(1))
-			Expect(len(existing)).To(Equal(1))
-
+			cmList := &corev1.ConfigMapList{}
+			opts := []client.ListOption{
+				client.InNamespace(constants.TKRNamespace),
+				client.HasLabels{constants.BomConfigMapTKRLabel},
+			}
+			Expect(fakeClient.List(context.Background(), cmList, opts...)).To(Succeed())
+			Expect(len(cmList.Items)).To(Equal(3))
 		})
 	})
 
@@ -164,13 +162,12 @@ var _ = Describe("SyncRelease", func() {
 
 var _ = Describe("UpdateTKRCompatibleCondition", func() {
 	var (
-		tkrs         []runv1.TanzuKubernetesRelease
-		fakeClient   client.Client
-		fakeRegistry *fakes.Registry
-		scheme       *runtime.Scheme
-		objects      []runtime.Object
-		r            reconciler
-		err          error
+		tkrs       []runv1.TanzuKubernetesRelease
+		fakeClient client.Client
+		scheme     *runtime.Scheme
+		objects    []runtime.Object
+		r          reconciler
+		err        error
 	)
 
 	JustBeforeEach(func() {
@@ -181,7 +178,6 @@ var _ = Describe("UpdateTKRCompatibleCondition", func() {
 			client:   fakeClient,
 			log:      ctrllog.Log,
 			scheme:   scheme,
-			registry: fakeRegistry,
 			bomImage: "my-registry.io/tkrs",
 		}
 		err = r.UpdateTKRCompatibleCondition(context.Background(), tkrs)
@@ -189,23 +185,18 @@ var _ = Describe("UpdateTKRCompatibleCondition", func() {
 
 	Context("When reconcile the compatible condition of the TKRs", func() {
 		BeforeEach(func() {
-			fakeRegistry = &fakes.Registry{}
-			fakeRegistry.ListImageTagsReturns([]string{"v0", "v1", "v2"}, nil)
-			fakeRegistry.GetFileReturnsOnCall(0, nil, errors.New("cannot retrieve file from the image"))
-			fakeRegistry.GetFileReturnsOnCall(1, metadataContent, nil)
-
 			tkr1, _ := NewTkrFromBom(version11713, bomContent17)
 			tkr2, _ := NewTkrFromBom(version11810, bomContent18)
 			tkr3, _ := NewTkrFromBom(version1193, bomContent193)
 			tkr4, _ := NewTkrFromBom(version1191, bomContent191)
+			cm := newMetadataConfigMap(metadataContent)
 			tkrs = []runv1.TanzuKubernetesRelease{tkr1, tkr4, tkr3, tkr2}
 
-			mgmtcluster := newManagemntCluster("mgmt-cluster", map[string]string{constants.ManagememtClusterRoleLabel: ""}, map[string]string{constants.TKGVersionKey: "v1.1"})
-			objects = []runtime.Object{mgmtcluster}
+			mgmtcluster := newManagementCluster(map[string]string{constants.ManagememtClusterRoleLabel: ""}, map[string]string{constants.TKGVersionKey: "v1.1"})
+			objects = []runtime.Object{mgmtcluster, cm}
 		})
 		It("should update the TKRs' compatible condition", func() {
 			Expect(err).ToNot(HaveOccurred())
-			Expect(fakeRegistry.GetFileCallCount()).To(Equal(2))
 			for _, tkr := range tkrs {
 				if tkr.Name == version1193 {
 					status, msg := getConditionStatusAndMessage(tkr.Status.Conditions, runv1.ConditionCompatible)
@@ -295,10 +286,12 @@ var _ = Describe("initialReconcile", func() {
 		stopChan     chan struct{}
 	)
 
-	JustBeforeEach(func() {
+	BeforeEach(func() {
 		scheme = runtime.NewScheme()
 		addToScheme(scheme)
 		fakeClient = fake.NewFakeClientWithScheme(scheme, objects...)
+	})
+	JustBeforeEach(func() {
 		r = reconciler{
 			client:                     fakeClient,
 			log:                        ctrllog.Log,
@@ -307,107 +300,185 @@ var _ = Describe("initialReconcile", func() {
 			bomImage:                   "my-registry.io/tkrs",
 			compatibilityMetadataImage: "",
 		}
-		initSyncDone := make(chan bool)
 		ticker := time.NewTicker(time.Second)
 		stopChan = make(chan struct{})
-		go r.initialReconcile(ticker, initSyncDone, stopChan, 3)
 		go func(stopChan chan struct{}) {
 			time.Sleep(time.Second * 5)
 			stopChan <- struct{}{}
 		}(stopChan)
-
-		<-initSyncDone
+		r.initialReconcile(ticker, stopChan, 3)
 	})
 
-	Context("When cluster is not ready,", func() {
+	Context("When in initial sync-up stage", func() {
 		BeforeEach(func() {
 			fakeRegistry = &fakes.Registry{}
 			fakeRegistry.ListImageTagsReturns([]string{"bom-v1.17.13+vmware.1", "bom-v1.18.10+vmware.1", "bom-v1.19.3+vmware.1"}, nil)
 
-			fakeRegistry.GetFileReturnsOnCall(0, bomContent17, nil)
-			fakeRegistry.GetFileReturnsOnCall(1, bomContent18, nil)
-			fakeRegistry.GetFileReturnsOnCall(2, bomContent193, nil)
+			// we'll fetch BOM metadata image first
+			fakeRegistry.ListImageTagsReturnsOnCall(0, []string{"v1"}, nil)
+			fakeRegistry.GetFileReturnsOnCall(0, metadataContent, nil)
 
-			for i := 3; i < 10; i++ {
-				fakeRegistry.GetFileReturnsOnCall(i, metadataContent, nil)
-			}
-
-			stopChan = make(chan struct{})
-
+			fakeRegistry.GetFileReturnsOnCall(1, bomContent17, nil)
+			fakeRegistry.GetFileReturnsOnCall(2, bomContent18, nil)
+			fakeRegistry.GetFileReturnsOnCall(3, bomContent193, nil)
 		})
-		It("should keep the controller in intitial sync-up stage", func() {
-			Expect(fakeRegistry.ListImageTagsCallCount()).Should(BeNumerically(">", 3))
-			tkrList := &runv1.TanzuKubernetesReleaseList{}
-			err := fakeClient.List(context.Background(), tkrList)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(tkrList.Items)).To(Equal(3))
-			for _, tkr := range tkrList.Items {
-				status, _ := getConditionStatusAndMessage(tkr.Status.Conditions, runv1.ConditionCompatible)
-				Expect(status).To(Equal(corev1.ConditionUnknown))
-			}
+		It("retrieve the list of images at least once", func() {
+			Expect(fakeRegistry.ListImageTagsCallCount()).Should(BeNumerically(">=", 1))
 		})
 	})
 
-	Context("When cluster is ready, but the bom content can not be retrieved", func() {
+	Context("When cluster is ready, but the some BOM content can not be retrieved", func() {
 		BeforeEach(func() {
 			fakeRegistry = &fakes.Registry{}
 			fakeRegistry.ListImageTagsReturns([]string{"bom-v1.17.13+vmware.1", "bom-v1.18.10+vmware.1", "bom-v1.19.3+vmware.1"}, nil)
-			for i := 0; i < 12; i += 3 {
-				fakeRegistry.ListImageTagsReturnsOnCall(i, []string{"bom-v1.17.13+vmware.1", "bom-v1.18.10+vmware.1", "bom-v1.19.3+vmware.1"}, nil)
-				fakeRegistry.ListImageTagsReturnsOnCall(i+1, []string{"v1"}, nil)
-				fakeRegistry.ListImageTagsReturnsOnCall(i+2, []string{"bom-v1.17.13+vmware.1", "bom-v1.18.10+vmware.1", "bom-v1.19.3+vmware.1"}, nil)
-			}
-			fakeRegistry.GetFileReturnsOnCall(0, bomContent17, nil)
-			fakeRegistry.GetFileReturnsOnCall(1, bomContent18, nil)
+
+			// we'll fetch BOM metadata image first
+			fakeRegistry.ListImageTagsReturnsOnCall(0, []string{"v1"}, nil)
+			fakeRegistry.GetFileReturnsOnCall(0, metadataContent, nil)
+
+			fakeRegistry.GetFileReturnsOnCall(1, bomContent17, nil)
 			fakeRegistry.GetFileReturnsOnCall(2, nil, errors.New("fake-error"))
-			fakeRegistry.GetFileReturnsOnCall(3, metadataContent, nil)
-			for i := 4; i < 16; i += 4 {
-				fakeRegistry.GetFileReturnsOnCall(i+2, nil, errors.New("fake-error"))
-				fakeRegistry.GetFileReturnsOnCall(i+3, metadataContent, nil)
-			}
-			mgmtcluster := newManagemntCluster("mgmt-cluster", map[string]string{constants.ManagememtClusterRoleLabel: ""}, map[string]string{constants.TKGVersionKey: "v1.1"})
+			fakeRegistry.GetFileReturnsOnCall(3, bomContent193, nil)
+			mgmtcluster := newManagementCluster(map[string]string{constants.ManagememtClusterRoleLabel: ""}, map[string]string{constants.TKGVersionKey: "v1.1"})
 			objects = []runtime.Object{mgmtcluster}
+			fakeClient = fake.NewFakeClientWithScheme(scheme, objects...)
 		})
 
-		It("should exist from initial sync-up stage after 3 retries", func() {
-			// 6 --> 3*(list_bom_tag + list_metadata_tag + initial-sync-up-check)
-			Expect(fakeRegistry.ListImageTagsCallCount()).Should(BeNumerically("==", 9))
-			tkrList := &runv1.TanzuKubernetesReleaseList{}
-			err := fakeClient.List(context.Background(), tkrList)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(len(tkrList.Items)).To(Equal(2))
-			for _, tkr := range tkrList.Items {
-				status, _ := getConditionStatusAndMessage(tkr.Status.Conditions, runv1.ConditionCompatible)
-				Expect(status).To(Equal(corev1.ConditionTrue))
+		It("should retrieve what can be retrieved and create appropriate ConfigMaps", func() {
+			cmList := &corev1.ConfigMapList{}
+			opts := []client.ListOption{
+				client.InNamespace(constants.TKRNamespace),
+				client.HasLabels{constants.BomConfigMapTKRLabel},
 			}
+			Expect(fakeClient.List(context.Background(), cmList, opts...)).To(Succeed())
+			Expect(len(cmList.Items)).To(Equal(2))
+
+			metadata, err := r.compatibilityMetadata(r.ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metadata).ToNot(BeNil())
 		})
 	})
 
 	Context("When cluster is ready, and bom content can be retrieved", func() {
 		BeforeEach(func() {
-
 			fakeRegistry = &fakes.Registry{}
+			fakeRegistry.ListImageTagsReturns([]string{"bom-v1.17.13+vmware.1", "bom-v1.18.10+vmware.1", "bom-v1.19.3+vmware.1"}, nil)
 
-			fakeRegistry.ListImageTagsReturnsOnCall(0, []string{"bom-v1.17.13+vmware.1", "bom-v1.18.10+vmware.1", "bom-v1.19.3+vmware.1"}, nil)
-			fakeRegistry.ListImageTagsReturnsOnCall(1, []string{"v1"}, nil)
-			fakeRegistry.ListImageTagsReturnsOnCall(2, []string{"bom-v1.17.13+vmware.1", "bom-v1.18.10+vmware.1", "bom-v1.19.3+vmware.1"}, nil)
+			// we'll fetch BOM metadata image first
+			fakeRegistry.ListImageTagsReturnsOnCall(0, []string{"v1"}, nil)
+			fakeRegistry.GetFileReturnsOnCall(0, metadataContent, nil)
 
-			fakeRegistry.GetFileReturnsOnCall(0, bomContent17, nil)
-			fakeRegistry.GetFileReturnsOnCall(1, bomContent18, nil)
-			fakeRegistry.GetFileReturnsOnCall(2, bomContent193, nil)
-			fakeRegistry.GetFileReturnsOnCall(3, metadataContent, nil)
-			mgmtcluster := newManagemntCluster("mgmt-cluster", map[string]string{constants.ManagememtClusterRoleLabel: ""}, map[string]string{constants.TKGVersionKey: "v1.1"})
+			fakeRegistry.GetFileReturnsOnCall(1, bomContent17, nil)
+			fakeRegistry.GetFileReturnsOnCall(2, bomContent18, nil)
+			fakeRegistry.GetFileReturnsOnCall(3, bomContent193, nil)
+
+			mgmtcluster := newManagementCluster(map[string]string{constants.ManagememtClusterRoleLabel: ""}, map[string]string{constants.TKGVersionKey: "v1.1"})
 			objects = []runtime.Object{mgmtcluster}
+			fakeClient = fake.NewFakeClientWithScheme(scheme, objects...)
 		})
-		It("should exist from initial sync-up stage after the first try", func() {
-			// 3 --> list_bom_tag + list_metadata_tag + initial-sync-up-check
-			Expect(fakeRegistry.ListImageTagsCallCount()).Should(BeNumerically("==", 3))
-			tkrList := &runv1.TanzuKubernetesReleaseList{}
-			err := fakeClient.List(context.Background(), tkrList)
+
+		It("should create the metadata ConfigMap and all BOM ConfigMaps", func() {
+			cmList := &corev1.ConfigMapList{}
+			opts := []client.ListOption{
+				client.InNamespace(constants.TKRNamespace),
+				client.HasLabels{constants.BomConfigMapTKRLabel},
+			}
+			Expect(fakeClient.List(context.Background(), cmList, opts...)).To(Succeed())
+			Expect(len(cmList.Items)).To(Equal(3))
+
+			metadata, err := r.compatibilityMetadata(r.ctx)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(len(tkrList.Items)).To(Equal(3))
-			for _, tkr := range tkrList.Items {
+			Expect(metadata).ToNot(BeNil())
+		})
+
+		When("creating a ConfigMap returns an error", func() {
+			BeforeEach(func() {
+				fakeClient = clientErrOnCreate{Client: fakeClient, err: errors.New("EXPECTED"), errOnName: "v1.18.10---vmware.1"}
+				fakeClient = clientErrOnCreate{Client: fakeClient, err: errors.New("EXPECTED"), errOnName: constants.BOMMetadataConfigMapName}
+			})
+
+			It("should create the metadata ConfigMap and all BOM ConfigMaps except those affected by the error", func() {
+				cmList := &corev1.ConfigMapList{}
+				opts := []client.ListOption{
+					client.InNamespace(constants.TKRNamespace),
+					client.HasLabels{constants.BomConfigMapTKRLabel},
+				}
+				Expect(fakeClient.List(context.Background(), cmList, opts...)).To(Succeed())
+				Expect(len(cmList.Items)).To(Equal(2)) // not all 3 are expected
+
+				metadata, err := r.compatibilityMetadata(r.ctx)
+				Expect(err).To(HaveOccurred())
+				Expect(metadata).To(BeNil())
+			})
+		})
+	})
+})
+
+type clientErrOnCreate struct {
+	client.Client
+	err       error
+	errOnName string
+}
+
+func (c clientErrOnCreate) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+	if cm, ok := obj.(*corev1.ConfigMap); ok && cm.Name == c.errOnName {
+		return c.err
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+var _ = Describe("r.Reconcile()", func() {
+	var (
+		fakeRegistry *fakes.Registry
+		fakeClient   client.Client
+		scheme       *runtime.Scheme
+		objects      []runtime.Object
+		r            reconciler
+	)
+
+	JustBeforeEach(func() {
+		scheme = runtime.NewScheme()
+		addToScheme(scheme)
+		fakeClient = fake.NewFakeClientWithScheme(scheme, objects...)
+		r = reconciler{
+			registry:                   fakeRegistry,
+			ctx:                        context.Background(),
+			client:                     fakeClient,
+			log:                        ctrllog.Log,
+			scheme:                     scheme,
+			compatibilityMetadataImage: "",
+		}
+	})
+
+	When("new BOM ConfigMaps are added", func() {
+		var (
+			cm1, cm2 *corev1.ConfigMap
+			err      error
+		)
+
+		BeforeEach(func() {
+			cm1 = newConfigMap(version11713, map[string]string{constants.BomConfigMapTKRLabel: version11713}, map[string]string{constants.BomConfigMapImageTagAnnotation: "bom-v1.17.13+vmware.1"}, bomContent17)
+			cm2 = newConfigMap(version1193, map[string]string{constants.BomConfigMapTKRLabel: version1193}, map[string]string{constants.BomConfigMapImageTagAnnotation: "bom-v1.19.3+vmware.1"}, bomContent193)
+			tkr1, _ := NewTkrFromBom(version11713, bomContent17)
+			mgmtCluster := newManagementCluster(map[string]string{constants.ManagememtClusterRoleLabel: ""}, map[string]string{constants.TKGVersionKey: "v1.1"})
+			cmMeta := newMetadataConfigMap(metadataContent)
+
+			objects = []runtime.Object{mgmtCluster, cmMeta, cm1, cm2, &tkr1}
+		})
+
+		It("should create the corresponding TKRs", func() {
+			_, err = r.Reconcile(req(cm2))
+			Expect(err).ToNot(HaveOccurred())
+
+			tkrList := &runv1.TanzuKubernetesReleaseList{}
+			Expect(r.client.List(r.ctx, tkrList)).To(Succeed())
+			Expect(tkrList.Items).To(HaveLen(2))
+
+			found1193 := false
+			for i := range tkrList.Items {
+				tkr := &tkrList.Items[i]
 				if tkr.Name == "v1.19.3---vmware.1" {
+					found1193 = true
 					status, _ := getConditionStatusAndMessage(tkr.Status.Conditions, runv1.ConditionCompatible)
 					Expect(status).To(Equal(corev1.ConditionFalse))
 					continue
@@ -415,9 +486,133 @@ var _ = Describe("initialReconcile", func() {
 				status, _ := getConditionStatusAndMessage(tkr.Status.Conditions, runv1.ConditionCompatible)
 				Expect(status).To(Equal(corev1.ConditionTrue))
 			}
+			Expect(found1193).To(BeTrue())
+
+		})
+	})
+
+	When("a TKR already exists for the BOM ConfigMap", func() {
+		var (
+			cm1, cm2 *corev1.ConfigMap
+			err      error
+		)
+
+		BeforeEach(func() {
+			cm1 = newConfigMap(version11713, map[string]string{constants.BomConfigMapTKRLabel: version11713}, map[string]string{constants.BomConfigMapImageTagAnnotation: "bom-v1.17.13+vmware.1"}, bomContent17)
+			cm2 = newConfigMap(version1193, map[string]string{constants.BomConfigMapTKRLabel: version1193}, map[string]string{constants.BomConfigMapImageTagAnnotation: "bom-v1.19.3+vmware.1"}, bomContent193)
+			tkr1, _ := NewTkrFromBom(version11713, bomContent17)
+			mgmtCluster := newManagementCluster(map[string]string{constants.ManagememtClusterRoleLabel: ""}, map[string]string{constants.TKGVersionKey: "v1.1"})
+			cmMeta := newMetadataConfigMap(metadataContent)
+
+			objects = []runtime.Object{mgmtCluster, cmMeta, cm1, cm2, &tkr1}
+		})
+
+		It("should not return an error", func() {
+			_, err = r.Reconcile(req(cm1))
+			Expect(err).ToNot(HaveOccurred())
+
+			tkrList := &runv1.TanzuKubernetesReleaseList{}
+			Expect(r.client.List(r.ctx, tkrList)).To(Succeed())
+			Expect(tkrList.Items).To(HaveLen(1))
+		})
+	})
+
+	When("a TKR cannot be created for the BOM ConfigMap", func() {
+		var (
+			cm1, cm2 *corev1.ConfigMap
+			err      error
+		)
+
+		BeforeEach(func() {
+			cm1 = newConfigMap(version11713, map[string]string{constants.BomConfigMapTKRLabel: version11713}, map[string]string{constants.BomConfigMapImageTagAnnotation: "bom-v1.17.13+vmware.1"}, bomContent17)
+			cm2 = newConfigMap(version1193, map[string]string{constants.BomConfigMapTKRLabel: version1193}, map[string]string{constants.BomConfigMapImageTagAnnotation: "bom-v1.19.3+vmware.1"}, bomContent193)
+			mgmtCluster := newManagementCluster(map[string]string{constants.ManagememtClusterRoleLabel: ""}, map[string]string{constants.TKGVersionKey: "v1.1"})
+			cmMeta := newMetadataConfigMap(metadataContent)
+
+			delete(cm1.BinaryData, constants.BomConfigMapContentKey)
+			delete(cm2.Labels, constants.BomConfigMapTKRLabel)
+
+			objects = []runtime.Object{mgmtCluster, cmMeta, cm1, cm2}
+		})
+
+		It("should not return an error, and TKR is not created", func() {
+			_, err = r.Reconcile(req(cm1))
+			Expect(err).ToNot(HaveOccurred())
+			_, err = r.Reconcile(req(cm2))
+			Expect(err).ToNot(HaveOccurred())
+
+			tkrList := &runv1.TanzuKubernetesReleaseList{}
+			Expect(r.client.List(r.ctx, tkrList)).To(Succeed())
+			Expect(tkrList.Items).To(HaveLen(0)) // no TKRs created
+		})
+	})
+
+	When("reconciling the BOM metadata ConfigMap", func() {
+		var (
+			cm1, cmMeta *corev1.ConfigMap
+			err         error
+		)
+
+		BeforeEach(func() {
+			cm1 = newConfigMap(version11713, map[string]string{constants.BomConfigMapTKRLabel: version11713}, map[string]string{constants.BomConfigMapImageTagAnnotation: "bom-v1.17.13+vmware.1"}, bomContent17)
+			tkr1, _ := NewTkrFromBom(version11713, bomContent17)
+			mgmtCluster := newManagementCluster(map[string]string{constants.ManagememtClusterRoleLabel: ""}, map[string]string{constants.TKGVersionKey: "v1.1"})
+			cmMeta = newMetadataConfigMap(metadataContent)
+
+			objects = []runtime.Object{mgmtCluster, cmMeta, cm1, &tkr1}
+		})
+
+		It("should not return an error", func() {
+			_, err = r.Reconcile(req(cmMeta))
+			Expect(err).ToNot(HaveOccurred())
+
+			tkrList := &runv1.TanzuKubernetesReleaseList{}
+			Expect(r.client.List(r.ctx, tkrList)).To(Succeed())
+			Expect(tkrList.Items).To(HaveLen(1))
+		})
+	})
+
+	When("BOM metadata ConfigMap cannot be obtained", func() {
+		var (
+			cm1, cm2 *corev1.ConfigMap
+			err      error
+		)
+
+		BeforeEach(func() {
+			cm1 = newConfigMap(version11713, map[string]string{constants.BomConfigMapTKRLabel: version11713}, map[string]string{constants.BomConfigMapImageTagAnnotation: "bom-v1.17.13+vmware.1"}, bomContent17)
+			cm2 = newConfigMap(version1193, map[string]string{constants.BomConfigMapTKRLabel: version1193}, map[string]string{constants.BomConfigMapImageTagAnnotation: "bom-v1.19.3+vmware.1"}, bomContent193)
+			tkr1, _ := NewTkrFromBom(version11713, bomContent17)
+			mgmtCluster := newManagementCluster(map[string]string{constants.ManagememtClusterRoleLabel: ""}, map[string]string{constants.TKGVersionKey: "v1.1"})
+
+			objects = []runtime.Object{mgmtCluster, cm1, cm2, &tkr1}
+		})
+
+		It("should still create the TKRs, but with default status conditions", func() {
+			_, err = r.Reconcile(req(cm2))
+			Expect(err).ToNot(HaveOccurred())
+
+			tkrList := &runv1.TanzuKubernetesReleaseList{}
+			Expect(r.client.List(r.ctx, tkrList)).To(Succeed())
+			Expect(tkrList.Items).To(HaveLen(2))
+
+			for i := range tkrList.Items {
+				tkr := &tkrList.Items[i]
+				condition := conditions.Get(tkr, runv1.ConditionCompatible)
+				Expect(condition == nil || condition.Status == corev1.ConditionUnknown || condition.Status == corev1.ConditionFalse).To(BeTrue())
+			}
 		})
 	})
 })
+
+var _ = Describe("errorSlice.Error()", func() {
+	err := errorSlice{errors.New("one"), errors.New("two"), errors.New("three")}
+	Expect(err.Error()).To(Equal("one, two, three"))
+	Expect(errorSlice{}.Error()).To(Equal(""))
+})
+
+func req(o metav1.Object) ctrl.Request {
+	return ctrl.Request{NamespacedName: client.ObjectKey{Namespace: o.GetNamespace(), Name: o.GetName()}}
+}
 
 func getConditionStatusAndMessage(conditions []capi.Condition, conditionType capi.ConditionType) (status corev1.ConditionStatus, msg string) {
 	for _, condition := range conditions {
@@ -443,10 +638,20 @@ func newConfigMap(name string, labels, annotations map[string]string, content []
 	}
 }
 
-func newManagemntCluster(name string, labels, annotations map[string]string) *capi.Cluster {
+func newMetadataConfigMap(content []byte) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.BOMMetadataConfigMapName,
+			Namespace: constants.TKRNamespace,
+		},
+		BinaryData: map[string][]byte{constants.BOMMetadataCompatibilityKey: content},
+	}
+}
+
+func newManagementCluster(labels, annotations map[string]string) *capi.Cluster {
 	return &capi.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
+			Name:        "mgmt-cluster",
 			Namespace:   constants.TKGNamespace,
 			Labels:      labels,
 			Annotations: annotations,

--- a/pkg/v1/tkr/controllers/source/tkr_source_controller.go
+++ b/pkg/v1/tkr/controllers/source/tkr_source_controller.go
@@ -17,19 +17,23 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	types2 "k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	runv1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/constants"
 	mgrcontext "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/context"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/registry"
-	types "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/types"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/types"
 )
 
 // TanzuKubernetesReleaseReconciler reconciles a TanzuKubernetesRelease object
@@ -47,72 +51,119 @@ type reconciler struct {
 
 // Reconcile performs the reconciliation step
 func (r *reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	_ = context.Background()
-	_ = r.log.WithValues("tanzukubernetesrelease", req.NamespacedName)
-	return ctrl.Result{}, nil
+	ctx, cancel := context.WithCancel(r.ctx)
+	defer cancel()
+
+	configMap := &corev1.ConfigMap{}
+	if err := r.client.Get(ctx, types2.NamespacedName{Namespace: req.Namespace, Name: req.Name}, configMap); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil // do nothing if the ConfigMap does not exist
+		}
+		return ctrl.Result{}, err
+	}
+	if configMap.Name == constants.BOMMetadataConfigMapName {
+		err := r.updateConditions(ctx)
+		return ctrl.Result{}, err
+	}
+
+	tkr, err := tkrFromConfigMap(configMap)
+	if err != nil {
+		r.log.Error(err, "could not create TKR from ConfigMap", "ConfigMap", configMap.Name)
+		return ctrl.Result{}, nil // no need to retry: if the ConfigMap changes, we'll get called
+	}
+	if tkr == nil {
+		return ctrl.Result{}, nil // no need to retry: no TKR in this ConfigMap
+	}
+
+	if err := r.client.Create(ctx, tkr); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			return ctrl.Result{}, nil // the TKR already exists, we're done.
+		}
+		return ctrl.Result{}, errors.Wrapf(err, "could not create TKR: ConfigMap.name='%s'", configMap.Name)
+	}
+	if err := r.client.Status().Update(ctx, tkr); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	err = r.updateConditions(ctx)
+	return ctrl.Result{}, err
+}
+
+func tkrFromConfigMap(configMap *corev1.ConfigMap) (*runv1.TanzuKubernetesRelease, error) {
+	tkrName, labelOK := configMap.ObjectMeta.Labels[constants.BomConfigMapTKRLabel]
+	if !labelOK {
+		return nil, nil // not interested in ConfigMaps without this label
+	}
+
+	bomContent, ok := configMap.BinaryData[constants.BomConfigMapContentKey]
+	if !ok {
+		return nil, errors.New("failed to get the BOM file content from the BOM ConfigMap")
+	}
+
+	newTkr, err := NewTkrFromBom(tkrName, bomContent)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate TKR from BOM ConfigMap")
+	}
+
+	return &newTkr, nil
+}
+
+func (r *reconciler) updateConditions(ctx context.Context) error {
+	tkrList := &runv1.TanzuKubernetesReleaseList{}
+	if err := r.client.List(ctx, tkrList); err != nil {
+		return errors.Wrap(err, "could not list TKRs")
+	}
+
+	r.UpdateTKRUpdatesAvailableCondition(tkrList.Items)
+
+	if err := r.UpdateTKRCompatibleCondition(ctx, tkrList.Items); err != nil {
+		r.log.Error(err, "failed to update Compatible condition for TKRs")
+	}
+
+	for i := range tkrList.Items {
+		if err := r.client.Status().Update(ctx, &tkrList.Items[i]); err != nil {
+			return errors.Wrapf(err, "failed to update status sub resrouce for TKr %s", tkrList.Items[i].ObjectMeta.Name)
+		}
+	}
+
+	return nil
 }
 
 // AddToManager adds this package's controller to the provided manager.
 func AddToManager(ctx *mgrcontext.ControllerManagerContext, mgr ctrl.Manager) error {
 	r := newReconciler(ctx)
-	err := mgr.Add(r.(*reconciler))
-	if err != nil {
+	if err := mgr.Add(r); err != nil {
 		return err
 	}
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&runv1.TanzuKubernetesRelease{}).
+		For(&corev1.ConfigMap{}). // we're watching ConfigMaps and producing TKRs
+		Named("tkr-source-controller").
+		WithEventFilter(inNamespace(constants.TKRNamespace)).
 		Complete(r)
+}
+
+func inNamespace(ns string) *predicate.Funcs {
+	return &predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Meta.GetNamespace() == ns
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Meta.GetNamespace() == ns
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.MetaOld.GetNamespace() == ns
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return e.Meta.GetNamespace() == ns
+		},
+	}
 }
 
 // +kubebuilder:rbac:groups=run.tanzu.vmware.com,resources=tanzukubernetesreleases,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=run.tanzu.vmware.com,resources=tanzukubernetesreleases/status,verbs=get;update;patch
 
-func (r *reconciler) diffRelease(ctx context.Context) (newReleases, existingReleases []runv1.TanzuKubernetesRelease, err error) {
-	// get TKRs that already exist
-	tkrList := &runv1.TanzuKubernetesReleaseList{}
-	err = r.client.List(ctx, tkrList)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to list current TKRs")
-	}
-	existingReleases = tkrList.Items
-
-	tkrMap := make(map[string]bool)
-	for i := range existingReleases {
-		tkrMap[existingReleases[i].ObjectMeta.Name] = true
-	}
-
-	// get all Configmap under the tkr-system namespace
-	cmList := &corev1.ConfigMapList{}
-	if err := r.client.List(ctx, cmList, &client.ListOptions{Namespace: constants.TKRNamespace}); err != nil {
-		return nil, nil, errors.Wrap(err, "failed to get BOM ConfigMaps")
-	}
-	for i := range cmList.Items {
-		// process ConfigMap with the tkr label
-		tkrName, labelOK := cmList.Items[i].ObjectMeta.Labels[constants.BomConfigMapTKRLabel]
-		if !labelOK {
-			continue
-		}
-		if _, ok := tkrMap[tkrName]; ok {
-			continue
-		}
-
-		bomContent, ok := cmList.Items[i].BinaryData[constants.BomConfigMapContentKey]
-		if !ok {
-			return nil, nil, errors.New("failed to get the BOM file content from the BOM ConfigMap")
-		}
-
-		// generate a TKR if the BOM ConfigMap does not have a corresponding one
-		newTkr, err := NewTkrFromBom(tkrName, bomContent)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to generate TKr from Bom configmap")
-		}
-		newReleases = append(newReleases, newTkr)
-	}
-
-	return newReleases, existingReleases, nil
-}
-
 func (r *reconciler) createBOMConfigMap(ctx context.Context, tag string) error {
+	r.log.Info("fetching BOM", "image", r.bomImage, "tag", tag)
 	bomContent, err := r.registry.GetFile(r.bomImage, tag, "")
 	if err != nil {
 		r.log.Error(err, "failed to get the BOM file from image", "name", fmt.Sprintf("%s:%s", r.bomImage, tag))
@@ -131,8 +182,7 @@ func (r *reconciler) createBOMConfigMap(ctx context.Context, tag string) error {
 		return nil
 	}
 
-	strs := strings.Split(releaseName, "+")
-	name := strings.Join(strs, "---")
+	name := strings.ReplaceAll(releaseName, "+", "---")
 
 	// label the ConfigMap with image tag and tkr name
 	labels := make(map[string]string)
@@ -154,10 +204,42 @@ func (r *reconciler) createBOMConfigMap(ctx context.Context, tag string) error {
 		BinaryData: binaryData,
 	}
 
-	return r.client.Create(ctx, &cm)
+	if err := r.client.Create(ctx, &cm); err != nil && !apierrors.IsAlreadyExists(err) {
+		return errors.Wrapf(err, "could not create ConfigMap: name='%s'", cm.Name)
+	}
+	return nil
 }
 
-func (r *reconciler) reconcileBOMConfigMap(ctx context.Context) (err error) {
+func (r *reconciler) reconcileBOMMetadataCM(ctx context.Context) error {
+	metadata, err := r.fetchCompatibilityMetadata()
+	if err != nil {
+		return err
+	}
+
+	metadataContent, err := yaml.Marshal(metadata)
+	if err != nil {
+		return err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.TKRNamespace,
+			Name:      constants.BOMMetadataConfigMapName,
+		},
+	}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, r.client, cm, func() error {
+		cm.BinaryData = map[string][]byte{
+			constants.BOMMetadataCompatibilityKey: metadataContent,
+		}
+		return nil
+	})
+
+	return err
+}
+
+func (r *reconciler) reconcileBOMConfigMap(ctx context.Context) error {
+	r.log.Info("listing BOM image tags", "image", r.bomImage)
 	imageTags, err := r.registry.ListImageTags(r.bomImage)
 	if err != nil {
 		return errors.Wrap(err, "failed to list current available BOM image tags")
@@ -179,34 +261,19 @@ func (r *reconciler) reconcileBOMConfigMap(ctx context.Context) (err error) {
 			}
 		}
 	}
+	var errs errorSlice
 	for tag, exist := range tagMap {
 		if !exist {
-			err = r.createBOMConfigMap(ctx, tag)
-			if err != nil {
-				return errors.Wrapf(err, "failed to create BOM ConfigMap for image %s", fmt.Sprintf("%s:%s", r.bomImage, tag))
+			if err := r.createBOMConfigMap(ctx, tag); err != nil {
+				errs = append(errs, errors.Wrapf(err, "failed to create BOM ConfigMap for image %s", fmt.Sprintf("%s:%s", r.bomImage, tag)))
 			}
 		}
 	}
-
-	return nil
-}
-
-func (r *reconciler) createTKR(ctx context.Context, tkrs []runv1.TanzuKubernetesRelease) (created []runv1.TanzuKubernetesRelease, err error) {
-	for i := range tkrs {
-		r.log.Info("Creating release", "name", tkrs[i].Name)
-		err := r.client.Create(ctx, &tkrs[i])
-		if err != nil {
-			return created, errors.Wrapf(err, "failed to create TKr %s", tkrs[i].Name)
-		}
-
-		err = r.client.Status().Update(ctx, &tkrs[i])
-		if err != nil {
-			return created, errors.Wrapf(err, "failed to update status sub resource for TKr %s", tkrs[i].Name)
-		}
-		created = append(created, tkrs[i])
+	if len(errs) != 0 {
+		return errs
 	}
 
-	return created, nil
+	return nil
 }
 
 func changeTKRCondition(tkr *runv1.TanzuKubernetesRelease, conditionType string, status corev1.ConditionStatus, message string) {
@@ -247,18 +314,56 @@ func (r *reconciler) UpdateTKRUpdatesAvailableCondition(tkrs []runv1.TanzuKubern
 func (r *reconciler) UpdateTKRCompatibleCondition(ctx context.Context, tkrs []runv1.TanzuKubernetesRelease) error {
 	// TODO: reconcile compatible status based on compatibility metadata
 
+	compatibleSet := make(map[string]struct{})
+	defer func() { // update conditions no matter what
+		for i := range tkrs {
+			if _, ok := compatibleSet[tkrs[i].Spec.Version]; ok {
+				changeTKRCondition(&tkrs[i], runv1.ConditionCompatible, corev1.ConditionTrue, "")
+			} else {
+				changeTKRCondition(&tkrs[i], runv1.ConditionCompatible, corev1.ConditionFalse, "")
+			}
+		}
+	}()
+
 	mgmtClusterVersion, err := r.GetManagementClusterVersion(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to get the management cluster info")
 	}
+
+	metadata, err := r.compatibilityMetadata(ctx)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get BOM compatibility metadata")
+	}
+
+	compatibleReleases := []string{}
+	for _, mgmtVersion := range metadata.ManagementClusterVersions {
+		// Fix before TKG v1.10: what if mgmtClusterVersion is "v1.10" and mgmtVersion.TKGVersion is "v1.1"?
+		// See https://github.com/vmware-tanzu/tanzu-framework/issues/452
+		if strings.HasPrefix(mgmtClusterVersion, mgmtVersion.TKGVersion) {
+			compatibleReleases = mgmtVersion.SupportedKubernetesVersions
+		}
+	}
+
+	for _, r := range compatibleReleases {
+		compatibleSet[r] = struct{}{}
+	}
+
+	return nil
+}
+
+func (r *reconciler) fetchCompatibilityMetadata() (*types.CompatibilityMetadata, error) {
+	r.log.Info("listing BOM metadata image tags", "image", r.compatibilityMetadataImage)
 	tags, err := r.registry.ListImageTags(r.compatibilityMetadataImage)
-	if err != nil || len(tags) == 0 {
-		return errors.Wrap(err, "failed to list compatibility metadata image tags")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list compatibility metadata image tags")
+	}
+	if len(tags) == 0 {
+		return nil, errors.New("no compatibility metadata image tags found")
 	}
 
 	tagNum := []int{}
 	for _, tag := range tags {
-		ver, err := strconv.Atoi(tag[1:])
+		ver, err := strconv.Atoi(strings.TrimPrefix(tag, "v"))
 		if err == nil {
 			tagNum = append(tagNum, ver)
 		}
@@ -271,6 +376,7 @@ func (r *reconciler) UpdateTKRCompatibleCondition(ctx context.Context, tkrs []ru
 
 	for i := len(tagNum) - 1; i >= 0; i-- {
 		tagName := fmt.Sprintf("v%d", tagNum[i])
+		r.log.Info("fetching BOM metadata image", "image", r.compatibilityMetadataImage, "tag", tagName)
 		metadataContent, err = r.registry.GetFile(r.compatibilityMetadataImage, tagName, "")
 		if err == nil {
 			if err = yaml.Unmarshal(metadataContent, &metadata); err == nil {
@@ -283,152 +389,73 @@ func (r *reconciler) UpdateTKRCompatibleCondition(ctx context.Context, tkrs []ru
 	}
 
 	if len(metadataContent) == 0 {
-		return errors.New("failed to get TKr compatibility metadata")
+		return nil, errors.New("failed to fetch TKR compatibility metadata")
 	}
 
-	compatibileReleases := []string{}
-	for _, mgmtVersion := range metadata.ManagementClusterVersions {
-		if strings.HasPrefix(mgmtClusterVersion, mgmtVersion.TKGVersion) {
-			compatibileReleases = mgmtVersion.SupportedKubernetesVersions
-		}
-	}
-
-	compatibleSet := make(map[string]bool)
-	for _, r := range compatibileReleases {
-		compatibleSet[r] = true
-	}
-
-	for i := range tkrs {
-		if _, ok := compatibleSet[tkrs[i].Spec.Version]; ok {
-			changeTKRCondition(&tkrs[i], runv1.ConditionCompatible, corev1.ConditionTrue, "")
-		} else {
-			changeTKRCondition(&tkrs[i], runv1.ConditionCompatible, corev1.ConditionFalse, "")
-		}
-	}
-
-	return nil
+	return &metadata, nil
 }
 
-func (r *reconciler) ReconcileConditions(ctx context.Context, added, existing []runv1.TanzuKubernetesRelease) error {
-	allTKRs := append(added, existing...)
-
-	err := r.UpdateTKRCompatibleCondition(ctx, allTKRs)
-	if err != nil {
-		return errors.Wrap(err, "failed to update Compatible condition for TKrs")
+func (r *reconciler) compatibilityMetadata(ctx context.Context) (*types.CompatibilityMetadata, error) {
+	cm := &corev1.ConfigMap{}
+	cmObjectKey := client.ObjectKey{Namespace: constants.TKRNamespace, Name: constants.BOMMetadataConfigMapName}
+	if err := r.client.Get(ctx, cmObjectKey, cm); err != nil {
+		return nil, err
 	}
 
-	r.UpdateTKRUpdatesAvailableCondition(allTKRs)
-
-	for i := range allTKRs {
-		if err = r.client.Status().Update(ctx, &allTKRs[i]); err != nil {
-			return errors.Wrapf(err, "failed to update status sub resrouce for TKr %s", allTKRs[i].ObjectMeta.Name)
-		}
+	metadataContent, ok := cm.BinaryData[constants.BOMMetadataCompatibilityKey]
+	if !ok {
+		return nil, errors.New("compatibility key not found in bom-metadata ConfigMap")
 	}
 
-	return nil
+	var metadata types.CompatibilityMetadata
+	if err := yaml.Unmarshal(metadataContent, &metadata); err != nil {
+		return nil, err
+	}
+	return &metadata, nil
 }
 
-func (r *reconciler) SyncRelease(ctx context.Context) (added, existing []runv1.TanzuKubernetesRelease, err error) {
+func (r *reconciler) SyncRelease(ctx context.Context) error {
+	// create/update bom-metadata ConfigMap
+	if err := r.reconcileBOMMetadataCM(ctx); err != nil {
+		// not returning: even if we fail to get BOM metadata, we still want to reconcile BOM ConfigMaps
+		r.log.Error(err, "failed to reconcile BOM metadata ConfigMap")
+	}
 	// create BOM ConfigMaps for new images
-	if err = r.reconcileBOMConfigMap(ctx); err != nil {
-		return added, existing, errors.Wrap(err, "failed to reconcile the BOM ConfigMap")
-	}
-
-	newTkrs, existingTkrs, err := r.diffRelease(ctx)
-	if err != nil {
-		return added, existing, errors.Wrap(err, "failed to sync up TKrs with BOM ConfigMap")
-	}
-
-	createdTkrs, err := r.createTKR(ctx, newTkrs)
-	if err != nil {
-		return added, existing, errors.Wrap(err, "failed to create TKrs")
-	}
-
-	return createdTkrs, existingTkrs, nil
+	err := r.reconcileBOMConfigMap(ctx)
+	return errors.Wrap(err, "failed to reconcile BOM ConfigMaps")
 }
 
-func (r *reconciler) ReconcileRelease(ctx context.Context) (err error) {
-	added, existing, err := r.SyncRelease(ctx)
-	if err != nil {
-		return errors.Wrap(err, "failed to sync up TKrs with the BOM repository")
-	}
-
-	err = r.ReconcileConditions(ctx, added, existing)
-	if err != nil {
-		return errors.Wrap(err, "failed to reconcile TKr conditions")
-	}
-
-	return nil
-}
-
-func (r *reconciler) checkInitialSync(ctx context.Context) error {
-	r.log.Info("performing checks on initial TKr discovery")
-	tkrList := &runv1.TanzuKubernetesReleaseList{}
-	err := r.client.List(ctx, tkrList)
-	if err != nil {
-		return errors.Wrap(err, "failed to list current TKrs")
-	}
-
-	tags, err := r.registry.ListImageTags(r.bomImage)
-	if err != nil {
-		return errors.Wrap(err, "failed to list BOM image tags")
-	}
-	if len(tags) != len(tkrList.Items) {
-		return errors.New("number of initial TKrs and BOM image tags do not match")
-	}
-	return nil
-}
-
-func (r *reconciler) initialReconcile(ticker *time.Ticker, initSyncDone chan bool, stopChan <-chan struct{}, initialDiscoveryRetry int) {
+func (r *reconciler) initialReconcile(ticker *time.Ticker, stopChan <-chan struct{}, initialDiscoveryRetry int) {
+	defer ticker.Stop()
 	for {
 		select {
 		case <-stopChan:
 			r.log.Info("Stop performing initial TKR discovery")
-			ticker.Stop()
-			close(initSyncDone)
 			return
 		case <-ticker.C:
-
-			var errReconcile error
-			var errCheck error
-
-			if errReconcile = r.ReconcileRelease(context.Background()); errReconcile == nil {
-				// The number of TKRs should be the same as the number of bom image tags for initial sync-up
-				errCheck = r.checkInitialSync(context.Background())
-			}
-
-			if errReconcile != nil {
-				r.log.Info("Failed to complete initial TKr discovery", "error", errReconcile.Error())
-				if isManagementClusterNotReadyError(errReconcile) {
+			if err := r.SyncRelease(context.Background()); err != nil {
+				r.log.Error(err, "Failed to complete initial TKR discovery")
+				initialDiscoveryRetry--
+				if initialDiscoveryRetry > 0 {
+					r.log.Info("Failed to complete initial TKR discovery, retrying")
 					continue
 				}
-			} else if errCheck != nil {
-				r.log.Info("Failed to complete initial TKr discovery", "error", errCheck.Error())
 			}
-
-			if (errReconcile == nil && errCheck == nil) || initialDiscoveryRetry == 0 {
-				ticker.Stop()
-				close(initSyncDone)
-				return
-			}
-			r.log.Info("Failed to complete initial TKr discovery, retrying")
-			initialDiscoveryRetry--
+			return
 		}
 	}
 }
 
-func (r *reconciler) tkrDiscovery(ticker *time.Ticker, done chan bool, stopChan <-chan struct{}) {
+func (r *reconciler) tkrDiscovery(ticker *time.Ticker, stopChan <-chan struct{}) {
+	defer ticker.Stop()
 	for {
 		select {
 		case <-stopChan:
 			r.log.Info("Stop performing TKr discovery")
-			ticker.Stop()
-			close(done)
 			return
 		case <-ticker.C:
-			err := r.ReconcileRelease(context.Background())
-			if err != nil {
-				r.log.Info("failed to reconcile TKrs, retrying", "error", err.Error())
+			if err := r.SyncRelease(context.Background()); err != nil {
+				r.log.Error(err, "failed to reconcile TKRs, retrying")
 			}
 		}
 	}
@@ -457,25 +484,19 @@ func (r *reconciler) Start(stopChan <-chan struct{}) error {
 	}
 
 	r.log.Info("Performing an initial release discovery")
-	initSyncDone := make(chan bool)
-	done := make(chan bool)
-
 	ticker := time.NewTicker(r.options.InitialDiscoveryFrequency)
-	initialDiscoveryRetry := InitialDiscoveryRetry
-	go r.initialReconcile(ticker, initSyncDone, stopChan, initialDiscoveryRetry)
+	r.initialReconcile(ticker, stopChan, InitialDiscoveryRetry)
 
-	<-initSyncDone
 	r.log.Info("Initial TKr discovery completed")
 
 	ticker = time.NewTicker(r.options.ContinuousDiscoveryFrequency)
-	go r.tkrDiscovery(ticker, done, stopChan)
+	r.tkrDiscovery(ticker, stopChan)
 
-	<-done
 	r.log.Info("Stopping Tanzu Kubernetes releaase Reconciler")
 	return nil
 }
 
-func newReconciler(ctx *mgrcontext.ControllerManagerContext) reconcile.Reconciler {
+func newReconciler(ctx *mgrcontext.ControllerManagerContext) *reconciler {
 	regOpts := ctlimg.RegistryOpts{
 		VerifyCerts: ctx.VerifyRegistryCert,
 		Anon:        true,

--- a/pkg/v1/tkr/pkg/constants/constants.go
+++ b/pkg/v1/tkr/pkg/constants/constants.go
@@ -30,4 +30,10 @@ const (
 
 	// TanzuKubernetesReleaseInactiveLabel is the TKR inactive label
 	TanzuKubernetesReleaseInactiveLabel = "inactive"
+
+	// BOMMetadataConfigMapName is the name of the ConfigMap holding BOM metadata
+	BOMMetadataConfigMapName = "bom-metadata"
+
+	// BOMMetadataCompatibilityKey in binaryData in bom-metadata ConfigMap holds compatibility metadata
+	BOMMetadataCompatibilityKey = "compatibility"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Split TKR Source Controller into two separate reconciliation loops:
- BOM/metadata images -> BOM/metadata ConfigMaps
- BOM ConfigMaps -> TKRs

This change fixes a problem in air-gap environments, when a BOM
ConfigMap creation results in an error, and TKR creation never happens.
With this change, no single BOM ConfigMap creation error blocks the
whole process.

Signed-off-by: Ivan Mikushin <imikushin@vmware.com>

**Describe testing done for PR**:

Testing done: added more unit tests to improve test coverage.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
