### PR TITLE
Remove unecessary logging in standalone-clusters

### DIFF
--- a/pkg/v1/tkg/client/init_standalone.go
+++ b/pkg/v1/tkg/client/init_standalone.go
@@ -17,7 +17,6 @@ limitations under the License.
 package client
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -161,9 +160,6 @@ func (c *TkgClient) InitStandaloneRegion(options *InitRegionOptions) error { //n
 	isStartedRegionalClusterCreation = true
 
 	targetClusterNamespace := defaultTkgNamespace
-	// if options.Namespace != "" {
-	// 	targetClusterNamespace = options.Namespace
-	// }
 
 	log.SendProgressUpdate(statusRunning, StepCreateStandaloneCluster, InitSARegionSteps)
 	log.Info("Start creating standalone cluster...")
@@ -174,7 +170,6 @@ func (c *TkgClient) InitStandaloneRegion(options *InitRegionOptions) error { //n
 
 	// save this context to tkg config incase the standalone cluster creation fails
 	regionContext = region.RegionContext{ClusterName: options.ClusterName, ContextName: "kind-" + bootstrapClusterName, SourceFilePath: bootstrapClusterKubeconfigPath, Status: region.Failed}
-	fmt.Printf("regionContext:\n%v", regionContext)
 
 	kubeConfigBytes, err := c.WaitForClusterInitializedAndGetKubeConfig(bootStrapClusterClient, options.ClusterName, targetClusterNamespace)
 	if err != nil {

--- a/pkg/v1/tkg/tkgctl/init_standalone.go
+++ b/pkg/v1/tkg/tkgctl/init_standalone.go
@@ -61,8 +61,6 @@ import (
 // InitStandalone initializes standalone cluster
 func (t *tkgctl) InitStandalone(options InitRegionOptions) error {
 	var err error
-
-	log.Infof("\nloading cluster config file at %s", options.ClusterConfigFile)
 	options.ClusterConfigFile, err = t.ensureClusterConfigFile(options.ClusterConfigFile)
 	if err != nil {
 		return err
@@ -77,7 +75,6 @@ func (t *tkgctl) InitStandalone(options InitRegionOptions) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("\nloaded coreprovider: %s, bootstrapprovider: %s, and cp-provider: %s", options.CoreProvider, options.BootstrapProvider, options.ControlPlaneProvider)
 
 	err = t.configureInitManagementClusterOptionsFromConfigFile(&options)
 	if err != nil {
@@ -194,9 +191,18 @@ func (t *tkgctl) InitStandalone(options InitRegionOptions) error {
 		if err != nil {
 			return errors.Wrap(err, "unable to set up standalone cluster")
 		}
-
-		log.Infof("\nStandalone cluster created!\n\n")
+		logStandaloneCreationSuccess()
 	}
 
 	return nil
+}
+
+func logStandaloneCreationSuccess() {
+	log.Infof("\nStandalone cluster created!\n\n")
+	log.Info("\nYou can now use Kubectl to access your cluster:\n\n")
+	log.Info("  kubectl get pods -A\n\n")
+	log.Info("\nYou can also delete the cluster by running the following:\n\n")
+	log.Info("  tanzu standalone-cluster delete [name]\n\n")
+	log.Info("\nSome addons might be getting installed! Check their status by running the following:\n\n")
+	log.Info("  kubectl get apps -A\n\n")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes unnecessary logging for standalone-clusters and brings standalone cluster `init-standalone.go` up to speed with management cluster's `init.go`

Will have follow up PR in the community-edition repo to bring this change in

**Which issue(s) this PR fixes**:
Related to https://github.com/vmware-tanzu/community-edition/issues/1380

**Describe testing done for PR**:
Deployed capd cluster locally and saw these log lines gone

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
