### PR TITLE
CLI tkr plugin: fix: available-upgrades returns no updates

### DIFF
--- a/cmd/cli/plugin/tkr/available_upgrade.go
+++ b/cmd/cli/plugin/tkr/available_upgrade.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 
 	runv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
@@ -40,17 +42,7 @@ func init() {
 }
 
 func getAvailableUpgrades(cmd *cobra.Command, args []string) error {
-	server, err := config.GetCurrentServer()
-	if err != nil {
-		return err
-	}
-
-	if server.IsGlobal() {
-		return errors.New("getting TanzuKubernetesRelease with a global server is not implemented yet")
-	}
-
-	clusterClientOptions := clusterclient.Options{GetClientInterval: 2 * time.Second, GetClientTimeout: 5 * time.Second}
-	clusterClient, err := clusterclient.NewClient(server.ManagementClusterOpts.Path, server.ManagementClusterOpts.Context, clusterClientOptions)
+	clusterClient, err := getClusterClient()
 	if err != nil {
 		return err
 	}
@@ -60,37 +52,134 @@ func getAvailableUpgrades(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	upgradeMsg := ""
-
-	for i := range tkrs {
-		if tkrs[i].Name == args[0] {
-			for _, condition := range tkrs[i].Status.Conditions {
-				if condition.Type == runv1alpha1.ConditionUpdatesAvailable {
-					upgradeMsg = condition.Message
-				}
-			}
-		}
-	}
-
-	candidates := make(map[string]bool)
-	if strs := strings.Split(upgradeMsg, ": "); len(strs) != lenMsg {
+	results := availableUpdatesInTKRs(tkrs, args[0])
+	if len(results) == 0 {
 		fmt.Println("There are no available upgrades for this TanzuKubernetesRelease")
-	} else {
-		names := strings.Split(strs[1], ",")
-		for _, name := range names {
-			candidates[name] = true
-		}
+		return nil
 	}
 
 	t := component.NewOutputWriter(availableUpgradesCmd.OutOrStdout(), outputFormat, "NAME", "VERSION")
-	for i := range tkrs {
-		if _, ok := candidates[tkrs[i].Name]; !ok {
-			continue
-		}
-
-		t.AddRow(tkrs[i].Name, tkrs[i].Spec.Version)
+	for i := range results {
+		t.AddRow(results[i].Name, results[i].Spec.Version)
 	}
 	t.Render()
 
+	return nil
+}
+
+func getClusterClient() (clusterclient.Client, error) {
+	server, err := config.GetCurrentServer()
+	if err != nil {
+		return nil, err
+	}
+
+	if server.IsGlobal() {
+		return nil, errors.New("getting TanzuKubernetesRelease with a global server is not implemented yet")
+	}
+
+	clusterClientOptions := clusterclient.Options{GetClientInterval: 2 * time.Second, GetClientTimeout: 5 * time.Second}
+	clusterClient, err := clusterclient.NewClient(server.ManagementClusterOpts.Path, server.ManagementClusterOpts.Context, clusterClientOptions)
+	if err != nil {
+		return nil, err
+	}
+	return clusterClient, nil
+}
+
+func availableUpdatesInTKRs(tkrs []runv1alpha1.TanzuKubernetesRelease, tkrName string) []runv1alpha1.TanzuKubernetesRelease {
+	tkr := tkrByName(tkrs, tkrName)
+	if tkr == nil {
+		return nil
+	}
+
+	candidates := namesFromUpdatesAvailable(tkr)
+	if len(candidates) == 0 {
+		candidates = namesFromUpgradeAvailable(tkr) // fall back to UpgradeAvailable condition
+	}
+
+	results := filterTKRs(tkrs, func(tkr *runv1alpha1.TanzuKubernetesRelease) bool {
+		if !conditions.IsTrue(tkr, runv1alpha1.ConditionCompatible) {
+			return false
+		}
+		_, exists := candidates[tkr.Name]
+		return exists
+	})
+	return results
+}
+
+type stringSet map[string]struct{}
+
+func (set stringSet) Add(ss ...string) stringSet {
+	for _, s := range ss {
+		set[s] = struct{}{}
+	}
+	return set
+}
+
+func namesFromUpdatesAvailable(tkr *runv1alpha1.TanzuKubernetesRelease) stringSet {
+	conditionUpdatesAvailable := conditions.Get(tkr, runv1alpha1.ConditionUpdatesAvailable)
+	if conditionUpdatesAvailable == nil || conditionUpdatesAvailable.Status != corev1.ConditionTrue {
+		return stringSet{}
+	}
+
+	message := strings.Trim(conditionUpdatesAvailable.Message, "[]")
+	message = strings.ReplaceAll(message, ",", " ")
+
+	versions := strings.Fields(message)
+
+	names := mapStrings(versions, tkrNameFromVersion)
+	candidates := stringSet{}.Add(names...)
+	return candidates
+}
+
+func namesFromUpgradeAvailable(tkr *runv1alpha1.TanzuKubernetesRelease) stringSet {
+	conditionUpgradeAvailable := conditions.Get(tkr, runv1alpha1.ConditionUpgradeAvailable)
+	if conditionUpgradeAvailable == nil || conditionUpgradeAvailable.Status != corev1.ConditionTrue {
+		return stringSet{}
+	}
+
+	strs := strings.Split(conditionUpgradeAvailable.Message, ": ")
+	if len(strs) != lenMsg {
+		return stringSet{}
+	}
+
+	versions := strings.Split(strs[1], ",")
+
+	names := mapStrings(versions, tkrNameFromVersion)
+	candidates := stringSet{}.Add(names...)
+	return candidates
+}
+
+func tkrNameFromVersion(version string) string {
+	return strings.ReplaceAll(version, "+", "---")
+}
+
+type stringMapper func(s string) string
+
+func mapStrings(ss []string, m stringMapper) []string {
+	result := make([]string, len(ss))
+	for i, s := range ss {
+		result[i] = m(s)
+	}
+	return result
+}
+
+type tkrPredicate func(release *runv1alpha1.TanzuKubernetesRelease) bool
+
+func filterTKRs(tkrs []runv1alpha1.TanzuKubernetesRelease, p tkrPredicate) []runv1alpha1.TanzuKubernetesRelease {
+	result := make([]runv1alpha1.TanzuKubernetesRelease, 0, len(tkrs))
+	for i := range tkrs {
+		if p(&tkrs[i]) {
+			result = append(result, tkrs[i])
+		}
+	}
+	return result
+}
+
+func tkrByName(tkrs []runv1alpha1.TanzuKubernetesRelease, name string) *runv1alpha1.TanzuKubernetesRelease {
+	for i := range tkrs {
+		if tkrs[i].Name == name {
+			return &tkrs[i]
+		}
+	}
 	return nil
 }

--- a/cmd/cli/plugin/tkr/available_upgrade_test.go
+++ b/cmd/cli/plugin/tkr/available_upgrade_test.go
@@ -1,0 +1,90 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util/conditions"
+
+	runv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
+)
+
+var _ = Describe("availableUpdatesInTKRs()", func() {
+	var tkrs []runv1alpha1.TanzuKubernetesRelease
+
+	tkr1 := getFakeTKR("v1.17.17---vmware.1-tkg.2", "v1.17.17+vmware.1", corev1.ConditionFalse, "[v1.17.18+vmware.1-tkg.1 v1.18.2+vmware.1-tkg.1]")
+	tkr2 := getFakeTKR("v1.17.18---vmware.1-tkg.1", "v1.17.18+vmware.1", corev1.ConditionTrue, "")
+	tkr3 := getFakeTKR("v1.18.1---vmware.1-tkg.2", "v1.18.1+vmware.1", corev1.ConditionFalse, "")
+	tkr4 := getFakeTKR("v1.18.2---vmware.1-tkg.1", "v1.18.2+vmware.1", corev1.ConditionTrue, "")
+
+	BeforeEach(func() {
+		tkrs = []runv1alpha1.TanzuKubernetesRelease{tkr1, tkr2, tkr3, tkr4}
+	})
+
+	When("given a non-existent tkrName", func() {
+		It("should return nil / empty list", func() {
+			Expect(availableUpdatesInTKRs(tkrs, "blah")).To(BeEmpty())
+		})
+	})
+
+	When("given a TKR with condition UpdatesAvailable=True", func() {
+		It("should return only TKRs that are mentioned in the condition message", func() {
+			Expect(availableUpdatesInTKRs(tkrs, "v1.17.17---vmware.1-tkg.2")).To(ContainElements(tkr2, tkr4))
+			Expect(availableUpdatesInTKRs(tkrs, "v1.17.17---vmware.1-tkg.2")).ToNot(ContainElements(tkr3))
+		})
+	})
+
+	When("given a TKR without condition UpdatesAvailable", func() {
+		BeforeEach(func() {
+			conditions.Delete(&tkrs[0], runv1alpha1.ConditionUpdatesAvailable)
+		})
+
+		When("the TKR does not have condition UpgradeAvailable=True", func() {
+			It("should return only TKRs that are mentioned in the condition message", func() {
+				Expect(availableUpdatesInTKRs(tkrs, "v1.17.17---vmware.1-tkg.2")).To(BeEmpty())
+			})
+		})
+
+		When("the TKR has condition UpgradeAvailable=True", func() {
+			BeforeEach(func() {
+				conditions.Set(&tkrs[0], &clusterv1.Condition{
+					Type:    runv1alpha1.ConditionUpgradeAvailable,
+					Status:  corev1.ConditionTrue,
+					Message: "Deprecated, TKR(s) with later version is available: v1.17.18---vmware.1-tkg.1,v1.18.2---vmware.1-tkg.1",
+				})
+			})
+
+			It("should return only TKRs that are mentioned in the condition message", func() {
+				Expect(availableUpdatesInTKRs(tkrs, "v1.17.17---vmware.1-tkg.2")).To(ContainElements(tkr2, tkr4))
+				Expect(availableUpdatesInTKRs(tkrs, "v1.17.17---vmware.1-tkg.2")).ToNot(ContainElements(tkr3))
+			})
+		})
+	})
+})
+
+var _ = Describe("filterTKRs()", func() {
+	tkr1 := getFakeTKR("v1.17.17---vmware.1-tkg.2", "v1.17.17+vmware.1", corev1.ConditionFalse, "")
+	tkr2 := getFakeTKR("v1.17.18---vmware.1-tkg.1", "v1.17.18+vmware.1", corev1.ConditionTrue, "")
+	tkr3 := getFakeTKR("v1.18.1---vmware.1-tkg.2", "v1.18.1+vmware.1", corev1.ConditionFalse, "")
+	tkr4 := getFakeTKR("v1.18.2---vmware.1-tkg.1", "v1.18.2+vmware.1", corev1.ConditionFalse, "")
+	tkrs := []runv1alpha1.TanzuKubernetesRelease{tkr1, tkr2, tkr3, tkr4}
+
+	It("should list only and all TKRs satisfying the predicate", func() {
+		nameBeginsWith117 := func(tkr *runv1alpha1.TanzuKubernetesRelease) bool {
+			return strings.HasPrefix(tkr.Name, "v1.17")
+		}
+		nameBeginsWith118 := func(tkr *runv1alpha1.TanzuKubernetesRelease) bool {
+			return strings.HasPrefix(tkr.Name, "v1.18")
+		}
+		Expect(filterTKRs(tkrs, nameBeginsWith117)).To(ContainElements(tkr1, tkr2)) // all beginning with v1.17
+		Expect(filterTKRs(tkrs, nameBeginsWith118)).To(ContainElements(tkr3, tkr4)) // all beginning with v1.18
+		Expect(filterTKRs(tkrs, nameBeginsWith117)).ToNot(ContainElement(tkr3))     // begins with v1.18
+		Expect(filterTKRs(tkrs, nameBeginsWith118)).ToNot(ContainElements(tkr1))    // begins with v1.17
+	})
+})

--- a/cmd/cli/plugin/tkr/get_tkr_test.go
+++ b/cmd/cli/plugin/tkr/get_tkr_test.go
@@ -103,11 +103,11 @@ func getFakeTKR(tkrName, k8sversion string, compatibleStatus corev1.ConditionSta
 	tkr.Spec.KubernetesVersion = k8sversion
 	tkr.Status.Conditions = []clusterv1.Condition{
 		{
-			Type:   clusterv1.ConditionType(runv1alpha1.ConditionCompatible),
+			Type:   runv1alpha1.ConditionCompatible,
 			Status: compatibleStatus,
 		},
 		{
-			Type:    clusterv1.ConditionType(runv1alpha1.ConditionUpgradeAvailable),
+			Type:    runv1alpha1.ConditionUpdatesAvailable,
 			Status:  corev1.ConditionTrue,
 			Message: updatesAvailableMsg,
 		},

--- a/pkg/v1/tkr/controllers/source/helper.go
+++ b/pkg/v1/tkr/controllers/source/helper.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/version"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	utilconditions "sigs.k8s.io/cluster-api/util/conditions"
 
 	runv1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/constants"
@@ -128,6 +129,10 @@ type TKRVersion struct {
 }
 
 func upgradeQualified(fromTKR, toTKR *runv1.TanzuKubernetesRelease) bool {
+	if !utilconditions.IsTrue(toTKR, runv1.ConditionCompatible) {
+		return false
+	}
+
 	from, err := NewTKRVersion(fromTKR.Spec.Version)
 	if err != nil {
 		return false

--- a/pkg/v1/tkr/controllers/source/suite_test.go
+++ b/pkg/v1/tkr/controllers/source/suite_test.go
@@ -244,6 +244,9 @@ var _ = Describe("UpdateTKRUpgradeAvailableCondition", func() {
 			tkr2, _ := NewTkrFromBom(version11810, bomContent18)
 			tkr3, _ := NewTkrFromBom(version1193, bomContent193)
 			tkr4, _ := NewTkrFromBom(version1191, bomContent191)
+			conditions.Set(&tkr2, conditions.TrueCondition(runv1.ConditionCompatible))
+			conditions.Set(&tkr3, conditions.TrueCondition(runv1.ConditionCompatible))
+			conditions.Set(&tkr4, conditions.TrueCondition(runv1.ConditionCompatible))
 			tkrs = []runv1.TanzuKubernetesRelease{tkr1, tkr4, tkr3, tkr2}
 		})
 		It("should update the UpgradeAvailable Condition with proper message", func() {

--- a/pkg/v1/tkr/controllers/source/tkr_source_controller.go
+++ b/pkg/v1/tkr/controllers/source/tkr_source_controller.go
@@ -124,11 +124,11 @@ func (r *reconciler) updateConditions(ctx context.Context) error {
 		return errors.Wrap(err, "could not list TKRs")
 	}
 
-	r.UpdateTKRUpdatesAvailableCondition(tkrList.Items)
-
 	if err := r.UpdateTKRCompatibleCondition(ctx, tkrList.Items); err != nil {
 		return errors.Wrap(err, "failed to update Compatible condition for TKRs")
 	}
+
+	r.UpdateTKRUpdatesAvailableCondition(tkrList.Items)
 
 	for i := range tkrList.Items {
 		if err := r.client.Status().Update(ctx, &tkrList.Items[i]); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Even if updates are clearly available, command
`tanzu kubernetes-release get available-upgrades ${TKR_NAME}`
would not list them.

This was happening due to incorrect interpretation of the TKR status
conditions that are supposed to carry update information:
- UpdatesAvailable - the correct condition to use
- UpgradeAvailable - now deprecated, but can be used as fallback.

Message fields in these conditions are formatted differently.

UpdatesAvailable condition was used, but its Message field
was parsed using the formatting for UpgradeAvailable.

Also, only TKrs that have Compatible=True condition should be considered
as available updates.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Manual testing on an AWS management cluster. Added unit tests to cover the affected CLI command.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Only TKRs with Compatible=True status condition are considered as available updates.
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
