### PR TITLE
set ceip to false by default

### DIFF
--- a/cmd/cli/plugin/managementcluster/common.go
+++ b/cmd/cli/plugin/managementcluster/common.go
@@ -15,6 +15,16 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 )
 
+const (
+	// DefaultCEIPSetting is the CEIP setting for created management-clusters
+	DefaultCEIPSetting = "true"
+	// DefaultCEIPTCESetting is the CEIP setting for TCE management-clusters
+	DefaultCEIPTCESetting = "false"
+	// TCEBuildEditionName is the name expected to represent a TCE build of the management-cluster plugin
+	// This value comes from the TCE build process (see the project's Makefile)
+	TCEBuildEditionName = "tce"
+)
+
 func newTKGCtlClient(forceUpdateTKGCompatibilityImage bool) (tkgctl.TKGClient, error) {
 	tkgConfigDir, err := getTKGConfigDir()
 	if err != nil {

--- a/cmd/cli/plugin/managementcluster/create.go
+++ b/cmd/cli/plugin/managementcluster/create.go
@@ -101,7 +101,13 @@ func init() {
 	createCmd.Flags().StringVarP(&iro.workerSize, "worker-size", "", "", "Specify size of the worker node. (See [+])")
 	createCmd.Flags().MarkHidden("worker-size") //nolint
 
-	createCmd.Flags().StringVarP(&iro.ceipOptIn, "ceip-participation", "", "", "Specify if this management cluster should participate in VMware CEIP. (See [*])")
+	// commercial Tanzu editions turn CEIP on by default.
+	// community edition turns it off
+	defaultCeip := DefaultCEIPSetting
+	if BuildEdition == TCEBuildEditionName {
+		defaultCeip = DefaultCEIPTCESetting
+	}
+	createCmd.Flags().StringVarP(&iro.ceipOptIn, "ceip-participation", "", defaultCeip, "Specify if this management cluster should participate in VMware CEIP. (See [*])")
 	createCmd.Flags().MarkHidden("ceip-participation") //nolint
 
 	createCmd.Flags().BoolVarP(&iro.deployTKGonVsphere7, "deploy-tkg-on-vSphere7", "", false, "Deploy TKG Management cluster on vSphere 7.0 without prompt")

--- a/pkg/v1/tkg/tkgctl/init.go
+++ b/pkg/v1/tkg/tkgctl/init.go
@@ -73,7 +73,7 @@ func (t *tkgctl) Init(options InitRegionOptions) error {
 
 	ceipOptIn, err := strconv.ParseBool(options.CeipOptIn)
 	if err != nil {
-		ceipOptIn = true
+		ceipOptIn = false
 	}
 
 	// init requires minimum 15 minutes timeout


### PR DESCRIPTION


**What this PR does / why we need it**:

CEIP should be opt-in. The current logic makes it opt-out. Namely, users
who deploy through the CLI (and don't know about the hiddent flag) are
automatically opted into CEIP.

**Which issue(s) this PR fixes**:

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/466

**Describe testing done for PR**:

Build and verify CEIP is off when flag is not set

**Special notes for your reviewer**:


```release-note
CEIP defaults to off when using the tanzu CLI to create management clusters
```

**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
