### PR TITLE
Imagepullsecret plugin: initial prototype and Add & Delete commands

### DIFF
--- a/addons/go.mod
+++ b/addons/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/onsi/gomega v1.13.0
 	github.com/pkg/errors v0.9.1
 	github.com/vmware-tanzu/carvel-kapp-controller v0.20.0-rc.1
+	github.com/vmware-tanzu/carvel-secretgen-controller v0.5.0
 	github.com/vmware-tanzu/carvel-vendir v0.19.0
 	github.com/vmware-tanzu/tanzu-framework v0.0.0-20201211200158-5838874f2c38
 	gopkg.in/yaml.v2 v2.4.0

--- a/addons/go.sum
+++ b/addons/go.sum
@@ -231,6 +231,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudfoundry/bosh-utils v0.0.0-20191216173634-505d7f919144/go.mod h1:JCrKwetZGjxbfq1U139TZuXDBfdGLtjOEAfxMWKV/QM=
+github.com/cloudfoundry/config-server v0.1.20/go.mod h1:Y3b/MHqyp22CcG0X1qvEHG8lujoebxjD9IAslyS/Yk0=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
@@ -1061,6 +1063,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vito/go-interact v0.0.0-20171111012221-fa338ed9e9ec/go.mod h1:wPlfmglZmRWMYv/qJy3P+fK/UnoQB5ISk4txfNd9tDo=
 github.com/vmware-tanzu/carvel-kapp-controller v0.20.0-rc.1 h1:TAGOPqde+Qvnn+37sx+m8aYrGCxSjswd479Z9tDS6vw=
 github.com/vmware-tanzu/carvel-kapp-controller v0.20.0-rc.1/go.mod h1:QI4z6DehAOzrsupQO5geZA8i5FoLymZZMAX8Td9L+t0=
+github.com/vmware-tanzu/carvel-secretgen-controller v0.5.0 h1:3mSDyzhf52Y0jdvHrhJUf4Sk97CILBOkQt/WUaD8G/8=
+github.com/vmware-tanzu/carvel-secretgen-controller v0.5.0/go.mod h1:UW9xzccG6vjNoq2emVderTX11epILNyxtmGxFupRsHc=
 github.com/vmware-tanzu/carvel-vendir v0.19.0 h1:4FTeDcxwEuZWdFlFqh+11NqnJciCkkOe/Pnd0CvBoj4=
 github.com/vmware-tanzu/carvel-vendir v0.19.0/go.mod h1:HF7iLB0NyEFHuCvM0EJ42fERk20l2ImpktJzhSEdqOU=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
@@ -1080,6 +1084,7 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/ziutek/telnet v0.0.0-20180329124119-c3b780dc415b/go.mod h1:IZpXDfkJ6tWD3PhBK5YzgQT+xJWh7OsdwiG8hA2MkO4=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -1193,6 +1198,7 @@ golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180730214132-a0f8a16cb08c/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1251,6 +1257,7 @@ golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
@@ -1357,12 +1364,16 @@ golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0 h1:xrCZDmdtoloIiooiA9q0OQb9r8HejIHYoHGhGCe1pGg=
+golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
@@ -1459,6 +1470,7 @@ golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
@@ -1475,6 +1487,7 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1775,6 +1788,7 @@ sigs.k8s.io/controller-runtime v0.7.0-alpha.8/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98Z
 sigs.k8s.io/controller-runtime v0.7.0 h1:bU20IBBEPccWz5+zXpLnpVsgBYxqclaHu1pVDl/gEt8=
 sigs.k8s.io/controller-runtime v0.7.0/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98ZrroV1p+pIhoHsMm9wdU=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
+sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/kind v0.7.1-0.20200303021537-981bd80d3802/go.mod h1:HIZ3PWUezpklcjkqpFbnYOqaqsAE1JeCTEwkgvPLXjk=
 sigs.k8s.io/kind v0.9.0/go.mod h1:cxKQWwmbtRDzQ+RNKnR6gZG6fjbeTtItp5cGf+ww+1Y=
 sigs.k8s.io/kind v0.11.1/go.mod h1:fRpgVhtqAWrtLB9ED7zQahUimpUXuG/iHT88xYqEGIA=

