### PR TITLE
Allow properly-annotated resources to halt cluster deletion

### DIFF
--- a/pkg/v1/tkg/client/workload_cluster.go
+++ b/pkg/v1/tkg/client/workload_cluster.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -105,6 +106,15 @@ func (c *TkgClient) DeleteWorkloadCluster(options DeleteWorkloadClusterOptions) 
 
 	if options.Namespace == "" {
 		options.Namespace = constants.DefaultNamespace
+	}
+
+	resources, err := clusterClient.ListUndeleteableResources()
+	if err != nil {
+		return errors.Wrap(err, "unable to locate undeleteable resources")
+	}
+	if err == nil && len(resources) > 0 {
+		msg := fmt.Sprintf("undeleteable resources found; please delete them: %+v", resources)
+		return errors.Wrap(err, msg)
 	}
 
 	isPacific, err := clusterClient.IsPacificRegionalCluster()

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -2494,7 +2494,7 @@ func NewClusterClientFactory() ClusterClientFactory {
 // Finds and returns resources with an undeleteable annotation on them
 func (c *client) ListUndeleteableResources() ([]string, error) {
 	query := fmt.Sprintf(
-		"{range .items[?(@.metadata.annotations.%s==\"true\")]}{.metadata.name}{\"\n\"}{end}",
+		"{range .items[?(@.metadata.annotations.%s==\"true\")]}{.metadata.name}{\"\\n\"}{end}",
 		strings.ReplaceAll(undeleteableResourcesAnnotation, ".", "\\."))
 	args := []string{"get", "all", fmt.Sprintf("-o=jsonpath='%s'", query)}
 	if c.kubeConfigPath != "" {

--- a/pkg/v1/tkg/fakes/clusterclient.go
+++ b/pkg/v1/tkg/fakes/clusterclient.go
@@ -604,6 +604,18 @@ type ClusterClient struct {
 	listResourcesReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ListUndeleteableResourcesStub        func() ([]string, error)
+	listUndeleteableResourcesMutex       sync.RWMutex
+	listUndeleteableResourcesArgsForCall []struct {
+	}
+	listUndeleteableResourcesReturns struct {
+		result1 []string
+		result2 error
+	}
+	listUndeleteableResourcesReturnsOnCall map[int]struct {
+		result1 []string
+		result2 error
+	}
 	LoadCurrentKubeconfigBytesStub        func() ([]byte, error)
 	loadCurrentKubeconfigBytesMutex       sync.RWMutex
 	loadCurrentKubeconfigBytesArgsForCall []struct {
@@ -3853,6 +3865,62 @@ func (fake *ClusterClient) ListResourcesReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *ClusterClient) ListUndeleteableResources() ([]string, error) {
+	fake.listUndeleteableResourcesMutex.Lock()
+	ret, specificReturn := fake.listUndeleteableResourcesReturnsOnCall[len(fake.listUndeleteableResourcesArgsForCall)]
+	fake.listUndeleteableResourcesArgsForCall = append(fake.listUndeleteableResourcesArgsForCall, struct {
+	}{})
+	stub := fake.ListUndeleteableResourcesStub
+	fakeReturns := fake.listUndeleteableResourcesReturns
+	fake.recordInvocation("ListUndeleteableResources", []interface{}{})
+	fake.listUndeleteableResourcesMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ClusterClient) ListUndeleteableResourcesCallCount() int {
+	fake.listUndeleteableResourcesMutex.RLock()
+	defer fake.listUndeleteableResourcesMutex.RUnlock()
+	return len(fake.listUndeleteableResourcesArgsForCall)
+}
+
+func (fake *ClusterClient) ListUndeleteableResourcesCalls(stub func() ([]string, error)) {
+	fake.listUndeleteableResourcesMutex.Lock()
+	defer fake.listUndeleteableResourcesMutex.Unlock()
+	fake.ListUndeleteableResourcesStub = stub
+}
+
+func (fake *ClusterClient) ListUndeleteableResourcesReturns(result1 []string, result2 error) {
+	fake.listUndeleteableResourcesMutex.Lock()
+	defer fake.listUndeleteableResourcesMutex.Unlock()
+	fake.ListUndeleteableResourcesStub = nil
+	fake.listUndeleteableResourcesReturns = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ClusterClient) ListUndeleteableResourcesReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listUndeleteableResourcesMutex.Lock()
+	defer fake.listUndeleteableResourcesMutex.Unlock()
+	fake.ListUndeleteableResourcesStub = nil
+	if fake.listUndeleteableResourcesReturnsOnCall == nil {
+		fake.listUndeleteableResourcesReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.listUndeleteableResourcesReturnsOnCall[i] = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *ClusterClient) LoadCurrentKubeconfigBytes() ([]byte, error) {
 	fake.loadCurrentKubeconfigBytesMutex.Lock()
 	ret, specificReturn := fake.loadCurrentKubeconfigBytesReturnsOnCall[len(fake.loadCurrentKubeconfigBytesArgsForCall)]
@@ -6153,6 +6221,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.listPacificClusterObjectsMutex.RUnlock()
 	fake.listResourcesMutex.RLock()
 	defer fake.listResourcesMutex.RUnlock()
+	fake.listUndeleteableResourcesMutex.RLock()
+	defer fake.listUndeleteableResourcesMutex.RUnlock()
 	fake.loadCurrentKubeconfigBytesMutex.RLock()
 	defer fake.loadCurrentKubeconfigBytesMutex.RUnlock()
 	fake.mergeAndUseConfigForClusterMutex.RLock()

--- a/pkg/v1/tkg/tkgctl/delete_cluster_test.go
+++ b/pkg/v1/tkg/tkgctl/delete_cluster_test.go
@@ -42,6 +42,15 @@ var _ = Describe("Unit tests for delete cluster", func() {
 		}
 		err = ctl.DeleteCluster(dcOps)
 	})
+	Context("When cluster exists but has undeleteable resources", func() {
+		BeforeEach(func() {
+			msg := "cluster has undeletable resources; please delete them: thing-1, thing-2, thing-3"
+			tkgClient.DeleteWorkloadClusterReturns(errors.New(msg))
+		})
+		It("should not delete the cluster", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
 	Context("When cluster exists and can be deleted successfully", func() {
 		BeforeEach(func() {
 			tkgClient.DeleteWorkloadClusterReturns(nil)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows users to mark resources within workload clusters as "undeleteable". These resources will prevent workload clusters from being deleted.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #751 

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

- Added unit tests for issue
- Verified that annotation is valid by using a local Kind cluster
- Verified that jsonpath query is valid with a local Kind cluster

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [X] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
