### PR TITLE
Copy images to tar format and vice versa

### DIFF
--- a/hack/gen-publish-images-fromtar.sh
+++ b/hack/gen-publish-images-fromtar.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+TANZU_BOM_DIR=${HOME}/.config/tanzu/tkg/bom
+INSTALL_INSTRUCTIONS='See https://github.com/mikefarah/yq#install for installation instructions'
+TKG_CUSTOM_IMAGE_REPOSITORY=${TKG_CUSTOM_IMAGE_REPOSITORY:-''}
+TKG_IMAGE_REPO=${TKG_IMAGE_REPO:-''}
+
+
+echodual() {
+  echo "$@" 1>&2
+  echo "#" "$@"
+}
+
+if [ -z "$TKG_CUSTOM_IMAGE_REPOSITORY" ]; then
+  echo "TKG_CUSTOM_IMAGE_REPOSITORY variable is required but is not defined" >&2
+  exit 1
+fi
+
+if [ -z "$TKG_IMAGE_REPO" ]; then
+  echo "TKG_IMAGE_REPO variable is required but is not defined" >&2
+  exit 2
+fi
+
+if ! [ -x "$(command -v imgpkg)" ]; then
+  echo 'Error: imgpkg is not installed.' >&2
+  exit 3
+fi
+
+if ! [ -x "$(command -v yq)" ]; then
+  echo 'Error: yq is not installed.' >&2
+  echo "${INSTALL_INSTRUCTIONS}" >&2
+  exit 3
+fi
+
+function imgpkg_copy() {
+    src=$1
+    dst=$2
+    echo ""
+    echo "imgpkg copy --tar $src.tar --to-repo $dst"
+}
+
+echo "set -euo pipefail"
+echodual "Note that yq must be version above or equal to version 4.9.2 and below version 5."
+
+actualImageRepository="$TKG_IMAGE_REPO"
+
+# Iterate through TKG BoM file to create the complete Image name
+# and then pull, retag and push image to custom registry.
+list=$(imgpkg  tag  list -i "${actualImageRepository}"/tkg-bom)
+for imageTag in ${list}; do
+  tanzucliversion=$(tanzu version | head -n 1 | cut -c10-15)
+  if [[ ${imageTag} == ${tanzucliversion}* ]]; then
+    TKG_BOM_FILE="tkg-bom-${imageTag//_/+}.yaml"
+    imgpkg pull --image "${actualImageRepository}/tkg-bom:${imageTag}" --output "tmp" > /dev/null 2>&1
+    echodual "Processing TKG BOM file ${TKG_BOM_FILE}"
+
+    actualTKGImage=${TKG_CUSTOM_IMAGE_REPOSITORY}/tkg-bom
+    customTKGImage=tkg-bom-${imageTag}
+    imgpkg_copy $customTKGImage $actualTKGImage
+
+    # Get components in the tkg-bom.
+    # Remove the leading '[' and trailing ']' in the output of yq.
+    components=(`yq e '.components | keys | .. style="flow"' "tmp/$TKG_BOM_FILE" | sed 's/^.//;s/.$//'`)
+    for comp in "${components[@]}"
+    do
+    # remove: leading and trailing whitespace, and trailing comma
+    comp=`echo $comp | sed -e 's/^[[:space:]]*//' | sed 's/,*$//g'`
+    get_comp_images="yq e '.components[\"${comp}\"][]  | select(has(\"images\"))|.images[] | .imagePath + \":\" + .tag' "\"tmp/\"$TKG_BOM_FILE""
+
+    flags="-i"
+    if [ $comp = "tkg-standard-packages" ]; then
+      flags="-b"
+    fi
+    eval $get_comp_images | while read -r image; do        
+        image2=$(echo "$image" | tr ':' '-' | tr '/' '-')
+        image3=$(echo "$image" | cut -f1 -d":")
+        actualImage=${TKG_CUSTOM_IMAGE_REPOSITORY}/${image3}
+        customImage=${image2}
+        imgpkg_copy $customImage $actualImage 
+      done
+    done
+
+    rm -rf tmp
+    echodual "Finished processing TKG BOM file ${TKG_BOM_FILE}"
+    echo ""
+  fi
+done
+
+# Iterate through TKR BoM file to create the complete Image name
+# and then pull, retag and push image to custom registry.
+list=$(imgpkg  tag  list -i ${actualImageRepository}/tkr-bom)
+for imageTag in ${list}; do
+  if [[ ${imageTag} == v* ]]; then
+    TKR_BOM_FILE="tkr-bom-${imageTag//_/+}.yaml"
+    echodual "Processing TKR BOM file ${TKR_BOM_FILE}"
+
+    actualTKRImage=${TKG_CUSTOM_IMAGE_REPOSITORY}/tkr-bom
+    customTKRImage=tkr-bom-${imageTag}
+    imgpkg_copy $customTKRImage $actualTKRImage
+    imgpkg pull --image ${actualImageRepository}/tkr-bom:${imageTag} --output "tmp" > /dev/null 2>&1
+
+    # Get components in the tkr-bom.
+    # Remove the leading '[' and trailing ']' in the output of yq.
+    components=(`yq e '.components | keys | .. style="flow"' "tmp/$TKR_BOM_FILE" | sed 's/^.//;s/.$//'`)
+    for comp in "${components[@]}"
+    do
+    # remove: leading and trailing whitespace, and trailing comma
+    comp=`echo $comp | sed -e 's/^[[:space:]]*//' | sed 's/,*$//g'`
+    get_comp_images="yq e '.components[\"${comp}\"][]  | select(has(\"images\"))|.images[] | .imagePath + \":\" + .tag' "\"tmp/\"$TKR_BOM_FILE""
+
+    flags="-i"
+    if [ $comp = "tkg-core-packages" ]; then
+      flags="-b"
+    fi
+    eval $get_comp_images | while read -r image; do
+        image2=$(echo "$image" | cut -f1 -d":")
+        actualImage=${TKG_CUSTOM_IMAGE_REPOSITORY}/${image2}
+        image3=$(echo "$image" | tr ':' '-' | tr '/' '-')
+        customImage=${image3}
+        imgpkg_copy $customImage $actualImage 
+      done
+    done
+
+    rm -rf tmp
+    echodual "Finished processing TKR BOM file ${TKR_BOM_FILE}"
+    echo ""
+  fi
+done
+
+list=$(imgpkg  tag  list -i ${actualImageRepository}/tkr-compatibility)
+for imageTag in ${list}; do
+  if [[ ${imageTag} == v* ]]; then
+    echodual "Processing TKR compatibility image"
+    actualImage=${TKG_CUSTOM_IMAGE_REPOSITORY}/tkr-compatibility
+    customImage=tkr-compatibility-${imageTag}
+    imgpkg_copy $customImage $actualImage 
+    echo ""
+    echodual "Finished processing TKR compatibility image"
+  fi
+done
+
+list=$(imgpkg  tag  list -i ${actualImageRepository}/tkg-compatibility)
+for imageTag in ${list}; do
+  if [[ ${imageTag} == v* ]]; then
+    echodual "Processing TKG compatibility image"
+    actualImage=${TKG_CUSTOM_IMAGE_REPOSITORY}/tkg-compatibility
+    customImage=tkg-compatibility-${imageTag}
+    imgpkg_copy $customImage $actualImage 
+    echo ""
+    echodual "Finished processing TKG compatibility image"
+  fi
+done