--- a/cmd/cli/plugin/imagepullsecret/README.md
+++ b/cmd/cli/plugin/imagepullsecret/README.md
@@ -1,0 +1,55 @@
+# imagepullsecret
+
+Manage image pull secret operations. Image pull secrets enable the package and package repository consumers to authenticate to private registries.
+
+## Usage
+
+tanzu imagepullsecret [command]
+
+```sh
+>>> tanzu imagepullsecret --help
+Manage image pull secret operations. Image pull secrets enable the package and package repository consumers to authenticate to private registries.
+
+Usage:
+  tanzu imagepullsecret [command]
+
+Available Commands:
+  add           Creates a v1/Secret resource of type kubernetes.io/dockerconfigjson
+  delete        Deletes v1/Secret  resource of type kubernetes.io/dockerconfigjson and the associated SecretExport from the cluster
+  list          Lists all v1/Secret of type kubernetes.io/dockerconfigjson and checks for the associated SecretExport by the same name
+
+Flags:
+  -h, --help              help for imagepullsecret
+      --log-file string   Log file path
+      --verbose int32     Number for the log level verbosity(0-9)
+
+Use "tanzu imagepullsecret [command] --help" for more information about a command.
+```
+
+## Supported commands
+
+imagepullsecret plugin can be used to:
+- add a secret
+- list secrets
+- delete a secret
+
+1. Add an image pull secret
+   The "add" command creates a v1/Secret of type kubernetes.io/dockerconfigjson. 
+   In case of specifying the --export-to-all-namespaces flag, a SecretExport resource with the same name will be created, which makes the secret available across all namespaces in the cluster.
+
+   ```sh
+   >>> tanzu imagepullsecret add tanzu-net -n test-ns --registry registry.pivotal.io --username test-user --password-file pass-file --export-to-all-namespaces
+   **/** Adding image pull secret 'test-secret'...
+      Added image pull secret 'test-secret' into namespace 'test-ns'
+   ```
+
+2. Delete an image pull secret
+   The "delete" command deletes a v1/Secret of type kubernetes.io/dockerconfigjson from the specified namespace. If no namespace is specified, the secret will be deleted from the default namespace (if existing).
+   In case a SecretExport resource with the same name exists, it will be deleted from the namespace as well.
+
+   ```sh
+   >>> tanzu imagepullsecret delete test-secret -n test-ns
+   Deleting image pull secret 'test-secret' from namespace 'test-ns'. Are you sure? [y/N]: y
+   **\** Deleting image pull secret 'test-secret'...
+      Deleted image pull secret 'test-secret' from namespace 'test-ns'
+   ```

