### PR TITLE
Fix the TKGS cluster template generation

### DIFF
--- a/pkg/v1/providers/ytt/03_customizations/add_mhc.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/add_mhc.yaml
@@ -1,7 +1,8 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
 
-#@ if (data.values.ENABLE_MHC != False and data.values.ENABLE_MHC_WORKER_NODE) or data.values.ENABLE_MHC and data.values.PROVIDER_TYPE != "tkg-service-vsphere":
+#@ if data.values.PROVIDER_TYPE != "tkg-service-vsphere":
+#@ if (data.values.ENABLE_MHC != False and data.values.ENABLE_MHC_WORKER_NODE) or data.values.ENABLE_MHC:
 ---
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineHealthCheck
@@ -24,7 +25,7 @@ spec:
     timeout: #@ data.values.MHC_FALSE_STATUS_TIMEOUT
 #@ end
 ---
-#@ if (data.values.ENABLE_MHC != False and data.values.ENABLE_MHC_CONTROL_PLANE) or data.values.ENABLE_MHC and data.values.PROVIDER_TYPE != "tkg-service-vsphere":
+#@ if (data.values.ENABLE_MHC != False and data.values.ENABLE_MHC_CONTROL_PLANE) or data.values.ENABLE_MHC:
 apiVersion: cluster.x-k8s.io/v1alpha3
 kind: MachineHealthCheck
 metadata:
@@ -44,4 +45,5 @@ spec:
   - type: Ready
     status: "False"
     timeout: #@ data.values.MHC_FALSE_STATUS_TIMEOUT
+#@ end
 #@ end

--- a/pkg/v1/providers/ytt/03_customizations/capabilities/add_capabilities.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/capabilities/add_capabilities.yaml
@@ -2,6 +2,8 @@
 #@ load("@ytt:yaml", "yaml")
 #@ load("/lib/helpers.star", "get_default_tkg_bom_data", "get_image_repo_for_component")
 
+#@ if data.values.PROVIDER_TYPE != "tkg-service-vsphere":
+
 #@ bomData = get_default_tkg_bom_data()
 
 #@ def capabilityDefinitions():
@@ -504,3 +506,4 @@ metadata:
 type: addons.cluster.x-k8s.io/resource-set
 stringData:
   value: #@ yaml.encode(capabilityDefinitions())
+#@ end


### PR DESCRIPTION
Signed-off-by: PremKumar Kalle <pkalle@vmware.com>

**What this PR does / why we need it**:
Fixes the cluster provider templates for TKGS caused by other PR merges which added the templates related to the MachineHealthChecks and Capabilties, and these are not applicable for TKGS providder

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # [Issue#628](https://github.com/vmware-tanzu/tanzu-framework/issues/628)

**Describe testing done for PR**:
Generated the template for TKGS workload cluster and it is correctly generated(earliier it has MHC andd capabilities resources which are not supported by TKGS)

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Fixes the cluster provider templates for TKGS to not include resources related to the MachineHealthChecks and Capabilties
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
