### PR TITLE
add ClusterResourceSet for installing Features and FeatureGates in management cluster

### DIFF
--- a/pkg/v1/providers/ytt/03_customizations/featuregates/add_featuregates.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/featuregates/add_featuregates.yaml
@@ -1,0 +1,370 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("/lib/helpers.star", "get_default_tkg_bom_data", "get_image_repo_for_component")
+
+#@ bomData = get_default_tkg_bom_data()
+
+#@ def FeatureGateDefinitions():
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+  name: featuregates.config.tanzu.vmware.com
+spec:
+  group: config.tanzu.vmware.com
+  names:
+    kind: FeatureGate
+    listKind: FeatureGateList
+    plural: featuregates
+    singular: featuregate
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: FeatureGate is the Schema for the featuregates API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Spec is the specification for gating features.
+          properties:
+            features:
+              description: Features is a slice of FeatureReference to gate features.
+                The Feature resource specified may or may not be present in the system.
+                If the Feature is present, the FeatureGate controller and webhook
+                sets the specified activation state only if the Feature is discoverable
+                and its immutability constraint is satisfied. If the Feature is not
+                present, the activation intent is applied when the Feature resource
+                appears in the system. The actual activation state of the Feature
+                is reported in the status.
+              items:
+                description: FeatureReference refers to a Feature resource and specifies
+                  its intended activation state.
+                properties:
+                  activate:
+                    description: Activate indicates the activation intent for the
+                      feature.
+                    type: boolean
+                  name:
+                    description: Name is the name of the Feature resource, which represents
+                      a feature the system offers.
+                    type: string
+                required:
+                  - name
+                type: object
+              type: array
+              x-kubernetes-list-map-keys:
+                - name
+              x-kubernetes-list-type: map
+            namespaceSelector:
+              description: NamespaceSelector is a selector to specify namespaces for
+                which this feature gate applies. Use an empty LabelSelector to match
+                all namespaces.
+              properties:
+                matchExpressions:
+                  description: matchExpressions is a list of label selector requirements.
+                    The requirements are ANDed.
+                  items:
+                    description: A label selector requirement is a selector that contains
+                      values, a key, and an operator that relates the key and values.
+                    properties:
+                      key:
+                        description: key is the label key that the selector applies
+                          to.
+                        type: string
+                      operator:
+                        description: operator represents a key's relationship to a
+                          set of values. Valid operators are In, NotIn, Exists and
+                          DoesNotExist.
+                        type: string
+                      values:
+                        description: values is an array of string values. If the operator
+                          is In or NotIn, the values array must be non-empty. If the
+                          operator is Exists or DoesNotExist, the values array must
+                          be empty. This array is replaced during a strategic merge
+                          patch.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - key
+                      - operator
+                    type: object
+                  type: array
+                matchLabels:
+                  additionalProperties:
+                    type: string
+                  description: matchLabels is a map of {key,value} pairs. A single
+                    {key,value} in the matchLabels map is equivalent to an element
+                    of matchExpressions, whose key field is "key", the operator is
+                    "In", and the values array contains only "value". The requirements
+                    are ANDed.
+                  type: object
+              type: object
+          required:
+            - namespaceSelector
+          type: object
+        status:
+          description: Status reports activation state and availability of features
+            in the system.
+          properties:
+            activatedFeatures:
+              description: ActivatedFeatures lists the discovered features that are
+                activated for the namespaces specified in the spec. This can include
+                features that are not explicitly gated in the spec, but are already
+                available in the system as Feature resources.
+              items:
+                type: string
+              type: array
+            deactivatedFeatures:
+              description: DeactivatedFeatures lists the discovered features that
+                are deactivated for the namespaces specified in the spec. This can
+                include features that are not explicitly gated in the spec, but are
+                already available in the system as Feature resources.
+              items:
+                type: string
+              type: array
+            namespaces:
+              description: Namespaces lists the existing namespaces for which this
+                feature gate applies. This is obtained from listing all namespaces
+                and applying the NamespaceSelector specified in spec.
+              items:
+                type: string
+              type: array
+            unavailableFeatures:
+              description: UnavailableFeatures lists the features that are gated in
+                the spec, but are not available in the system as Feature resources.
+              items:
+                type: string
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: tanzu-featuregates-selfsigned-issuer
+  namespace: tkg-system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tanzu-featuregates-serving-cert
+  namespace: tkg-system
+spec:
+  dnsNames:
+    - tanzu-featuregates-webhook-service.tkg-system.svc
+    - tanzu-featuregates-webhook-service-cert.tkg-system.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: tanzu-featuregates-selfsigned-issuer
+  secretName: tanzu-featuregates-webhook-server-cert
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: tanzu-featuregates-validating-webhook
+  annotations:
+    cert-manager.io/inject-ca-from: tkg-system/tanzu-featuregates-serving-cert
+webhooks:
+  - admissionReviewVersions:
+      - v1beta1
+    clientConfig:
+      service:
+        name: tanzu-featuregates-webhook-service
+        namespace: tkg-system
+        path: /validate-config-tanzu-vmware-com-v1alpha1-featuregate
+    failurePolicy: Fail
+    name: featuregate.config.tanzu.vmware.com
+    rules:
+      - apiGroups:
+          - config.tanzu.vmware.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - featuregates
+    sideEffects: None
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tanzu-featuregates-manager
+  name: tanzu-featuregates-manager-sa
+  namespace: tkg-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tanzu-featuregates-manager-clusterrole
+rules:
+  - apiGroups:
+      - config.tanzu.vmware.com
+    resources:
+      - featuregates
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - config.tanzu.vmware.com
+    resources:
+      - featuregates/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - config.tanzu.vmware.com
+    resources:
+      - features
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - config.tanzu.vmware.com
+    resources:
+      - features/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tanzu-featuregates-manager-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tanzu-featuregates-manager-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: tanzu-featuregates-manager-sa
+    namespace: tkg-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tanzu-featuregates-webhook-service
+  namespace: tkg-system
+spec:
+  ports:
+    - port: 443
+      targetPort: 9443
+  selector:
+    app: tanzu-featuregates-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tanzu-featuregates-manager
+  name: tanzu-featuregates-controller-manager
+  namespace: tkg-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tanzu-featuregates-manager
+  template:
+    metadata:
+      labels:
+        app: tanzu-featuregates-manager
+    spec:
+      containers:
+        - image: #@ "{}/{}:{}".format(get_image_repo_for_component(bomData.components["tanzu-framework"][0].images.featuregatesImage), bomData.components["tanzu-framework"][0].images.featuregatesImage.imagePath, bomData.components["tanzu-framework"][0].images.featuregatesImage.tag)
+          imagePullPolicy: IfNotPresent
+          name: manager
+          resources:
+            limits:
+              cpu: 100m
+              memory: 30Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: tanzu-featuregates-webhook-server-cert
+      serviceAccount: tanzu-featuregates-manager-sa
+      terminationGracePeriodSeconds: 10
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+#@ end
+
+#@ if data.values.TKG_CLUSTER_ROLE != "workload":
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name: #@ "{}-featuregates".format(data.values.CLUSTER_NAME)
+  labels:
+    cluster.x-k8s.io/cluster-name: #@ data.values.CLUSTER_NAME
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: "featuregates/featuregates-controller"
+  namespace: tkg-system
+spec:
+  strategy: "ApplyOnce"
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: #@ data.values.CLUSTER_NAME
+  resources:
+    - name: #@ "{}-featuregates".format(data.values.CLUSTER_NAME)
+      kind: Secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #@ "{}-featuregates".format(data.values.CLUSTER_NAME)
+  namespace: tkg-system
+type: addons.cluster.x-k8s.io/resource-set
+stringData:
+  value: #@ yaml.encode(FeatureGateDefinitions())
+#@ end

