### PR TITLE
Add empty 04_user_customizations directory for end users

### DIFF
--- a/pkg/v1/providers/ytt/04_user_customizations/README.md
+++ b/pkg/v1/providers/ytt/04_user_customizations/README.md
@@ -1,0 +1,3 @@
+# User Customizations
+
+ytt traverses directories in alphabetical order and overwrites duplicate settings. You can create template files here to contain configurations that take precedence over any in lower-numbered ytt subdirectories.


### PR DESCRIPTION
The `/providers/ytt/` directory is copied to a users `~/.config/tanzu/tkg/providers/ytt`.  The [documentation encourages users to create an 04_user_customizations](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.3/vmware-tanzu-kubernetes-grid-13/GUID-ytt.html?hWord=N4IghgNiBcIAwBYD6BXAzgUwE5IMboBcB7AWwEsAvMAsogOzRAF8g) within this directory for additional configuration that they may provide via templates.  Users may miss this point in the docs and/or forget and then modify other files, such as those in `/providers/ytt/03_customizations`.  Therefore, it seems better if we provide this directory by default. It may be self-documenting in several ways:
- Encourage/remind users to put their customizations in the correct place
- Encourage/remind users not to touch built-in configuration files

As a future follow to this PR, I wonder what kind of direction we can provide for templates here.  Users can do anything they like, however, we may want to provide limits, best practices, and support guidelines. 