### PR TITLE
change FeatureGate API to cluster scoped

### DIFF
--- a/apis/config/v1alpha1/featuregate_types.go
+++ b/apis/config/v1alpha1/featuregate_types.go
@@ -51,6 +51,7 @@ type FeatureGateStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:resource:scope=Cluster
 
 // FeatureGate is the Schema for the featuregates API
 type FeatureGate struct {

--- a/config/crd/bases/config.tanzu.vmware.com_featuregates.yaml
+++ b/config/crd/bases/config.tanzu.vmware.com_featuregates.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: FeatureGateList
     plural: featuregates
     singular: featuregate
-  scope: Namespaced
+  scope: Cluster
   subresources:
     status: {}
   validation:


### PR DESCRIPTION
Signed-off-by: Harish Yayi <yharish991@gmail.com>

**What this PR does / why we need it**:
This PR changes FeatureGate API scope to cluster scoped
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #631 

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Changed FeatureGate CRD to cluster scoped from namespace scoped. This is a breaking change. Existing users of this API should perform the following steps:
1. Back up existing featuregate resources using kubectl get featuregate -o yaml -A
2. Delete featuregate CRD using kubectl delete customresourcedefinitions.apiextensions.k8s.io featuregates.config.tanzu.vmware.com
3. Apply new featuregate CRD.
4. Remove namespace field from metadata in backed up CRs.
5. Apply CRs again.
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
