### PR TITLE
Adding list command to image pull secret plugin

### DIFF
--- a/cmd/cli/plugin/imagepullsecret/README.md
+++ b/cmd/cli/plugin/imagepullsecret/README.md
@@ -44,7 +44,58 @@ imagepullsecret plugin can be used to:
       Added image pull secret 'test-secret' into namespace 'test-ns'
    ```
 
-1. Delete an image pull secret
+2. List an image pull secret
+
+   The "list" command lists a v1/Secret of type kubernetes.io/dockerconfigjson for a specified namespace. If namespace flag is not specified, it lists the secrets from `default` namespace.
+   It also supports -A flag to list the secrets across all namespaces.
+   In case a SecretExport resource exists with the same name as the Secret, it will check if it is exported `to all namespaces` or `to some namespaces` and display that in EXPORTED column. If not, it will display `not exported` in the EXPORTED column.
+
+   ```sh
+   # List image pull secrets from specified namespace
+   >>> tanzu imagepullsecret list -n test-ns
+   **/** Retrieving image pull secrets...
+     NAME         REGISTRY                 EXPORTED           AGE
+     pkg-dev-reg  registry.pivotal.io      to all namespaces  15d
+
+   # List image pull secrets across all namespaces
+   >>> tanzu imagepullsecret list -A
+   \ Retrieving image pull secrets...
+     NAME                          REGISTRY             EXPORTED           AGE  NAMESPACE
+     pkg-dev-reg                   registry.pivotal.io  to all namespaces  15d  test-ns
+     tanzu-standard-fetch-0        registry.pivotal.io  not exported       15d  tanzu-package-repo-global
+     private-repo-fetch-0          registry.pivotal.io  not exported       15d  test-ns
+     antrea-fetch-0                registry.pivotal.io  not exported       15d  tkg-system
+     metrics-server-fetch-0        registry.pivotal.io  not exported       15d  tkg-system
+     tanzu-addons-manager-fetch-0  registry.pivotal.io  not exported       15d  tkg-system
+     tanzu-core-fetch-0            registry.pivotal.io  not exported       15d  tkg-system
+
+   # List image pull secrets in json output format
+   >>> tanzu imagepullsecret list -n kapp-controller-packaging-global -o json
+   [
+     {
+       "age": "15d",
+       "exported": "to all namespaces",
+       "name": "pkg-dev-reg",
+       "registry": "us-east4-docker.pkg.dev"
+     }
+   ]
+
+   # List image pull secrets in json output format
+   >>> tanzu imagepullsecret list -n kapp-controller-packaging-global -o yaml
+   - age: 15d
+     exported: to all namespaces
+     name: pkg-dev-reg
+     registry: us-east4-docker.pkg.dev
+
+   # List image pull secrets in json output format
+   >>> tanzu imagepullsecret list -n kapp-controller-packaging-global -o table
+   / Retrieving image pull secrets...
+     NAME         REGISTRY                 EXPORTED           AGE
+     pkg-dev-reg  us-east4-docker.pkg.dev  to all namespaces  15d
+   ```
+
+3. Delete an image pull secret
+
    The "delete" command deletes a v1/Secret of type kubernetes.io/dockerconfigjson from the specified namespace. If no namespace is specified, the secret will be deleted from the default namespace (if existing).
    In case a SecretExport resource with the same name exists, it will be deleted from the namespace as well.
 

--- a/cmd/cli/plugin/imagepullsecret/secret_list.go
+++ b/cmd/cli/plugin/imagepullsecret/secret_list.go
@@ -4,7 +4,17 @@
 package main
 
 import (
+	"encoding/json"
+	"strconv"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/duration"
+
 	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackageclient"
 )
 
 var imagePullSecretListCmd = &cobra.Command{
@@ -12,8 +22,14 @@ var imagePullSecretListCmd = &cobra.Command{
 	Short: "Lists all v1/Secret of type kubernetes.io/dockerconfigjson and checks for the associated SecretExport by the same name",
 	Args:  cobra.NoArgs,
 	Example: `
-    # List all image pull secrets
-    tanzu imagepullsecret list`,
+    # List image pull secrets across all namespaces
+    tanzu imagepullsecret list -A
+	
+    # List image pull secrets from specified namespace	
+    tanzu imagepullsecret list -n test-ns
+	
+    # List image pull secrets in json output format	
+    tanzu imagepullsecret list -n test-ns -o json`,
 	PreRunE: secretGenAvailabilityCheck,
 	RunE:    imagePullSecretList,
 }
@@ -26,5 +42,110 @@ func init() {
 }
 
 func imagePullSecretList(cmd *cobra.Command, args []string) error {
+	var t component.OutputWriterSpinner
+	var exported string
+	var registry string
+
+	pkgClient, err := tkgpackageclient.NewTKGPackageClient(imagePullSecretOp.KubeConfig)
+	if err != nil {
+		return err
+	}
+
+	if imagePullSecretOp.AllNamespaces {
+		imagePullSecretOp.Namespace = ""
+	}
+
+	if imagePullSecretOp.AllNamespaces {
+		t, err = component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat,
+			"Retrieving image pull secrets...", true, "NAME", "REGISTRY", "EXPORTED", "AGE", "NAMESPACE")
+	} else {
+		t, err = component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat, "Retrieving image pull secrets...", true,
+			"NAME", "REGISTRY", "EXPORTED", "AGE")
+	}
+	if err != nil {
+		return err
+	}
+
+	imagePullSecretList, err := pkgClient.ListImagePullSecrets(imagePullSecretOp)
+	if err != nil {
+		t.StopSpinner()
+		return err
+	}
+
+	secretExportList, err := pkgClient.ListSecretExports(imagePullSecretOp)
+	if err != nil {
+		return err
+	}
+
+	for i := range imagePullSecretList.Items {
+		exported = "not exported"
+		imagePullSecret := imagePullSecretList.Items[i]
+		for j := range secretExportList.Items {
+			secretExport := secretExportList.Items[j]
+			if secretExport.Name == imagePullSecret.Name {
+				if findInList(secretExport.Spec.ToNamespaces, "*") || secretExport.Spec.ToNamespace == "*" {
+					exported = "to all namespaces"
+				} else {
+					exported = "to some namespaces"
+				}
+			}
+		}
+
+		registry, err = getRegistryValue(&imagePullSecret)
+		if err != nil {
+			return err
+		}
+
+		age := duration.HumanDuration(time.Since(imagePullSecret.CreationTimestamp.UTC()))
+
+		if imagePullSecretOp.AllNamespaces {
+			t.AddRow(
+				imagePullSecret.Name,
+				registry,
+				exported,
+				age,
+				imagePullSecret.Namespace)
+		} else {
+			t.AddRow(
+				imagePullSecret.Name,
+				registry,
+				exported,
+				age)
+		}
+	}
+	t.RenderWithSpinner()
+
 	return nil
+}
+
+func findInList(slice []string, val string) bool {
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}
+
+func getRegistryValue(secret *corev1.Secret) (string, error) {
+	registry := ""
+
+	var dataMap tkgpackageclient.DockerConfigJSON
+	if err := json.Unmarshal(secret.Data[corev1.DockerConfigJsonKey], &dataMap); err != nil {
+		return registry, err
+	}
+
+	/* If there is no auths field, then there is no associated registry. In that case, registry field will be displayed empty in cli */
+	regCount := 0
+	for reg := range dataMap.Auths {
+		if registry == "" {
+			registry = reg
+		}
+		regCount++
+	}
+	if regCount > 1 {
+		registry = registry + ", +" + strconv.Itoa(regCount-1)
+	}
+
+	return registry, nil
 }

