### PR TITLE
Switch contrib docs from DCO to CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@
 * [Propose a Change](#propose-a-change)
   * [Pull Request Etiquette](#pull-request-etiquette)
   * [Issues Lifecycle](#issues-lifecycle)
-  * [DCO Sign off](#dco-sign-off)
   * [Commit Messages](#commit-messages)
+* [Contributor License Agreement](#contributor-license-agreement)
 
 --------------
 
@@ -94,58 +94,18 @@ tests.
 
 To build the project from source, please consider the docs on [local development](docs/dev/build.md).
 
-### DCO Sign off
+## Contributor License Agreement
 
-All authors to the project retain copyright to their work. However, to ensure
-that they are only submitting work that they have rights to, we are requiring
-everyone to acknowledge this by signing their work.
+All contributors to this project must have a signed Contributor License
+Agreement (**"CLA"**) on file with us. The CLA grants us the permissions we
+need to use and redistribute your contributions as part of the project; you or
+your employer retain the copyright to your contribution. Before a PR can pass
+all required checks, our CLA action will prompt you to accept the agreement.
+Head over to [https://cla.vmware.com/](https://cla.vmware.com/) to see your
+current agreement(s) on file or to sign a new one.
 
-To sign your work, just add a line like this at the end of your commit message:
+We generally only need you (or your employer) to sign our CLA once and once
+signed, you should be able to submit contributions to any VMware project.
 
-```txt
-Signed-off-by: Joe Beda <joe@heptio.com>
-```
-
-This can easily be done with the `--signoff` option to `git commit`.
-
-By doing this you state that you can certify the following [from https://developercertificate.org/](https://developercertificate.org/):
-
-```txt
-Developer Certificate of Origin
-Version 1.1
-
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-1 Letterman Drive
-Suite D4700
-San Francisco, CA, 94129
-
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
-
-
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
-
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
-
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
-```
+Note: if you would like to submit an "_obvious fix_" for something like a typo,
+formatting issue or spelling mistake, you may not need to sign the CLA.


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates our CONTRIBUTING doc to state the need for signing a CLA to
contribute.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #667

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

CLA bot already in place, just need to make sure text looks right.

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```

**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
