### PR TITLE
Enable kapp-controller port in workload cluster for calico cni

### DIFF
--- a/pkg/v1/providers/ytt/02_addons/cni/add_cni.yaml
+++ b/pkg/v1/providers/ytt/02_addons/cni/add_cni.yaml
@@ -54,6 +54,8 @@ type: addons.cluster.x-k8s.io/resource-set
 stringData:
   value: #@ yaml.encode(overlay.apply(cni_calico_lib.with_data_values(calicodatavalues()).eval(), updatecalicoimage()))
 
+#@ end
+
 #! Add ingress rules to AWS cluster for Calico ports.
 #! Add ingress rules to AWS cluster for kapp controller API port
 #@overlay/match missing_ok=True,by=overlay.subset({"kind":"AWSCluster"})
@@ -76,7 +78,6 @@ spec:
           fromPort: 10100
           protocol: tcp
           toPort: 10100
-#@ end
 
 ---
 apiVersion: v1


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable kapp-controller port in workload cluster for calico cni.
Enable calico cni ports for bgp and IP-in-IP mode.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #704

**Describe testing done for PR**:
Created aws workload cluster to verify change.

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
