### PR TITLE
Fix issue with deleting failed MC when using an existing bootstrap cluster

### DIFF
--- a/pkg/v1/tkg/client/init.go
+++ b/pkg/v1/tkg/client/init.go
@@ -206,7 +206,14 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 	}
 
 	// save this context to tkg config incase the management cluster creation fails
-	regionContext = region.RegionContext{ClusterName: options.ClusterName, ContextName: "kind-" + bootstrapClusterName, SourceFilePath: bootstrapClusterKubeconfigPath, Status: region.Failed}
+	bootstrapClusterContext := "kind-" + bootstrapClusterName
+	if options.UseExistingCluster {
+		bootstrapClusterContext, err = getCurrentContextFromDefaultKubeConfig()
+		if err != nil {
+			return err
+		}
+	}
+	regionContext = region.RegionContext{ClusterName: options.ClusterName, ContextName: bootstrapClusterContext, SourceFilePath: bootstrapClusterKubeconfigPath, Status: region.Failed}
 
 	kubeConfigBytes, err := c.WaitForClusterInitializedAndGetKubeConfig(bootStrapClusterClient, options.ClusterName, targetClusterNamespace)
 	if err != nil {

--- a/pkg/v1/tkg/client/utils.go
+++ b/pkg/v1/tkg/client/utils.go
@@ -29,6 +29,16 @@ func getDefaultKubeConfigFile() string {
 	return rules.GetDefaultFilename()
 }
 
+func getCurrentContextFromDefaultKubeConfig() (string, error) {
+	defaultKubeconfig := getDefaultKubeConfigFile()
+	config, err := clientcmd.LoadFromFile(defaultKubeconfig)
+	if err != nil {
+		return "", err
+	}
+
+	return config.CurrentContext, nil
+}
+
 // MergeKubeConfigAndSwitchContext merges kubeconfig and switches the kube-context
 func MergeKubeConfigAndSwitchContext(kubeConfig []byte, mergeFile string) (string, error) {
 	if mergeFile == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug wrt to saving config of the failed management cluster to the tanzu config file when using an existing cluster as a bootstrap cluster.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
1. Simulated a MC failure and observed changes to the tanzu config file
```
➜  tanzu-framework git:(main) ✗ ./artifacts/darwin/amd64/cli/management-cluster/v1.4.0-pre-alpha-2/tanzu-management-cluster-darwin_amd64 create -v 6 -e -i azure -t 5m
compatibility file (/Users/saib/.config/tanzu/tkg/compatibility/tkg-compatibility.yaml) already exists, skipping download
BOM files inside /Users/saib/.config/tanzu/tkg/bom already exists, skipping download
cluster config file not provided using default config file at '/Users/saib/.config/tanzu/tkg/cluster-config.yaml'
CEIP Opt-in status: true
timeout duration of at least 15 minutes is required, using default timeout 30m0s

Validating the pre-requisites...
Identity Provider not configured. Some authentication features won't work.
Setting config 'AZURE_ENVIRONMENT' to 'AzurePublicCloud'
no os options provided, selecting based on default os options
consuming Azure Image info: { vmware-inc tkg-capi k8s-1dot21dot2-ubuntu-20041 true     2021.06.28 {ubuntu 20.04 amd64} map[]}

Setting up management cluster...
Validating configuration...
Using infrastructure provider azure:v0.4.15
Generating cluster configuration...
Setting up bootstrapper...
Bootstrapper created. Kubeconfig: /Users/saib/.kube-tkg/tmp/config_OLIzDME6

.
.
.
.
Failure while deploying management cluster, Here are some steps to investigate the cause:

Debug:
    kubectl get po,deploy,cluster,kubeadmcontrolplane,machine,machinedeployment -A --kubeconfig /Users/saib/.kube-tkg/tmp/config_OLIzDME6
    kubectl logs deployment.apps/<deployment-name> -n <deployment-namespace> manager --kubeconfig /Users/saib/.kube-tkg/tmp/config_OLIzDME6
Error: unable to set up management cluster: unable to wait for cluster and get the cluster kubeconfig: error waiting for cluster to be provisioned (this may take a few minutes): timed out waiting for cluster creation to complete: cluster control plane is still being initialized
Usage:
  tanzu management-cluster create [flags]

```
```
- managementClusterOpts:
    context: test-cluster-saib6-admin@test-cluster-saib6
    path: /Users/saib/.kube-tkg/tmp/config_OLIzDME6
  name: tkg-mgmt-azure-20210817122950
  type: managementcluster
```
`test-cluster-saib6-admin@test-cluster-saib6` is the context of the existing bootstrap cluster.

2. Delete failed MC.
```
./artifacts/darwin/amd64/cli/management-cluster/v1.4.0-pre-alpha-2/tanzu-management-cluster-darwin_amd64 delete -v 6
compatibility file (/Users/saib/.config/tanzu/tkg/compatibility/tkg-compatibility.yaml) already exists, skipping download
BOM files inside /Users/saib/.config/tanzu/tkg/bom already exists, skipping download
Deleting management cluster 'tkg-mgmt-azure-20210817122950'. Are you sure? [y/N]: y

Deleting management cluster...
Verifying management cluster...
Deleting management cluster...
Waiting for tkg-mgmt-azure-20210817122950 resource of type *v1alpha3.Cluster to be deleted
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
resource is still present, retrying
Management cluster 'tkg-mgmt-azure-20210817122950' deleted.
Deleting the management cluster context from the kubeconfig file '/Users/saib/.kube/config'
warning: this removed your active context, use "kubectl config use-context" to select a different one
Deleting kind cluster: test-cluster-saib6-admin@test-cluster-saib6

Management cluster deleted!
```
**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
