### PR TITLE
Adds tests to enforce public API signatures

### DIFF
--- a/pkg/v1/tkg/client/api_sig_enforce_more_test.go
+++ b/pkg/v1/tkg/client/api_sig_enforce_more_test.go
@@ -1,0 +1,977 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package client_test
+
+import (
+	"reflect"
+	"testing"
+
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/aws"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/azure"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/providersupgradeclient"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/region"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/vc"
+)
+
+func Test_DeleteMachineHealthCheck_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DeleteMachineHealthCheck",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.MachineHealthCheckOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DeleteMachineHealthCheckWithClusterClient_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DeleteMachineHealthCheckWithClusterClient",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(client.MachineHealthCheckOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetMachineHealthChecks_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetMachineHealthChecks",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.MachineHealthCheckOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf([]client.MachineHealthCheck{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetMachineHealthChecksWithClusterClient_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetMachineHealthChecksWithClusterClient",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(client.MachineHealthCheckOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf([]client.MachineHealthCheck{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetMachineHealthCheck_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "SetMachineHealthCheck",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.SetMachineHealthCheckOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_CreateMachineHealthCheck_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "CreateMachineHealthCheck",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(&client.SetMachineHealthCheckOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_UpdateMachineHealthCheck_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "UpdateMachineHealthCheck",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&capi.MachineHealthCheck{}),
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(&client.SetMachineHealthCheckOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_VerifyRegion_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "VerifyRegion",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(region.RegionContext{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_AddRegionContext_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "AddRegionContext",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(region.RegionContext{}),
+			reflect.TypeOf(false),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetRegionContexts_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetRegionContexts",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf([]region.RegionContext{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetRegionContext_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "SetRegionContext",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetCurrentRegionContext_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetCurrentRegionContext",
+		ParamTypes: []reflect.Type{},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(region.RegionContext{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_RegisterManagementClusterToTmc_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "RegisterManagementClusterToTmc",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ScaleCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ScaleCluster",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.ScaleClusterOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ScalePacificCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ScalePacificCluster",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.ScaleClusterOptions{}),
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_UpdateCredentialsRegion_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "UpdateCredentialsRegion",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.UpdateCredentialsOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_UpdateCredentialsCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "UpdateCredentialsCluster",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.UpdateCredentialsOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_UpdateVSphereClusterCredentials_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "UpdateVSphereClusterCredentials",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(&client.UpdateCredentialsOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_UpgradeAddon_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "UpgradeAddon",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.UpgradeAddonOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DoUpgradeAddon_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DoUpgradeAddon",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(&client.UpgradeAddonOptions{}),
+			reflect.TypeOf(func(*client.CreateClusterOptions) ([]byte, error) { return nil, nil }),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_UpgradeCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "UpgradeCluster",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.UpgradeClusterOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DoPacificClusterUpgrade_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DoPacificClusterUpgrade",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(&client.UpgradeClusterOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DoClusterUpgrade_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DoClusterUpgrade",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(&client.UpgradeClusterOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_UpgradeManagementCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "UpgradeManagementCluster",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.UpgradeClusterOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DoProvidersUpgrade_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DoProvidersUpgrade",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+			reflect.TypeOf((*providersupgradeclient.Client)(nil)).Elem(),
+			reflect.TypeOf(&client.UpgradeClusterOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_WaitForAddonsDeployments_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "WaitForAddonsDeployments",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_WaitForPackages_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "WaitForPackages",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DownloadBomFile_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DownloadBomFile",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureAndValidateTkrVersion_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureAndValidateTkrVersion",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureAzureVMImage_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureAzureVMImage",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureAndValidateAzureConfig_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureAndValidateAzureConfig",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+			reflect.TypeOf(client.NodeSizeOptions{}),
+			reflect.TypeOf(false),
+			reflect.TypeOf(false),
+			reflect.TypeOf(int64(0)),
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ValidateAzurePublicSSHKey_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ValidateAzurePublicSSHKey",
+		ParamTypes: []reflect.Type{},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureAndValidateDockerConfig_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureAndValidateDockerConfig",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+			reflect.TypeOf(client.NodeSizeOptions{}),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureAndValidateWindowsVsphereConfig_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureAndValidateWindowsVsphereConfig",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+			reflect.TypeOf(client.NodeSizeOptions{}),
+			reflect.TypeOf(""),
+			reflect.TypeOf(false),
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*client.ValidationError)(nil)),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureAndValidateAwsConfig_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureAndValidateAwsConfig",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+			reflect.TypeOf(false),
+			reflect.TypeOf(false),
+			reflect.TypeOf(int64(0)),
+			reflect.TypeOf(false),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureAndValidateAWSConfig_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureAndValidateAWSConfig",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+			reflect.TypeOf(client.NodeSizeOptions{}),
+			reflect.TypeOf(false),
+			reflect.TypeOf(false),
+			reflect.TypeOf(int64(0)),
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_TrimVsphereSSHKey_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:      tkgClientVal,
+		MethodName:  "TrimVsphereSSHKey",
+		ParamTypes:  []reflect.Type{},
+		ReturnTypes: []reflect.Type{},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureAndValidateVSphereTemplate_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureAndValidateVSphereTemplate",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*vc.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetVSphereEndpoint_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetVSphereEndpoint",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*vc.Client)(nil)).Elem(),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureAndValidateManagementClusterConfiguration_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureAndValidateManagementClusterConfiguration",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.InitRegionOptions{}),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*client.ValidationError)(nil)),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ValidateVsphereControlPlaneEndpointIP_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ValidateVsphereControlPlaneEndpointIP",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*client.ValidationError)(nil)),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureAndValidateVsphereConfig_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureAndValidateVsphereConfig",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+			reflect.TypeOf(client.NodeSizeOptions{}),
+			reflect.TypeOf(""),
+			reflect.TypeOf(false),
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*client.ValidationError)(nil)),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ValidateVsphereVipWorkloadCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ValidateVsphereVipWorkloadCluster",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ValidateVsphereResources_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ValidateVsphereResources",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*vc.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetAndValidateDefaultAWSVPCConfiguration_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "SetAndValidateDefaultAWSVPCConfiguration",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(false),
+			reflect.TypeOf((*aws.Client)(nil)).Elem(),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(false),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ValidateVsphereNodeSize_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ValidateVsphereNodeSize",
+		ParamTypes: []reflect.Type{},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetVsphereNodeSize_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:      tkgClientVal,
+		MethodName:  "SetVsphereNodeSize",
+		ParamTypes:  []reflect.Type{},
+		ReturnTypes: []reflect.Type{},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_OverrideAzureNodeSizeWithOptions_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "OverrideAzureNodeSizeWithOptions",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*azure.Client)(nil)).Elem(),
+			reflect.TypeOf(client.NodeSizeOptions{}),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_OverrideAWSNodeSizeWithOptions_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "OverrideAWSNodeSizeWithOptions",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.NodeSizeOptions{}),
+			reflect.TypeOf((*aws.Client)(nil)).Elem(),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_OverrideVsphereNodeSizeWithOptions_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "OverrideVsphereNodeSizeWithOptions",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.NodeSizeOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetTKGClusterRole_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "SetTKGClusterRole",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*client.TKGClusterType)(nil)).Elem(),
+		},
+		ReturnTypes: []reflect.Type{},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_EncodeAzureCredentialsAndGetClient_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "EncodeAzureCredentialsAndGetClient",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*azure.Client)(nil)).Elem(),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureAndValidateCNIType_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureAndValidateCNIType",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DistributeMachineDeploymentWorkers_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DistributeMachineDeploymentWorkers",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(int64(0)),
+			reflect.TypeOf(false),
+			reflect.TypeOf(false),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf([]int{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetMachineDeploymentWorkerCounts_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "SetMachineDeploymentWorkerCounts",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf([]int{}),
+			reflect.TypeOf(int64(0)),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_EncodeAWSCredentialsAndGetClient_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "EncodeAWSCredentialsAndGetClient",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*aws.Client)(nil)).Elem(),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureAndValidateHTTPProxyConfiguration_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureAndValidateHTTPProxyConfiguration",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetDefaultProxySettings_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:      tkgClientVal,
+		MethodName:  "SetDefaultProxySettings",
+		ParamTypes:  []reflect.Type{},
+		ReturnTypes: []reflect.Type{},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetWorkloadClusterCredentials_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetWorkloadClusterCredentials",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.GetWorkloadClusterCredentialsOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DeleteWorkloadCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DeleteWorkloadCluster",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.DeleteWorkloadClusterOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}

