### PR TITLE
imagepullsecret: add gcp auth provider

### DIFF
--- a/cmd/cli/plugin/imagepullsecret/main.go
+++ b/cmd/cli/plugin/imagepullsecret/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"os"
 
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"


### PR DESCRIPTION
**What this PR does / why we need it:**
- This PR adds gcp auth provider for the imagepullsecret plugin

**Describe testing done for PR:**
Manual testing in the cluster

**Does this PR introduce a user-facing change?:**
None

Fixes #688

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Add gcp auth provider for the imagepullsecret plugin
```

**New PR Checklist**
- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
