### PR TITLE
simplifiy pinniped kubeconfig logic by getting control plane endpoint from Cluster

### DIFF
--- a/pkg/v1/tkg/client/get_cluster_pinniped_info.go
+++ b/pkg/v1/tkg/client/get_cluster_pinniped_info.go
@@ -5,17 +5,14 @@ package client
 
 import (
 	"fmt"
-	"strings"
+	"net"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	capvv1alpha3 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
-
-	capav1alpha3 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
-	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
@@ -136,7 +133,7 @@ func (c *TkgClient) GetMCClusterPinnipedInfo(regionalClusterClient clusterclient
 
 func (c *TkgClient) getClusterAPIServerURL(regionalClusterClient clusterclient.Client, clusterName, namespace string) (string, error) {
 	var apiServerHost string
-	var apiServerPort int32
+	var apiServerPort string
 	var cluster capi.Cluster
 	err := regionalClusterClient.GetResource(&cluster, clusterName, namespace, nil, nil)
 	if err != nil {
@@ -147,51 +144,16 @@ func (c *TkgClient) getClusterAPIServerURL(regionalClusterClient clusterclient.C
 		}
 		return "", errors.Wrap(err, "failed to get 'cluster' resource")
 	}
-	clusterKind := cluster.Spec.InfrastructureRef.Kind
-	switch strings.ToLower(clusterKind) {
-	case "vspherecluster":
-		var vSphereCluster capvv1alpha3.VSphereCluster
-		err := regionalClusterClient.GetResource(&vSphereCluster, clusterName, namespace, nil, nil)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				errMsg := fmt.Sprintf("VSphereCluster object '%s' is not present in namespace '%s' ", clusterName, namespace)
-				log.V(4).Info(errMsg)
-				return "", errors.New(errMsg)
-			}
-			return "", errors.Wrap(err, "failed to get 'VSphereCluster' resource")
-		}
 
-		apiServerHost = vSphereCluster.Spec.ControlPlaneEndpoint.Host
-		apiServerPort = vSphereCluster.Spec.ControlPlaneEndpoint.Port
-	case "awscluster":
-		var awsCluster capav1alpha3.AWSCluster
-		err := regionalClusterClient.GetResource(&awsCluster, clusterName, namespace, nil, nil)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				errMsg := fmt.Sprintf("AWSCluster object '%s' is not present in namespace '%s' ", clusterName, namespace)
-				log.V(4).Info(errMsg)
-				return "", errors.New(errMsg)
-			}
-			return "", errors.Wrap(err, "failed to get 'AWSCluster' resource")
-		}
-		apiServerHost = awsCluster.Spec.ControlPlaneEndpoint.Host
-		apiServerPort = awsCluster.Spec.ControlPlaneEndpoint.Port
-
-	case "azurecluster":
-		var azureCluster capzv1alpha3.AzureCluster
-		err := regionalClusterClient.GetResource(&azureCluster, clusterName, namespace, nil, nil)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				errMsg := fmt.Sprintf("AzureCluster object '%s' is not present in namespace '%s' ", clusterName, namespace)
-				log.V(4).Info(errMsg)
-				return "", errors.New(errMsg)
-			}
-			return "", errors.Wrap(err, "failed to get 'AzureCluster' resource")
-		}
-		apiServerHost = azureCluster.Spec.ControlPlaneEndpoint.Host
-		apiServerPort = azureCluster.Spec.ControlPlaneEndpoint.Port
-	default:
-		return "", errors.Errorf("failed to determine the Infra-cluster object type")
+	if cluster.Spec.ControlPlaneEndpoint.Host == "" {
+		return "", errors.New("controlplane endpoint 'host' was not set in 'cluster' resource")
 	}
-	return fmt.Sprintf("https://%s:%d", apiServerHost, apiServerPort), nil
+
+	if cluster.Spec.ControlPlaneEndpoint.Port == 0 {
+		return "", errors.New("controlplane endpoint 'port' was not set in 'cluster' resource")
+	}
+
+	apiServerHost = cluster.Spec.ControlPlaneEndpoint.Host
+	apiServerPort = strconv.Itoa(int(cluster.Spec.ControlPlaneEndpoint.Port))
+	return net.JoinHostPort(apiServerHost, apiServerPort), nil
 }


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What this PR does / why we need it**:
This PR simplifies the kubeconfig generation logic for pinniped where we get the control plane endpoint from the generic Cluster resource, as opposed to checking infrastructure-specific resources like VSphereCluster, AWSCluster and AzureCluster. This generalizes the logic a bit so it can work against any cluster with a valid control plane endpoint regardless of the infrastructure provider. It also fixes a minor bug when in the host / port joining logic where square brackets wouldn't be added if the address was IPv6. 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
Only unit tests so far.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
