### PR TITLE
Update CAPI v1alpha2 to v1alpha3 for TKGS life cycle operations

### DIFF
--- a/pkg/v1/tkg/client/client_suite_test.go
+++ b/pkg/v1/tkg/client/client_suite_test.go
@@ -36,7 +36,6 @@ import (
 	capav1alpha3 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capvv1alpha3 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
-	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 
@@ -67,7 +66,6 @@ var scheme = runtime.NewScheme()
 
 func init() {
 	_ = capi.AddToScheme(scheme)
-	_ = capiv1alpha2.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
 	_ = controlplanev1.AddToScheme(scheme)

--- a/pkg/v1/tkg/client/get_cluster_helper.go
+++ b/pkg/v1/tkg/client/get_cluster_helper.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/yalp/jsonpath"
-	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	crtclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,8 +33,8 @@ type clusterObjects struct {
 
 type clusterObjectsForPacific struct {
 	cluster  interface{}
-	md       capiv1alpha2.MachineDeployment
-	machines []capiv1alpha2.Machine
+	md       capi.MachineDeployment
+	machines []capi.Machine
 }
 
 // ################### Helpers for Pacific ##################
@@ -43,7 +42,7 @@ type clusterObjectsForPacific struct {
 func getRunningCPMachineCountForPacific(clusterInfo *clusterObjectsForPacific) int {
 	cpMachineCount := 0
 	for i := range clusterInfo.machines {
-		if _, labelExists := clusterInfo.machines[i].GetLabels()[capiv1alpha2.MachineControlPlaneLabelName]; labelExists && strings.EqualFold(clusterInfo.machines[i].Status.Phase, "running") {
+		if _, labelExists := clusterInfo.machines[i].GetLabels()[capi.MachineControlPlaneLabelName]; labelExists && strings.EqualFold(clusterInfo.machines[i].Status.Phase, "running") {
 			cpMachineCount++
 		}
 	}
@@ -57,13 +56,13 @@ func getClusterObjectsMapForPacific(clusterClient clusterclient.Client, apiVersi
 		return nil, errors.Wrap(err, "unable to get list of clusters")
 	}
 
-	var mdList capiv1alpha2.MachineDeploymentList
+	var mdList capi.MachineDeploymentList
 	err = clusterClient.ListResources(&mdList, listOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get list of MachineDeployment objects")
 	}
 
-	var machineList capiv1alpha2.MachineList
+	var machineList capi.MachineList
 	err = clusterClient.ListResources(&machineList, listOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get list of Machine objects")

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -40,7 +40,6 @@ import (
 	capav1alpha3 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capvv1alpha3 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
-	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	bootstrapv1alpha3 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
@@ -378,7 +377,6 @@ var (
 
 func init() {
 	_ = capi.AddToScheme(scheme)
-	_ = capiv1alpha2.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
 	_ = clusterctlv1.AddToScheme(scheme)
@@ -1683,13 +1681,13 @@ func (c *client) verifyPacificK8sVersionUpdate(clusterName, namespace, newK8sVer
 	return nil
 }
 
-func (c *client) getWorkerMachineObjectsForPacificCluster(clusterName, namespace string) ([]capiv1alpha2.Machine, error) {
-	mdList := &capiv1alpha2.MachineList{}
+func (c *client) getWorkerMachineObjectsForPacificCluster(clusterName, namespace string) ([]capi.Machine, error) {
+	mdList := &capi.MachineList{}
 	if err := c.GetResourceList(mdList, clusterName, namespace, nil, nil); err != nil {
 		return nil, err
 	}
 
-	workerMachines := []capiv1alpha2.Machine{}
+	workerMachines := []capi.Machine{}
 	for i := range mdList.Items {
 		if _, labelFound := mdList.Items[i].Labels[capi.MachineControlPlaneLabelName]; !labelFound {
 			workerMachines = append(workerMachines, mdList.Items[i])

--- a/pkg/v1/tkg/clusterclient/clusterclient_test.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/utils/pointer"
 	capav1alpha3 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
-	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1alpha3"
 	crtclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -71,7 +70,6 @@ var imageRepository = "registry.tkg.vmware.new"
 
 func init() {
 	_ = capi.AddToScheme(scheme)
-	_ = capiv1alpha2.AddToScheme(scheme)
 	_ = capav1alpha3.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 	_ = controlplanev1.AddToScheme(scheme)
@@ -126,11 +124,10 @@ var _ = Describe("Cluster Client", func() {
 		currentKubeCtx         string
 		clusterClientOptions   Options
 
-		tkcPhase           string
-		mdReplicas         Replicas
-		kcpReplicas        Replicas
-		machineObjects     []capi.Machine
-		v1a2machineObjects []capiv1alpha2.Machine
+		tkcPhase       string
+		mdReplicas     Replicas
+		kcpReplicas    Replicas
+		machineObjects []capi.Machine
 	)
 
 	BeforeSuite(createTempDirectory)
@@ -1262,13 +1259,13 @@ var _ = Describe("Cluster Client", func() {
 			clstClient, err = NewClient(kubeConfigPath, "", clusterClientOptions)
 			Expect(err).NotTo(HaveOccurred())
 
-			v1a2machineObjects = []capiv1alpha2.Machine{}
+			machineObjects = []capi.Machine{}
 		})
 		JustBeforeEach(func() {
 			clientset.ListCalls(func(ctx context.Context, o runtime.Object, opts ...crtclient.ListOption) error {
 				switch o := o.(type) {
-				case *capiv1alpha2.MachineList:
-					o.Items = append(o.Items, v1a2machineObjects...)
+				case *capi.MachineList:
+					o.Items = append(o.Items, machineObjects...)
 				default:
 					return errors.New("invalid object type")
 				}
@@ -1316,8 +1313,8 @@ var _ = Describe("Cluster Client", func() {
 			Context("When some worker machine objects has old k8s version", func() {
 				BeforeEach(func() {
 					tkcPhase = statusRunning
-					v1a2machineObjects = append(v1a2machineObjects, getv1alpha2DummyMachine("fake-machine-1", "fake-new-version", false))
-					v1a2machineObjects = append(v1a2machineObjects, getv1alpha2DummyMachine("fake-machine-2", "fake-old-version", false))
+					machineObjects = append(machineObjects, getDummyMachine("fake-machine-1", "fake-new-version", false))
+					machineObjects = append(machineObjects, getDummyMachine("fake-machine-2", "fake-old-version", false))
 				})
 				It("should not return error", func() {
 					Expect(err).To(HaveOccurred())
@@ -1327,8 +1324,8 @@ var _ = Describe("Cluster Client", func() {
 			Context("When all worker machine objects has new k8s version", func() {
 				BeforeEach(func() {
 					tkcPhase = statusRunning
-					v1a2machineObjects = append(v1a2machineObjects, getv1alpha2DummyMachine("fake-machine-1", "fake-new-version", false))
-					v1a2machineObjects = append(v1a2machineObjects, getv1alpha2DummyMachine("fake-machine-1", "fake-new-version", false))
+					machineObjects = append(machineObjects, getDummyMachine("fake-machine-1", "fake-new-version", false))
+					machineObjects = append(machineObjects, getDummyMachine("fake-machine-1", "fake-new-version", false))
 				})
 				It("should not return error", func() {
 					Expect(err).ToNot(HaveOccurred())
@@ -2270,19 +2267,6 @@ func getDummySecret(secretName string, secretData map[string][]byte, secretStrin
 
 func getDummyMachine(name, currentK8sVersion string, isCP bool) capi.Machine {
 	machine := capi.Machine{}
-	machine.Name = name
-	machine.Namespace = fakeMdNameSpace
-	machine.Spec.Version = &currentK8sVersion
-	machine.Labels = map[string]string{}
-	if isCP {
-		machine.Labels["cluster.x-k8s.io/control-plane"] = ""
-	}
-	return machine
-}
-
-func getv1alpha2DummyMachine(name, currentK8sVersion string, isCP bool) capiv1alpha2.Machine { //nolint:unparam
-	// TODO: Add test cases where isCP is true, currently there are no such tests
-	machine := capiv1alpha2.Machine{}
 	machine.Name = name
 	machine.Namespace = fakeMdNameSpace
 	machine.Spec.Version = &currentK8sVersion

--- a/pkg/v1/tkg/clusterclient/resource.go
+++ b/pkg/v1/tkg/clusterclient/resource.go
@@ -21,7 +21,6 @@ import (
 	capav1alpha3 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capvv1alpha3 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
-	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	bootstrapv1alpha3 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
@@ -189,8 +188,6 @@ func (c *client) getRuntimeObject(o interface{}) (runtime.Object, error) { //nol
 		return obj, nil
 	case *capi.MachineHealthCheckList:
 		return obj, nil
-	case *capiv1alpha2.MachineList:
-		return obj, nil
 	case *capi.MachineList:
 		return obj, nil
 	case *capi.MachineDeploymentList:
@@ -218,8 +215,6 @@ func (c *client) getRuntimeObject(o interface{}) (runtime.Object, error) { //nol
 	case *capdv1alpha3.DockerMachineTemplate:
 		return obj, nil
 	case *capav1alpha3.AWSCluster:
-		return obj, nil
-	case *capiv1alpha2.MachineDeploymentList:
 		return obj, nil
 	case *appsv1.DaemonSet:
 		return obj, nil

--- a/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
+++ b/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
@@ -22,7 +22,6 @@ import (
 	capav1alpha3 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	capzv1alpha3 "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	capvv1alpha3 "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
-	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	cabpkv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
@@ -400,16 +399,16 @@ func NewPacificCluster(options TestAllClusterComponentOptions) runtime.Object {
 
 // NewMDForPacific returns new v1aplha2.MachineDeployment object
 func NewMDForPacific(options TestAllClusterComponentOptions) runtime.Object {
-	md := &capiv1alpha2.MachineDeployment{
+	md := &capi.MachineDeployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "md-" + options.ClusterName,
 			Namespace: options.Namespace,
-			Labels:    map[string]string{capiv1alpha2.MachineClusterLabelName: options.ClusterName},
+			Labels:    map[string]string{capi.ClusterLabelName: options.ClusterName},
 		},
-		Spec: capiv1alpha2.MachineDeploymentSpec{
+		Spec: capi.MachineDeploymentSpec{
 			Replicas: &options.ListMDOptions[0].SpecReplicas,
 		},
-		Status: capiv1alpha2.MachineDeploymentStatus{
+		Status: capi.MachineDeploymentStatus{
 			Replicas:        options.ListMDOptions[0].Replicas,
 			ReadyReplicas:   options.ListMDOptions[0].ReadyReplicas,
 			UpdatedReplicas: options.ListMDOptions[0].UpdatedReplicas,
@@ -422,16 +421,16 @@ func NewMDForPacific(options TestAllClusterComponentOptions) runtime.Object {
 func NewMachinesForPacific(options TestAllClusterComponentOptions) []runtime.Object {
 	machines := []runtime.Object{}
 	for i, machineOption := range options.MachineOptions {
-		machine := &capiv1alpha2.Machine{
+		machine := &capi.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: options.Namespace,
 				Name:      "machine-" + strconv.Itoa(i) + options.ClusterName,
 				Labels:    map[string]string{capi.ClusterLabelName: options.ClusterName},
 			},
-			Spec: capiv1alpha2.MachineSpec{
+			Spec: capi.MachineSpec{
 				Version: &machineOption.K8sVersion,
 			},
-			Status: capiv1alpha2.MachineStatus{
+			Status: capi.MachineStatus{
 				Phase: machineOption.Phase,
 			},
 		}


### PR DESCRIPTION
Signed-off-by: PremKumar Kalle <pkalle@vmware.com>

**What this PR does / why we need it**:
This PR updates the CAPI v1alpha2 references to v1alpha3 for TKGS cluster lifecycle operations
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
- Created a workload cluster and it was success
- Upgrade workload cluster and it was success
- Delete a workload cluster and it was success


**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Updates the CAPI v1alpha2 references to v1alpha3 for TKGS cluster lifecycle operations
```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