--- a/cmd/cli/plugin/imagepullsecret/main.go
+++ b/cmd/cli/plugin/imagepullsecret/main.go
@@ -1,0 +1,57 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
+	capdiscovery "github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/capabilities/discovery"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
+)
+
+var descriptor = cliv1alpha1.PluginDescriptor{
+	Name:        "imagepullsecret",
+	Description: "Manage image pull secret operations. Image pull secrets enable the package and package repository consumers to authenticate to private registries.",
+	Group:       cliv1alpha1.RunCmdGroup,
+}
+
+var (
+	logLevel     int32
+	logFile      string
+	outputFormat string
+)
+
+func main() {
+	p, err := plugin.NewPlugin(&descriptor)
+	if err != nil {
+		log.Fatal(err, "failed to create a new instance of the plugin")
+	}
+
+	p.Cmd.PersistentFlags().Int32VarP(&logLevel, "verbose", "", 0, "Number for the log level verbosity(0-9)")
+	p.Cmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Log file path")
+
+	p.AddCommands(
+		imagePullSecretAddCmd,
+		imagePullSecretDeleteCmd,
+		imagePullSecretListCmd,
+	)
+	if err := p.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func isSecretGenAPIAvailable() (bool, error) {
+	clusterQueryClient, err := capdiscovery.NewClusterQueryClientForConfig(ctrl.GetConfigOrDie())
+	if err != nil {
+		log.Error(err, "failed to create a new instance of the cluster query builder")
+		return false, err
+	}
+
+	apiGroup := capdiscovery.Group("secretGenAPIQuery", "secretgen.carvel.dev").WithVersions("v1alpha1").WithResource("secretexports")
+	return clusterQueryClient.Query(apiGroup).Execute()
+}

--- a/cmd/cli/plugin/imagepullsecret/secret_add.go
+++ b/cmd/cli/plugin/imagepullsecret/secret_add.go
@@ -1,0 +1,144 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackageclient"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
+)
+
+var imagePullSecretOp = tkgpackagedatamodel.NewImagePullSecretOptions()
+
+var imagePullSecretAddCmd = &cobra.Command{
+	Use:   "add SECRET_NAME --registry REGISTRY_URL --username USERNAME --password PASSWORD",
+	Short: "Creates a v1/Secret resource of type kubernetes.io/dockerconfigjson. In case of specifying the --export-to-all-namespaces flag, a SecretExport resource will also get created",
+	Example: `
+    # Add an image pull secret
+    tanzu imagepullsecret add test-secret --registry projects-stg.registry.vmware.com --username test-user --password-file test-file,
+
+	# Add an image pull secret with 'export-to-all-namespaces' flag being set
+	tanzu imagepullsecret add test-secret --registry projects-stg.registry.vmware.com --username test-user --password test-pass --export-to-all-namespaces`,
+	PreRunE: secretGenAvailabilityCheck,
+	RunE:    imagePullSecretAdd,
+}
+
+func init() {
+	imagePullSecretAddCmd.Flags().StringVarP(&imagePullSecretOp.Registry, "registry", "", "", "URL of the private registry")
+	imagePullSecretAddCmd.Flags().StringVarP(&imagePullSecretOp.Username, "username", "", "", "Username for authenticating to the private registry")
+	imagePullSecretAddCmd.Flags().StringVarP(&imagePullSecretOp.PasswordInput, "password", "", "", "Password for authenticating to the private registry")
+	imagePullSecretAddCmd.Flags().StringVarP(&imagePullSecretOp.PasswordFile, "password-file", "", "", "File containing the password for authenticating to the private registry")
+	imagePullSecretAddCmd.Flags().StringVarP(&imagePullSecretOp.PasswordEnvVar, "password-env-var", "", "", "Environment variable containing the password for authenticating to the private registry")
+	imagePullSecretAddCmd.Flags().StringVarP(&imagePullSecretOp.Namespace, "namespace", "n", "default", "Target namespace to add the image pull secret, optional")
+	imagePullSecretAddCmd.Flags().StringVarP(&imagePullSecretOp.KubeConfig, "kubeconfig", "", "", "The path to the kubeconfig file, optional")
+	imagePullSecretAddCmd.Flags().BoolVarP(&imagePullSecretOp.PasswordStdin, "password-stdin", "", false, "When provided, password for authenticating to the private registry would be taken from the standard input, optional")
+	imagePullSecretAddCmd.Flags().BoolVarP(&imagePullSecretOp.ExportToAllNamespaces, "export-to-all-namespaces", "", false, "Make the image pull secret available across all namespaces (i.e. create SecretExport with toNamespace=*), optional")
+	imagePullSecretAddCmd.Args = cobra.ExactArgs(1)
+	imagePullSecretAddCmd.MarkFlagRequired("registry") //nolint
+	imagePullSecretAddCmd.MarkFlagRequired("username") //nolint
+}
+
+func secretGenAvailabilityCheck(cmd *cobra.Command, _ []string) error {
+	const secretGenGVR = "secretgen.carvel.dev/v1alpha1"
+	found, err := isSecretGenAPIAvailable()
+	if err != nil {
+		cmd.SilenceUsage = true
+		return errors.Wrap(err, fmt.Sprintf("failed to check for the availability of '%s' API", secretGenGVR))
+	}
+	if !found {
+		cmd.SilenceUsage = true
+		return errors.New(fmt.Sprintf("imagepullsecret plugin can not be used as '%s' API is not available in the cluster", secretGenGVR))
+	}
+	return nil
+}
+
+func imagePullSecretAdd(cmd *cobra.Command, args []string) error {
+	imagePullSecretOp.SecretName = args[0]
+
+	password, err := extractPassword()
+	if err != nil {
+		return err
+	}
+	imagePullSecretOp.Password = password
+
+	if imagePullSecretOp.ExportToAllNamespaces {
+		log.Warning("Warning: By choosing --export-to-all-namespaces, given secret contents will be available to ALL users in ALL namespaces. Please ensure that included registry credentials are read only and are safe to share.\n\n")
+	}
+
+	pkgClient, err := tkgpackageclient.NewTKGPackageClient(imagePullSecretOp.KubeConfig)
+	if err != nil {
+		return err
+	}
+
+	if _, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat,
+		fmt.Sprintf("Adding image pull secret '%s'...", imagePullSecretOp.SecretName), true); err != nil {
+		return err
+	}
+
+	if err := pkgClient.AddImagePullSecret(imagePullSecretOp); err != nil {
+		return err
+	}
+
+	log.Infof("\n Added image pull secret '%s' into namespace '%s'", imagePullSecretOp.SecretName, imagePullSecretOp.Namespace)
+	return nil
+}
+
+// extractPassword extracts the password from one of the corresponding flags
+func extractPassword() (string, error) {
+	var (
+		isPasswordSet bool
+		password      string
+	)
+
+	errInvalidPasswordFlags := "exactly one of --password, --password-file, --password-env-var flags should be provided"
+
+	if imagePullSecretOp.PasswordInput != "" {
+		password = imagePullSecretOp.PasswordInput
+		isPasswordSet = true
+	}
+	if imagePullSecretOp.PasswordStdin {
+		if isPasswordSet {
+			return "", errors.New(errInvalidPasswordFlags)
+		}
+		isPasswordSet = true
+		log.Info("Password:")
+		b, err := term.ReadPassword(0)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to read the password from standard input")
+		}
+		password = string(b)
+	}
+	if imagePullSecretOp.PasswordFile != "" {
+		if isPasswordSet {
+			return "", errors.New(errInvalidPasswordFlags)
+		}
+		isPasswordSet = true
+		b, err := ioutil.ReadFile(imagePullSecretOp.PasswordFile)
+		if err != nil {
+			return "", errors.Wrap(err, fmt.Sprintf("failed to read from the password file '%s'", imagePullSecretOp.PasswordFile))
+		}
+		password = string(b)
+	}
+	if imagePullSecretOp.PasswordEnvVar != "" {
+		if isPasswordSet {
+			return "", errors.New(errInvalidPasswordFlags)
+		}
+		password = os.Getenv(imagePullSecretOp.PasswordEnvVar)
+	}
+
+	if password == "" {
+		return "", errors.New(errInvalidPasswordFlags)
+	}
+
+	return password, nil
+}

