### PR TITLE
make AWS_SSH_KEY_NAME optional in UI supporting backend

### DIFF
--- a/pkg/v1/providers/ytt/lib/validate.star
+++ b/pkg/v1/providers/ytt/lib/validate.star
@@ -12,8 +12,7 @@ required_variable_list_vsphere = [
   "VSPHERE_SSH_AUTHORIZED_KEY"]
 
 required_variable_list_aws = [
-  "AWS_REGION",
-  "AWS_SSH_KEY_NAME"]
+  "AWS_REGION"]
 
 required_variable_list_azure = [
   "AZURE_TENANT_ID",


### PR DESCRIPTION
**What this PR does / why we need it**:
 AWS_SSH_KEY_NAME is optional on frontend, but it's required on backend. This causes failure when deploying a management cluster on AWS through the Kickstart UI if the EC2 Key Pair is not provided, when using one-time credentials.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
