### PR TITLE
Cherry-picking the commit to set gcp bucket to tanzu-cli-framework

### DIFF
--- a/pkg/v1/config/defaults.go
+++ b/pkg/v1/config/defaults.go
@@ -11,7 +11,7 @@ import (
 const CoreRepositoryName = "core"
 
 // CoreBucketName is the name of the core plugin repository bucket to use.
-var CoreBucketName = "tanzu-cli"
+var CoreBucketName = "tanzu-cli-framework"
 
 // DefaultVersionSelector is to only use stable versions of plugins
 const DefaultVersionSelector = configv1alpha1.NoUnstableVersions


### PR DESCRIPTION
Signed-off-by: Sudarshan <asudarshan@vmware.com>

**What this PR does / why we need it**:
This PR cherry-picks the change (https://github.com/vmware-tanzu/tanzu-framework/commit/6f285290596cdd1d59a3fac2a57072a3bff884f3) to update the default name of the bucket to tanzu-cli-framework
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
The default gcp bucket was set to tanzu-cli-framework in v0.1.0
We are setting the default gcp bucket to tanzu-cli-framework in v0.2.1 as well
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