--- a/cmd/cli/plugin/imagepullsecret/secret_delete.go
+++ b/cmd/cli/plugin/imagepullsecret/secret_delete.go
@@ -1,0 +1,65 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackageclient"
+)
+
+var imagePullSecretDeleteCmd = &cobra.Command{
+	Use:   "delete SECRET_NAME",
+	Short: "Deletes v1/Secret  resource of type kubernetes.io/dockerconfigjson and the associated SecretExport from the cluster",
+	Example: `
+    # Delete an image pull secret
+    tanzu imagepullsecret delete test-secret`,
+	PreRunE: secretGenAvailabilityCheck,
+	RunE:    imagePullSecretDelete,
+}
+
+func init() {
+	imagePullSecretDeleteCmd.Flags().StringVarP(&imagePullSecretOp.Namespace, "namespace", "n", "default", "Namespace for the image pull secret, optional")
+	imagePullSecretDeleteCmd.Flags().StringVarP(&imagePullSecretOp.KubeConfig, "kubeconfig", "", "", "The path to the kubeconfig file, optional")
+	imagePullSecretDeleteCmd.Flags().BoolVarP(&imagePullSecretOp.SkipPrompt, "yes", "y", false, "Delete the image pull secret without asking for confirmation, optional")
+	imagePullSecretDeleteCmd.Args = cobra.ExactArgs(1)
+}
+
+func imagePullSecretDelete(cmd *cobra.Command, args []string) error {
+	imagePullSecretOp.SecretName = args[0]
+
+	pkgClient, err := tkgpackageclient.NewTKGPackageClient(imagePullSecretOp.KubeConfig)
+	if err != nil {
+		return err
+	}
+
+	if !imagePullSecretOp.SkipPrompt {
+		if err := cli.AskForConfirmation(fmt.Sprintf("Deleting image pull secret '%s' from namespace '%s'. Are you sure?",
+			imagePullSecretOp.SecretName, imagePullSecretOp.Namespace)); err != nil {
+			return err
+		}
+	}
+
+	if _, err = component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat,
+		fmt.Sprintf("Deleting image pull secret '%s'...", imagePullSecretOp.SecretName), true); err != nil {
+		return err
+	}
+
+	found, err := pkgClient.DeleteImagePullSecret(imagePullSecretOp)
+	if !found {
+		log.Warningf("\n image pull secret '%s' does not exist in namespace '%s'", imagePullSecretOp.SecretName, imagePullSecretOp.Namespace)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	log.Infof("\n Deleted image pull secret '%s' from namespace '%s'", imagePullSecretOp.SecretName, imagePullSecretOp.Namespace)
+	return nil
+}

--- a/cmd/cli/plugin/imagepullsecret/secret_list.go
+++ b/cmd/cli/plugin/imagepullsecret/secret_list.go
@@ -1,0 +1,30 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var imagePullSecretListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Lists all v1/Secret of type kubernetes.io/dockerconfigjson and checks for the associated SecretExport by the same name",
+	Args:  cobra.NoArgs,
+	Example: `
+    # List all image pull secrets
+    tanzu imagepullsecret list`,
+	PreRunE: secretGenAvailabilityCheck,
+	RunE:    imagePullSecretList,
+}
+
+func init() {
+	imagePullSecretListCmd.Flags().BoolVarP(&imagePullSecretOp.AllNamespaces, "all-namespaces", "A", false, "If present, list image pull secrets across all namespaces, optional")
+	imagePullSecretListCmd.Flags().StringVarP(&imagePullSecretOp.Namespace, "namespace", "n", "default", "Namespace for the image pull secret, optional")
+	imagePullSecretListCmd.Flags().StringVarP(&imagePullSecretOp.KubeConfig, "kubeconfig", "", "", "The path to the kubeconfig file, optional")
+	imagePullSecretListCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table), optional")
+}
+
+func imagePullSecretList(cmd *cobra.Command, args []string) error {
+	return nil
+}

