### PR TITLE
Enable checks on release-* branches

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,10 +1,8 @@
 name: Main
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release-* ]
 
 jobs:
 

--- a/.github/workflows/plugin_tests.yaml
+++ b/.github/workflows/plugin_tests.yaml
@@ -1,10 +1,8 @@
 name: Plugin Tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, release-*]
     paths:
       - "cmd/cli/plugin/cluster/**"
       - "cmd/cli/plugin/managementcluster/**"

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -5,7 +5,7 @@ on:
   # only on pull requests as some tests involves comparing results based on differences
   # between source and target branches
   pull_request:
-    branches: [ main ]
+    branches: [ main, release-* ]
     paths:
     - 'pkg/v1/tkg/**'
     - 'pkg/v1/providers/**'

--- a/.github/workflows/tkg_integration_tests.yaml
+++ b/.github/workflows/tkg_integration_tests.yaml
@@ -1,10 +1,8 @@
 name: TKG Integration Tests
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release-* ]
     paths:
     - 'pkg/v1/tkg/**'
     - '!pkg/v1/tkg/tkgpackage*/*'

--- a/.github/workflows/tkgpackage_integration_test.yaml
+++ b/.github/workflows/tkgpackage_integration_test.yaml
@@ -1,10 +1,8 @@
 name: TKG Package Plugin Integration Tests
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, release-* ]
     paths:
       - '.github/workflows/tkgpackage_integration_test.yaml'
       - 'pkg/v1/tkg/tkgpackage*/*'


### PR DESCRIPTION
Also, having enabled requirement that PRs be up-to-date before merge,
remove redundant CI on push to target branch.

Signed-off-by: Vui Lam <vui@vmware.com>

**What this PR does / why we need it**:
Release branches should undergo CI checks as well. See #229

**Which issue(s) this PR fixes**:
Closes: #229

**Describe testing done for PR**:
Monitor CI runs 

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- x Ensure PR contains only public links or terms
- x Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- x Squash the commits in this branch before merge to preserve our git history
- x If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- x Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
