### PR TITLE
Provision dual-stack bootstrap cluster when TKG_IP_FAMILY is `ipv4,ipv6`

### DIFF
--- a/pkg/v1/tkg/fakes/config/config_ipv4_ipv6.yaml
+++ b/pkg/v1/tkg/fakes/config/config_ipv4_ipv6.yaml
@@ -1,0 +1,20 @@
+providers:
+  - name: cluster-api
+    url: providers/cluster-api/v0.0.0/core-components.yaml
+    type: CoreProvider
+  - name: aws
+    url: providers/infrastructure-aws/v0.5.1/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere
+    url: providers/infrastructure-vsphere/v0.6.2/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere-pacific
+    url: providers/infrastructure-tkg-service-vsphere/v1.0.0/unused.yaml
+    type: InfrastructureProvider
+  - name: kubeadm
+    url: providers/bootstrap-kubeadm/v0.3.2/bootstrap-components.yaml
+    type: BootstrapProvider
+  - name: kubeadm
+    url: providers/control-plane-kubeadm/v0.3.2/control-plane-components.yaml
+    type: ControlPlaneProvider
+TKG_IP_FAMILY: "ipv4,ipv6"

--- a/pkg/v1/tkg/kind/client.go
+++ b/pkg/v1/tkg/kind/client.go
@@ -352,20 +352,30 @@ type criRegistryTLSConfig struct {
 // set the podSubnet and serviceSubnet fields
 // if TKG_IP_FAMILY is set then set the ipFamily field
 func (k *KindClusterProxy) getKindNetworkingConfig() kindv1.Networking {
-	ipFamily, _ := k.getIPFamily()
+	ipFamily, err := k.options.Readerwriter.Get(constants.ConfigVariableIPFamily)
+	if err != nil {
+		// ignore this error as TKG_IP_FAMILY is optional
+		ipFamily = ""
+	}
 	podSubnet, err := k.options.Readerwriter.Get(constants.ConfigVariableClusterCIDR)
 	if err != nil {
-		if ipFamily == constants.IPv6Family {
+		switch ipFamily {
+		case constants.DualStackPrimaryIPv4Family:
+			podSubnet = constants.DefaultDualStackPrimaryIPv4ClusterCIDR
+		case constants.IPv6Family:
 			podSubnet = constants.DefaultIPv6ClusterCIDR
-		} else {
+		default:
 			podSubnet = constants.DefaultIPv4ClusterCIDR
 		}
 	}
 	serviceSubnet, err := k.options.Readerwriter.Get(constants.ConfigVariableServiceCIDR)
 	if err != nil {
-		if ipFamily == constants.IPv6Family {
+		switch ipFamily {
+		case constants.DualStackPrimaryIPv4Family:
+			serviceSubnet = constants.DefaultDualStackPrimaryIPv4ServiceCIDR
+		case constants.IPv6Family:
 			serviceSubnet = constants.DefaultIPv6ServiceCIDR
-		} else {
+		default:
 			serviceSubnet = constants.DefaultIPv4ServiceCIDR
 		}
 	}
@@ -373,24 +383,28 @@ func (k *KindClusterProxy) getKindNetworkingConfig() kindv1.Networking {
 	networkConfig := kindv1.Networking{
 		PodSubnet:     podSubnet,
 		ServiceSubnet: serviceSubnet,
-		IPFamily:      ipFamily,
+		IPFamily:      k.getKindIPFamily(),
 	}
 
 	return networkConfig
 }
 
 // if TKG_IP_FAMILY is set then set the networking field
-func (k *KindClusterProxy) getIPFamily() (kindv1.ClusterIPFamily, error) {
+func (k *KindClusterProxy) getKindIPFamily() kindv1.ClusterIPFamily {
 	ipFamily, err := k.options.Readerwriter.Get(constants.ConfigVariableIPFamily)
 	if err != nil {
 		// ignore this error as TKG_IP_FAMILY is optional
 		ipFamily = ""
 	}
-	normalisedIPFamily := kindv1.ClusterIPFamily(strings.ToLower(ipFamily))
-	switch normalisedIPFamily {
-	case kindv1.IPv4Family, kindv1.IPv6Family, kindv1.DualStackFamily, kindv1.ClusterIPFamily(""):
-		return normalisedIPFamily, nil
+
+	switch strings.ToLower(ipFamily) {
+	case constants.IPv4Family:
+		return kindv1.IPv4Family
+	case constants.IPv6Family:
+		return kindv1.IPv6Family
+	case constants.DualStackPrimaryIPv4Family:
+		return kindv1.DualStackFamily
 	default:
-		return "", fmt.Errorf("TKG_IP_FAMILY should be one of %s, %s, %s, got %s", kindv1.IPv4Family, kindv1.IPv6Family, kindv1.DualStackFamily, normalisedIPFamily)
+		return ""
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows the tanzu cli to automatically provision dual-stack bootstrap clusters when the TKG_IP_FAMILY is `ipv4,ipv6` so a user doesn't have to create their own externally and pass it to the tanzu cli using the `-e` flag.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part of #616

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

Created a cluster with TKG_IP_FAMILY `ipv4,ipv6` with `tanzu management-cluster create`, without creating my own bootstrap cluster, and saw it successfully create a management cluster.

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```

**Note:** Wrote `NONE` for the release note because I think the release note on #617 covers it.

**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
