### PR TITLE
generate binaries for darwin-arm64 and linux-arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ PRIVATE_REPOS=github.com/vmware-tanzu/tanzu-framework
 GO := GOPRIVATE=${PRIVATE_REPOS} go
 
 # Add supported OS-ARCHITECTURE combinations here
-ENVS := linux-amd64 windows-amd64 darwin-amd64
+ENVS := linux-amd64 windows-amd64 darwin-amd64 darwin-arm64
 
 .DEFAULT_GOAL:=help
 


### PR DESCRIPTION
Signed-off-by: Joe Fitzgerald <jfitzgerald@vmware.com>

**What this PR does / why we need it**: Adds `darwin-arm64` and `linux-arm64` architecture to build binaries that will work on these OS/architecture pairs. While the `amd64` binaries will run on `darwin` using Rosetta, it is preferable to avoid this emulation.

**Which issue(s) this PR fixes**: Not sure it completely fixes any existing issues, but is related to #35, #440, and #855.
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Describe testing done for PR**: Ran `make release`.
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**: N/A

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
