### PR TITLE
Mark the `API Token` prompt in login command as sensitive

### DIFF
--- a/cmd/cli/plugin/login/main.go
+++ b/cmd/cli/plugin/login/main.go
@@ -423,7 +423,8 @@ func promptAPIToken() (apiToken string, err error) {
 	fmt.Println()
 	err = component.Prompt(
 		&component.PromptConfig{
-			Message: "API Token",
+			Message:   "API Token",
+			Sensitive: true,
 		},
 		&apiToken,
 		promptOpts...,


### PR DESCRIPTION
**What this PR does / why we need it**:
Without this flag the API Token is visible on the command line and
can lead to information leak when the screen is visible to others.

**Which issue(s) this PR fixes**:
Fixes #454 

**Describe testing done for PR**:
Tested locally.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
```release-note
Fixed the input format for `API Token` in the login command flow. Previously this field was visible to users. Now marking it as sensitive.
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
