### PR TITLE
Fixed instance type being passed as null

### DIFF
--- a/pkg/v1/providers/config_default.yaml
+++ b/pkg/v1/providers/config_default.yaml
@@ -218,8 +218,8 @@ AWS_NODE_OS_DISK_SIZE_GIB: 80
 #! For node sizing recommendations, refer to TKG documentation.
 CONTROL_PLANE_MACHINE_TYPE: t3.large
 NODE_MACHINE_TYPE: m5.large
-NODE_MACHINE_TYPE_1:
-NODE_MACHINE_TYPE_2:
+NODE_MACHINE_TYPE_1: ""
+NODE_MACHINE_TYPE_2: ""
 
 #! Name of the SSH private key that you registered with your Amazon EC2 accoun
 AWS_SSH_KEY_NAME:


### PR DESCRIPTION
Signed-off-by: Sudarshan <asudarshan@vmware.com>
This fixes NODE_MACHINE_TYPE_1 and NODE_MACHINE_TYPE_2 being passed as null to the manifest, and thus not passing any instance types to the manifest

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
1. Unset NODE_MACHINE_TYPE_1, and NODE_MACHINE_TYPE_2.
2. Ran tanzu management-cluster create -i aws --dry-run and captured the manifest
3. The manifest has instance types for the different machine deployments

*Manifest before making the fix*
```
---
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
kind: AWSMachineTemplate
metadata:
  name: test-aws-2-md-1
  namespace: default
spec:
  template:
    spec:
      ami:
        id: ami-0c687784b0671fc49
      iamInstanceProfile: nodes.tkg.cloud.vmware.com
      instanceType: null
      rootVolume:
        size: 80
      sshKeyName: default
---
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
kind: AWSMachineTemplate
metadata:
  name: test-aws-2-md-2
  namespace: default
spec:
  template:
    spec:
      ami:
        id: ami-0c687784b0671fc49
      iamInstanceProfile: nodes.tkg.cloud.vmware.com
      instanceType: null
      rootVolume:
        size: 80
      sshKeyName: default
---
```

*Manifest after making the fix*
```
---
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
kind: AWSMachineTemplate
metadata:
  name: test-aws-2-md-1
  namespace: default
spec:
  template:
    spec:
      ami:
        id: ami-0c687784b0671fc49
      iamInstanceProfile: nodes.tkg.cloud.vmware.com
      instanceType: m5.large
      rootVolume:
        size: 80
      sshKeyName: default
---
apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
kind: AWSMachineTemplate
metadata:
  name: test-aws-2-md-2
  namespace: default
spec:
  template:
    spec:
      ami:
        id: ami-0c687784b0671fc49
      iamInstanceProfile: nodes.tkg.cloud.vmware.com
      instanceType: m5.large
      rootVolume:
        size: 80
      sshKeyName: default
---

```
4. Ran CLUSTER_PLAN=prod tanzu cluster create test-aws-4, and was able to successfully create a cluster
```
./artifacts/darwin/amd64/cli/cluster/v1.4.0-pre-alpha-2/tanzu-cluster-darwin_amd64 list
  NAME        NAMESPACE  STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES   PLAN
  test-aws-4  default    running  3/3           3/3      v1.21.2+vmware.1  <none>  prod 
```
**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
