### PR TITLE
package plugin: fix fluent-bit values file example

### DIFF
--- a/cmd/cli/plugin/package/README.md
+++ b/cmd/cli/plugin/package/README.md
@@ -157,9 +157,7 @@ Use "tanzu package repository [command] --help" for more information about a com
 
     An example values.yaml is as follows:
     ```sh
-    ---
-    fluent_bit:
-      outputs: |
+    outputs: |
         [OUTPUT]
           Name     stdout
           Match    *
@@ -198,9 +196,7 @@ Use "tanzu package repository [command] --help" for more information about a com
    / Retrieving installation details for myfb...
 
    cat config.yaml
-   ---
-   fluent_bit:
-     outputs: |
+   outputs: |
        [OUTPUT]
          Name     stdout
          Match    *
@@ -245,12 +241,10 @@ Use "tanzu package repository [command] --help" for more information about a com
 
     An example values.yaml is as follows:
     ```sh
-    ---
-    fluent_bit:
-      outputs: |
+    outputs: |
         [OUTPUT]
           Name     stdout
-          Match    *
+          Match    /
     ```
 
 11. Uninstall a package

--- a/pkg/v1/tkg/test/tkgpackageclient/config/values.yaml
+++ b/pkg/v1/tkg/test/tkgpackageclient/config/values.yaml
@@ -1,6 +1,4 @@
----
-fluent_bit:
-  outputs: |
+outputs: |
     [OUTPUT]
       Name     stdout
       Match    *

--- a/pkg/v1/tkg/test/tkgpackageclient/config/values_update.yaml
+++ b/pkg/v1/tkg/test/tkgpackageclient/config/values_update.yaml
@@ -1,6 +1,4 @@
----
-fluent_bit:
-  outputs: |
+outputs: |
     [OUTPUT]
       Name     stdout
       Match    /


### PR DESCRIPTION
**What this PR does / why we need it:**
- This PR is to fix fluent-bit values file example with regard to the recent ytt errors in extensions test-infra tests (error details as as follows):
 
```
  Error: package reconciliation failed: ytt: Error: 
  - library.eval: Evaluating library 'bundle/config': Overlaying data values (in following order: _ytt_lib/bundle/config/values.yaml, 
  additional data values): Document on line ?: Map item (key 'fluent_bit') on line ?: Map item (key 'outputs') on line ?: Expected 
  number of matched nodes to be 1, but was 0
  in <toplevel>
  fluent-bit.yaml:13 | --- #@ template.replace(upstream_lib.with_data_values(downstream_values()).eval())
``` 

**Describe testing done for PR:**
Manual testing in the cluster and existing unit tests & integration tests.

**Does this PR introduce a user-facing change?:**
None

**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
