### PR TITLE
Utilize tkgclient `configureVariablesForProvidersInstallation` in standalone clusters

### DIFF
--- a/pkg/v1/tkg/client/delete_standalone.go
+++ b/pkg/v1/tkg/client/delete_standalone.go
@@ -117,6 +117,10 @@ func (c *TkgClient) DeleteStandalone(options DeleteRegionOptions) error {
 		return errors.Wrap(err, "cannot create cleanup cluster client")
 	}
 
+	if err := c.configureVariablesForProvidersInstallation(nil); err != nil {
+		return errors.Wrap(err, "unable to configure variables for provider installation")
+	}
+
 	log.Info("Installing providers to cleanup cluster...")
 	initOptionsForCleanupCluster, err := RestoreInitOptions(options.ClusterName)
 	if err != nil {

--- a/pkg/v1/tkg/client/init_standalone.go
+++ b/pkg/v1/tkg/client/init_standalone.go
@@ -129,6 +129,10 @@ func (c *TkgClient) InitStandaloneRegion(options *InitRegionOptions) error { //n
 		return errors.Wrap(err, "unable to get bootstrap cluster client")
 	}
 
+	if err := c.configureVariablesForProvidersInstallation(nil); err != nil {
+		return errors.Wrap(err, "unable to configure variables for provider installation")
+	}
+
 	log.SendProgressUpdate(statusRunning, StepInstallProvidersOnBootstrapCluster, InitRegionSteps)
 	log.Info("Installing providers on bootstrapper...")
 	// Initialize bootstrap cluster with providers


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures we are correctly populating environment variables for the installation of providers onto the bootstrap clusters when installing and deleting standalone clusters

**Which issue(s) this PR fixes**:
Related to https://github.com/vmware-tanzu/tce/issues/1354

**Describe testing done for PR**:
Build and deployed standalone cluster. Able to delete standalone cluster

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?
```release-note
NONE
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