--- a/cmd/cli/plugin/package/repository_list.go
+++ b/cmd/cli/plugin/package/repository_list.go
@@ -60,7 +60,8 @@ func repositoryList(cmd *cobra.Command, _ []string) error {
 		t.StopSpinner()
 		return err
 	}
-	for _, packageRepository := range packageRepositoryList.Items { //nolint:gocritic
+	for i := range packageRepositoryList.Items {
+		packageRepository := packageRepositoryList.Items[i]
 		status := packageRepository.Status.FriendlyDescription
 		details := packageRepository.Status.UsefulErrorMessage
 		if len(status) > tkgpackagedatamodel.ShortDescriptionMaxLength {

--- a/pkg/v1/tkg/fakes/kappclient.go
+++ b/pkg/v1/tkg/fakes/kappclient.go
@@ -4,11 +4,13 @@ package fakes
 import (
 	"sync"
 
+	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1alpha1a "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	v1alpha1b "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
+	v1alpha1c "github.com/vmware-tanzu/carvel-secretgen-controller/pkg/apis/secretgen2/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/kappclient"
 )
 
@@ -142,6 +144,19 @@ type KappClient struct {
 		result1 []byte
 		result2 error
 	}
+	ListImagePullSecretsStub        func(string) (*v1.SecretList, error)
+	listImagePullSecretsMutex       sync.RWMutex
+	listImagePullSecretsArgsForCall []struct {
+		arg1 string
+	}
+	listImagePullSecretsReturns struct {
+		result1 *v1.SecretList
+		result2 error
+	}
+	listImagePullSecretsReturnsOnCall map[int]struct {
+		result1 *v1.SecretList
+		result2 error
+	}
 	ListPackageInstallsStub        func(string) (*v1alpha1.PackageInstallList, error)
 	listPackageInstallsMutex       sync.RWMutex
 	listPackageInstallsArgsForCall []struct {
@@ -193,6 +208,19 @@ type KappClient struct {
 	}
 	listPackagesReturnsOnCall map[int]struct {
 		result1 *v1alpha1b.PackageList
+		result2 error
+	}
+	ListSecretExportsStub        func(string) (*v1alpha1c.SecretExportList, error)
+	listSecretExportsMutex       sync.RWMutex
+	listSecretExportsArgsForCall []struct {
+		arg1 string
+	}
+	listSecretExportsReturns struct {
+		result1 *v1alpha1c.SecretExportList
+		result2 error
+	}
+	listSecretExportsReturnsOnCall map[int]struct {
+		result1 *v1alpha1c.SecretExportList
 		result2 error
 	}
 	UpdatePackageInstallStub        func(*v1alpha1.PackageInstall, bool) error
@@ -850,6 +878,70 @@ func (fake *KappClient) GetSecretValueReturnsOnCall(i int, result1 []byte, resul
 	}{result1, result2}
 }
 
+func (fake *KappClient) ListImagePullSecrets(arg1 string) (*v1.SecretList, error) {
+	fake.listImagePullSecretsMutex.Lock()
+	ret, specificReturn := fake.listImagePullSecretsReturnsOnCall[len(fake.listImagePullSecretsArgsForCall)]
+	fake.listImagePullSecretsArgsForCall = append(fake.listImagePullSecretsArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ListImagePullSecretsStub
+	fakeReturns := fake.listImagePullSecretsReturns
+	fake.recordInvocation("ListImagePullSecrets", []interface{}{arg1})
+	fake.listImagePullSecretsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *KappClient) ListImagePullSecretsCallCount() int {
+	fake.listImagePullSecretsMutex.RLock()
+	defer fake.listImagePullSecretsMutex.RUnlock()
+	return len(fake.listImagePullSecretsArgsForCall)
+}
+
+func (fake *KappClient) ListImagePullSecretsCalls(stub func(string) (*v1.SecretList, error)) {
+	fake.listImagePullSecretsMutex.Lock()
+	defer fake.listImagePullSecretsMutex.Unlock()
+	fake.ListImagePullSecretsStub = stub
+}
+
+func (fake *KappClient) ListImagePullSecretsArgsForCall(i int) string {
+	fake.listImagePullSecretsMutex.RLock()
+	defer fake.listImagePullSecretsMutex.RUnlock()
+	argsForCall := fake.listImagePullSecretsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *KappClient) ListImagePullSecretsReturns(result1 *v1.SecretList, result2 error) {
+	fake.listImagePullSecretsMutex.Lock()
+	defer fake.listImagePullSecretsMutex.Unlock()
+	fake.ListImagePullSecretsStub = nil
+	fake.listImagePullSecretsReturns = struct {
+		result1 *v1.SecretList
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *KappClient) ListImagePullSecretsReturnsOnCall(i int, result1 *v1.SecretList, result2 error) {
+	fake.listImagePullSecretsMutex.Lock()
+	defer fake.listImagePullSecretsMutex.Unlock()
+	fake.ListImagePullSecretsStub = nil
+	if fake.listImagePullSecretsReturnsOnCall == nil {
+		fake.listImagePullSecretsReturnsOnCall = make(map[int]struct {
+			result1 *v1.SecretList
+			result2 error
+		})
+	}
+	fake.listImagePullSecretsReturnsOnCall[i] = struct {
+		result1 *v1.SecretList
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *KappClient) ListPackageInstalls(arg1 string) (*v1alpha1.PackageInstallList, error) {
 	fake.listPackageInstallsMutex.Lock()
 	ret, specificReturn := fake.listPackageInstallsReturnsOnCall[len(fake.listPackageInstallsArgsForCall)]
@@ -1107,6 +1199,70 @@ func (fake *KappClient) ListPackagesReturnsOnCall(i int, result1 *v1alpha1b.Pack
 	}{result1, result2}
 }
 
+func (fake *KappClient) ListSecretExports(arg1 string) (*v1alpha1c.SecretExportList, error) {
+	fake.listSecretExportsMutex.Lock()
+	ret, specificReturn := fake.listSecretExportsReturnsOnCall[len(fake.listSecretExportsArgsForCall)]
+	fake.listSecretExportsArgsForCall = append(fake.listSecretExportsArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.ListSecretExportsStub
+	fakeReturns := fake.listSecretExportsReturns
+	fake.recordInvocation("ListSecretExports", []interface{}{arg1})
+	fake.listSecretExportsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *KappClient) ListSecretExportsCallCount() int {
+	fake.listSecretExportsMutex.RLock()
+	defer fake.listSecretExportsMutex.RUnlock()
+	return len(fake.listSecretExportsArgsForCall)
+}
+
+func (fake *KappClient) ListSecretExportsCalls(stub func(string) (*v1alpha1c.SecretExportList, error)) {
+	fake.listSecretExportsMutex.Lock()
+	defer fake.listSecretExportsMutex.Unlock()
+	fake.ListSecretExportsStub = stub
+}
+
+func (fake *KappClient) ListSecretExportsArgsForCall(i int) string {
+	fake.listSecretExportsMutex.RLock()
+	defer fake.listSecretExportsMutex.RUnlock()
+	argsForCall := fake.listSecretExportsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *KappClient) ListSecretExportsReturns(result1 *v1alpha1c.SecretExportList, result2 error) {
+	fake.listSecretExportsMutex.Lock()
+	defer fake.listSecretExportsMutex.Unlock()
+	fake.ListSecretExportsStub = nil
+	fake.listSecretExportsReturns = struct {
+		result1 *v1alpha1c.SecretExportList
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *KappClient) ListSecretExportsReturnsOnCall(i int, result1 *v1alpha1c.SecretExportList, result2 error) {
+	fake.listSecretExportsMutex.Lock()
+	defer fake.listSecretExportsMutex.Unlock()
+	fake.ListSecretExportsStub = nil
+	if fake.listSecretExportsReturnsOnCall == nil {
+		fake.listSecretExportsReturnsOnCall = make(map[int]struct {
+			result1 *v1alpha1c.SecretExportList
+			result2 error
+		})
+	}
+	fake.listSecretExportsReturnsOnCall[i] = struct {
+		result1 *v1alpha1c.SecretExportList
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *KappClient) UpdatePackageInstall(arg1 *v1alpha1.PackageInstall, arg2 bool) error {
 	fake.updatePackageInstallMutex.Lock()
 	ret, specificReturn := fake.updatePackageInstallReturnsOnCall[len(fake.updatePackageInstallArgsForCall)]
@@ -1253,6 +1409,8 @@ func (fake *KappClient) Invocations() map[string][][]interface{} {
 	defer fake.getPackageRepositoryMutex.RUnlock()
 	fake.getSecretValueMutex.RLock()
 	defer fake.getSecretValueMutex.RUnlock()
+	fake.listImagePullSecretsMutex.RLock()
+	defer fake.listImagePullSecretsMutex.RUnlock()
 	fake.listPackageInstallsMutex.RLock()
 	defer fake.listPackageInstallsMutex.RUnlock()
 	fake.listPackageMetadataMutex.RLock()
@@ -1261,6 +1419,8 @@ func (fake *KappClient) Invocations() map[string][][]interface{} {
 	defer fake.listPackageRepositoriesMutex.RUnlock()
 	fake.listPackagesMutex.RLock()
 	defer fake.listPackagesMutex.RUnlock()
+	fake.listSecretExportsMutex.RLock()
+	defer fake.listSecretExportsMutex.RUnlock()
 	fake.updatePackageInstallMutex.RLock()
 	defer fake.updatePackageInstallMutex.RUnlock()
 	fake.updatePackageRepositoryMutex.RLock()

--- a/pkg/v1/tkg/kappclient/client.go
+++ b/pkg/v1/tkg/kappclient/client.go
@@ -189,6 +189,34 @@ func (c *client) ListPackageRepositories(namespace string) (*kappipkg.PackageRep
 	return repositoryList, nil
 }
 
+// ListImagePullSecrets gets the list of all Secrets of type "kubernetes.io/dockerconfigjson"
+func (c *client) ListImagePullSecrets(namespace string) (*corev1.SecretList, error) {
+	var selectors []crtclient.ListOption
+	secretList := &corev1.SecretList{}
+
+	selectors = []crtclient.ListOption{crtclient.InNamespace(namespace), crtclient.MatchingFields(map[string]string{"type": string(corev1.SecretTypeDockerConfigJson)})}
+
+	err := c.client.List(context.Background(), secretList, selectors...)
+	if err != nil {
+		return nil, err
+	}
+	return secretList, nil
+}
+
+// ListSecretExports gets the list of all SecretExports
+func (c *client) ListSecretExports(namespace string) (*secretgenctrl.SecretExportList, error) {
+	var selectors []crtclient.ListOption
+	secretExportList := &secretgenctrl.SecretExportList{}
+
+	selectors = []crtclient.ListOption{crtclient.InNamespace(namespace)}
+
+	err := c.client.List(context.Background(), secretExportList, selectors...)
+	if err != nil {
+		return nil, err
+	}
+	return secretExportList, nil
+}
+
 // ListPackageMetadata gets the list of PackageMetadata CRs
 func (c *client) ListPackageMetadata(namespace string) (*kapppkg.PackageMetadataList, error) {
 	var selectors []crtclient.ListOption

--- a/pkg/v1/tkg/kappclient/interface.go
+++ b/pkg/v1/tkg/kappclient/interface.go
@@ -5,11 +5,13 @@
 package kappclient
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	crtclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	kappctrl "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	kappipkg "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	kapppkg "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
+	secretgen "github.com/vmware-tanzu/carvel-secretgen-controller/pkg/apis/secretgen2/v1alpha1"
 )
 
 //go:generate counterfeiter -o ../fakes/kappclient.go --fake-name KappClient . Client
@@ -30,6 +32,8 @@ type Client interface {
 	ListPackageMetadata(namespace string) (*kapppkg.PackageMetadataList, error)
 	ListPackages(packageName string, namespace string) (*kapppkg.PackageList, error)
 	ListPackageRepositories(namespace string) (*kappipkg.PackageRepositoryList, error)
+	ListImagePullSecrets(namespace string) (*corev1.SecretList, error)
+	ListSecretExports(namespace string) (*secretgen.SecretExportList, error)
 	UpdatePackageInstall(packageInstall *kappipkg.PackageInstall, isPkgPluginCreatedSecret bool) error
 	UpdatePackageRepository(repository *kappipkg.PackageRepository) error
 }

--- a/pkg/v1/tkg/tkgpackageclient/imagepullsecret_add.go
+++ b/pkg/v1/tkg/tkgpackageclient/imagepullsecret_add.go
@@ -16,9 +16,10 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
 )
 
+// DockerConfigJSON represents auth information for pulling images
 // Note: datapolicy is seemingly used for log sanitization: https://github.com/kubernetes/enhancements/blob/master/keps/sig-security/1933-secret-logging-static-analysis/README.md
 // TODO: change to use k8s types after upgrading the K8s version
-type dockerConfigJSON struct {
+type DockerConfigJSON struct {
 	Auths map[string]dockerConfigEntry `json:"auths" datapolicy:"token"`
 }
 
@@ -29,7 +30,7 @@ type dockerConfigEntry struct {
 
 // AddImagePullSecret adds an image pull secret to the cluster
 func (p *pkgClient) AddImagePullSecret(o *tkgpackagedatamodel.ImagePullSecretOptions) error {
-	dockerCfg := dockerConfigJSON{Auths: map[string]dockerConfigEntry{o.Registry: {Username: o.Username, Password: o.Password}}}
+	dockerCfg := DockerConfigJSON{Auths: map[string]dockerConfigEntry{o.Registry: {Username: o.Username, Password: o.Password}}}
 	dockerCfgContent, err := json.Marshal(dockerCfg)
 	if err != nil {
 		return err

--- a/pkg/v1/tkg/tkgpackageclient/imagepullsecret_list.go
+++ b/pkg/v1/tkg/tkgpackageclient/imagepullsecret_list.go
@@ -1,0 +1,33 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgpackageclient
+
+import (
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+
+	secretgenctrl "github.com/vmware-tanzu/carvel-secretgen-controller/pkg/apis/secretgen2/v1alpha1"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
+)
+
+// ListImagePullSecret lists all image pull secrets of type kubernetes.io/dockerconfigjson across the cluster.
+func (p *pkgClient) ListImagePullSecrets(o *tkgpackagedatamodel.ImagePullSecretOptions) (*corev1.SecretList, error) {
+	imagePullSecretList, err := p.kappClient.ListImagePullSecrets(o.Namespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list existing image pull secrets in the cluster")
+	}
+
+	return imagePullSecretList, nil
+}
+
+// ListSecretExports lists all SecretExports across the cluster.
+func (p *pkgClient) ListSecretExports(o *tkgpackagedatamodel.ImagePullSecretOptions) (*secretgenctrl.SecretExportList, error) {
+	secretExportList, err := p.kappClient.ListSecretExports(o.Namespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list existing secret exports in the cluster")
+	}
+
+	return secretExportList, nil
+}

--- a/pkg/v1/tkg/tkgpackageclient/imagepullsecret_list_test.go
+++ b/pkg/v1/tkg/tkgpackageclient/imagepullsecret_list_test.go
@@ -1,0 +1,137 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgpackageclient
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	secretgenctrl "github.com/vmware-tanzu/carvel-secretgen-controller/pkg/apis/secretgen2/v1alpha1"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
+)
+
+const testSecretExportName = "test-secret"
+
+var testDockerconfig = DockerConfigJSON{Auths: map[string]dockerConfigEntry{"us-east4-docker.pkg.dev": {Username: "test_user", Password: "test_password"}}}
+
+var testSecret = &corev1.Secret{
+	TypeMeta:   metav1.TypeMeta{Kind: tkgpackagedatamodel.KindSecret, APIVersion: corev1.SchemeGroupVersion.String()},
+	ObjectMeta: metav1.ObjectMeta{Name: testSecretName, Namespace: testNamespaceName},
+	Type:       corev1.SecretTypeDockerConfigJson,
+	Data:       map[string][]byte{},
+}
+
+var testSecretExport = &secretgenctrl.SecretExport{
+	TypeMeta:   metav1.TypeMeta{Kind: tkgpackagedatamodel.KindSecretExport, APIVersion: secretgenctrl.SchemeGroupVersion.String()},
+	ObjectMeta: metav1.ObjectMeta{Name: testSecretExportName, Namespace: testNamespaceName},
+	Spec:       secretgenctrl.SecretExportSpec{ToNamespaces: []string{"*"}},
+}
+
+var _ = Describe("List Secrets", func() {
+	var (
+		ctl     *pkgClient
+		kappCtl *fakes.KappClient
+		err     error
+		opts    = tkgpackagedatamodel.ImagePullSecretOptions{
+			Namespace:     testNamespaceName,
+			AllNamespaces: false,
+		}
+		options    = opts
+		secrets    *corev1.SecretList
+		secretList = &corev1.SecretList{
+			TypeMeta: metav1.TypeMeta{Kind: "SecretList"},
+			Items:    []corev1.Secret{*testSecret},
+		}
+	)
+
+	JustBeforeEach(func() {
+		ctl = &pkgClient{kappClient: kappCtl}
+		dockerCfgContent, _ := json.Marshal(testDockerconfig)
+		testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+		secrets, err = ctl.ListImagePullSecrets(&options)
+	})
+
+	Context("failure in listing secrets due to ListImagePullSecrets API error", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			kappCtl.ListImagePullSecretsReturns(nil, errors.New("failure in ListImagePullSecrets"))
+			ctl = &pkgClient{kappClient: kappCtl}
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failure in ListImagePullSecrets"))
+			Expect(secrets).To(BeNil())
+		})
+	})
+
+	Context("success in listing secrets", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			kappCtl.ListImagePullSecretsReturns(secretList, nil)
+			ctl = &pkgClient{kappClient: kappCtl}
+		})
+		It(testSuccessMsg, func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secrets).NotTo(BeNil())
+			Expect(secrets).To(Equal(secretList))
+		})
+	})
+})
+
+var _ = Describe("List Secret Exports", func() {
+	var (
+		ctl     *pkgClient
+		kappCtl *fakes.KappClient
+		err     error
+		opts    = tkgpackagedatamodel.ImagePullSecretOptions{
+			Namespace:     testNamespaceName,
+			AllNamespaces: false,
+		}
+		options          = opts
+		secretExports    *secretgenctrl.SecretExportList
+		secretExportList = &secretgenctrl.SecretExportList{
+			TypeMeta: metav1.TypeMeta{Kind: "SecretList"},
+			Items:    []secretgenctrl.SecretExport{*testSecretExport},
+		}
+	)
+
+	JustBeforeEach(func() {
+		ctl = &pkgClient{kappClient: kappCtl}
+		secretExports, err = ctl.ListSecretExports(&options)
+	})
+
+	Context("failure in listing secret exports due to ListSecretExports API error", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			kappCtl.ListSecretExportsReturns(nil, errors.New("failure in ListSecretExports"))
+			ctl = &pkgClient{kappClient: kappCtl}
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failure in ListSecretExports"))
+			Expect(secretExports).To(BeNil())
+		})
+	})
+
+	Context("success in listing secret exports", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			kappCtl.ListSecretExportsReturns(secretExportList, nil)
+			ctl = &pkgClient{kappClient: kappCtl}
+		})
+		It(testSuccessMsg, func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secretExports).NotTo(BeNil())
+			Expect(secretExports).To(Equal(secretExportList))
+		})
+	})
+})