--- a/pkg/v1/tkg/client/api_sig_enforce_test.go
+++ b/pkg/v1/tkg/client/api_sig_enforce_test.go
@@ -1,0 +1,882 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package client_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"sigs.k8s.io/cluster-api-provider-aws/cmd/clusterawsadm/credentials"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/tree"
+	crtclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	runv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/region"
+)
+
+func Test_ActivateTanzuKubernetesReleases_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ActivateTanzuKubernetesReleases",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DeactivateTanzuKubernetesReleases_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DeactivateTanzuKubernetesReleases",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetCEIPParticipation_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "SetCEIPParticipation",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(false),
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DoSetCEIPParticipation_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DoSetCEIPParticipation",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(region.RegionContext{}),
+			reflect.TypeOf(false),
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetCEIPParticipation_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetCEIPParticipation",
+		ParamTypes: []reflect.Type{},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(client.ClusterCeipInfo{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DoGetCEIPParticipation_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DoGetCEIPParticipation",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(client.ClusterCeipInfo{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_CreateCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "CreateCluster",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.CreateClusterOptions{}),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DoCreateCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DoCreateCluster",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_WaitForClusterInitializedAndGetKubeConfig_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "WaitForClusterInitializedAndGetKubeConfig",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf([]byte{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_WaitForClusterReadyForMove_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "WaitForClusterReadyForMove",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_WaitForClusterReadyAfterCreate_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "WaitForClusterReadyAfterCreate",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_WaitForClusterReadyAfterReverseMove_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "WaitForClusterReadyAfterReverseMove",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureAndValidateWorkloadClusterConfiguration_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureAndValidateWorkloadClusterConfiguration",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.CreateClusterOptions{}),
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ValidateSupportOfK8sVersionForManagmentCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ValidateSupportOfK8sVersionForManagmentCluster",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_IsPacificManagementCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "IsPacificManagementCluster",
+		ParamTypes: []reflect.Type{},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(false),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ValidateAndConfigureClusterOptions_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ValidateAndConfigureClusterOptions",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.CreateClusterOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ValidateManagementClusterVersionWithCLI_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ValidateManagementClusterVersionWithCLI",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ValidatePrerequisites_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ValidatePrerequisites",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(false),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ConfigureTimeout_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ConfigureTimeout",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*time.Duration)(nil)).Elem(),
+		},
+		ReturnTypes: []reflect.Type{},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_CreateAWSCloudFormationStack_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "CreateAWSCloudFormationStack",
+		ParamTypes: []reflect.Type{},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetAWSCreds_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetAWSCreds",
+		ParamTypes: []reflect.Type{},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(&credentials.AWSCredentials{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetClusterConfiguration_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetClusterConfiguration",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.CreateClusterOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf([]byte{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetPlan_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "SetPlan",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetProviderType_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "SetProviderType",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetVsphereVersion_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "SetVsphereVersion",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetBuildEdition_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "SetBuildEdition",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetTKGVersion_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:      tkgClientVal,
+		MethodName:  "SetTKGVersion",
+		ParamTypes:  []reflect.Type{},
+		ReturnTypes: []reflect.Type{},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetPinnipedConfigForWorkloadCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "SetPinnipedConfigForWorkloadCluster",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DeleteRegion_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DeleteRegion",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.DeleteRegionOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_IsManagementClusterAKindCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "IsManagementClusterAKindCluster",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(false),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DeRegisterManagementClusterFromTmc_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DeRegisterManagementClusterFromTmc",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DescribeCluster_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DescribeCluster",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.DescribeTKGClustersOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(&tree.ObjectTree{}),
+			reflect.TypeOf(&capi.Cluster{}),
+			reflect.TypeOf(&clusterctlv1.ProviderList{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DescribeProvider_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DescribeProvider",
+		ParamTypes: []reflect.Type{},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(&clusterctlv1.ProviderList{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetClusterPinnipedInfo_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetClusterPinnipedInfo",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.GetClusterPinnipedInfoOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(&client.ClusterPinnipedInfo{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetWCClusterPinnipedInfo_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetWCClusterPinnipedInfo",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(region.RegionContext{}),
+			reflect.TypeOf(client.GetClusterPinnipedInfoOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(&client.ClusterPinnipedInfo{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetMCClusterPinnipedInfo_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetMCClusterPinnipedInfo",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(region.RegionContext{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(&client.ClusterPinnipedInfo{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ListTKGClusters_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ListTKGClusters",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.ListTKGClustersOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf([]client.ClusterInfo{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetClusterObjects_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetClusterObjects",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(&crtclient.ListOptions{}),
+			reflect.TypeOf(""),
+			reflect.TypeOf(false),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf([]client.ClusterInfo{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetClusterObjectsForPacific_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetClusterObjectsForPacific",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+			reflect.TypeOf(&crtclient.ListOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf([]client.ClusterInfo{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetKubernetesVersions_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetKubernetesVersions",
+		ParamTypes: []reflect.Type{},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(&client.KubernetesVersionsInfo{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DoGetTanzuKubernetesReleases_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DoGetTanzuKubernetesReleases",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf(&client.KubernetesVersionsInfo{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetTanzuKubernetesReleases_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetTanzuKubernetesReleases",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf([]runv1alpha1.TanzuKubernetesRelease{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_InitRegionDryRun_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "InitRegionDryRun",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.InitRegionOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf([]byte{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_InitRegion_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "InitRegion",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.InitRegionOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_PatchClusterInitOperations_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "PatchClusterInitOperations",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(&client.InitRegionOptions{}),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_MoveObjects_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "MoveObjects",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_InitializeProviders_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "InitializeProviders",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.InitRegionOptions{}),
+			reflect.TypeOf((*clusterclient.Client)(nil)).Elem(),
+			reflect.TypeOf(""),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_BuildRegionalClusterConfiguration_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "BuildRegionalClusterConfiguration",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.InitRegionOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf([]byte{}),
+			reflect.TypeOf(""),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_ParseHiddenArgsAsFeatureFlags_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "ParseHiddenArgsAsFeatureFlags",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.InitRegionOptions{}),
+		},
+		ReturnTypes: []reflect.Type{},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SaveFeatureFlags_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "SaveFeatureFlags",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(map[string]string{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_SetMachineDeployment_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "SetMachineDeployment",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(&client.SetMachineDeploymentOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_DeleteMachineDeployment_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "DeleteMachineDeployment",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.DeleteMachineDeploymentOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+func Test_GetMachineDeployments_Signature(t *testing.T) {
+	tkgClientVal := reflect.ValueOf(&client.TkgClient{})
+	enforce := EnforceMethodParams{
+		Target:     tkgClientVal,
+		MethodName: "GetMachineDeployments",
+		ParamTypes: []reflect.Type{
+			reflect.TypeOf(client.GetMachineDeploymentOptions{}),
+		},
+		ReturnTypes: []reflect.Type{
+			reflect.TypeOf([]capi.MachineDeployment{}),
+			reflect.TypeOf((*error)(nil)).Elem(),
+		},
+	}
+	enforceMethodSignature(&enforce, t)
+}
+
+type EnforceMethodParams struct {
+	Target      reflect.Value
+	MethodName  string
+	ParamTypes  []reflect.Type
+	ReturnTypes []reflect.Type
+}
+
+func enforceMethodSignature(en *EnforceMethodParams, t *testing.T) {
+	methodVal := en.Target.MethodByName(en.MethodName)
+	if methodVal.IsZero() {
+		t.Fatalf("target value does not contain method %s", en.MethodName)
+	}
+
+	if numParams := methodVal.Type().NumIn(); numParams != len(en.ParamTypes) {
+		t.Fatalf("Expected %d parameters on method %s, got %d", len(en.ParamTypes), en.MethodName, numParams)
+	}
+
+	for i, paramType := range en.ParamTypes {
+		if !methodVal.Type().In(i).AssignableTo(paramType) {
+			t.Errorf("param at index %d is not of type %s", i, paramType.String())
+		}
+	}
+
+	if numReturns := methodVal.Type().NumOut(); numReturns != len(en.ReturnTypes) {
+		t.Fatalf("Expected %d parameters on method %s, got %d", len(en.ReturnTypes), en.MethodName, numReturns)
+	}
+
+	for i, returnType := range en.ReturnTypes {
+		if !methodVal.Type().Out(i).AssignableTo(returnType) {
+			t.Errorf("return value at index %d is not of type %s", i, returnType.String())
+		}
+	}
+}


### PR DESCRIPTION
This change adds tests to enforce the API method signatures for public
apis on the TKG client.

**What this PR does / why we need it**:
This PR adds tests that will fail if changes are made to the method signatures for public methods on the tkg client. These tests should only be changed when moving between minor versions. If your change breaks these tests on a patch release, then those changes should not go into the patch release.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:
The most interesting part of this change is in api_sig_enforce_test.go. This has a method that uses reflection to compare the TKG client methods against a struct that defines the name and input/output parameters types. Any changes to these methods on the client will result in a test failure. These tests should only be updated if the change is for a minor or major version. Changes in patch versions that cause these tests to fail are not allowed and the tests should not be updated.
**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
