### PR TITLE
Update BOM file to match v0.2.0 release names

### DIFF
--- a/pkg/v1/tkg/tkgconfigpaths/zz_bundled_default_bom_files_configdata.go
+++ b/pkg/v1/tkg/tkgconfigpaths/zz_bundled_default_bom_files_configdata.go
@@ -11,6 +11,6 @@ package tkgconfigpaths
 // Note: Please !!DO NOT!!! change the name or remove this variable
 var (
 	TKGDefaultImageRepo               string = "projects-stg.registry.vmware.com/tkg"
-	TKGDefaultCompatibilityImagePath  string = "v1.4.0-zshippable/tkg-compatibility"
-	TKGManagementClusterPluginVersion string = "v1.4.0-pre-alpha-2"
+	TKGDefaultCompatibilityImagePath  string = "framework-zshippable/tkg-compatibility"
+	TKGManagementClusterPluginVersion string = "v0.2.0"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

With the new v0.2.0 tag, the configure-bom target now replaces strings
in the bom with the v0.2.0 values, causing our dirty file check to fail.

This updates the bom to accomodate the new tag.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #590

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

Ran `make configure-bom` locally and verified no dirty files after completion.

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
NONE
```