--- a/pkg/v1/tkg/tkgpackageclient/interface.go
+++ b/pkg/v1/tkg/tkgpackageclient/interface.go
@@ -5,8 +5,11 @@
 package tkgpackageclient
 
 import (
+	corev1 "k8s.io/api/core/v1"
+
 	kappipkg "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	kapppkg "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
+	secretgen "github.com/vmware-tanzu/carvel-secretgen-controller/pkg/apis/secretgen2/v1alpha1"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
 )
@@ -21,10 +24,12 @@ type TKGPackageClient interface {
 	GetPackage(o *tkgpackagedatamodel.PackageOptions) (*kapppkg.PackageMetadata, *kapppkg.Package, error)
 	GetRepository(o *tkgpackagedatamodel.RepositoryOptions) (*kappipkg.PackageRepository, error)
 	InstallPackage(o *tkgpackagedatamodel.PackageOptions, packageProgress *tkgpackagedatamodel.PackageProgress, update bool)
+	ListImagePullSecrets(o *tkgpackagedatamodel.ImagePullSecretOptions) (*corev1.SecretList, error)
 	ListPackageInstalls(o *tkgpackagedatamodel.PackageOptions) (*kappipkg.PackageInstallList, error)
 	ListPackageMetadata(o *tkgpackagedatamodel.PackageAvailableOptions) (*kapppkg.PackageMetadataList, error)
 	ListPackages(o *tkgpackagedatamodel.PackageAvailableOptions) (*kapppkg.PackageList, error)
 	ListRepositories(o *tkgpackagedatamodel.RepositoryOptions) (*kappipkg.PackageRepositoryList, error)
+	ListSecretExports(o *tkgpackagedatamodel.ImagePullSecretOptions) (*secretgen.SecretExportList, error)
 	UninstallPackage(o *tkgpackagedatamodel.PackageOptions, packageProgress *tkgpackagedatamodel.PackageProgress)
 	UpdatePackage(o *tkgpackagedatamodel.PackageOptions, packageProgress *tkgpackagedatamodel.PackageProgress)
 	UpdateRepository(o *tkgpackagedatamodel.RepositoryOptions) error


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding list command to image pull secret plugin

**Describe testing done for PR**:

**Testing with namespace flag (-n & -A)**
```
➜   tanzu imagepullsecret list -A
| Retrieving image pull secrets... 
  NAME                                  REGISTRY         EXPORTED           AGE      NAMESPACE                         
  pkg-dev-reg               us-east4-docker.pkg.dev  to all namespaces      15d      kapp-controller-packaging-global  
  tanzu-standard-fetch-0    us-east4-docker.pkg.dev  not exported           15d      tanzu-package-repo-global         
  ...
                   
➜   tanzu imagepullsecret list -n kapp-controller-packaging-global
/ Retrieving image pull secrets... 
  NAME              REGISTRY                    EXPORTED       AGE              
  pkg-dev-reg  us-east4-docker.pkg.dev  to all namespaces     15d
```
 **Testing -o flag with different options:** 
```
➜   tanzu imagepullsecret list -A -o json
[
  {
    "age": "15d",
    "exported": "to all namespaces",
    "name": "pkg-dev-reg",
    "namespace": "kapp-controller-packaging-global",
    "registry": "us-east4-docker.pkg.dev"
  },
  {
    "age": "15d",
    "exported": "not exported",
    "name": "tanzu-standard-fetch-0",
    "namespace": "tanzu-package-repo-global",
    "registry": "us-east4-docker.pkg.dev"
  },
  {
    "age": "15d",
    "exported": "not exported",
    "name": "private-repo-fetch-0",
    "namespace": "test-ns",
    "registry": "us-east4-docker.pkg.dev"
  },
  {
    "age": "15d",
    "exported": "not exported",
    "name": "antrea-fetch-0",
    "namespace": "tkg-system",
    "registry": "us-east4-docker.pkg.dev"
  },
  {
    "age": "15d",
    "exported": "not exported",
    "name": "metrics-server-fetch-0",
    "namespace": "tkg-system",
    "registry": "us-east4-docker.pkg.dev"
  },
  {
    "age": "15d",
    "exported": "not exported",
    "name": "tanzu-addons-manager-fetch-0",
    "namespace": "tkg-system",
    "registry": "us-east4-docker.pkg.dev"
  },
  {
    "age": "66h45m6.946506s",
    "exported": "not exported",
    "name": "tanzu-core-fetch-0",
    "namespace": "tkg-system",
    "registry": "us-east4-docker.pkg.dev"
  }
]                                                                                                                                                  
➜   tanzu imagepullsecret list -A -o yaml
- age: 15d
  exported: to all namespaces
  name: pkg-dev-reg
  namespace: kapp-controller-packaging-global
  registry: us-east4-docker.pkg.dev
- age: 15d
  exported: not exported
  name: tanzu-standard-fetch-0
  namespace: tanzu-package-repo-global
  registry: us-east4-docker.pkg.dev
- age: 15d
  exported: not exported
  name: private-repo-fetch-0
  namespace: test-ns
  registry: us-east4-docker.pkg.dev
- age: 15d
  exported: not exported
  name: antrea-fetch-0
  namespace: tkg-system
  registry: us-east4-docker.pkg.dev
- age: 15d
  exported: not exported
  name: metrics-server-fetch-0
  namespace: tkg-system
  registry: us-east4-docker.pkg.dev
- age: 15d
  exported: not exported
  name: tanzu-addons-manager-fetch-0
  namespace: tkg-system
  registry: us-east4-docker.pkg.dev
- age: 15d
  exported: not exported
  name: tanzu-core-fetch-0
  namespace: tkg-system
  registry: us-east4-docker.pkg.dev

➜   tanzu imagepullsecret list -A -o table
- Retrieving image pull secrets... 
  NAME                          REGISTRY                 EXPORTED           AGE               NAMESPACE                         
  pkg-dev-reg                   us-east4-docker.pkg.dev  to all namespaces  15d  kapp-controller-packaging-global  
  tanzu-standard-fetch-0        us-east4-docker.pkg.dev  not exported       15d  tanzu-package-repo-global         
  private-repo-fetch-0          us-east4-docker.pkg.dev  not exported       15d   test-ns                           
  antrea-fetch-0                us-east4-docker.pkg.dev  not exported       15d  tkg-system                        
  metrics-server-fetch-0        us-east4-docker.pkg.dev  not exported       15d  tkg-system                        
  tanzu-addons-manager-fetch-0  us-east4-docker.pkg.dev  not exported       15d   tkg-system                        
  tanzu-core-fetch-0            us-east4-docker.pkg.dev  not exported       15d  tkg-system 
```
 
**Special notes for your reviewer**:
1. Update REGISTRY column value, in case we have more than 1 registry
2. Exhaustive testing

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
[Feature]: Add list command for imagepullsecret plugin 
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
