### PR TITLE
Add imagepullsecret update command

### DIFF
--- a/cmd/cli/plugin/imagepullsecret/main.go
+++ b/cmd/cli/plugin/imagepullsecret/main.go
@@ -40,6 +40,7 @@ func main() {
 		imagePullSecretAddCmd,
 		imagePullSecretDeleteCmd,
 		imagePullSecretListCmd,
+		imagePullSecretUpdateCmd,
 	)
 	if err := p.Execute(); err != nil {
 		os.Exit(1)

--- a/cmd/cli/plugin/imagepullsecret/secret_delete.go
+++ b/cmd/cli/plugin/imagepullsecret/secret_delete.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
@@ -42,9 +43,11 @@ func imagePullSecretDelete(cmd *cobra.Command, args []string) error {
 	if !imagePullSecretOp.SkipPrompt {
 		if err := cli.AskForConfirmation(fmt.Sprintf("Deleting image pull secret '%s' from namespace '%s'. Are you sure?",
 			imagePullSecretOp.SecretName, imagePullSecretOp.Namespace)); err != nil {
-			return err
+			return errors.New("deletion of the secret got aborted")
 		}
 	}
+
+	cmd.SilenceUsage = true
 
 	if _, err = component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat,
 		fmt.Sprintf("Deleting image pull secret '%s'...", imagePullSecretOp.SecretName), true); err != nil {

--- a/cmd/cli/plugin/imagepullsecret/secret_update.go
+++ b/cmd/cli/plugin/imagepullsecret/secret_update.go
@@ -1,0 +1,96 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackageclient"
+)
+
+var imagePullSecretUpdateCmd = &cobra.Command{
+	Use:   "update SECRET_NAME --username USERNAME --password PASSWORD",
+	Short: "Updates the v1/Secret resource of type kubernetes.io/dockerconfigjson. In case of specifying the --export-to-all-namespaces flag, the SecretExport resource will also get updated. Otherwise, there will be no changes in the SecretExport resource",
+	Example: `
+    # Update an image pull secret. There will be no changes in the associated SecretExport resource
+    tanzu imagepullsecret update test-secret --username test-user --password-file test-file
+
+    # Update an image pull secret with 'export-to-all-namespaces' flag being set
+    tanzu imagepullsecret update test-secret --username test-user --password test-pass --export-to-all-namespaces
+
+    # Update an image pull secret with 'export-to-all-namespaces' flag being clear. In this case, the associated SecretExport resource will get deleted
+    tanzu imagepullsecret update test-secret --username test-user --password test-pass --export-to-all-namespaces=false`,
+	PreRunE: secretGenAvailabilityCheck,
+	RunE:    imagePullSecretUpdate,
+}
+
+func init() {
+	imagePullSecretUpdateCmd.Flags().StringVarP(&imagePullSecretOp.Username, "username", "", "", "Username for authenticating to the private registry")
+	imagePullSecretUpdateCmd.Flags().StringVarP(&imagePullSecretOp.PasswordInput, "password", "", "", "Password for authenticating to the private registry")
+	imagePullSecretUpdateCmd.Flags().StringVarP(&imagePullSecretOp.PasswordFile, "password-file", "", "", "File containing the password for authenticating to the private registry")
+	imagePullSecretUpdateCmd.Flags().StringVarP(&imagePullSecretOp.PasswordEnvVar, "password-env-var", "", "", "Environment variable containing the password for authenticating to the private registry")
+	imagePullSecretUpdateCmd.Flags().StringVarP(&imagePullSecretOp.Namespace, "namespace", "n", "default", "Target namespace for the image pull secret, optional")
+	imagePullSecretUpdateCmd.Flags().StringVarP(&imagePullSecretOp.KubeConfig, "kubeconfig", "", "", "The path to the kubeconfig file, optional")
+	imagePullSecretUpdateCmd.Flags().BoolVarP(&imagePullSecretOp.PasswordStdin, "password-stdin", "", false, "When provided, password for authenticating to the private registry would be taken from the standard input")
+	imagePullSecretUpdateCmd.Flags().VarPF(&imagePullSecretOp.Export, "export-to-all-namespaces", "", "If set to true, the secret gets available across all namespaces. If set to false, the secret will get unexported from ALL namespaces in which it was previously exported to. In case of not specifying this flag, no changes will be made in the existing SecretExport resource. optional").NoOptDefVal = "true"
+	imagePullSecretUpdateCmd.Args = cobra.ExactArgs(1)
+}
+
+func imagePullSecretUpdate(cmd *cobra.Command, args []string) error {
+	imagePullSecretOp.SecretName = args[0]
+
+	password, err := extractPassword()
+	if err != nil {
+		return err
+	}
+	imagePullSecretOp.Password = password
+
+	if imagePullSecretOp.Username == "" && imagePullSecretOp.Password == "" && imagePullSecretOp.Export.ExportToAllNamespaces == nil {
+		return errors.New("no changes made in the image pull secret, as neither of username, password or export-to-all-namespaces flag options were provided")
+	}
+
+	cmd.SilenceUsage = true
+
+	if imagePullSecretOp.Export.ExportToAllNamespaces != nil {
+		if *imagePullSecretOp.Export.ExportToAllNamespaces {
+			log.Warning("Warning: By specifying --export-to-all-namespaces as true, given secret contents will be available to ALL users in ALL namespaces. Please ensure that included registry credentials allow only read-only access to the registry with minimal necessary scope.\n")
+		} else {
+			log.Warning("Warning: By specifying --export-to-all-namespaces as false, the secret contents will get unexported from ALL namespaces in which it was previously available to.\n")
+		}
+		if err := cli.AskForConfirmation("Are you sure you want to proceed?"); err != nil {
+			return errors.New("update of the secret got aborted")
+		}
+		log.Info("\n")
+	}
+
+	pkgClient, err := tkgpackageclient.NewTKGPackageClient(imagePullSecretOp.KubeConfig)
+	if err != nil {
+		return err
+	}
+
+	if _, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat,
+		fmt.Sprintf("Updating image pull secret '%s'...", imagePullSecretOp.SecretName), true); err != nil {
+		return err
+	}
+
+	if err := pkgClient.UpdateImagePullSecret(imagePullSecretOp); err != nil {
+		return err
+	}
+
+	log.Infof("\n Updated image pull secret '%s' in namespace '%s'", imagePullSecretOp.SecretName, imagePullSecretOp.Namespace)
+	if imagePullSecretOp.Export.ExportToAllNamespaces != nil {
+		if *imagePullSecretOp.Export.ExportToAllNamespaces {
+			log.Infof(" Exported image pull secret '%s' to all namespaces", imagePullSecretOp.SecretName)
+		} else {
+			log.Infof(" Unexported image pull secret '%s' from all namespaces", imagePullSecretOp.SecretName)
+		}
+	}
+	return nil
+}

