### PR TITLE
remove enhancement labelling process from support process

### DIFF
--- a/docs/community/support-process.md
+++ b/docs/community/support-process.md
@@ -53,10 +53,6 @@ The point person will use the following process for each issue:
   * Label the issue with `kind/feature`.
   * Remove `needs-triage` label and add `triage/accepted` label.
   * Determine the area of the Framework the issue belongs to and add appropriate area label.
-* Enhancement request
-  * Label the issue with `kind/enhancement`.
-  * Remove `needs-triage` label and add `triage/accepted` label.
-  * Determine the area of the Framework the issue belongs to and add appropriate area label.
 * Bug
   * Label the issue with `kind/bug`.
   * Remove `needs-triage` label and add `triage/accepted`.


### PR DESCRIPTION
Signed-off-by: Harish Yayi <yharish991@gmail.com>

**What this PR does / why we need it**:
This PR removes enhancement labelling process from community support process

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
