### PR TITLE
Add a component for accepting stdin from the console (#478)

### DIFF
--- a/pkg/v1/cli/component/reader.go
+++ b/pkg/v1/cli/component/reader.go
@@ -1,0 +1,56 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package component
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/aunum/log"
+	"github.com/pkg/errors"
+)
+
+const (
+	stdInIdentifier = "-"
+)
+
+// ReadInput reads from file or std input and return a byte array.
+func ReadInput(filePath string) ([]byte, error) {
+	if filePath == stdInIdentifier {
+		return readFromStdInput()
+	}
+	return readFromFile(filePath)
+}
+
+// readFromFile opens the file at path and reads the file into a byte array.
+func readFromFile(filePath string) ([]byte, error) {
+	inputFile, err := os.Open(filePath)
+	if err != nil {
+		return nil, errors.WithMessage(err, fmt.Sprintf("Error opening the input file %s.", filePath))
+	}
+	defer func() {
+		if err = inputFile.Close(); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	buf := bytes.NewBuffer(nil)
+	_, err = io.Copy(buf, inputFile)
+	if err != nil {
+		return nil, errors.WithMessage(err, fmt.Sprintf("Error reading from input file %s.", filePath))
+	}
+	log.Debugf("read object --> \n---\n%s\n---\n", buf.String())
+	return buf.Bytes(), nil
+}
+
+// readFromStdInput reads the incoming stream of bytes from console and return a byte array.
+func readFromStdInput() ([]byte, error) {
+	inBytes, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		return nil, errors.WithMessage(err, "Error reading from stdin.")
+	}
+	return inBytes, nil
+}

--- a/pkg/v1/test/cli/framework.go
+++ b/pkg/v1/test/cli/framework.go
@@ -15,14 +15,12 @@ import (
 	"time"
 
 	"github.com/aunum/log"
-	"github.com/golang/protobuf/proto" //nolint
 	uuid "github.com/satori/go.uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
-	encproto "github.com/vmware-tanzu/tanzu-framework/pkg/v1/encoding/proto"
 )
 
 // Main holds state for multiple command tests.
@@ -396,36 +394,6 @@ func cleanCommand(command string) []string {
 		c = c[1:]
 	}
 	return c
-}
-
-// ExecUnmarshal executes the command and unmarshals it into the message.
-func (t *Test) ExecUnmarshal(outputMessage proto.Message, format string) error {
-	err := ExecUnmarshal(t.Command, outputMessage, format)
-	if err != nil {
-		t.Result.Error(err)
-		return err
-	}
-	t.Result.Success()
-	return nil
-}
-
-// ExecUnmarshal executes the given command and unmarshals it into the message.
-func ExecUnmarshal(command string, outputMessage proto.Message, format string) error {
-	stdOut, _, err := Exec(command)
-	if err != nil {
-		return err
-	}
-
-	// empty list response
-	if strings.HasSuffix(stdOut.String(), "to list \n") {
-		return nil
-	}
-
-	err = encproto.BufferToProto(stdOut, outputMessage, format)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 // ExecContainsString executes the command and checks if the output contains the given string.


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently TMC resources can be created only via the file. This PR adds capability for the Tanzu CLI to accept stdin from console to create TMC resources.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #478 

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Tested locally by pulling into TMC plugin repo.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Added capability to create a resource in the server via the standard input.
eg : cat <file> | tanzu example-resource create -f -
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