--- a/pkg/v1/tkg/tkgpackageclient/imagepullsecret_add.go
+++ b/pkg/v1/tkg/tkgpackageclient/imagepullsecret_add.go
@@ -36,14 +36,14 @@ func (p *pkgClient) AddImagePullSecret(o *tkgpackagedatamodel.ImagePullSecretOpt
 		return err
 	}
 
-	secret := p.newSecret(o.SecretName, o.Namespace, corev1.SecretTypeDockerConfigJson)
+	secret = p.newSecret(o.SecretName, o.Namespace, corev1.SecretTypeDockerConfigJson)
 	secret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
 	if err := p.kappClient.GetClient().Create(context.Background(), secret); err != nil {
 		return errors.Wrap(err, "failed to create Secret resource")
 	}
 
 	if o.ExportToAllNamespaces {
-		secretExport := p.newSecretExport(o.SecretName, o.Namespace)
+		secretExport = p.newSecretExport(o.SecretName, o.Namespace)
 		if err := p.kappClient.GetClient().Create(context.Background(), secretExport); err != nil {
 			return errors.Wrap(err, "failed to create SecretExport resource")
 		}

--- a/pkg/v1/tkg/tkgpackageclient/imagepullsecret_delete.go
+++ b/pkg/v1/tkg/tkgpackageclient/imagepullsecret_delete.go
@@ -18,7 +18,7 @@ import (
 
 // DeleteImagePullSecret deletes an image pull secret from the cluster
 func (p *pkgClient) DeleteImagePullSecret(o *tkgpackagedatamodel.ImagePullSecretOptions) (bool, error) {
-	secretExport := &secretgenctrl.SecretExport{
+	secretExport = &secretgenctrl.SecretExport{
 		TypeMeta:   metav1.TypeMeta{Kind: tkgpackagedatamodel.KindSecretExport, APIVersion: secretgenctrl.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{Name: o.SecretName, Namespace: o.Namespace},
 	}
@@ -28,7 +28,7 @@ func (p *pkgClient) DeleteImagePullSecret(o *tkgpackagedatamodel.ImagePullSecret
 		}
 	}
 
-	secret := &corev1.Secret{
+	secret = &corev1.Secret{
 		TypeMeta:   metav1.TypeMeta{Kind: tkgpackagedatamodel.KindSecret, APIVersion: corev1.SchemeGroupVersion.String()},
 		ObjectMeta: metav1.ObjectMeta{Name: o.SecretName, Namespace: o.Namespace},
 	}

--- a/pkg/v1/tkg/tkgpackageclient/imagepullsecret_list_test.go
+++ b/pkg/v1/tkg/tkgpackageclient/imagepullsecret_list_test.go
@@ -21,7 +21,7 @@ import (
 
 const testSecretExportName = "test-secret"
 
-var testDockerconfig = DockerConfigJSON{Auths: map[string]dockerConfigEntry{"us-east4-docker.pkg.dev": {Username: "test_user", Password: "test_password"}}}
+var testDockerConfig = DockerConfigJSON{Auths: map[string]dockerConfigEntry{"us-east4-docker.pkg.dev": {Username: "test_user", Password: "test_password"}}}
 
 var testSecret = &corev1.Secret{
 	TypeMeta:   metav1.TypeMeta{Kind: tkgpackagedatamodel.KindSecret, APIVersion: corev1.SchemeGroupVersion.String()},
@@ -55,7 +55,7 @@ var _ = Describe("List Secrets", func() {
 
 	JustBeforeEach(func() {
 		ctl = &pkgClient{kappClient: kappCtl}
-		dockerCfgContent, _ := json.Marshal(testDockerconfig)
+		dockerCfgContent, _ := json.Marshal(testDockerConfig)
 		testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
 		secrets, err = ctl.ListImagePullSecrets(&options)
 	})

--- a/pkg/v1/tkg/tkgpackageclient/imagepullsecret_update.go
+++ b/pkg/v1/tkg/tkgpackageclient/imagepullsecret_update.go
@@ -1,0 +1,134 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgpackageclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crtclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	secretgenctrl "github.com/vmware-tanzu/carvel-secretgen-controller/pkg/apis/secretgen2/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
+)
+
+var (
+	secret       = &corev1.Secret{}
+	secretExport = &secretgenctrl.SecretExport{}
+)
+
+// UpdateImagePullSecret updates an image pull Secret in the cluster
+func (p *pkgClient) UpdateImagePullSecret(o *tkgpackagedatamodel.ImagePullSecretOptions) error {
+	var (
+		registry string
+		username string
+		password string
+		dataMap  map[string]interface{}
+	)
+
+	if err := p.kappClient.GetClient().Get(context.Background(), crtclient.ObjectKey{Name: o.SecretName, Namespace: o.Namespace}, secret); err != nil {
+		if apierrors.IsNotFound(err) {
+			return errors.New(fmt.Sprintf("secret '%s' does not exist in namespace '%s'", o.SecretName, o.Namespace))
+		}
+		return err
+	}
+
+	secretToUpdate := secret.DeepCopy()
+	if err := json.Unmarshal(secretToUpdate.Data[corev1.DockerConfigJsonKey], &dataMap); err != nil {
+		return err
+	}
+
+	auths, ok := dataMap["auths"]
+	if !ok {
+		return errors.New(fmt.Sprintf("no 'auths' entry exists in secret '%s'", o.SecretName))
+	}
+
+	entries := auths.(map[string]interface{})
+	if len(entries) != 1 {
+		return errors.New(fmt.Sprintf("updating secret '%s' is not allowed as multiple registry entries exists", o.SecretName))
+	}
+
+	for reg, v := range entries {
+		registry = reg
+		credentials := v.(map[string]interface{})
+		currentUsername, ok := credentials["username"]
+		if !ok {
+			return errors.New(fmt.Sprintf("no 'username' entry exists in secret '%s'", o.SecretName))
+		}
+		username = currentUsername.(string)
+		currentPassword, ok := credentials["password"]
+		if !ok {
+			return errors.New(fmt.Sprintf("no 'password' entry exists in secret '%s'", o.SecretName))
+		}
+		password = currentPassword.(string)
+	}
+
+	if o.Username != "" {
+		username = o.Username
+	}
+
+	if o.Password != "" {
+		password = o.Password
+	}
+
+	dockerCfg := DockerConfigJSON{Auths: map[string]dockerConfigEntry{registry: {Username: username, Password: password}}}
+	dockerCfgContent, err := json.Marshal(dockerCfg)
+	if err != nil {
+		return err
+	}
+	secretToUpdate.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+
+	if err := p.kappClient.GetClient().Update(context.Background(), secretToUpdate); err != nil {
+		return errors.Wrap(err, "failed to update Secret resource")
+	}
+
+	if err := p.UpdateSecretExport(o); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// UpdateSecretExport updates the SecretExport resource in the cluster
+func (p *pkgClient) UpdateSecretExport(o *tkgpackagedatamodel.ImagePullSecretOptions) error {
+	if o.Export.ExportToAllNamespaces == nil {
+		return nil
+	}
+
+	if *o.Export.ExportToAllNamespaces {
+		err := p.kappClient.GetClient().Get(context.Background(), crtclient.ObjectKey{Name: o.SecretName, Namespace: o.Namespace}, secretExport)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+			secretExport = p.newSecretExport(o.SecretName, o.Namespace)
+			if err := p.kappClient.GetClient().Create(context.Background(), secretExport); err != nil {
+				return errors.Wrap(err, "failed to create SecretExport resource")
+			}
+			return nil
+		}
+		secretExportToUpdate := secretExport.DeepCopy()
+		secretExportToUpdate.Spec = secretgenctrl.SecretExportSpec{ToNamespaces: []string{"*"}}
+		if err := p.kappClient.GetClient().Update(context.Background(), secretExportToUpdate); err != nil {
+			return errors.Wrap(err, "failed to update SecretExport resource")
+		}
+	} else { // un-export already exported secrets
+		secretExport = &secretgenctrl.SecretExport{
+			TypeMeta:   metav1.TypeMeta{Kind: tkgpackagedatamodel.KindSecretExport, APIVersion: secretgenctrl.SchemeGroupVersion.String()},
+			ObjectMeta: metav1.ObjectMeta{Name: o.SecretName, Namespace: o.Namespace},
+		}
+		if err := p.kappClient.GetClient().Delete(context.Background(), secretExport); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return errors.Wrap(err, "failed to delete SecretExport resource")
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/v1/tkg/tkgpackageclient/imagepullsecret_update_test.go
+++ b/pkg/v1/tkg/tkgpackageclient/imagepullsecret_update_test.go
@@ -1,0 +1,334 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgpackageclient
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
+)
+
+var _ = Describe("Update Secret", func() {
+	type invalidDockerCfgJSON struct {
+		Auths map[string]dockerConfigEntry `json:"invalid-key" datapolicy:"token"`
+	}
+	var (
+		ctl              *pkgClient
+		crtCtl           *fakes.CRTClusterClient
+		kappCtl          *fakes.KappClient
+		err              error
+		dockerCfgContent []byte
+		f                = false
+		t                = true
+		opts             = tkgpackagedatamodel.ImagePullSecretOptions{
+			Export:     tkgpackagedatamodel.TypeBoolPtr{ExportToAllNamespaces: &t},
+			Namespace:  testNamespaceName,
+			Password:   testPassword,
+			SecretName: testSecretName,
+			Username:   testUsername,
+		}
+		options                         = opts
+		testDockerCfgInvalid            = invalidDockerCfgJSON{Auths: map[string]dockerConfigEntry{"us-east4-docker.pkg.dev": {Username: "test_user", Password: "test_password"}}}
+		testDockerCfgMultipleRegistries = DockerConfigJSON{Auths: map[string]dockerConfigEntry{"us-east4-docker.pkg.dev": {Username: "test_user", Password: "test_password"}, "us-west-docker.pkg.dev": {Username: "test_user", Password: "test_password"}}}
+		testDockerCfgNoUsername         = DockerConfigJSON{Auths: map[string]dockerConfigEntry{"us-east4-docker.pkg.dev": {Password: "test_password"}}}
+		testDockerCfgNoPassword         = DockerConfigJSON{Auths: map[string]dockerConfigEntry{"us-east4-docker.pkg.dev": {Username: "test_user"}}}
+	)
+
+	JustBeforeEach(func() {
+		ctl = &pkgClient{kappClient: kappCtl}
+		err = ctl.UpdateImagePullSecret(&options)
+	})
+
+	Context("failure in updating Secret due to Secret Get NotFound error", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			crtCtl.GetReturnsOnCall(0, apierrors.NewNotFound(schema.GroupResource{Resource: tkgpackagedatamodel.KindSecret}, testSecretName))
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("secret '%s' does not exist in namespace '%s'", options.SecretName, options.Namespace)))
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("failure in updating the Secret due to Secret Get error", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			crtCtl.GetReturnsOnCall(0, errors.New("failure in Secret Get"))
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failure in Secret Get"))
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("failure in updating the Secret due to the non-existence of the 'auths' field in the secret", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			secret = testSecret
+			crtCtl.GetReturnsOnCall(0, nil)
+			dockerCfgContent, err = json.Marshal(testDockerCfgInvalid)
+			Expect(err).NotTo(HaveOccurred())
+			testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no 'auths' entry exists in secret '%s'", testSecretName)))
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("failure in updating the Secret due to the existence of multiple registries in the secret", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			secret = testSecret
+			crtCtl.GetReturnsOnCall(0, nil)
+			dockerCfgContent, err = json.Marshal(testDockerCfgMultipleRegistries)
+			Expect(err).NotTo(HaveOccurred())
+			testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("updating secret '%s' is not allowed as multiple registry entries exists", testSecretName)))
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("failure in updating the Secret due to the non-existence of the 'username' field in the secret", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			secret = testSecret
+			crtCtl.GetReturnsOnCall(0, nil)
+			dockerCfgContent, err = json.Marshal(testDockerCfgNoUsername)
+			Expect(err).NotTo(HaveOccurred())
+			testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no 'username' entry exists in secret '%s'", testSecretName)))
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("failure in updating the Secret due to the non-existence of the 'password' field in the secret", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			secret = testSecret
+			crtCtl.GetReturnsOnCall(0, nil)
+			dockerCfgContent, err = json.Marshal(testDockerCfgNoPassword)
+			Expect(err).NotTo(HaveOccurred())
+			testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no 'password' entry exists in secret '%s'", testSecretName)))
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("failure in updating the Secret due to Secret Update error", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			secret = testSecret
+			crtCtl.GetReturnsOnCall(0, nil)
+			dockerCfgContent, err = json.Marshal(testDockerConfig)
+			Expect(err).NotTo(HaveOccurred())
+			testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+			crtCtl.UpdateReturnsOnCall(0, errors.New("failure in Secret Update"))
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failure in Secret Update"))
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("failure in updating the Secret due to SecretExport Get error", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			secret = testSecret
+			crtCtl.GetReturnsOnCall(0, nil)
+			dockerCfgContent, err = json.Marshal(testDockerConfig)
+			Expect(err).NotTo(HaveOccurred())
+			testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+			crtCtl.UpdateReturnsOnCall(0, nil)
+			crtCtl.GetReturnsOnCall(1, errors.New("failure in SecretExport Get"))
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failure in SecretExport Get"))
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("failure in updating the Secret due to SecretExport Create error", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			secret = testSecret
+			crtCtl.GetReturnsOnCall(0, nil)
+			dockerCfgContent, err = json.Marshal(testDockerConfig)
+			Expect(err).NotTo(HaveOccurred())
+			testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+			crtCtl.UpdateReturnsOnCall(0, nil)
+			crtCtl.GetReturnsOnCall(1, apierrors.NewNotFound(schema.GroupResource{Resource: tkgpackagedatamodel.KindSecretExport}, testSecretName))
+			crtCtl.CreateReturnsOnCall(0, errors.New("failure in SecretExport Create"))
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failure in SecretExport Create"))
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("success in updating the Secret and Creating SecretExport", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			secret = testSecret
+			crtCtl.GetReturnsOnCall(0, nil)
+			dockerCfgContent, err = json.Marshal(testDockerConfig)
+			Expect(err).NotTo(HaveOccurred())
+			testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+			crtCtl.UpdateReturnsOnCall(0, nil)
+			crtCtl.GetReturnsOnCall(1, apierrors.NewNotFound(schema.GroupResource{Resource: tkgpackagedatamodel.KindSecretExport}, testSecretName))
+			crtCtl.CreateReturnsOnCall(0, nil)
+		})
+		It(testSuccessMsg, func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("failure in updating the Secret due to SecretExport Update error", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			secret = testSecret
+			crtCtl.GetReturnsOnCall(0, nil)
+			dockerCfgContent, err = json.Marshal(testDockerConfig)
+			Expect(err).NotTo(HaveOccurred())
+			testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+			crtCtl.UpdateReturnsOnCall(0, nil)
+			crtCtl.GetReturnsOnCall(1, nil)
+			crtCtl.UpdateReturnsOnCall(1, errors.New("failure in SecretExport Update"))
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failure in SecretExport Update"))
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("success in updating the Secret and updating SecretExport", func() {
+		BeforeEach(func() {
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			secret = testSecret
+			crtCtl.GetReturnsOnCall(0, nil)
+			dockerCfgContent, err = json.Marshal(testDockerConfig)
+			Expect(err).NotTo(HaveOccurred())
+			testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+			crtCtl.UpdateReturnsOnCall(0, nil)
+			crtCtl.GetReturnsOnCall(1, nil)
+			crtCtl.UpdateReturnsOnCall(0, nil)
+		})
+		It(testSuccessMsg, func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("failure in updating the Secret with --export-to-all-namespaces=false due to SecretExport Delete error", func() {
+		BeforeEach(func() {
+			options.Export = tkgpackagedatamodel.TypeBoolPtr{ExportToAllNamespaces: &f}
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			secret = testSecret
+			crtCtl.GetReturnsOnCall(0, nil)
+			dockerCfgContent, err = json.Marshal(testDockerConfig)
+			Expect(err).NotTo(HaveOccurred())
+			testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+			crtCtl.UpdateReturnsOnCall(0, nil)
+			crtCtl.DeleteReturnsOnCall(0, errors.New("failure in SecretExport Delete"))
+		})
+		It(testFailureMsg, func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failure in SecretExport Delete"))
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("success in updating the Secret with --export-to-all-namespaces=false (SecretExport already not found)", func() {
+		BeforeEach(func() {
+			options.Export = tkgpackagedatamodel.TypeBoolPtr{ExportToAllNamespaces: &f}
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			secret = testSecret
+			crtCtl.GetReturnsOnCall(0, nil)
+			dockerCfgContent, err = json.Marshal(testDockerConfig)
+			Expect(err).NotTo(HaveOccurred())
+			testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+			crtCtl.UpdateReturnsOnCall(0, nil)
+			crtCtl.DeleteReturnsOnCall(0, apierrors.NewNotFound(schema.GroupResource{Resource: tkgpackagedatamodel.KindSecretExport}, testSecretName))
+		})
+		It(testSuccessMsg, func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+		AfterEach(func() { options = opts })
+	})
+
+	Context("success in updating the Secret and deleting SecretExport (--export-to-all-namespaces=false)", func() {
+		BeforeEach(func() {
+			options.Export = tkgpackagedatamodel.TypeBoolPtr{ExportToAllNamespaces: &f}
+			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
+			secret = testSecret
+			crtCtl.GetReturnsOnCall(0, nil)
+			dockerCfgContent, err = json.Marshal(testDockerConfig)
+			Expect(err).NotTo(HaveOccurred())
+			testSecret.Data[corev1.DockerConfigJsonKey] = dockerCfgContent
+			crtCtl.UpdateReturnsOnCall(0, nil)
+			crtCtl.DeleteReturnsOnCall(0, nil)
+		})
+		It(testSuccessMsg, func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+		AfterEach(func() { options = opts })
+	})
+})

--- a/pkg/v1/tkg/tkgpackageclient/interface.go
+++ b/pkg/v1/tkg/tkgpackageclient/interface.go
@@ -31,6 +31,7 @@ type TKGPackageClient interface {
 	ListRepositories(o *tkgpackagedatamodel.RepositoryOptions) (*kappipkg.PackageRepositoryList, error)
 	ListSecretExports(o *tkgpackagedatamodel.ImagePullSecretOptions) (*secretgen.SecretExportList, error)
 	UninstallPackage(o *tkgpackagedatamodel.PackageOptions, packageProgress *tkgpackagedatamodel.PackageProgress)
+	UpdateImagePullSecret(o *tkgpackagedatamodel.ImagePullSecretOptions) error
 	UpdatePackage(o *tkgpackagedatamodel.PackageOptions, packageProgress *tkgpackagedatamodel.PackageProgress)
 	UpdateRepository(o *tkgpackagedatamodel.RepositoryOptions) error
 }

--- a/pkg/v1/tkg/tkgpackageclient/package_install.go
+++ b/pkg/v1/tkg/tkgpackageclient/package_install.go
@@ -188,7 +188,7 @@ func (p *pkgClient) createDataValuesSecret(o *tkgpackagedatamodel.PackageOptions
 	if dataValues[filepath.Base(o.ValuesFile)], err = ioutil.ReadFile(o.ValuesFile); err != nil {
 		return false, errors.Wrap(err, fmt.Sprintf("failed to read from data values file '%s'", o.ValuesFile))
 	}
-	secret := &corev1.Secret{
+	secret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        o.SecretName,
 			Namespace:   o.Namespace,

--- a/pkg/v1/tkg/tkgpackageclient/package_update.go
+++ b/pkg/v1/tkg/tkgpackageclient/package_update.go
@@ -109,7 +109,7 @@ func (p *pkgClient) updateDataValuesSecret(o *tkgpackagedatamodel.PackageOptions
 	if dataValues[filepath.Base(o.ValuesFile)], err = ioutil.ReadFile(o.ValuesFile); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to read from data values file '%s'", o.ValuesFile))
 	}
-	secret := &corev1.Secret{
+	secret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: o.SecretName, Namespace: o.Namespace}, Data: dataValues,
 	}
 

--- a/pkg/v1/tkg/tkgpackagedatamodel/secret.go
+++ b/pkg/v1/tkg/tkgpackagedatamodel/secret.go
@@ -9,6 +9,7 @@ type ImagePullSecretOptions struct {
 	ExportToAllNamespaces bool
 	PasswordStdin         bool
 	SkipPrompt            bool
+	Export                TypeBoolPtr
 	KubeConfig            string
 	Namespace             string
 	Password              string

--- a/pkg/v1/tkg/tkgpackagedatamodel/types.go
+++ b/pkg/v1/tkg/tkgpackagedatamodel/types.go
@@ -3,9 +3,48 @@
 
 package tkgpackagedatamodel
 
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
 // PackagePluginNonCriticalError is used for non critical package plugin errors which should be treated more like warnings
 type PackagePluginNonCriticalError struct {
 	Reason string
 }
 
 func (e *PackagePluginNonCriticalError) Error() string { return e.Reason }
+
+// TypeBoolPtr satisfies Value interface defined in "https://github.com/spf13/pflag/blob/master/flag.go"
+type TypeBoolPtr struct {
+	ExportToAllNamespaces *bool
+}
+
+// Type returns the default type for a TypeBoolPtr variable
+func (v *TypeBoolPtr) Type() string {
+	return ""
+}
+
+// Set sets the TypeBoolPtr variable based on the string argument
+func (v *TypeBoolPtr) Set(val string) error {
+	f := false
+	t := true
+	if val == "true" || val == "True" {
+		v.ExportToAllNamespaces = &t
+	} else if val == "false" || val == "False" {
+		v.ExportToAllNamespaces = &f
+	} else if val != "" {
+		return errors.New(fmt.Sprintf("invalid argument '%s'", val))
+	}
+
+	return nil
+}
+
+// String returns the string representation of a TypeBoolPtr variable
+func (v *TypeBoolPtr) String() string {
+	if v.ExportToAllNamespaces != nil {
+		return fmt.Sprint(*v.ExportToAllNamespaces)
+	}
+	return ""
+}


### PR DESCRIPTION
**What this PR does / why we need it:**
- This PR adds imagepullsecret update command
Fixes #653
Fixes #736  for imagepullsecret plugin

**Describe testing done for PR:**
Manual testing in the cluster and added unit tests in the same PR

**Example outputs:**
```
tanzu imagepullsecret update test-secret --username test-user -n test-ns --password-env-var PASSENV
- Updating image pull secret 'test-secret'...
 Updated image pull secret 'test-secret' in namespace 'test-ns'
```

```
tanzu imagepullsecret update test-secret --username test-user -n test-ns --password-env-var PASSENV --export-to-all-namespaces=false
Warning: By specifying --export-to-all-namespaces as false, the secret contents will get unexported from ALL namespaces in which it was previously available to.
Are you sure you want to proceed? [y/N]: y

\ Updating image pull secret 'test-secret'...
 Updated image pull secret 'test-secret' in namespace 'test-ns'
 Unexported image pull secret 'test-secret' from all namespaces
```

```
tanzu imagepullsecret update test-secret--username test-user -n test-ns --password-env-var PASSENV --export-to-all-namespaces=true
Warning: By specifying --export-to-all-namespaces as true, given secret contents will be available to ALL users in ALL namespaces. Please ensure that included registry credentials allow only read-only access to the registry with minimal necessary scope.
Are you sure you want to proceed? [y/N]: y

\ Updating image pull secret 'test-secret'...
 Updated image pull secret 'test-secret' in namespace 'test-ns'
 Exported image pull secret 'test-secret' to all namespaces
```

```
tanzu imagepullsecret update test-secret --username test-user -n test-ns --password-env-var PASSENV --export-to-all-namespaces
Warning: By specifying --export-to-all-namespaces as true, given secret contents will be available to ALL users in ALL namespaces. Please ensure that included registry credentials allow only read-only access to the registry with minimal necessary scope.
Are you sure you want to proceed? [y/N]: y

\ Updating image pull secret 'test-secret'...
 Updated image pull secret 'test-secret' in namespace 'test-ns'
 Exported image pull secret 'test-secret' to all namespaces
```

```
 tanzu imagepullsecret update test-secret --username test-user -n test-ns --password-env-var PASSENV --export-to-all-namespaces
Warning: By specifying --export-to-all-namespaces as true, given secret contents will be available to ALL users in ALL namespaces. Please ensure that included registry credentials allow only read-only access to the registry with minimal necessary scope.
Are you sure you want to proceed? [y/N]: n
Error: update of the secret got aborted
Error: exit status 1
```

```
tanzu imagepullsecret update test-secret
Error: no changes made in the image pull secret, as neither of username, password or export-to-all-namespaces flag options were provided
Error: exit status 1
```

**Does this PR introduce a user-facing change?:**
None

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Adds imagepullsecret update command
```

**New PR Checklist**
- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
