### PR TITLE
Fix segv on tanzu update

### DIFF
--- a/pkg/v1/cli/catalog.go
+++ b/pkg/v1/cli/catalog.go
@@ -238,8 +238,8 @@ func ValidatePlugin(p *cliv1alpha1.PluginDescriptor) (err error) {
 
 // HasPluginUpdateIn checks if the plugin has an update in any of the given repositories.
 func HasPluginUpdateIn(repos *MultiRepo, p *cliv1alpha1.PluginDescriptor) (update bool, repo Repository, version string, err error) {
-	versionSelector := repo.VersionSelector()
 	for _, repo := range repos.repositories {
+		versionSelector := repo.VersionSelector()
 		update, version, err := HasPluginUpdate(repo, versionSelector, p)
 		if err != nil {
 			log.Debugf("could not check for update for plugin %q in repo %q: %v", p.Name, repo.Name, err)


### PR DESCRIPTION
Fixes a use-before-assign on HasPluginUpdateIn. Added unit tests.

Closes: #389

Signed-off-by: Vui Lam <vui@vmware.com>

**What this PR does / why we need it**:
```tanzu update``` segv's otherwise.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #389

**Describe testing done for PR**:
Added unit tests
Verified tanzu update does not segfault.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
NONE
```release-note

```
**New PR Checklist**

- x Ensure PR contains only public links or terms
- x Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- x Squash the commits in this branch before merge to preserve our git history
- x If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- x Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
