### PR TITLE
Encode build information into the built binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+ARG LD_FLAGS
+ENV LD_FLAGS="$LD_FLAGS "'-extldflags "-static"'
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "$LD_FLAGS" -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -29,7 +29,9 @@ COPY ./ ./
 RUN go mod download
 
 # Build
-RUN cd addons && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags '-extldflags "-static"' -o bin/manager main.go
+ARG LD_FLAGS
+ENV LD_FLAGS="$LD_FLAGS "'-extldflags "-static"'
+RUN cd addons && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "$LD_FLAGS" -o bin/manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/addons/Makefile
+++ b/addons/Makefile
@@ -1,6 +1,8 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+include ../common.mk
+
 .DEFAULT_GOAL := help
 
 ROOT_DIR	:= $(dir $(shell pwd))
@@ -55,7 +57,7 @@ test-verbose: ## Verbose tests with streaming output for debugging
 .PHONY: manager-binary
 manager-binary: $(MANAGER) ## Build manager binary
 $(MANAGER):
-	go build -o $@ -ldflags '-extldflags "-static"'
+	go build -o $@ -ldflags "$(LD_FLAGS) "'-extldflags "-static"'
 
 .PHONY: manager
 manager: fmt vet manager-binary ## Build manager binary
@@ -78,7 +80,7 @@ vet: ## Vet codebase
 
 .PHONY: run
 run: fmt vet ## Run locally
-	go run ./main.go
+	go run -ldflags "$(LD_FLAGS)" ./main.go
 
 ## --------------------------------------
 ## Docker
@@ -87,7 +89,7 @@ run: fmt vet ## Run locally
 .PHONY: docker-build
 docker-build: ## Build the docker image
 	@[ -f ../$(SSH_PRIVATE_KEY) ] || { echo "an SSH key file named $(SSH_PRIVATE_KEY) must exist and have read access to github.com" 1>&2; exit 1; }
-	cd .. && docker build -t $(IMG) -f addons/Dockerfile --build-arg SSH_PRIVATE_KEY=$(SSH_PRIVATE_KEY) .
+	cd .. && docker build -t $(IMG) -f addons/Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-arg SSH_PRIVATE_KEY=$(SSH_PRIVATE_KEY) .
 
 .PHONY: docker-push
 docker-push: ## Push the docker image