--- a/pkg/v1/providers/ytt/03_customizations/features/add_features.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/features/add_features.yaml
@@ -1,0 +1,131 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("/lib/helpers.star", "get_default_tkg_bom_data", "get_image_repo_for_component")
+
+#@ bomData = get_default_tkg_bom_data()
+
+#@ def FeatureGateDefinitions():
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+  name: features.config.tanzu.vmware.com
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .spec.activated
+      name: Activated
+      type: boolean
+    - JSONPath: .spec.description
+      name: Description
+      type: string
+    - JSONPath: .spec.immutable
+      name: Immutable
+      type: boolean
+    - JSONPath: .spec.maturity
+      name: Maturity
+      type: string
+  group: config.tanzu.vmware.com
+  names:
+    kind: Feature
+    listKind: FeatureList
+    plural: features
+    singular: feature
+  scope: Cluster
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: Feature is the Schema for the features API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: FeatureSpec defines the desired state of Feature
+          properties:
+            activated:
+              description: Activated defines the default state of the features activation
+              type: boolean
+            description:
+              description: Description of the feature.
+              type: string
+            discoverable:
+              description: Discoverable indicates if clients should include consider
+                the Feature available for their use Allowing clients to control discoverability
+                is one of the ways the API allows gradual rollout of functionality
+              type: boolean
+            immutable:
+              description: Immutable indicates this feature cannot be toggled once
+                set If set at creation time, this state will persist for the life
+                of the cluster
+              type: boolean
+            maturity:
+              description: 'Maturity indicates maturity level of this feature. Maturity
+                levels are Dev, Alpha, Beta, GA and Deprecated. - dev: the default
+                for new resources, represents local dev. intended to be hidden and
+                deactivated - alpha: the first milestone meant for limited wider consumption,
+                discoverable and defaults to deactivated - beta: greater visibility
+                for proven designs, discoverable and defaults to activated - ga: intended
+                to be part of the mainline codebase, non-optional - deprecated: destined
+                for future removal'
+              enum:
+                - dev
+                - alpha
+                - beta
+                - ga
+                - deprecated
+              type: string
+          required:
+            - activated
+            - discoverable
+            - immutable
+            - maturity
+          type: object
+        status:
+          description: FeatureStatus defines the observed state of Feature
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+#@ end
+
+#@ if data.values.TKG_CLUSTER_ROLE != "workload":
+---
+apiVersion: addons.cluster.x-k8s.io/v1alpha3
+kind: ClusterResourceSet
+metadata:
+  name: #@ "{}-features".format(data.values.CLUSTER_NAME)
+  labels:
+    cluster.x-k8s.io/cluster-name: #@ data.values.CLUSTER_NAME
+  namespace: tkg-system
+spec:
+  strategy: "ApplyOnce"
+  clusterSelector:
+    matchLabels:
+      tkg.tanzu.vmware.com/cluster-name: #@ data.values.CLUSTER_NAME
+  resources:
+    - name: #@ "{}-features".format(data.values.CLUSTER_NAME)
+      kind: Secret
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #@ "{}-features".format(data.values.CLUSTER_NAME)
+  namespace: tkg-system
+type: addons.cluster.x-k8s.io/resource-set
+stringData:
+  value: #@ yaml.encode(FeatureGateDefinitions())
+#@ end


### PR DESCRIPTION
Signed-off-by: yharish991 <yharish991@gmail.com>

**What this PR does / why we need it**:
This PR adds ClusterResourceSet CR for Feature and FeatureGates in providers template to install them in management cluster.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #89

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Added ClusterResourceSet CR to install Features and FeatureGates in management cluster
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
