### PR TITLE
fix missing secret ref to PackageInstall spec when values-file provided

### DIFF
--- a/pkg/v1/tkg/tkgpackageclient/package_update.go
+++ b/pkg/v1/tkg/tkgpackageclient/package_update.go
@@ -42,7 +42,7 @@ func (p *pkgClient) UpdatePackage(o *tkgpackagedatamodel.PackageOptions, progres
 
 	if pkgInstall == nil {
 		if !o.Install {
-			err = errors.New(fmt.Sprintf("package '%s' is not among the list of installed packages in namespace '%s'", o.PkgInstallName, o.Namespace))
+			err = errors.New(fmt.Sprintf("package '%s' is not among the list of installed packages in namespace '%s'. Consider using the install flag to install the package", o.PkgInstallName, o.Namespace))
 			return
 		}
 		if o.PackageName == "" {
@@ -70,7 +70,6 @@ func (p *pkgClient) UpdatePackage(o *tkgpackagedatamodel.PackageOptions, progres
 
 	if o.ValuesFile != "" {
 		o.SecretName = fmt.Sprintf(tkgpackagedatamodel.SecretName, o.PkgInstallName, o.Namespace)
-
 		if o.SecretName == pkgInstallToUpdate.GetAnnotations()[tkgpackagedatamodel.TanzuPkgPluginAnnotation+"-Secret"] {
 			progress.ProgressMsg <- fmt.Sprintf("Updating secret '%s'", o.SecretName)
 			if err = p.updateDataValuesSecret(o); err != nil {
@@ -84,6 +83,14 @@ func (p *pkgClient) UpdatePackage(o *tkgpackagedatamodel.PackageOptions, progres
 				err = errors.Wrap(err, "failed to create secret based on values file")
 				return
 			}
+		}
+
+		pkgInstallToUpdate.Spec.Values = []kappipkg.PackageInstallValues{
+			{
+				SecretRef: &kappipkg.PackageInstallValuesSecretRef{
+					Name: fmt.Sprintf(tkgpackagedatamodel.SecretName, o.PkgInstallName, o.Namespace),
+				},
+			},
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it:**
- This PR is to fix missing secret ref to PackageInstall spec when values-file provided.

**Describe testing done for PR:**
Manual testing in the cluster and existing unit tests & integration tests.

**Does this PR introduce a user-facing change?:**
None

**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
