### PR TITLE
Update PR template to better invite release notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,11 +13,13 @@ Example: Created vSphere workload cluster to verify change.
 
 **Special notes for your reviewer**:
 
-**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
+**Release note**:
 <!--
-If no, just write "NONE" in the release-note block below.
-If yes, a release note is required:
-Enter your extended release note in the block below.
+See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
+for more details.
+
+Please add a short text in the release-note block below (or "NONE" if not applicable)
+if there is anything in this PR that is worthy of mention in the next release.
 -->
 ```release-note
 


### PR DESCRIPTION
Signed-off-by: Vui Lam <vui@vmware.com>

**What this PR does / why we need it**:
We don't _just_ want notes for user-facing changes, and even for those, release notes are sometimes skipped depending on what an author's assumption of what user-facing means.

**Describe testing done for PR**:
Confirm with subsequent PR attempt for accuracy.

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
