### PR TITLE
Add package plugin to the default plugin distro

### DIFF
--- a/pkg/v1/cli/defaults.go
+++ b/pkg/v1/cli/defaults.go
@@ -4,4 +4,4 @@
 package cli
 
 // DefaultDistro is the core set of plugins that should be included with the CLI.
-var DefaultDistro = []string{"login", "pinniped-auth", "cluster", "management-cluster", "kubernetes-release"}
+var DefaultDistro = []string{"login", "pinniped-auth", "cluster", "management-cluster", "kubernetes-release", "package"}


### PR DESCRIPTION
Addresses: #554

Signed-off-by: Vui Lam <vui@vmware.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Addresses #554
(will port to main later)

**Describe testing done for PR**:
built local cli, verify that package plugin is install on initialization

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
tanzu CLI initialization installs these plugins:
"login", "pinniped-auth", "cluster", "management-cluster", "kubernetes-release", "package"
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
