### PR TITLE
De-clutter TKR Controller logs

### DIFF
--- a/pkg/v1/tkr/main.go
+++ b/pkg/v1/tkr/main.go
@@ -21,6 +21,7 @@ import (
 
 	runv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
 	tkrsourcectr "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/controllers/source"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/constants"
 	mgrcontext "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/context"
 )
 
@@ -61,7 +62,9 @@ func main() {
 		Scheme:           scheme,
 		Port:             9443,
 		LeaderElection:   enableLeaderElection,
-		LeaderElectionID: "abf9f9ab.tanzu.vmware.com",
+		LeaderElectionID: constants.TKRControllerLeaderElectionCM,
+
+		LeaderElectionNamespace: constants.TKRNamespace,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/pkg/v1/tkr/pkg/constants/constants.go
+++ b/pkg/v1/tkr/pkg/constants/constants.go
@@ -25,6 +25,9 @@ const (
 	// TKRNamespace is the TKR namespace
 	TKRNamespace = "tkr-system"
 
+	// TKRControllerLeaderElectionCM is the ConfigMap used as the TKR Controller leader election lock
+	TKRControllerLeaderElectionCM = "abf9f9ab.tanzu.vmware.com"
+
 	// TKGNamespace is the TKG namespace
 	TKGNamespace = "tkg-system"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

TKR Controller logs are flooded with messages like:
```
2021-08-24T15:53:02.125Z DEBUG controller-runtime.controller Successfully Reconciled {"controller": "tkr-source-controller", "name": "abf9f9ab.tanzu.vmware.com", "namespace": "tkr-system"}
```

This change filters out any events about the leader-election ConfigMap from reconciliation requests.


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Ran and watched the logs: no longer cluttered! TKR ConfigMaps are still reconciled as expected.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
