### PR TITLE
Refer to Tech Leads consistently in MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,6 +15,7 @@
 | Tech Lead | Vui Lam [vuil](https://github.com/vuil) |
 | Tech Lead  | Vijay Katam [vijaykatam](https://github.com/vijaykatam) |
 | Tech Lead  | Jeff Moroski [jmoroski](https://github.com/jmoroski) |
+| Tech Lead | Justin Miclette [miclettej](https://github.com/miclettej) |
 | Eng Management | Shyaam Nagarajan [shyaamsn](https://github.com/shyaamsn) |
 | Eng Management | Maggie Cai [Maggiecai-vmw](https://github.com/Maggiecai-vmw) |
 | Product Management | Natalie Fisher [nfisher-tkg](https://github.com/nfisher-tkg) |
@@ -27,7 +28,6 @@
 | Engineering | Jesse Hu [jessehu](https://github.com/jessehu) |
 | Engineering | Rajath Agasthya [rajathagasthya](https://github.com/rajathagasthya) |
 | Engineering | Harish Yayi [yharish991](https://github.com/yharish991) |
-| Engineering Lead | Justin Miclette [miclettej](https://github.com/miclettej) |
 
 ## Emeritus
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The MAINTAINERS.md inconsistently refers to both "Tech Leads" and "Engineering Leads". Let's use a consistent term.

**Which issue(s) this PR fixes**:
N/A

**Describe testing done for PR**:
N/A

**Special notes for your reviewer**:
cc @miclettej

**Release note**:
```release-note
NONE
```

**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