--- a/cmd/cli/plugin/imagepullsecret/test/main.go
+++ b/cmd/cli/plugin/imagepullsecret/test/main.go
@@ -1,0 +1,31 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
+)
+
+var descriptor = cli.NewTestFor("imagepullsecret")
+
+func main() {
+	p, err := plugin.NewPlugin(descriptor)
+	if err != nil {
+		log.Fatal(err, "failed to create a new instance of the plugin")
+	}
+	p.Cmd.RunE = test
+	if err := p.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func test(c *cobra.Command, _ []string) error {
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -83,17 +83,18 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.1-0.20210427113832-6241f9ab9942
 	github.com/vmware-tanzu/carvel-kapp-controller v0.20.0-rc.1
+	github.com/vmware-tanzu/carvel-secretgen-controller v0.5.0
 	github.com/vmware-tanzu/carvel-vendir v0.19.0
 	github.com/vmware/govmomi v0.23.1
 	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0
 	go.uber.org/multierr v1.5.0
 	golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e // indirect
-	golang.org/x/mod v0.4.0
+	golang.org/x/mod v0.4.2
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
-	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
+	golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0 // indirect
+	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 	golang.org/x/time v0.0.0-20210611083556-38a9dc6acbc6 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/api v0.40.0
@@ -116,7 +117,7 @@ require (
 	sigs.k8s.io/cluster-api-provider-vsphere v0.7.10
 	sigs.k8s.io/cluster-api/test/infrastructure/docker v0.0.0-20210720023132-dfeb8d447bdc
 	sigs.k8s.io/controller-runtime v0.7.0
-	sigs.k8s.io/controller-tools v0.3.0
+	sigs.k8s.io/controller-tools v0.4.1
 	sigs.k8s.io/kind v0.11.1
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -259,6 +259,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudfoundry/bosh-utils v0.0.0-20191216173634-505d7f919144/go.mod h1:JCrKwetZGjxbfq1U139TZuXDBfdGLtjOEAfxMWKV/QM=
+github.com/cloudfoundry/config-server v0.1.20/go.mod h1:Y3b/MHqyp22CcG0X1qvEHG8lujoebxjD9IAslyS/Yk0=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
@@ -1178,6 +1180,8 @@ github.com/vito/go-interact v0.0.0-20171111012221-fa338ed9e9ec h1:Klu98tQ9Z1t23g
 github.com/vito/go-interact v0.0.0-20171111012221-fa338ed9e9ec/go.mod h1:wPlfmglZmRWMYv/qJy3P+fK/UnoQB5ISk4txfNd9tDo=
 github.com/vmware-tanzu/carvel-kapp-controller v0.20.0-rc.1 h1:TAGOPqde+Qvnn+37sx+m8aYrGCxSjswd479Z9tDS6vw=
 github.com/vmware-tanzu/carvel-kapp-controller v0.20.0-rc.1/go.mod h1:QI4z6DehAOzrsupQO5geZA8i5FoLymZZMAX8Td9L+t0=
+github.com/vmware-tanzu/carvel-secretgen-controller v0.5.0 h1:3mSDyzhf52Y0jdvHrhJUf4Sk97CILBOkQt/WUaD8G/8=
+github.com/vmware-tanzu/carvel-secretgen-controller v0.5.0/go.mod h1:UW9xzccG6vjNoq2emVderTX11epILNyxtmGxFupRsHc=
 github.com/vmware-tanzu/carvel-vendir v0.19.0 h1:4FTeDcxwEuZWdFlFqh+11NqnJciCkkOe/Pnd0CvBoj4=
 github.com/vmware-tanzu/carvel-vendir v0.19.0/go.mod h1:HF7iLB0NyEFHuCvM0EJ42fERk20l2ImpktJzhSEdqOU=
 github.com/vmware/govmomi v0.20.3/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
@@ -1199,6 +1203,7 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/ziutek/telnet v0.0.0-20180329124119-c3b780dc415b/go.mod h1:IZpXDfkJ6tWD3PhBK5YzgQT+xJWh7OsdwiG8hA2MkO4=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -1311,8 +1316,9 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.1-0.20200828183125-ce943fd02449/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
+golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180730214132-a0f8a16cb08c/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1371,6 +1377,7 @@ golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
@@ -1474,12 +1481,14 @@ golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
-golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0 h1:xrCZDmdtoloIiooiA9q0OQb9r8HejIHYoHGhGCe1pGg=
+golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b h1:9zKuko04nR4gjZ4+DNjHqRlAJqbJETHwiNKDqTfOjfE=
@@ -1575,6 +1584,7 @@ golang.org/x/tools v0.0.0-20200505023115-26f46d2f7ef8/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
@@ -1589,8 +1599,9 @@ golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.5 h1:ouewzE6p+/VEB31YYnTbEJdi8pFqKp4P4n85vwo3DHA=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1882,8 +1893,9 @@ sigs.k8s.io/cluster-api/test/infrastructure/docker v0.0.0-20210720023132-dfeb8d4
 sigs.k8s.io/cluster-api/test/infrastructure/docker v0.0.0-20210720023132-dfeb8d447bdc/go.mod h1:GnnUN8rgrz4OO4G/LoJVlOTZOzwET5HYUM0IR2uf/r8=
 sigs.k8s.io/controller-runtime v0.5.14 h1:lmoRaPvLg9877ZOnjFivjtyIdqyLbWfcCEilxHXTEj4=
 sigs.k8s.io/controller-runtime v0.5.14/go.mod h1:OTqxLuz7gVcrq+BHGUgedRu6b2VIKCEc7Pu4Jbwui0A=
-sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
+sigs.k8s.io/controller-tools v0.4.1 h1:VkuV0MxlRPmRu5iTgBZU4UxUX2LiR99n3sdQGRxZF4w=
+sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/kind v0.11.1 h1:pVzOkhUwMBrCB0Q/WllQDO3v14Y+o2V0tFgjTqIUjwA=
 sigs.k8s.io/kind v0.11.1/go.mod h1:fRpgVhtqAWrtLB9ED7zQahUimpUXuG/iHT88xYqEGIA=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=

--- a/pkg/v1/tkg/kappclient/client.go
+++ b/pkg/v1/tkg/kappclient/client.go
@@ -21,6 +21,7 @@ import (
 	kappctrl "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	kappipkg "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	kapppkg "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
+	secretgenctrl "github.com/vmware-tanzu/carvel-secretgen-controller/pkg/apis/secretgen2/v1alpha1"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
 )
@@ -55,6 +56,9 @@ func NewKappClient(kubeCfgPath string) (Client, error) {
 		return nil, err
 	}
 	if err := kappctrl.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := secretgenctrl.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 

--- a/pkg/v1/tkg/tkgpackageclient/imagepullsecret_add.go
+++ b/pkg/v1/tkg/tkgpackageclient/imagepullsecret_add.go
@@ -1,0 +1,71 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgpackageclient
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	secretgenctrl "github.com/vmware-tanzu/carvel-secretgen-controller/pkg/apis/secretgen2/v1alpha1"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
+)
+
+// Note: datapolicy is seemingly used for log sanitization: https://github.com/kubernetes/enhancements/blob/master/keps/sig-security/1933-secret-logging-static-analysis/README.md
+// TODO: change to use k8s types after upgrading the K8s version
+type dockerConfigJSON struct {
+	Auths map[string]dockerConfigEntry `json:"auths" datapolicy:"token"`
+}
+
+type dockerConfigEntry struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty" datapolicy:"password"`
+}
+
+// AddImagePullSecret adds an image pull secret to the cluster
+func (p *pkgClient) AddImagePullSecret(o *tkgpackagedatamodel.ImagePullSecretOptions) error {
+	dockerCfg := dockerConfigJSON{Auths: map[string]dockerConfigEntry{o.Registry: {Username: o.Username, Password: o.Password}}}
+	dockerCfgContent, err := json.Marshal(dockerCfg)
+	if err != nil {
+		return err
+	}
+
+	secret := p.newSecret(o.SecretName, o.Namespace, corev1.SecretTypeDockerConfigJson)
+	secret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+	if err := p.kappClient.GetClient().Create(context.Background(), secret); err != nil {
+		return errors.Wrap(err, "failed to create Secret resource")
+	}
+
+	if o.ExportToAllNamespaces {
+		secretExport := p.newSecretExport(o.SecretName, o.Namespace)
+		if err := p.kappClient.GetClient().Create(context.Background(), secretExport); err != nil {
+			return errors.Wrap(err, "failed to create SecretExport resource")
+		}
+	}
+
+	return nil
+}
+
+// newSecret creates a new secret object
+func (p *pkgClient) newSecret(name, namespace string, secretType corev1.SecretType) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta:   metav1.TypeMeta{Kind: tkgpackagedatamodel.KindSecret, APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Type:       secretType,
+		Data:       map[string][]byte{},
+	}
+}
+
+// newSecretExport creates a new SecretExport object
+func (p *pkgClient) newSecretExport(name, namespace string) *secretgenctrl.SecretExport {
+	return &secretgenctrl.SecretExport{
+		TypeMeta:   metav1.TypeMeta{Kind: tkgpackagedatamodel.KindSecretExport, APIVersion: secretgenctrl.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       secretgenctrl.SecretExportSpec{ToNamespaces: []string{"*"}},
+	}
+}

--- a/pkg/v1/tkg/tkgpackageclient/imagepullsecret_add_test.go
+++ b/pkg/v1/tkg/tkgpackageclient/imagepullsecret_add_test.go
@@ -1,0 +1,88 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgpackageclient
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
+)
+
+const (
+	testSecretName = "test-secret"
+	testPassword   = "test-password"
+	testRegistry   = "test-registry"
+	testUsername   = "test-username"
+)
+
+var _ = Describe("Add Secret", func() {
+	var (
+		ctl     *pkgClient
+		crtCtl  *fakes.CRTClusterClient
+		kappCtl *fakes.KappClient
+		err     error
+		opts    = tkgpackagedatamodel.ImagePullSecretOptions{
+			ExportToAllNamespaces: false,
+			Namespace:             testNamespaceName,
+			Password:              testPassword,
+			Registry:              testRegistry,
+			SecretName:            testSecretName,
+			Username:              testUsername,
+		}
+		options = opts
+	)
+
+	JustBeforeEach(func() {
+		ctl = &pkgClient{kappClient: kappCtl}
+		err = ctl.AddImagePullSecret(&options)
+	})
+
+	Context("failure in creating Secret due to Create API error", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			crtCtl.CreateReturnsOnCall(0, errors.New("failure in create Secret"))
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failure in create Secret"))
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("failure in creating SecretExport due to Create API error", func() {
+		BeforeEach(func() {
+			options.ExportToAllNamespaces = true
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			crtCtl.CreateReturnsOnCall(0, nil)
+			crtCtl.CreateReturnsOnCall(1, errors.New("failure in create SecretExport"))
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failure in create SecretExport"))
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("success in creating Secret and SecretExport", func() {
+		BeforeEach(func() {
+			options.ExportToAllNamespaces = true
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			crtCtl.CreateReturnsOnCall(0, nil)
+			crtCtl.CreateReturnsOnCall(1, nil)
+		})
+		It(testSuccessMsg, func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+		AfterEach(func() { options = opts })
+	})
+})

--- a/pkg/v1/tkg/tkgpackageclient/imagepullsecret_delete.go
+++ b/pkg/v1/tkg/tkgpackageclient/imagepullsecret_delete.go
@@ -1,0 +1,43 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgpackageclient
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	secretgenctrl "github.com/vmware-tanzu/carvel-secretgen-controller/pkg/apis/secretgen2/v1alpha1"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
+)
+
+// DeleteImagePullSecret deletes an image pull secret from the cluster
+func (p *pkgClient) DeleteImagePullSecret(o *tkgpackagedatamodel.ImagePullSecretOptions) (bool, error) {
+	secretExport := &secretgenctrl.SecretExport{
+		TypeMeta:   metav1.TypeMeta{Kind: tkgpackagedatamodel.KindSecretExport, APIVersion: secretgenctrl.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: o.SecretName, Namespace: o.Namespace},
+	}
+	if err := p.kappClient.GetClient().Delete(context.Background(), secretExport); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return true, errors.Wrap(err, "failed to delete SecretExport resource")
+		}
+	}
+
+	secret := &corev1.Secret{
+		TypeMeta:   metav1.TypeMeta{Kind: tkgpackagedatamodel.KindSecret, APIVersion: corev1.SchemeGroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: o.SecretName, Namespace: o.Namespace},
+	}
+	if err := p.kappClient.GetClient().Delete(context.Background(), secret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return true, errors.Wrap(err, "failed to delete Secret resource")
+		}
+		return false, nil
+	}
+
+	return true, nil
+}

--- a/pkg/v1/tkg/tkgpackageclient/imagepullsecret_delete_test.go
+++ b/pkg/v1/tkg/tkgpackageclient/imagepullsecret_delete_test.go
@@ -1,0 +1,118 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgpackageclient
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
+)
+
+var _ = Describe("Delete Secret", func() {
+	var (
+		ctl           *pkgClient
+		crtCtl        *fakes.CRTClusterClient
+		kappCtl       *fakes.KappClient
+		err           error
+		isSecretFound bool
+		opts          = tkgpackagedatamodel.ImagePullSecretOptions{
+			ExportToAllNamespaces: false,
+			Namespace:             testNamespaceName,
+			Password:              testPassword,
+			Registry:              testRegistry,
+			SecretName:            testSecretName,
+			Username:              testUsername,
+			SkipPrompt:            true,
+		}
+		options = opts
+	)
+
+	JustBeforeEach(func() {
+		ctl = &pkgClient{kappClient: kappCtl}
+		isSecretFound, err = ctl.DeleteImagePullSecret(&options)
+	})
+
+	Context("success when trying to delete SecretExport returns NotFound error", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			crtCtl.DeleteReturnsOnCall(0, apierrors.NewNotFound(schema.GroupResource{Resource: tkgpackagedatamodel.KindSecretExport}, testSecretName))
+		})
+		It(testSuccessMsg, func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("failure in deleting SecretExport due to Delete API error", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			crtCtl.DeleteReturnsOnCall(0, errors.New("failure in delete SecretExport"))
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failure in delete SecretExport"))
+			Expect(isSecretFound).To(BeTrue())
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("success when trying to delete Secret returns NotFound error", func() {
+		BeforeEach(func() {
+			options.ExportToAllNamespaces = true
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			crtCtl.DeleteReturnsOnCall(0, nil)
+			crtCtl.DeleteReturnsOnCall(1, apierrors.NewNotFound(schema.GroupResource{Resource: tkgpackagedatamodel.KindSecret}, testSecretName))
+		})
+		It(testSuccessMsg, func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isSecretFound).To(BeFalse())
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("failure in deleting Secret due to Delete API error", func() {
+		BeforeEach(func() {
+			options.ExportToAllNamespaces = true
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			crtCtl.DeleteReturnsOnCall(0, nil)
+			crtCtl.DeleteReturnsOnCall(1, errors.New("failure in delete Secret"))
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failure in delete Secret"))
+			Expect(isSecretFound).To(BeTrue())
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("success in deleting Secret and SecretExport", func() {
+		BeforeEach(func() {
+			options.ExportToAllNamespaces = true
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			crtCtl.DeleteReturnsOnCall(0, nil)
+			crtCtl.DeleteReturnsOnCall(1, nil)
+		})
+		It(testSuccessMsg, func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isSecretFound).To(BeTrue())
+		})
+		AfterEach(func() { options = opts })
+	})
+})

--- a/pkg/v1/tkg/tkgpackageclient/interface.go
+++ b/pkg/v1/tkg/tkgpackageclient/interface.go
@@ -13,7 +13,9 @@ import (
 
 // TKGPackageClient is the TKG package client interface
 type TKGPackageClient interface {
+	AddImagePullSecret(o *tkgpackagedatamodel.ImagePullSecretOptions) error
 	AddRepository(o *tkgpackagedatamodel.RepositoryOptions) error
+	DeleteImagePullSecret(o *tkgpackagedatamodel.ImagePullSecretOptions) (bool, error)
 	DeleteRepository(o *tkgpackagedatamodel.RepositoryOptions) (bool, error)
 	GetPackageInstall(o *tkgpackagedatamodel.PackageOptions) (*kappipkg.PackageInstall, error)
 	GetPackage(o *tkgpackagedatamodel.PackageOptions) (*kapppkg.PackageMetadata, *kapppkg.Package, error)

--- a/pkg/v1/tkg/tkgpackagedatamodel/constants.go
+++ b/pkg/v1/tkg/tkgpackagedatamodel/constants.go
@@ -20,6 +20,7 @@ const (
 	KindPackageInstall         = "PackageInstall"
 	KindPackageRepository      = "PackageRepository"
 	KindSecret                 = "Secret"
+	KindSecretExport           = "SecretExport"
 	KindServiceAccount         = "ServiceAccount"
 	SecretName                 = "%s-%s-values"
 	ServiceAccountName         = "%s-%s-sa"

--- a/pkg/v1/tkg/tkgpackagedatamodel/secret.go
+++ b/pkg/v1/tkg/tkgpackagedatamodel/secret.go
@@ -1,0 +1,26 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgpackagedatamodel
+
+// ImagePullSecretOptions includes fields for image pull secret operations
+type ImagePullSecretOptions struct {
+	AllNamespaces         bool
+	ExportToAllNamespaces bool
+	PasswordStdin         bool
+	SkipPrompt            bool
+	KubeConfig            string
+	Namespace             string
+	Password              string
+	PasswordEnvVar        string
+	PasswordFile          string
+	PasswordInput         string
+	Registry              string
+	SecretName            string
+	Username              string
+}
+
+// NewImagePullSecretOptions instantiates ImagePullSecretOptions
+func NewImagePullSecretOptions() *ImagePullSecretOptions {
+	return &ImagePullSecretOptions{}
+}


### PR DESCRIPTION
**What this PR does / why we need it:**
- This PR adds the initial prototype for the Imagepullsecret plugin, as well as add & delete secret commands (and unit tests). The supported secret type in this PR is only secrets of type .dockerconfigjson

**Describe testing done for PR:**
Manual testing in the cluster and added unit tests
```
➜ tanzu imagepullsecret add test-secret -n test-ns --registry us-east4-docker.pkg.dev --username test-user --password-file pass-file --export-to-all-namespaces
/ Adding image pull secret 'test-secret'...
 Added image pull secret 'test-secret' into namespace 'test-ns'



➜ k get secret test-secret -n test-ns -o yaml
apiVersion: v1
data:
  .dockerconfigjson:...
kind: Secret
metadata:
  creationTimestamp: "2021-09-10T02:48:25Z"
  managedFields:
  - apiVersion: v1
    fieldsType: FieldsV1
    fieldsV1:
      f:data:
        .: {}
        f:.dockerconfigjson: {}
      f:type: {}
    manager: tanzu-plugin-imagepullsecret
    operation: Update
    time: "2021-09-10T02:48:25Z"
  name: test-secret
  namespace: test-ns
  resourceVersion: "1916486"
  uid: 851cee47-48e1-4d93-80a7-d5d487f17603
type: kubernetes.io/dockerconfigjson



➜ k get secretexports test-secret -n test-ns -o yaml
apiVersion: secretgen.carvel.dev/v1alpha1
kind: SecretExport
metadata:
  creationTimestamp: "2021-09-10T02:48:25Z"
  generation: 1
  managedFields:
  - apiVersion: secretgen.carvel.dev/v1alpha1
    fieldsType: FieldsV1
    fieldsV1:
      f:status:
        .: {}
        f:conditions: {}
        f:friendlyDescription: {}
        f:observedGeneration: {}
        f:observedSecretResourceVersion: {}
    manager: secretgen-controller
    operation: Update
    time: "2021-09-10T02:48:25Z"
  - apiVersion: secretgen.carvel.dev/v1alpha1
    fieldsType: FieldsV1
    fieldsV1:
      f:spec:
        .: {}
        f:toNamespaces: {}
    manager: tanzu-plugin-imagepullsecret
    operation: Update
    time: "2021-09-10T02:48:25Z"
  name: test-secret
  namespace: test-ns
  resourceVersion: "1916488"
  uid: 915e0281-9413-41bd-897d-b1135d57d891
spec:
  toNamespaces:
  - '*'
status:
  conditions:
  - status: "True"
    type: ReconcileSucceeded
  friendlyDescription: Reconcile succeeded
  observedGeneration: 1
  observedSecretResourceVersion: "1916486"



➜ tanzu imagepullsecret delete test-secret -n test-ns
Deleting image pull secret 'test-secret' in namespace 'test-ns'. Are you sure? [y/N]: y
\ Deleting image pull secret 'test-secret'...
 Deleted image pull secret 'test-secret' from namespace 'test-ns'



➜ k get secret test-secret -n test-ns -o yaml
Error from server (NotFound): secrets "test-secret" not found



➜ k get secretexports test-secret -n test-ns -o yaml
Error from server (NotFound): secretexports.secretgen.carvel.dev "test-secret" not found
```

**Does this PR introduce a user-facing change?:**
None

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
[Feature]: Add imagepullsecret plugin initial prototype and Add & Delete commands
```


**New PR Checklist**
- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
