### PR TITLE
Move Jesse Hu to Emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -26,10 +26,10 @@
 | Engineering | Shivaani Gupta [shivaani0505](https://github.com/shivaani0505) |
 | Engineering | Guanpeng Gao [ggpaue](https://github.com/ggpaue) |
 | Engineering | Lucheng Bao [blc1996](https://github.com/blc1996) |
-| Engineering | Jesse Hu [jessehu](https://github.com/jessehu) |
 | Engineering | Rajath Agasthya [rajathagasthya](https://github.com/rajathagasthya) |
 | Engineering | Harish Yayi [yharish991](https://github.com/yharish991) |
 
 ## Emeritus
 
 * Ian Coffey [iancoffey](https://github.com/iancoffey)
+* Jesse Hu [jessehu](https://github.com/jessehu)


### PR DESCRIPTION
Signed-off-by: Vijay Katam <vkatam@vmware.com>

**What this PR does / why we need it**: Moves Jesse Hu from maintainers to Emeritus

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
