### PR TITLE
Do not run release workflow for *-dev tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,8 @@ on:
     branches:
       - "!not_activated_on_branches!*"
     tags:
-      - "v*"
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "!*-*"
 
 jobs:
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Release workflow now only runs for
tag pattern: `v[0-9]+.[0-9]+.[0-9]+`
and skips for `*-*`.

Signed-off-by: Navid Shaikh <navids@vmware.com>

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #694 

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Pushed the changeset to main branch of my fork and
- pushed a `*-dev` tag and verified that release workflow doesn't trigger
- pushed a release tag and verified that release workflow triggers

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
