### PR TITLE
Usage of registry CA cert while copying images

### DIFF
--- a/hack/gen-publish-images.sh
+++ b/hack/gen-publish-images.sh
@@ -45,8 +45,20 @@ function imgpkg_copy() {
     echo "imgpkg copy $flags $src --to-repo $dst"
 }
 
+if [ -n "$TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE" ]; then
+  echo $TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE > /tmp/cacrtbase64
+  base64 -d /tmp/cacrtbase64 > /tmp/cacrtbase64d.crt
+  function imgpkg_copy() {
+      flags=$1
+      src=$2
+      dst=$3
+      echo ""
+      echo "imgpkg copy $flags $src --to-repo $dst --registry-ca-cert-path /tmp/cacrtbase64d.crt"
+  }
+fi
+
 echo "set -euo pipefail"
-echodual "Note that yq must be version above or equal to version 4.9.2 and below version 5.."
+echodual "Note that yq must be version above or equal to version 4.9.2 and below version 5."
 
 actualImageRepository="$TKG_IMAGE_REPO"
 


### PR DESCRIPTION
This change will help users to use their registry CA cert while copying images when TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE is set.

Signed-off-by: Meghana Jangi <mjangi@vmware.com>

**What this PR does / why we need it**:
Users are setting the variable TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE but it is not being used in this script while copying images. This change will fix the same. 

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:

Generated the publish-images.sh script to verify the imgcopy command syntax.

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Fixes the issue where gen-publish-images.sh script fails to use the certificate set in environment variable while copying the images to private registry.
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
