### PR TITLE
Add link to the doc when blocking management-cluster upgrade if not supported by TMC

### DIFF
--- a/pkg/v1/tkg/client/upgrade_region.go
+++ b/pkg/v1/tkg/client/upgrade_region.go
@@ -29,8 +29,7 @@ import (
 )
 
 // ErrorBlockUpgradeTMCIncompatible defines the error message to display during upgrade when cluster is registred to TMC and TMC does not support latest version of TKG
-// TODO: Add link to the document related to error message.
-const ErrorBlockUpgradeTMCIncompatible = "The management cluster cannot be upgraded to Tanzu Kubernetes Grid '%v' while registered to Tanzu Mission Control."
+const ErrorBlockUpgradeTMCIncompatible = "The management cluster cannot be upgraded to Tanzu Kubernetes Grid '%v' while registered to Tanzu Mission Control. See https://via.vmw.com/tkg-14-tmc-compat for more information."
 
 // UpgradeManagementClusterOptions upgrade management cluster options
 type UpgradeManagementClusterOptions struct {
@@ -481,8 +480,8 @@ func (c *TkgClient) validateCompatibilityWithTMC(regionalClusterClient clustercl
 
 		if !skipPrompt {
 			log.Infof("error occurred while validating compatibility with Tanzu Mission Control, %v", err)
-			// TODO: Add link to the document related compatiility as part of the prompt message
-			if err := cli.AskForConfirmation("Unable to validate compatibility of new version with Tanzu Mission Control. Do you want to continue?"); err != nil {
+			log.Warning("Unable to validate compatibility of new version with Tanzu Mission Control. See https://via.vmw.com/tkg-14-tmc-compat for more information.")
+			if err := cli.AskForConfirmation("Do you want to continue with the upgrade?"); err != nil {
 				return err
 			}
 		} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
- This change adds a link to the error message when CLI blocks upgrade
  of management cluster if not supported by TMC. This will allow user to
  get more detailed information regarding the compatibility with TMC

Signed-off-by: Anuj Chaudhari <anujc@vmware.com>

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