--- a/addons/main.go
+++ b/addons/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/addons/controllers"
 	addonconfig "github.com/vmware-tanzu/tanzu-framework/addons/pkg/config"
 	runtanzuv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 )
 
 var (
@@ -88,6 +89,8 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(klogr.New())
+
+	setupLog.Info("Version", "version", buildinfo.Version, "buildDate", buildinfo.Date, "sha", buildinfo.SHA)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,

--- a/cmd/cli/plugin-admin/builder/main.go
+++ b/cmd/cli/plugin-admin/builder/main.go
@@ -8,7 +8,7 @@ import (
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/builder/command"
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
 )
 
@@ -16,7 +16,7 @@ var descriptor = cliv1alpha1.PluginDescriptor{
 	Name:        "builder",
 	Description: "Build Tanzu components",
 	Group:       cliv1alpha1.AdminCmdGroup,
-	Version:     cli.BuildVersion,
+	Version:     buildinfo.Version,
 }
 
 func main() {

--- a/cmd/cli/plugin-admin/codegen/main.go
+++ b/cmd/cli/plugin-admin/codegen/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aunum/log"
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/codegen"
 )
@@ -16,7 +16,7 @@ var descriptor = cliv1alpha1.PluginDescriptor{
 	Name:        "codegen",
 	Description: "Tanzu code generation tool",
 	Group:       cliv1alpha1.AdminCmdGroup,
-	Version:     cli.BuildVersion,
+	Version:     buildinfo.Version,
 }
 
 func main() {

--- a/cmd/cli/plugin/managementcluster/main.go
+++ b/cmd/cli/plugin/managementcluster/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aunum/log"
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
 )
 
@@ -21,7 +21,7 @@ var (
 var descriptor = cliv1alpha1.PluginDescriptor{
 	Name:            "management-cluster",
 	Description:     "Kubernetes management cluster operations",
-	Version:         cli.BuildVersion,
+	Version:         buildinfo.Version,
 	BuildSHA:        "",
 	Group:           cliv1alpha1.RunCmdGroup,
 	Aliases:         []string{"mc", "management-clusters"},

--- a/cmd/cli/plugin/pinniped-auth/login.go
+++ b/cmd/cli/plugin/pinniped-auth/login.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 )
@@ -110,8 +111,8 @@ func loginoidcCmd(pinnipedloginCliExec func(args []string) error) *cobra.Command
 
 // pinnipedLoginExec executes embedded pinniped cli binary
 func pinnipedLoginExec(oidcLoginArgs []string) error {
-	buildSHA := strings.ReplaceAll(cli.BuildSHA, "-dirty", "")
-	pinnipedCLIBinFile := fmt.Sprintf("tanzu-pinniped-client-%s-%s", cli.BuildVersion, buildSHA)
+	buildSHA := strings.ReplaceAll(buildinfo.SHA, "-dirty", "")
+	pinnipedCLIBinFile := fmt.Sprintf("tanzu-pinniped-client-%s-%s", buildinfo.Version, buildSHA)
 	if runtime.GOOS == "windows" {
 		pinnipedCLIBinFile += ".exe"
 	}

--- a/cmd/managers/capabilities/main.go
+++ b/cmd/managers/capabilities/main.go
@@ -16,6 +16,7 @@ import (
 	// +kubebuilder:scaffold:imports
 
 	runv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/capabilities/controllers"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/capabilities/discovery"
 )
@@ -38,6 +39,8 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	setupLog.Info("Version", "version", buildinfo.Version, "buildDate", buildinfo.Date, "sha", buildinfo.SHA)
 
 	var err error
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{Scheme: scheme, MetricsBindAddress: "0"})

--- a/cmd/managers/featuregate/main.go
+++ b/cmd/managers/featuregate/main.go
@@ -17,6 +17,7 @@ import (
 	// +kubebuilder:scaffold:imports
 
 	configv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/features/controllers"
 )
 
@@ -39,6 +40,8 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	setupLog.Info("Version", "version", buildinfo.Version, "buildDate", buildinfo.Date, "sha", buildinfo.SHA)
 
 	var err error
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{Scheme: scheme, MetricsBindAddress: "0", Port: 9443})

--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,41 @@
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+GOHOSTOS ?= $(shell go env GOHOSTOS)
+GOHOSTARCH ?= $(shell go env GOHOSTARCH)
+
+# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+ifeq (,$(shell go env GOBIN))
+GOBIN=$(shell go env GOPATH)/bin
+else
+GOBIN=$(shell go env GOBIN)
+endif
+
+PRIVATE_REPOS=github.com/vmware-tanzu/tanzu-framework
+GO := GOPRIVATE=${PRIVATE_REPOS} go
+
+NUL = /dev/null
+ifeq ($(GOHOSTOS),windows)
+	NUL = NUL
+endif
+
+BUILD_SHA ?= $$(git describe --match=$(git rev-parse --short HEAD) --always --dirty)
+BUILD_DATE ?= $$(date -u +"%Y-%m-%d")
+BUILD_VERSION ?= $(shell git describe --tags --abbrev=0 2>$(NUL))
+
+ifeq ($(strip $(BUILD_VERSION)),)
+BUILD_VERSION = dev
+endif
+
+# BUILD_EDITION is the Tanzu Edition, the plugin should be built for.
+# Valid values for BUILD_EDITION are 'tce' and 'tkg'. Default value of BUILD_EDITION is 'tkg'.
+ifneq ($(BUILD_EDITION), tce)
+BUILD_EDITION = tkg
+endif
+
+LD_FLAGS = -s -w
+LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.Date=$(BUILD_DATE)'
+LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.SHA=$(BUILD_SHA)'
+LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.Version=$(BUILD_VERSION)'

--- a/pkg/v1/buildinfo/buildvar.go
+++ b/pkg/v1/buildinfo/buildvar.go
@@ -1,0 +1,22 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package buildinfo holds global vars set at build time to provide information about the build.
+// This package SHOULD NOT import other packages -- to avoid dependency cycles.
+package buildinfo
+
+// This package
+
+var (
+	// Date is the date the binary was built.
+	// Set by go build -ldflags "-X" flag
+	Date string
+
+	// SHA is the git commit SHA the binary was built with.
+	// Set by go build -ldflags "-X" flag
+	SHA string
+
+	// Version is the version the binary was built with.
+	// Set by go build -ldflags "-X" flag
+	Version string
+)

--- a/pkg/v1/buildinfo/metadata.go
+++ b/pkg/v1/buildinfo/metadata.go
@@ -1,0 +1,8 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package buildinfo
+
+// IsOfficialBuild is the flag that gets set to True if it is an official build being released.
+// Set by go build -ldflags "-X" flag
+var IsOfficialBuild string

--- a/pkg/v1/cli/buildvar.go
+++ b/pkg/v1/cli/buildvar.go
@@ -3,13 +3,20 @@
 
 package cli
 
+import "github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
+
+// Variables defined in this file are deprecated in favor of their equivalents defined in a dedicated package.
+
 var (
 	// BuildDate is the date the CLI was built.
-	BuildDate string
+	// Deprecated: use github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.Date
+	BuildDate = buildinfo.Date
 
 	// BuildSHA is the git sha the CLI was built with.
-	BuildSHA string
+	// Deprecated: use github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.SHA
+	BuildSHA = buildinfo.SHA
 
 	// BuildVersion is the version the CLI was built with.
-	BuildVersion string
+	// Deprecated: use github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.Version
+	BuildVersion = buildinfo.Version
 )

--- a/pkg/v1/cli/catalog.go
+++ b/pkg/v1/cli/catalog.go
@@ -24,6 +24,7 @@ import (
 	apimachineryjson "k8s.io/apimachinery/pkg/runtime/serializer/json"
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 )
 
 const (
@@ -59,7 +60,7 @@ func NewTestFor(pluginName string) *cliv1alpha1.PluginDescriptor {
 		Name:        fmt.Sprintf("%s-test", pluginName),
 		Description: fmt.Sprintf("test for %s", pluginName),
 		Version:     "v0.0.1",
-		BuildSHA:    BuildSHA,
+		BuildSHA:    buildinfo.SHA,
 		Group:       cliv1alpha1.TestCmdGroup,
 		Aliases:     []string{fmt.Sprintf("%s-alias", pluginName)},
 	}
@@ -201,9 +202,9 @@ func TestCmd(p *cliv1alpha1.PluginDescriptor) *cobra.Command {
 
 // ApplyDefaultConfig applies default configurations to plugin descriptor.
 func ApplyDefaultConfig(p *cliv1alpha1.PluginDescriptor) {
-	p.BuildSHA = BuildSHA
+	p.BuildSHA = buildinfo.SHA
 	if p.Version == "" {
-		p.Version = BuildVersion
+		p.Version = buildinfo.Version
 	}
 	if p.PostInstallHook == nil {
 		p.PostInstallHook = func() error {

--- a/pkg/v1/cli/command/core/update.go
+++ b/pkg/v1/cli/command/core/update.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
 )
 
@@ -77,7 +78,7 @@ var updateCmd = &cobra.Command{
 
 		log.Info("the following updates will take place:")
 		if coreUpdate {
-			fmt.Printf("     %s %s → %s\n", cli.CoreName, cli.BuildVersion, coreVersion)
+			fmt.Printf("     %s %s → %s\n", cli.CoreName, buildinfo.Version, coreVersion)
 		}
 		for plugin, version := range updateMap {
 			fmt.Printf("     %s %s → %s\n", plugin.Name, plugin.Version, version)

--- a/pkg/v1/cli/command/core/version.go
+++ b/pkg/v1/cli/command/core/version.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
 )
 
@@ -23,7 +24,7 @@ var versionCmd = &cobra.Command{
 		"group": string(cliv1alpha1.SystemCmdGroup),
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Printf("version: %s\nbuildDate: %s\nsha: %s\n", cli.BuildVersion, cli.BuildDate, cli.BuildSHA)
+		fmt.Printf("version: %s\nbuildDate: %s\nsha: %s\n", buildinfo.Version, buildinfo.Date, buildinfo.SHA)
 		return nil
 	},
 }

--- a/pkg/v1/cli/command/core/version_test.go
+++ b/pkg/v1/cli/command/core/version_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 )
 
 func readOutput(t *testing.T, r io.Reader, c chan<- []byte) {
@@ -41,13 +41,13 @@ func TestVersion(t *testing.T) {
 	os.Stdout = w
 	os.Stderr = w
 
-	cli.BuildVersion = "1.2.3"
-	cli.BuildDate = "today"
-	cli.BuildSHA = "cafecafe"
+	buildinfo.Version = "1.2.3"
+	buildinfo.Date = "today"
+	buildinfo.SHA = "cafecafe"
 	defer func() {
-		cli.BuildVersion = ""
-		cli.BuildDate = ""
-		cli.BuildSHA = ""
+		buildinfo.Version = ""
+		buildinfo.Date = ""
+		buildinfo.SHA = ""
 	}()
 
 	err = versionCmd.Execute()

--- a/pkg/v1/cli/core.go
+++ b/pkg/v1/cli/core.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/mod/semver"
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 )
 
 // CoreName is the name of the core binary.
@@ -24,8 +25,8 @@ const coreDescription = "The core Tanzu CLI"
 var CoreDescriptor = cliv1alpha1.PluginDescriptor{
 	Name:        CoreName,
 	Description: coreDescription,
-	Version:     BuildVersion,
-	BuildSHA:    BuildSHA,
+	Version:     buildinfo.Version,
+	BuildSHA:    buildinfo.SHA,
 }
 
 // CorePlugin is the core plugin.
@@ -43,7 +44,7 @@ func HasUpdate(repo Repository) (update bool, version string, err error) {
 	versionSelector := repo.VersionSelector()
 
 	version = plugin.FindVersion(versionSelector)
-	compared := semver.Compare(version, BuildVersion)
+	compared := semver.Compare(version, buildinfo.Version)
 	if compared == 1 {
 		return true, version, nil
 	}

--- a/pkg/v1/cli/metadata.go
+++ b/pkg/v1/cli/metadata.go
@@ -8,6 +8,7 @@ import (
 
 	"google.golang.org/grpc/metadata"
 
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 )
 
@@ -25,13 +26,13 @@ func AppendClientMetadata(ctx context.Context) context.Context {
 	if !ok {
 		return metadata.NewOutgoingContext(ctx, map[string][]string{
 			config.NameHeader:    {ClientName},
-			config.VersionHeader: {BuildVersion},
+			config.VersionHeader: {buildinfo.Version},
 		})
 	}
 	// Append to outgoing metadata if context has existing metadata
 	return metadata.AppendToOutgoingContext(ctx,
 		config.NameHeader, ClientName,
-		config.VersionHeader, BuildVersion,
+		config.VersionHeader, buildinfo.Version,
 	)
 }
 

--- a/pkg/v1/sdk/capabilities/Dockerfile
+++ b/pkg/v1/sdk/capabilities/Dockerfile
@@ -37,7 +37,9 @@ COPY cmd/managers/capabilities/main.go main.go
 
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags '-extldflags "-static"' -o manager main.go
+ARG LD_FLAGS
+ENV LD_FLAGS="$LD_FLAGS "'-extldflags "-static"'
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "$LD_FLAGS" -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/pkg/v1/sdk/capabilities/Makefile
+++ b/pkg/v1/sdk/capabilities/Makefile
@@ -1,19 +1,10 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+include ../../../../common.mk
+
 IMG ?= capabilities-controller-manager:latest
-GOOS ?= $(shell go env GOOS)
-GOARCH ?= $(shell go env GOARCH)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
-
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
-PRIVATE_REPOS="github.com/vmware-tanzu/tanzu-framework"
-GO := GOPRIVATE=${PRIVATE_REPOS} go
 
 # ssh private key file name
 SSH_PRIVATE_KEY ?= .private_ssh_key
@@ -26,11 +17,11 @@ test: fmt vet manifests
 
 # Build manager binary
 manager: fmt vet
-	go build -o bin/manager ../../../../cmd/managers/capabilities/main.go
+	go build -ldflags "$(LD_FLAGS)" -o bin/manager ../../../../cmd/managers/capabilities/main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: fmt vet
-	go run ../../../../cmd/managers/capabilities/main.go
+	go run -ldflags "$(LD_FLAGS)" ../../../../cmd/managers/capabilities/main.go
 
 # Run go fmt against code
 fmt:
@@ -68,4 +59,4 @@ endif
 
 .PHONY: docker-build
 docker-build:
-	cd ../../../../ && docker build -t $(IMG) -f pkg/v1/sdk/capabilities/Dockerfile --build-arg SSH_PRIVATE_KEY=$(SSH_PRIVATE_KEY) .
+	cd ../../../../ && docker build -t $(IMG) -f pkg/v1/sdk/capabilities/Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-arg SSH_PRIVATE_KEY=$(SSH_PRIVATE_KEY) .

--- a/pkg/v1/sdk/features/Dockerfile
+++ b/pkg/v1/sdk/features/Dockerfile
@@ -37,7 +37,9 @@ COPY cmd/managers/featuregate/main.go main.go
 
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags '-extldflags "-static"' -o manager main.go
+ARG LD_FLAGS
+ENV LD_FLAGS="$LD_FLAGS "'-extldflags "-static"'
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "$LD_FLAGS" -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/pkg/v1/sdk/features/Makefile
+++ b/pkg/v1/sdk/features/Makefile
@@ -1,19 +1,10 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+include ../../../../common.mk
+
 IMG ?= featuregates-controller-manager:latest
-GOOS ?= $(shell go env GOOS)
-GOARCH ?= $(shell go env GOARCH)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
-
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
-PRIVATE_REPOS="github.com/vmware-tanzu/tanzu-framework"
-GO := GOPRIVATE=${PRIVATE_REPOS} go
 
 # ssh private key file name
 SSH_PRIVATE_KEY ?= .private_ssh_key
@@ -26,11 +17,11 @@ test: fmt vet manifests
 
 # Build manager binary
 manager: fmt vet
-	go build -o bin/manager ../../../../cmd/managers/featuregate/main.go
+	go build -ldflags "$(LD_FLAGS)" -o bin/manager ../../../../cmd/managers/featuregate/main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: fmt vet
-	go run ../../../../cmd/managers/featuregate/main.go
+	go run -ldflags "$(LD_FLAGS)" ../../../../cmd/managers/featuregate/main.go
 
 # Run go fmt against code
 fmt:
@@ -68,4 +59,4 @@ endif
 
 .PHONY: docker-build
 docker-build:
-	cd ../../../../ && docker build -t $(IMG) -f pkg/v1/sdk/features/Dockerfile --build-arg SSH_PRIVATE_KEY=$(SSH_PRIVATE_KEY) .
+	cd ../../../../ && docker build -t $(IMG) -f pkg/v1/sdk/features/Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-arg SSH_PRIVATE_KEY=$(SSH_PRIVATE_KEY) .

--- a/pkg/v1/tkg/buildinfo/metadata.go
+++ b/pkg/v1/tkg/buildinfo/metadata.go
@@ -3,5 +3,8 @@
 
 package buildinfo
 
+import "github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
+
 // IsOfficialBuild is the flag that gets set to True if it is an official build being released, it is set with the go linker's -X flag.
-var IsOfficialBuild string
+// Deprecated: use github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.IsOfficialBuild
+var IsOfficialBuild = buildinfo.IsOfficialBuild

--- a/pkg/v1/tkg/buildinfo/version.go
+++ b/pkg/v1/tkg/buildinfo/version.go
@@ -2,12 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package buildinfo ...
+// Deprecated: use github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo
 package buildinfo
 
+import "github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
+
 var (
-	// Version is the current git version version of tkg, set with the go linker's -X flag.
-	Version string
+	// Version is the current git version of tkg, set with the go linker's -X flag.
+	// Deprecated: use github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.Version
+	Version = buildinfo.Version
 
 	// Commit is the actual commit that is being built, set with the go linker's -X flag.
-	Commit string
+	// Deprecated: use github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.SHA
+	Commit = buildinfo.SHA
 )

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -57,10 +57,10 @@ import (
 	kappipkg "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 
 	runv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	capdiscovery "github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/capabilities/discovery"
 	tmcv1alpha1 "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/api/tmc/v1alpha1"
 	azureclient "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/azure"
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/docker"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"

--- a/pkg/v1/tkg/cmd/version.go
+++ b/pkg/v1/tkg/cmd/version.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/buildinfo"
 )
 
 type versionInfo struct {
@@ -34,7 +34,7 @@ func init() {
 }
 
 func runVersion(cmd *cobra.Command) error {
-	verInfo := versionInfo{Version: buildinfo.Version, GitCommit: buildinfo.Commit}
+	verInfo := versionInfo{Version: buildinfo.Version, GitCommit: buildinfo.SHA}
 
 	if outputFormat == string(component.JSONOutputType) || outputFormat == string(component.YAMLOutputType) {
 		output := component.NewObjectWriter(cmd.OutOrStdout(), outputFormat, verInfo)

--- a/pkg/v1/tkg/tkgconfigupdater/helper.go
+++ b/pkg/v1/tkg/tkgconfigupdater/helper.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/buildinfo"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 
 	"gopkg.in/yaml.v3"

--- a/pkg/v1/tkr/Dockerfile
+++ b/pkg/v1/tkr/Dockerfile
@@ -38,7 +38,9 @@ COPY pkg/v1/tkr/pkg/ pkg/v1/tkr/pkg/
 
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags '-extldflags "-static"' -o manager pkg/v1/tkr/main.go
+ARG LD_FLAGS
+ENV LD_FLAGS="$LD_FLAGS "'-extldflags "-static"'
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "$LD_FLAGS" -o manager pkg/v1/tkr/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/pkg/v1/tkr/Makefile
+++ b/pkg/v1/tkr/Makefile
@@ -1,19 +1,10 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+include ../../../common.mk
+
 IMG ?= tkr-controller-manager:latest
-GOOS ?= $(shell go env GOOS)
-GOARCH ?= $(shell go env GOARCH)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
-
-ifeq (,$(shell go env GOBIN))
-GOBIN=$(shell go env GOPATH)/bin
-else
-GOBIN=$(shell go env GOBIN)
-endif
-
-PRIVATE_REPOS="github.com/vmware-tanzu/tanzu-framework"
-GO := GOPRIVATE=${PRIVATE_REPOS} go
 
 # ssh private key file name
 SSH_PRIVATE_KEY ?= .private_ssh_key
@@ -26,11 +17,11 @@ test: fmt vet manifests
 
 # Build manager binary
 manager: fmt vet
-	go build -o bin/manager main.go
+	go build -ldflags "$(LD_FLAGS)" -o bin/manager main.go
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: fmt vet
-	go run ./main.go
+	go run -ldflags "$(LD_FLAGS)" ./main.go
 
 # Run go fmt against code
 fmt:
@@ -73,4 +64,4 @@ fakes: ## Generate fake files for go unit tests
 
 .PHONY: docker-build
 docker-build:
-	cd ../../../ && docker build -t $(IMG) -f pkg/v1/tkr/Dockerfile --build-arg SSH_PRIVATE_KEY=$(SSH_PRIVATE_KEY) .
+	cd ../../../ && docker build -t $(IMG) -f pkg/v1/tkr/Dockerfile --build-arg LD_FLAGS="$(LD_FLAGS)" --build-arg SSH_PRIVATE_KEY=$(SSH_PRIVATE_KEY) .

--- a/pkg/v1/tkr/main.go
+++ b/pkg/v1/tkr/main.go
@@ -20,6 +20,7 @@ import (
 	// +kubebuilder:scaffold:imports
 
 	runv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	tkrsourcectr "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/controllers/source"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/constants"
 	mgrcontext "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/context"
@@ -57,6 +58,8 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	setupLog.Info("Version", "version", buildinfo.Version, "buildDate", buildinfo.Date, "sha", buildinfo.SHA)
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:           scheme,


### PR DESCRIPTION
**What this PR does / why we need it**:

This is necessary to trace the exact commit used to build the
binaries used as controllers or CLI commands in a uniform way.

Now, any controllers built from this repo will emit this
version information in one of the first lines printed in the
log.

It is worth noting that before this change, this build
information was encoded and used in a few different places.
This is an attempt to fix it. A single package holds variables
into which version information is injected at build time.

Other variables that used to hold similar information are being
deprecated and are pointing to the one and only true buildinfo
package.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #534

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Manually run `make docker-build` for controllers. 

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Controllers now output build version information in one of the first lines printed in the log
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
