### PR TITLE
Fix scale func to avoid scaling excess MDs to zero

### DIFF
--- a/pkg/v1/tkg/client/scale_test.go
+++ b/pkg/v1/tkg/client/scale_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
@@ -100,6 +101,110 @@ var _ = Describe("Unit tests for scalePacificCluster", func() {
 		It("returns an error", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("unable to scale workers nodes for workload cluster"))
+		})
+	})
+})
+
+var _ = Describe("Scale API", func() {
+	Context("DoScaleCluster", func() {
+		var (
+			err                   error
+			regionalClusterClient *fakes.ClusterClient
+			tkgClient             *TkgClient
+			scaleClusterOptions   ScaleClusterOptions
+		)
+
+		const (
+			defaultNamespaceName = "default"
+			md1Name              = "test-cluster-md-0"
+			md2Name              = "test-cluster-md-1"
+			md3Name              = "test-cluster-md-2"
+		)
+
+		BeforeEach(func() {
+			tkgClient, err = CreateTKGClient("../fakes/config/config.yaml", testingDir, defaultTKGBoMFileForTesting, 2*time.Second)
+			regionalClusterClient = &fakes.ClusterClient{}
+			scaleClusterOptions = ScaleClusterOptions{}
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("management cluster is not a Pacific cluster", func() {
+			When("a user scales worker nodes greater than num of machine deployments", func() {
+				It("should update mds with the correct number of workers", func() {
+					regionalClusterClient.IsPacificRegionalClusterReturns(false, nil)
+					regionalClusterClient.GetKCPObjectForClusterReturns(nil, nil)
+					md1 := v1alpha3.MachineDeployment{}
+					md1.Name = md1Name
+					md1.Namespace = defaultNamespaceName
+					md2 := v1alpha3.MachineDeployment{}
+					md2.Name = md2Name
+					md2.Namespace = defaultNamespaceName
+					md3 := v1alpha3.MachineDeployment{}
+					md3.Name = md3Name
+					md3.Namespace = defaultNamespaceName
+					regionalClusterClient.GetMDObjectForClusterReturns([]v1alpha3.MachineDeployment{md1, md2, md3}, nil)
+
+					scaleClusterOptions.ControlPlaneCount = 0
+					scaleClusterOptions.WorkerCount = 4
+
+					err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(regionalClusterClient.UpdateReplicasCallCount()).To(Equal(3))
+					_, name, namespace, count := regionalClusterClient.UpdateReplicasArgsForCall(0)
+					Expect(name).To(Equal(md1.Name))
+					Expect(namespace).To(Equal(md1.Namespace))
+					Expect(count).To(BeEquivalentTo(2))
+
+					_, name, namespace, count = regionalClusterClient.UpdateReplicasArgsForCall(1)
+					Expect(name).To(Equal(md2.Name))
+					Expect(namespace).To(Equal(md2.Namespace))
+					Expect(count).To(BeEquivalentTo(1))
+
+					_, name, namespace, count = regionalClusterClient.UpdateReplicasArgsForCall(2)
+					Expect(name).To(Equal(md3.Name))
+					Expect(namespace).To(Equal(md3.Namespace))
+					Expect(count).To(BeEquivalentTo(1))
+				})
+			})
+			When("a user scales worker nodes less than num of machine deployments", func() {
+				It("should return an error", func() {
+					regionalClusterClient.IsPacificRegionalClusterReturns(false, nil)
+					regionalClusterClient.GetKCPObjectForClusterReturns(nil, nil)
+					md1 := v1alpha3.MachineDeployment{}
+					md1.Name = md1Name
+					md1.Namespace = defaultNamespaceName
+					md2 := v1alpha3.MachineDeployment{}
+					md2.Name = md2Name
+					md2.Namespace = defaultNamespaceName
+					md3 := v1alpha3.MachineDeployment{}
+					md3.Name = md3Name
+					md3.Namespace = defaultNamespaceName
+					regionalClusterClient.GetMDObjectForClusterReturns([]v1alpha3.MachineDeployment{md1, md2, md3}, nil)
+
+					scaleClusterOptions.ControlPlaneCount = 0
+					scaleClusterOptions.WorkerCount = 2
+
+					err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("worker count must be greater than"))
+				})
+			})
+			When("a user calls ScaleCluster with a worker count less than 1", func() {
+				It("should not update any mds", func() {
+					regionalClusterClient.IsPacificRegionalClusterReturns(false, nil)
+					regionalClusterClient.GetKCPObjectForClusterReturns(nil, nil)
+
+					scaleClusterOptions.ControlPlaneCount = 0
+					scaleClusterOptions.WorkerCount = 0
+
+					err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(regionalClusterClient.GetMDObjectForClusterCallCount()).To(Equal(0))
+					Expect(regionalClusterClient.UpdateReplicasCallCount()).To(Equal(0))
+				})
+			})
 		})
 	})
 })


### PR DESCRIPTION
This change updates the ScaleCluster method to distribute the requested
number of worker nodes across all of the available machine deployments
in the specified cluster. This fixes a bug where user created
machinedeployments would be scaled to zero using this method.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes an issue where the scale API would scale user created MachineDeployments to zero when the number of MachineDeployments exceeded the expected number of MachineDeployments for the given provider/plan combo.  

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Fixes bug where scale operation would scale user created MachineDeployments in a cluster to zero. Workers are now distributed evenly across all MachineDeployments in the cluster.
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
