### PR TITLE
Revert "Introduce BUILD_EDITION as ytt variable as a parameter for co…

### DIFF
--- a/pkg/v1/providers/config_default.yaml
+++ b/pkg/v1/providers/config_default.yaml
@@ -54,9 +54,7 @@ ENABLE_TKGS_ON_VSPHERE7:
 #! management cluster for it to register with Tanzu Mission Control
 TMC_REGISTRATION_URL:
 
-#! BUILD_EDITION is the Tanzu Edition, the plugin should be built for.
-#! Valid values for BUILD_EDITION are 'tce' and 'tkg'.
-BUILD_EDITION:
+
 
 #! ---------------------------------------------------------------------
 #! Settings for vSphere infrastructure provider

--- a/pkg/v1/providers/ytt/02_addons/standard-repo/add_standard_repo.yaml
+++ b/pkg/v1/providers/ytt/02_addons/standard-repo/add_standard_repo.yaml
@@ -25,7 +25,7 @@ spec:
       image: #@ "{}/{}:{}".format(get_image_repo_for_component(standard_package_repo_bundle), standard_package_repo_bundle.imagePath, standard_package_repo_bundle.tag)
 #@ end
 
-#@ if data.values.PROVIDER_TYPE != "tkg-service-vsphere" and data.values.BUILD_EDITION == "tkg":
+#@ if data.values.PROVIDER_TYPE != "tkg-service-vsphere":
 #! We need to install standard package repository on both management cluster and workload clusters because it contains the bundles
 #! for all standard addons which can be optionally installed.
 ---

--- a/pkg/v1/tkg/client/config.go
+++ b/pkg/v1/tkg/client/config.go
@@ -142,11 +142,6 @@ func (c *TkgClient) SetVsphereVersion(vsphereVersion string) {
 	c.TKGConfigReaderWriter().Set(constants.ConfigVariableVsphereVersion, vsphereVersion)
 }
 
-// SetBuildEdition saves the build edition
-func (c *TkgClient) SetBuildEdition(buildEdition string) {
-	c.TKGConfigReaderWriter().Set(constants.ConfigVariableBuildEdition, buildEdition)
-}
-
 // SetTKGVersion saves the tkg version based on Default BoM file
 func (c *TkgClient) SetTKGVersion() {
 	bomConfig, err := c.tkgBomClient.GetDefaultTkgBOMConfiguration()

--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -546,13 +546,6 @@ func (c *TkgClient) ConfigureAndValidateManagementClusterConfiguration(options *
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
-	// BUILD_EDITION is the Tanzu Edition, the plugin should be built for. Its value is supposed be constructed from
-	// cmd/cli/plugin/managementcluster/create.go. So empty value at this point is not expected.
-	if options.Edition == "" {
-		return NewValidationError(ValidationErrorCode, "required config variable 'BUILD_EDITION' is not set")
-	}
-	c.SetBuildEdition(options.Edition)
-
 	c.SetTKGClusterRole(ManagementCluster)
 	c.SetTKGVersion()
 

--- a/pkg/v1/tkg/client/validate_test.go
+++ b/pkg/v1/tkg/client/validate_test.go
@@ -102,7 +102,6 @@ var _ = Describe("Validate", func() {
 				Plan:                        "dev",
 				InfrastructureProvider:      "vsphere",
 				VsphereControlPlaneEndpoint: "foo.bar",
-				Edition:                     "tkg",
 			}
 			tkgConfigReaderWriter.Set(constants.ConfigVariableVsphereNetwork, "foo network")
 		})

--- a/pkg/v1/tkg/constants/config_variables.go
+++ b/pkg/v1/tkg/constants/config_variables.go
@@ -103,7 +103,6 @@ const (
 	ConfigVariableForceRole              = "_TKG_CLUSTER_FORCE_ROLE"
 	ConfigVariableProviderType           = "PROVIDER_TYPE"
 	ConfigVariableTKGVersion             = "TKG_VERSION"
-	ConfigVariableBuildEdition           = "BUILD_EDITION"
 	ConfigVariableFilterByAddonType      = "FILTER_BY_ADDON_TYPE"
 	ConfigVaraibleDisableCRSForAddonType = "DISABLE_CRS_FOR_ADDON_TYPE"
 	ConfigVariableEnableAutoscaler       = "ENABLE_AUTOSCALER"

--- a/pkg/v1/tkg/test/tkgctl/aws/aws_suite_test.go
+++ b/pkg/v1/tkg/test/tkgctl/aws/aws_suite_test.go
@@ -105,7 +105,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			DeployTKGonVsphere7:         e2eConfig.ManagementClusterOptions.DeployTKGonVsphere7,
 			EnableTKGSOnVsphere7:        e2eConfig.ManagementClusterOptions.EnableTKGSOnVsphere7,
 			VsphereControlPlaneEndpoint: e2eConfig.ManagementClusterOptions.Endpoint,
-			Edition:                     "tkg",
 		})
 
 		Expect(err).To(BeNil())

