### PR TITLE
Use correct Proxy and IP_FAMILY settings during workload cluster upgrade

### DIFF
--- a/pkg/v1/tkg/client/delete_region.go
+++ b/pkg/v1/tkg/client/delete_region.go
@@ -94,7 +94,7 @@ func (c *TkgClient) DeleteRegion(options DeleteRegionOptions) error { //nolint:f
 		return err
 	}
 
-	err = c.retriveRegionalClusterConfiguration(regionalClusterClient)
+	err = c.retrieveRegionalClusterConfiguration(regionalClusterClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to set configurations for deletion")
 	}

--- a/pkg/v1/tkg/client/upgrade_addon.go
+++ b/pkg/v1/tkg/client/upgrade_addon.go
@@ -217,7 +217,12 @@ func (c *TkgClient) DoUpgradeAddon(regionalClusterClient clusterclient.Client, /
 			c.TKGConfigReaderWriter().Set(constants.ConfigVaraibleDisableCRSForAddonType, addonName)
 		}
 
-		if err := c.retriveRegionalClusterConfiguration(regionalClusterClient); err != nil {
+		if options.IsRegionalCluster {
+			err = c.retrieveRegionalClusterConfiguration(regionalClusterClient)
+		} else {
+			err = c.retrieveWorkloadClusterConfiguration(regionalClusterClient, currentClusterClient, options.ClusterName, options.Namespace)
+		}
+		if err != nil {
 			return errors.Wrap(err, "unable to set cluster configuration")
 		}
 
@@ -243,9 +248,9 @@ func (c *TkgClient) DoUpgradeAddon(regionalClusterClient clusterclient.Client, /
 	return nil
 }
 
-// retriveRegionalClusterConfiguration gets TKG configurations from regional cluster and sets the TKGConfigReaderWriter.
+// retrieveRegionalClusterConfiguration gets TKG configurations from regional cluster and updates the in-memory config.
 // this is required when we want to mutate the existing regional cluster.
-func (c *TkgClient) retriveRegionalClusterConfiguration(regionalClusterClient clusterclient.Client) error {
+func (c *TkgClient) retrieveRegionalClusterConfiguration(regionalClusterClient clusterclient.Client) error {
 	if err := c.setProxyConfiguration(regionalClusterClient); err != nil {
 		return errors.Wrapf(err, "error while getting proxy configuration from cluster and setting it")
 	}
@@ -254,14 +259,38 @@ func (c *TkgClient) retriveRegionalClusterConfiguration(regionalClusterClient cl
 		return errors.Wrapf(err, "error while getting custom image repository configuration from cluster and setting it")
 	}
 
-	if err := c.setNetworkingConfiguration(regionalClusterClient); err != nil {
+	clusterName, regionalClusterNamespace, err := c.getRegionalClusterNameAndNamespace(regionalClusterClient)
+	if err != nil {
+		return errors.Wrap(err, "unable to get name and namespace of current management cluster")
+	}
+
+	if err := c.setNetworkingConfiguration(regionalClusterClient, clusterName, regionalClusterNamespace); err != nil {
+		return errors.Wrap(err, "error while initializing networking configuration")
+	}
+	return nil
+}
+
+// retrieveWorkloadClusterConfiguration gets TKG configurations from regional cluster as well as workload cluster
+// and updates the in-memory config. This is required when we want to mutate the existing workload cluster.
+func (c *TkgClient) retrieveWorkloadClusterConfiguration(regionalClusterClient, workloadClusterClient clusterclient.Client, clusterName, clusterNamespace string) error {
+	if err := c.setProxyConfiguration(workloadClusterClient); err != nil {
+		return errors.Wrapf(err, "error while getting proxy configuration from cluster and setting it")
+	}
+
+	// Sets custom image repository configuration from Management Cluster even for workload cluster
+	// Currently, TKG does not support using different image repositories for management and workload clusters.
+	if err := c.setCustomImageRepositoryConfiguration(regionalClusterClient); err != nil {
+		return errors.Wrapf(err, "error while getting custom image repository configuration from cluster and setting it")
+	}
+
+	if err := c.setNetworkingConfiguration(regionalClusterClient, clusterName, clusterNamespace); err != nil {
 		return errors.Wrap(err, "error while initializing networking configuration")
 	}
 
 	return nil
 }
 
-func (c *TkgClient) setProxyConfiguration(regionalClusterClient clusterclient.Client) (retErr error) {
+func (c *TkgClient) setProxyConfiguration(clusterClusterClient clusterclient.Client) (retErr error) {
 	// make sure proxy parameters are non-empty
 	defer func() {
 		if retErr == nil {
@@ -269,7 +298,7 @@ func (c *TkgClient) setProxyConfiguration(regionalClusterClient clusterclient.Cl
 		}
 	}()
 	configmap := &corev1.ConfigMap{}
-	if err := regionalClusterClient.GetResource(configmap, constants.KappControllerConfigMapName, constants.KappControllerNamespace, nil, nil); err != nil {
+	if err := clusterClusterClient.GetResource(configmap, constants.KappControllerConfigMapName, constants.KappControllerNamespace, nil, nil); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
@@ -326,16 +355,11 @@ func (c *TkgClient) setCustomImageRepositoryConfiguration(regionalClusterClient 
 	return nil
 }
 
-func (c *TkgClient) setNetworkingConfiguration(regionalClusterClient clusterclient.Client) error {
-	clusterName, regionalClusterNamespace, err := c.getRegionalClusterNameAndNamespace(regionalClusterClient)
-	if err != nil {
-		return errors.Wrap(err, "unable to get name and namespace of current management cluster")
-	}
-
+func (c *TkgClient) setNetworkingConfiguration(regionalClusterClient clusterclient.Client, clusterName, clusterNamespace string) error {
 	cluster := &capi.Cluster{}
-	err = regionalClusterClient.GetResource(cluster, clusterName, regionalClusterNamespace, nil, nil)
+	err := regionalClusterClient.GetResource(cluster, clusterName, clusterNamespace, nil, nil)
 	if err != nil {
-		return errors.Wrapf(err, "unable to get cluster %q from namespace %q", clusterName, regionalClusterNamespace)
+		return errors.Wrapf(err, "unable to get cluster %q from namespace %q", clusterName, clusterNamespace)
 	}
 
 	if cluster.Spec.ClusterNetwork != nil {

--- a/pkg/v1/tkg/client/upgrade_region.go
+++ b/pkg/v1/tkg/client/upgrade_region.go
@@ -194,7 +194,7 @@ func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterCl
 	}
 	// retrieve required variables required for infrastructure component spec rendering
 	// set them to default values if they don't exist.
-	err = c.retriveRegionalClusterConfiguration(regionalClusterClient)
+	err = c.retrieveRegionalClusterConfiguration(regionalClusterClient)
 	if err != nil {
 		return errors.Wrap(err, "failed to set configurations for upgrade")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
- During workload cluster upgrade it was found that CLI is using
  using incorrect proxy and ip_family configuration
- It was using configuration from management cluster instead of using
  that configuration from workload cluster
- This change fixes this issue by implementing another
  retriveWorkloadClusterConfiguration function which configures workload
  cluster configuration.

Signed-off-by: Anuj Chaudhari <anujc@vmware.com>

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
✅  Upgrade tests
✅  Proxy tests
✅  IPv6 tests

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
