### PR TITLE
fix default akodeploymentconfig can't be modified error

### DIFF
--- a/pkg/v1/providers/ytt/02_addons/avi/add_adc.yaml
+++ b/pkg/v1/providers/ytt/02_addons/avi/add_adc.yaml
@@ -1,0 +1,45 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("static.lib.yaml", "crd")
+#@ load("akodeploymentconfig.lib.yaml", "akoconfigyaml")
+
+#@ if data.values.PROVIDER_TYPE == "vsphere" and data.values.TKG_CLUSTER_ROLE != "workload" and data.values.AVI_ENABLE:
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name: #@ "{}-ako-operator".format(data.values.CLUSTER_NAME)
+  labels:
+    cluster.x-k8s.io/cluster-name: #@ data.values.CLUSTER_NAME
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: "networking/ako-operator"
+spec:
+  strategy: "ApplyOnce"
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: #@ data.values.CLUSTER_NAME
+  resources:
+  - name: #@ "{}-ako-operator-static".format(data.values.CLUSTER_NAME)
+    kind: Secret
+  - name: #@ "{}-ako".format(data.values.CLUSTER_NAME)
+    kind: Secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #@ "{}-ako-operator-static".format(data.values.CLUSTER_NAME)
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: "networking/ako-operator"
+type: addons.cluster.x-k8s.io/resource-set
+stringData:
+  value: #@ yaml.encode(crd())
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #@ "{}-ako".format(data.values.CLUSTER_NAME)
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: "networking/ako-operator"
+type: addons.cluster.x-k8s.io/resource-set
+stringData:
+  value: #@ yaml.encode(akoconfigyaml())
+#@ end

--- a/pkg/v1/providers/ytt/02_addons/avi/akodeploymentconfig.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/avi/akodeploymentconfig.lib.yaml
@@ -1,6 +1,16 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:overlay", "overlay")
-#@ load("/02_addons/avi/spec.lib.yaml","avi_configs_spec","avi_credentials","avi_certificate")
+#@ load("/02_addons/avi/spec.lib.yaml","avi_configs_spec")
+
+#@ def update_default_akodeploymentconfig():
+#@overlay/match missing_ok=True
+extraConfigs:
+  ingress:
+    #@ if data.values.AVI_INGRESS_NODE_NETWORK_LIST != "":
+    #@overlay/match missing_ok=True
+    nodeNetworkList: #@ data.values.AVI_INGRESS_NODE_NETWORK_LIST
+    #@ end
+#@ end
 
 #@ def update_mc_akodeploymentconfig():
 #@overlay/match missing_ok=True
@@ -13,8 +23,20 @@ clusterSelector:
 #@overlay/match missing_ok=True
 dataNetwork:
   #@overlay/replace
+  #@ if data.values.AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_NAME and data.values.AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_CIDR: 
   name: #@ data.values.AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_NAME
   cidr: #@ data.values.AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_CIDR 
+  #@ else:
+  name: #@ data.values.AVI_DATA_NETWORK
+  cidr: #@ data.values.AVI_DATA_NETWORK_CIDR
+  #@ end
+#@overlay/match missing_ok=True
+extraConfigs:
+  ingress:
+    #@ if data.values.AVI_INGRESS_NODE_NETWORK_LIST != "":
+    #@overlay/match missing_ok=True 
+    nodeNetworkList: #@ data.values.AVI_INGRESS_NODE_NETWORK_LIST
+    #@ end  
 #@ end
 
 #@ def akoconfigyaml():
@@ -23,13 +45,11 @@ apiVersion: networking.tkg.tanzu.vmware.com/v1alpha1
 kind: AKODeploymentConfig
 metadata:
   name: install-ako-for-all
-spec: #@ avi_configs_spec()
+spec: #@ overlay.apply(avi_configs_spec(), update_default_akodeploymentconfig())
 ---
 apiVersion: networking.tkg.tanzu.vmware.com/v1alpha1
 kind: AKODeploymentConfig
 metadata:
   name: install-ako-for-management-cluster
 spec: #@ overlay.apply(avi_configs_spec(), update_mc_akodeploymentconfig())
---- #@ avi_credentials()
---- #@ avi_certificate()
 #@ end

--- a/pkg/v1/providers/ytt/02_addons/avi/static.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/avi/static.lib.yaml
@@ -182,6 +182,7 @@ spec:
                         enum:
                         - NodePort
                         - ClusterIP
+                        - NodePortLocal
                         type: string
                       shardVSSize:
                         description: ShardVSSize string describes ingress shared virtual service size Valid value should be SMALL, MEDIUM or LARGE, default value is SMALL


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, we deploy default `AKODeploymentConfig` using add-on manager, which makes it uneditable. 

To allow users to enable L7 or modify other AKO configurations in the management cluster or default select-all `AKODeploymentConfig`, we need to change it to use `ClusterResourceSet` to deploy default `AKODeploymentConfig`

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
