### PR TITLE
Add license check for shell scripts and Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,6 +347,8 @@ lint: tools doc-lint ## Run linting checks
 	$(GOLANGCI_LINT) run -v
 	cd $(ADDONS_DIR); $(GOLANGCI_LINT) run -v
 	cd $(ADDONS_DIR)/pinniped/post-deploy/; $(GOLANGCI_LINT) run -v
+	# Check licenses in shell scripts and Makefile
+	hack/check-license.sh
 
 doc-lint: tools ## Run linting checks for docs
 	$(VALE) --config=.vale/config.ini --glob='*.md' ./

--- a/addons/pinniped/post-deploy/Makefile
+++ b/addons/pinniped/post-deploy/Makefile
@@ -1,3 +1,6 @@
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # If you update this file, please follow:
 # https://suva.sh/posts/well-documented-makefiles/
 

--- a/addons/pinniped/post-deploy/hack/scripts/build-images.sh
+++ b/addons/pinniped/post-deploy/hack/scripts/build-images.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/addons/pinniped/post-deploy/hack/scripts/common.sh
+++ b/addons/pinniped/post-deploy/hack/scripts/common.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/check-license.sh
+++ b/hack/check-license.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# TODO(navidshaikh): Add shellcheck and merge
+
+verify_license() {
+  printf "Checking License in shell scripts and Makefiles ...\n"
+  local required_keywords=("VMware, Inc." "SPDX-License-Identifier: Apache-2.0")
+  local file_patterns_to_check=("*.sh" "Makefile")
+
+  local result
+  result=$(mktemp /tmp/tf-licence-check.XXXXXX)
+  for ext in "${file_patterns_to_check[@]}"; do
+    find . -type d \( -path ./vendor -o -name node_modules \) -prune -o -name "$ext" -type f -print0 |
+      while IFS= read -r -d '' path; do
+        for rword in "${required_keywords[@]}"; do
+          if ! grep -q "$rword" "$path"; then
+            echo "   $path" >> "$result"
+          fi
+        done
+      done
+  done
+
+  if [ -s "$result" ]; then
+    echo "No required license header found in:"
+    sort < "$result" | uniq
+    echo "License check failed!"
+    echo "Please add the license in each listed file and verify using './hack/check-license.sh'"
+    rm "$result"
+    return 1
+  else
+    echo "License check passed!"
+    rm "$result"
+    return 0
+  fi
+}
+
+verify_license || exit 1; exit 0

--- a/hack/check-mdlint.sh
+++ b/hack/check-mdlint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 set -o errexit

--- a/hack/clustergen/ci-validate-clustergen.sh
+++ b/hack/clustergen/ci-validate-clustergen.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Usage:
 # ci-validate-clustergen.sh branch_name target-branch-name
-
 
 SCRIPT_DIR="$(cd -P "$(dirname "$0")" && pwd)"
 

--- a/hack/clustergen/cluster-check.sh
+++ b/hack/clustergen/cluster-check.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Usage:
 # clustergen-check.sh base-commit current-commit
 

--- a/hack/clustergen/rebuild-cli.sh
+++ b/hack/clustergen/rebuild-cli.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 # Usage:
 # rebuild-cli.sh [provider-repo-path]
 

--- a/pkg/v1/providers/tests/clustergen/diffcluster/example/demo.sh
+++ b/pkg/v1/providers/tests/clustergen/diffcluster/example/demo.sh
@@ -1,17 +1,7 @@
 #!/usr/bin/env bash
-# Copyright 2020 The TKG Contributors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 # shellcheck disable=SC1091
 . ../helpers.sh
@@ -21,5 +11,3 @@ normalize generated.yaml dst
 
 #vimdiff src dst
 kapp tools diff -c --file2 dst --file src
-
-

--- a/pkg/v1/providers/tests/clustergen/diffcluster/helpers.sh
+++ b/pkg/v1/providers/tests/clustergen/diffcluster/helpers.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" || exit; pwd)"
 
 normalize() {
@@ -14,4 +17,3 @@ ytt -f "${SCRIPT_ROOT}"/normalize.yaml -f "$1" >> /tmp/norm.yaml
 # stand-in string _^_, sort results, output result after replacing stand-in back to newline
 awk '/^---/{if(s){print s}s=$0} !/^---/{s=s"_^_"$0}END{print s}' /tmp/norm.yaml | sort | sed $'s/_\^_/\\\n/g' > "$2"
 }
-

--- a/pkg/v1/providers/tests/clustergen/gen_testcases.sh
+++ b/pkg/v1/providers/tests/clustergen/gen_testcases.sh
@@ -1,19 +1,7 @@
 #!/usr/bin/env bash
-# Copyright 2020 The TKG Contributors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
-# Generates pair-wise combinatorial test cases. http://pairwise.org/
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 # alternate location of the pict (https://github.com/microsoft/pict) binary if not in PATH
 PICT=${PICT:=pict}

--- a/pkg/v1/providers/tests/clustergen/run_tests.sh
+++ b/pkg/v1/providers/tests/clustergen/run_tests.sh
@@ -1,20 +1,7 @@
 #!/usr/bin/env bash
-# Copyright 2020 The TKG Contributors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
-# Runs the cluster configurmation command described in each test case report
-# any discreptancies from the expected output.
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 
 SCRIPT=$(realpath "${BASH_SOURCE[0]}")
 TESTROOT=$(dirname "$SCRIPT")

--- a/pkg/v1/tkg/web/e2e/e2e.sh
+++ b/pkg/v1/tkg/web/e2e/e2e.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 #### Setup environmental variables
 #GLOBAL_ENVS="../../../globals.env";
 #if [[ -f ${GLOBAL_ENVS} ]]
 #then
-    # shellcheck source=/dev/null       
+    # shellcheck source=/dev/null
 #    source ${GLOBAL_ENVS}
 #fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add hack/check-license.sh for verifying licenses
  - Ignores vendor and node_modules dirs
- Wire in 'make lint' target
- Update licenses for misc files

Signed-off-by: Navid Shaikh <navids@vmware.com>

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #626 

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:
Script ignores `pkg/v1/tkg/web/node_modules` dir for license check, there are a lot of shell scripts and Makefiles there
with other licenses.

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
