### PR TITLE
Add deprecation notice to tanzu management-cluster import command

### DIFF
--- a/cmd/cli/plugin/managementcluster/import.go
+++ b/cmd/cli/plugin/managementcluster/import.go
@@ -13,6 +13,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
 
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/region"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgctl"
 )
@@ -45,6 +46,8 @@ var importCmd = &cobra.Command{
 
 func init() {
 	importCmd.Flags().StringVarP(&importOption.file, "file", "f", "", "TKG settings file (default '$HOME/.tkg/config.yaml')")
+
+	cli.DeprecateCommand(importCmd, "1.5.0")
 }
 
 func getOldTKGConfigDir() (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
- `tanzu management-cluster import` command was introduced to migrate
  TKG CLI v1.2 settings to Tanzu CLI v1.3. As with v1.4 release we do
  not expect users to use this command to migrate TKG setting and hence
  adding deprecation notice this command for now. We can eventually remove this command

Signed-off-by: Anuj Chaudhari <anujc@vmware.com>

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Hide `tanzu management-cluster import` command
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
