### PR TITLE
Fix typos in validation error messages

### DIFF
--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -1656,13 +1656,13 @@ func (c *TkgClient) validateCIDRsForIPFamily(configVariableName, cidrs, ipFamily
 	case constants.DualStackPrimaryIPv4Family:
 		cidrSlice := strings.Split(cidrs, ",")
 		if len(cidrSlice) != 2 || !isCIDRIPv4(cidrSlice[0]) || !isCIDRIPv6(cidrSlice[1]) {
-			return fmt.Errorf(`invalid %s %q, expepcted to have "<IPv4 CIDR>,<IPv6 CIDR>" for %s %q`,
+			return fmt.Errorf(`invalid %s %q, expected to have "<IPv4 CIDR>,<IPv6 CIDR>" for %s %q`,
 				configVariableName, cidrs, constants.ConfigVariableIPFamily, ipFamily)
 		}
 	case constants.DualStackPrimaryIPv6Family:
 		cidrSlice := strings.Split(cidrs, ",")
 		if len(cidrSlice) != 2 || !isCIDRIPv6(cidrSlice[0]) || !isCIDRIPv4(cidrSlice[1]) {
-			return fmt.Errorf(`invalid %s %q, expepcted to have "<IPv6 CIDR>,<IPv4 CIDR>" for %s %q`,
+			return fmt.Errorf(`invalid %s %q, expected to have "<IPv6 CIDR>,<IPv4 CIDR>" for %s %q`,
 				configVariableName, cidrs, constants.ConfigVariableIPFamily, ipFamily)
 		}
 	}

--- a/pkg/v1/tkg/client/validate_test.go
+++ b/pkg/v1/tkg/client/validate_test.go
@@ -643,7 +643,7 @@ var _ = Describe("Validate", func() {
 				validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
 				Expect(validationError).To(HaveOccurred())
 				Expect(validationError).To(MatchError(
-					fmt.Sprintf(`invalid SERVICE_CIDR %q, expepcted to have %q for TKG_IP_FAMILY %q`,
+					fmt.Sprintf(`invalid SERVICE_CIDR %q, expected to have %q for TKG_IP_FAMILY %q`,
 						serviceCIDRs,
 						expectedFormat,
 						ipFamily,
@@ -685,7 +685,7 @@ var _ = Describe("Validate", func() {
 				validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
 				Expect(validationError).To(HaveOccurred())
 				Expect(validationError).To(MatchError(
-					fmt.Sprintf(`invalid CLUSTER_CIDR %q, expepcted to have %q for TKG_IP_FAMILY %q`,
+					fmt.Sprintf(`invalid CLUSTER_CIDR %q, expected to have %q for TKG_IP_FAMILY %q`,
 						clusterCIDRs,
 						expectedFormat,
 						ipFamily,


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a couple typos identified by @vuil in review of https://github.com/vmware-tanzu/tanzu-framework/pull/617