--- a/pkg/v1/tkg/test/tkgctl/azure/azure_suite_test.go
+++ b/pkg/v1/tkg/test/tkgctl/azure/azure_suite_test.go
@@ -99,7 +99,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			DeployTKGonVsphere7:         e2eConfig.ManagementClusterOptions.DeployTKGonVsphere7,
 			EnableTKGSOnVsphere7:        e2eConfig.ManagementClusterOptions.EnableTKGSOnVsphere7,
 			VsphereControlPlaneEndpoint: e2eConfig.ManagementClusterOptions.Endpoint,
-			Edition:                     "tkg",
 		})
 
 		Expect(err).To(BeNil())

--- a/pkg/v1/tkg/test/tkgctl/docker/docker_suite_test.go
+++ b/pkg/v1/tkg/test/tkgctl/docker/docker_suite_test.go
@@ -97,7 +97,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			EnableTKGSOnVsphere7:        e2eConfig.ManagementClusterOptions.EnableTKGSOnVsphere7,
 			VsphereControlPlaneEndpoint: e2eConfig.ManagementClusterOptions.Endpoint,
 			CniType:                     "calico",
-			Edition:                     "tkg",
 		})
 
 		Expect(err).To(BeNil())

--- a/pkg/v1/tkg/test/tkgctl/vsphere67/vsphere_suite_test.go
+++ b/pkg/v1/tkg/test/tkgctl/vsphere67/vsphere_suite_test.go
@@ -106,7 +106,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			DeployTKGonVsphere7:         e2eConfig.ManagementClusterOptions.DeployTKGonVsphere7,
 			EnableTKGSOnVsphere7:        e2eConfig.ManagementClusterOptions.EnableTKGSOnVsphere7,
 			VsphereControlPlaneEndpoint: e2eConfig.ManagementClusterOptions.Endpoint,
-			Edition:                     "tkg",
 		})
 
 		Expect(err).To(BeNil())

--- a/pkg/v1/tkg/tkgctl/init.go
+++ b/pkg/v1/tkg/tkgctl/init.go
@@ -253,14 +253,6 @@ func (t *tkgctl) configureInitManagementClusterOptionsFromConfigFile(iro *InitRe
 		}
 	}
 
-	// set BuildEdition from config variable
-	if iro.Edition == "" {
-		edition, err := t.TKGConfigReaderWriter().Get(constants.ConfigVariableBuildEdition)
-		if err == nil {
-			iro.Edition = edition
-		}
-	}
-
 	// set vSphereControlPlaneEndpoint from config variable
 	if iro.VsphereControlPlaneEndpoint == "" {
 		vSphereControlPlaneEndpoint, err := t.TKGConfigReaderWriter().Get(constants.ConfigVariableVsphereControlPlaneEndpoint)


### PR DESCRIPTION
**What this PR does / why we need it**:

This reverts commit c61ece4d41db6e1802abd5999d5d9e5847a4cb92 (PR: #377). There are additional works need to be done in order to handle the upgrade case. We are currently seeing error message from upgrade:

```
[2021-08-17T02:44:49.652Z] Error: failed to deploy additional components after kubernetes upgrade: error while upgrading additional component 'addons-management/standard-package-repo': kubectl apply failed, output: error: no objects passed to apply
``` 

Seeing above error is because `BUILD_EDITION` is not set properly during upgrade.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
