### PR TITLE
Update kapp-controller api port to 10349 for non dev plans

### DIFF
--- a/pkg/v1/providers/ytt/02_addons/kapp-controller/kapp-controller_addon_data.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/kapp-controller/kapp-controller_addon_data.lib.yaml
@@ -23,7 +23,15 @@ kappController:
     concurrency: 4
     hostNetwork: true
     priorityClassName: system-cluster-critical
+    #! CAPA clusters restrict ports that can be used due to security group rules. Currently cniIngressRules on CAPA don't work on upgrade which places restrictions on the port usage.
+    #! On a dev plan the port that is already allowed(10349) in cniIngressRules conflicts with antrea 10349 and can cause issues with cluster creation, so
+    #! dev plan will use 32767 (service port range) and this okay because the chance of a port collision with a service on dev plan is low.
+    #! Prod plan will use 10349 because there are multiple control and worker nodes where kapp-controller and antrea controller pod can be scheduled.
+    #@ if data.values.CLUSTER_PLAN == 'dev':
     apiPort: 32767
+    #@ else:
+    apiPort: 10349
+    #@ end
 #@ if data.values.TKG_CLUSTER_ROLE == "workload": #! For mgmt cluster tolerations needs to be added using overlay due to ytt's array handling behavior
     tolerations:
     - key: CriticalAddonsOnly


### PR DESCRIPTION
Address the issue of potential port conflict with service port range in prod plan

Signed-off-by: Vijay Katam <vkatam@vmware.com>

**What this PR does / why we need it**:  Updates kapp-controller to use a low port in existing AWS security groups. Prevents conflicts with potential services in service port range.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # N/A

**Describe testing done for PR**:
Test pipelines

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
