### PR TITLE
Use custom steps for standalone cluster init

### DIFF
--- a/pkg/v1/tkg/tkgctl/init_standalone.go
+++ b/pkg/v1/tkg/tkgctl/init_standalone.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"


### PR DESCRIPTION
**What this PR does / why we need it**:

We've had an issue where the deployment UI shows steps during deployment
that mention management clusters instead of standalone clusters. This
was due to the steps the standalone cluster plugin was sending to the
UI. Progress would also fail to update due to a mismatch between the
step reported and the available steps.

This updates the deployment sequence steps for the standalone cluster
init so they only mention standalone clusters and they match the actual
steps taken.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related: https://github.com/vmware-tanzu/tce/issues/845
Related: https://github.com/vmware-tanzu/tce/issues/1376

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

Created local build of standalone-cluster plugin. Performed Docker deployment and made sure steps shown where correct.


**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
