### PR TITLE
package update: make version flag optional

### DIFF
--- a/cmd/cli/plugin/package/package_available_get.go
+++ b/cmd/cli/plugin/package/package_available_get.go
@@ -114,7 +114,7 @@ func packageAvailableGet(cmd *cobra.Command, args []string) error {
 
 func getValuesSchema(cmd *cobra.Command, args []string, kc kappclient.Client) error {
 	if pkgVersion == "" {
-		return errors.New("version is required when values-schema flag is declared. Please specify <PACKAGE-NAME>/<VERSION>")
+		return errors.New("version is required when --values-schema flag is declared. Please specify <PACKAGE-NAME>/<VERSION>")
 	}
 	pkg, pkgGetErr := kc.GetPackage(fmt.Sprintf("%s.%s", pkgName, pkgVersion), packageAvailableOp.Namespace)
 	if pkgGetErr != nil {

--- a/cmd/cli/plugin/package/package_installed_update.go
+++ b/cmd/cli/plugin/package/package_installed_update.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
@@ -14,7 +15,7 @@ import (
 )
 
 var packageInstalledUpdateCmd = &cobra.Command{
-	Use:   "update INSTALLED_PACKAGE_NAME --version VERSION",
+	Use:   "update INSTALLED_PACKAGE_NAME",
 	Short: "Update an installed package",
 	Args:  cobra.ExactArgs(1),
 	Example: `
@@ -24,20 +25,23 @@ var packageInstalledUpdateCmd = &cobra.Command{
 }
 
 func init() {
-	packageInstalledUpdateCmd.Flags().StringVarP(&packageInstalledOp.Version, "version", "v", "", "The version which installed package needs to be updated to")
-	packageInstalledUpdateCmd.Flags().StringVarP(&packageInstalledOp.ValuesFile, "values-file", "f", "", "The path to the configuration values file")
+	packageInstalledUpdateCmd.Flags().StringVarP(&packageInstalledOp.Version, "version", "v", "", "The version which installed package needs to be updated to, optional")
+	packageInstalledUpdateCmd.Flags().StringVarP(&packageInstalledOp.ValuesFile, "values-file", "f", "", "The path to the configuration values file, optional")
 	packageInstalledUpdateCmd.Flags().BoolVarP(&packageInstalledOp.Install, "install", "", false, "Install package if the installed package does not exist, optional")
 	packageInstalledUpdateCmd.Flags().StringVarP(&packageInstalledOp.PackageName, "package-name", "p", "", "The public name for the package, optional")
 	packageInstalledUpdateCmd.Flags().StringVarP(&packageInstalledOp.Namespace, "namespace", "n", "default", "The namespace to locate the installed package which needs to be updated")
 	packageInstalledUpdateCmd.Flags().BoolVarP(&packageInstalledOp.Wait, "wait", "", true, "Wait for the package reconciliation to complete, optional. To disable wait, specify --wait=false")
 	packageInstalledUpdateCmd.Flags().DurationVarP(&packageInstalledOp.PollInterval, "poll-interval", "", tkgpackagedatamodel.DefaultPollInterval, "Time interval between subsequent polls of package reconciliation status, optional")
 	packageInstalledUpdateCmd.Flags().DurationVarP(&packageInstalledOp.PollTimeout, "poll-timeout", "", tkgpackagedatamodel.DefaultPollTimeout, "Timeout value for polls of package reconciliation status, optional")
-	packageInstalledUpdateCmd.MarkFlagRequired("version") //nolint
 	packageInstalledCmd.AddCommand(packageInstalledUpdateCmd)
 }
 
 func packageUpdate(cmd *cobra.Command, args []string) error {
 	packageInstalledOp.PkgInstallName = args[0]
+
+	if packageInstalledOp.Version == "" && packageInstalledOp.ValuesFile == "" {
+		return errors.New("please provide --version and/or --values-file for updating the installed package")
+	}
 
 	cmd.SilenceUsage = true
 

--- a/pkg/v1/tkg/tkgpackageclient/package_update_test.go
+++ b/pkg/v1/tkg/tkgpackageclient/package_update_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Update Package", func() {
 		})
 		It(testFailureMsg, func() {
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("package-name is required when install flag is declared"))
+			Expect(err.Error()).To(ContainSubstring("package-name is required when --install flag is declared"))
 		})
 		AfterEach(func() { options = opts })
 	})


### PR DESCRIPTION
**What this PR does / why we need it:**
- This PR is to change version flag in package update to an optional flag

**Describe testing done for PR:**
Manual testing in the cluster and existing unit tests & integration tests.

**Does this PR introduce a user-facing change?:**
None

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
change version flag in package update to an optional flag
```

**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
