### PR TITLE
Updates node pool creation to fix label/matchlabel

### DIFF
--- a/pkg/v1/tkg/client/machine_deployment.go
+++ b/pkg/v1/tkg/client/machine_deployment.go
@@ -98,6 +98,7 @@ func (c *TkgClient) SetMachineDeployment(options *SetMachineDeploymentOptions) e
 	for k, v := range options.Labels {
 		baseWorker.Spec.Template.Labels[k] = v
 	}
+	baseWorker.Spec.Template.Labels["cluster.x-k8s.io/deployment-name"] = options.Name
 
 	kcTemplate, err := retrieveKubeadmConfigTemplate(clusterClient, baseWorker.Spec.Template.Spec.Bootstrap.ConfigRef)
 	if err != nil {
@@ -131,6 +132,7 @@ func (c *TkgClient) SetMachineDeployment(options *SetMachineDeploymentOptions) e
 		}
 
 		baseWorker.ResourceVersion = ""
+		baseWorker.Spec.Selector.MatchLabels["cluster.x-k8s.io/deployment-name"] = options.Name
 		baseWorker.Spec.Template.Spec.Bootstrap.ConfigRef.Name = kcTemplate.Name
 		baseWorker.Spec.Template.Spec.InfrastructureRef.Name = machineTemplateName
 		if options.AZ != "" {


### PR DESCRIPTION
This change fixes a potential issue in AWS/Azure where the match label
and label for 'deployment-name' are not correctly updated.

**What this PR does / why we need it**:
Fixes labels in Azure/AWS on newly created machine deployments.

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested on AWS, Azure and vSphere. Confirmed that the labels are properly updated on newly created node pools in all three.
**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
