### PR TITLE
Updating version tag used for BOM retrieval to v0.5.0

### DIFF
--- a/pkg/v1/tkg/tkgconfigpaths/zz_bundled_default_bom_files_configdata.go
+++ b/pkg/v1/tkg/tkgconfigpaths/zz_bundled_default_bom_files_configdata.go
@@ -12,5 +12,5 @@ package tkgconfigpaths
 var (
 	TKGDefaultImageRepo               string = "projects-stg.registry.vmware.com/tkg"
 	TKGDefaultCompatibilityImagePath  string = "framework-zshippable/tkg-compatibility"
-	TKGManagementClusterPluginVersion string = "v0.5.0-dev"
+	TKGManagementClusterPluginVersion string = "v0.5.0"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
BOM file now contains v0.5.0 tag in preparation for the release
**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
