### PR TITLE
Add v1.5 to mgmt cluster support matrix

### DIFF
--- a/pkg/v1/tkg/tkgconfighelper/tkgconfighelper_test.go
+++ b/pkg/v1/tkg/tkgconfighelper/tkgconfighelper_test.go
@@ -124,14 +124,14 @@ var _ = Describe("ValidateK8sVersionSupport", func() {
 				Expect(err.Error()).To(ContainSubstring("kubernetes version v1.20.1+vmware.1 is not supported on current v1.2.1 management cluster."))
 			})
 		})
-		Context("mgmtClusterVersion= v1.5.0, kubernetesVersion=v1.21.1+vmware.1", func() {
+		Context("mgmtClusterVersion= v1.6.0, kubernetesVersion=v1.21.1+vmware.1", func() {
 			BeforeEach(func() {
-				mgmtClusterVersion = "v1.5.0"
+				mgmtClusterVersion = "v1.6.0"
 				kubernetesVersion = "v1.21.1+vmware.1"
 			})
 			It("should return error", func() {
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("only [v1.0 v1.1 v1.2 v1.3 v1.4] management cluster versions are supported with current version of TKG CLI. Please upgrade TKG CLI to latest version if you are using it on latest version of management cluster."))
+				Expect(err.Error()).To(ContainSubstring("only [v1.0 v1.1 v1.2 v1.3 v1.4 v1.5] management cluster versions are supported with current version of TKG CLI. Please upgrade TKG CLI to latest version if you are using it on latest version of management cluster."))
 			})
 		})
 	})

--- a/pkg/v1/tkg/tkgconfighelper/validate.go
+++ b/pkg/v1/tkg/tkgconfighelper/validate.go
@@ -20,6 +20,7 @@ var ManagementClusterVersionToK8sVersionSupportMatrix map[string][]string = map[
 	"v1.2": {"v1.17", "v1.18", "v1.19"},
 	"v1.3": {"v1.17", "v1.18", "v1.19", "v1.20"},
 	"v1.4": {"v1.17", "v1.18", "v1.19", "v1.20", "v1.21"},
+	"v1.5": {"v1.19", "v1.20", "v1.21", "v1.22"},
 }
 
 // ValidateK8sVersionSupport validates the k8s version is supported on management cluster or not


### PR DESCRIPTION
Signed-off-by: PremKumar Kalle <pkalle@vmware.com>

**What this PR does / why we need it**:

This PR adds v1.5 to management cluster support matrix

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
All the unit tests passed

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**: No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Updated the supported kubernetes version matrix for v1.5 management clusters which was blocking the workload cluster creation for v1.5 management-cluster
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