--- a/hack/gen-publish-images-totar.sh
+++ b/hack/gen-publish-images-totar.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+TANZU_BOM_DIR=${HOME}/.config/tanzu/tkg/bom
+INSTALL_INSTRUCTIONS='See https://github.com/mikefarah/yq#install for installation instructions'
+TKG_IMAGE_REPO=${TKG_IMAGE_REPO:-''}
+
+
+echodual() {
+  echo "$@" 1>&2
+  echo "#" "$@"
+}
+
+if [ -z "$TKG_IMAGE_REPO" ]; then
+  echo "TKG_IMAGE_REPO variable is required but is not defined" >&2
+  exit 2
+fi
+
+if ! [ -x "$(command -v imgpkg)" ]; then
+  echo 'Error: imgpkg is not installed.' >&2
+  exit 3
+fi
+
+if ! [ -x "$(command -v yq)" ]; then
+  echo 'Error: yq is not installed.' >&2
+  echo "${INSTALL_INSTRUCTIONS}" >&2
+  exit 3
+fi
+
+function imgpkg_copy() {
+    flags=$1
+    src=$2
+    dst=$3
+    echo ""
+    echo "imgpkg copy $flags $src --to-tar $dst.tar"
+}
+
+echo "set -euo pipefail"
+echodual "Note that yq must be version above or equal to version 4.9.2 and below version 5."
+
+actualImageRepository="$TKG_IMAGE_REPO"
+
+# Iterate through TKG BoM file to create the complete Image name
+# and then pull, retag and push image to custom registry.
+list=$(imgpkg  tag  list -i "${actualImageRepository}"/tkg-bom)
+for imageTag in ${list}; do
+  tanzucliversion=$(tanzu version | head -n 1 | cut -c10-15)
+  if [[ ${imageTag} == ${tanzucliversion}* ]]; then
+    TKG_BOM_FILE="tkg-bom-${imageTag//_/+}.yaml"
+    imgpkg pull --image "${actualImageRepository}/tkg-bom:${imageTag}" --output "tmp" > /dev/null 2>&1
+    echodual "Processing TKG BOM file ${TKG_BOM_FILE}"
+
+    actualTKGImage=${actualImageRepository}/tkg-bom:${imageTag}
+    customTKGImage=tkg-bom-${imageTag}
+    imgpkg_copy "-i" $actualTKGImage $customTKGImage
+
+    # Get components in the tkg-bom.
+    # Remove the leading '[' and trailing ']' in the output of yq.
+    components=(`yq e '.components | keys | .. style="flow"' "tmp/$TKG_BOM_FILE" | sed 's/^.//;s/.$//'`)
+    for comp in "${components[@]}"
+    do
+    # remove: leading and trailing whitespace, and trailing comma
+    comp=`echo $comp | sed -e 's/^[[:space:]]*//' | sed 's/,*$//g'`
+    get_comp_images="yq e '.components[\"${comp}\"][]  | select(has(\"images\"))|.images[] | .imagePath + \":\" + .tag' "\"tmp/\"$TKG_BOM_FILE""
+
+    flags="-i"
+    if [ $comp = "tkg-standard-packages" ]; then
+      flags="-b"
+    fi
+    eval $get_comp_images | while read -r image; do
+        actualImage=${actualImageRepository}/${image}
+        image2=$(echo "$image" | tr ':' '-' | tr '/' '-')
+        customImage=${image2}
+        imgpkg_copy $flags $actualImage $customImage
+      done
+    done
+
+    rm -rf tmp
+    echodual "Finished processing TKG BOM file ${TKG_BOM_FILE}"
+    echo ""
+  fi
+done
+
+# Iterate through TKR BoM file to create the complete Image name
+# and then pull, retag and push image to custom registry.
+list=$(imgpkg  tag  list -i ${actualImageRepository}/tkr-bom)
+for imageTag in ${list}; do
+  if [[ ${imageTag} == v* ]]; then
+    TKR_BOM_FILE="tkr-bom-${imageTag//_/+}.yaml"
+    echodual "Processing TKR BOM file ${TKR_BOM_FILE}"
+
+    actualTKRImage=${actualImageRepository}/tkr-bom:${imageTag}
+    customTKRImage=tkr-bom-${imageTag}
+    imgpkg_copy "-i" $actualTKRImage $customTKRImage
+    imgpkg pull --image ${actualImageRepository}/tkr-bom:${imageTag} --output "tmp" > /dev/null 2>&1
+
+    # Get components in the tkr-bom.
+    # Remove the leading '[' and trailing ']' in the output of yq.
+    components=(`yq e '.components | keys | .. style="flow"' "tmp/$TKR_BOM_FILE" | sed 's/^.//;s/.$//'`)
+    for comp in "${components[@]}"
+    do
+    # remove: leading and trailing whitespace, and trailing comma
+    comp=`echo $comp | sed -e 's/^[[:space:]]*//' | sed 's/,*$//g'`
+    get_comp_images="yq e '.components[\"${comp}\"][]  | select(has(\"images\"))|.images[] | .imagePath + \":\" + .tag' "\"tmp/\"$TKR_BOM_FILE""
+
+    flags="-i"
+    if [ $comp = "tkg-core-packages" ]; then
+      flags="-b"
+    fi
+    eval $get_comp_images | while read -r image; do
+        actualImage=${actualImageRepository}/${image}
+        image2=$(echo "$image" | tr ':' '-' | tr '/' '-')
+        customImage=${image2}
+        imgpkg_copy $flags $actualImage $customImage
+      done
+    done
+
+    rm -rf tmp
+    echodual "Finished processing TKR BOM file ${TKR_BOM_FILE}"
+    echo ""
+  fi
+done
+
+list=$(imgpkg  tag  list -i ${actualImageRepository}/tkr-compatibility)
+for imageTag in ${list}; do
+  if [[ ${imageTag} == v* ]]; then
+    echodual "Processing TKR compatibility image"
+    actualImage=${actualImageRepository}/tkr-compatibility:${imageTag}
+    customImage=tkr-compatibility-${imageTag}
+    imgpkg_copy "-i" $actualImage $customImage
+    echo ""
+    echodual "Finished processing TKR compatibility image"
+  fi
+done
+
+list=$(imgpkg  tag  list -i ${actualImageRepository}/tkg-compatibility)
+for imageTag in ${list}; do
+  if [[ ${imageTag} == v* ]]; then
+    echodual "Processing TKG compatibility image"
+    actualImage=${actualImageRepository}/tkg-compatibility:${imageTag}
+    customImage=tkg-compatibility-${imageTag}
+    imgpkg_copy "-i" $actualImage $customImage
+    echo ""
+    echodual "Finished processing TKG compatibility image"
+  fi
+done


### PR DESCRIPTION
Copy images to tar format and vice versa to a private repo in a completely airgapped environment.

Signed-off-by: Meghana Jangi <mjangi@vmware.com>

**What this PR does / why we need it**:
At present, there is no script to copy the images to completely air-gapped environment like AWS secret region.
This PR consists of 2 scripts. One of them generates a script to copy required images from projects.registry.vmware.com/tkg and save them in a tar format. Other script generates a script to copy the images to a private repo in an air-gapped environment from the tar format. 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

**Describe testing done for PR**:

Tested the scripts in an AWS environment.

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Added the capability of copying images required for TKG installation in completely airgapped environments. 
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
