### PR TITLE
Fix standalone-cluster delete credential encoding

### DIFF
--- a/pkg/v1/tkg/client/delete_standalone.go
+++ b/pkg/v1/tkg/client/delete_standalone.go
@@ -240,16 +240,12 @@ func (c *TkgClient) EncodeCredentials(initOptions *InitRegionOptions, clusterCli
 	// since provider templates need Base64 values of credentials, encode them
 	switch providerName {
 	case AzureProviderName:
-		if _, err := c.EncodeAzureCredentialsAndGetClient(clusterClient); err != nil {
+		if _, err := c.EncodeAzureCredentialsAndGetClient(nil); err != nil {
 			return errors.Wrap(err, "failed to encode azure credentials")
 		}
 	case AWSProviderName:
-		if _, err := c.EncodeAWSCredentialsAndGetClient(clusterClient); err != nil {
+		if _, err := c.EncodeAWSCredentialsAndGetClient(nil); err != nil {
 			return errors.Wrap(err, "failed to encode AWS credentials")
-		}
-	case VSphereProviderName:
-		if err := c.configureVsphereCredentialsFromCluster(clusterClient); err != nil {
-			return errors.Wrap(err, "failed to configure vSphere credentials")
 		}
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it:
This PR does 2 things:
- Don't provide a cluster client when attempting to encode credentials for Azure or AWS (since we are getting the credentials from the cluster config file or the aws CLI
- Don't attempt to encode credentials for vSphere. Since these creds _should_ already be saved in the standalone cluster's clusterConfig file (which is reloaded on `delete`), this removes an necessary cal to populate the vSphere username and password

### Which issue(s) this PR fixes:
Related to https://github.com/vmware-tanzu/community-edition/issues/1241
Related to https://github.com/vmware-tanzu/community-edition/issues/1432

### Describe testing done for PR:
- ✅ Deployed standalone cluster to AWS and able to delete
- ✅ Deployed standalone cluster to Azure and able to delete 
- ⚠️ Need help validating this assumption for vSphere: cc @stmcginnis 

### Special notes for your reviewer:
N/a

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
