### PR TITLE
Fix docker build in capabilities and features packages

### DIFF
--- a/pkg/v1/sdk/capabilities/Dockerfile
+++ b/pkg/v1/sdk/capabilities/Dockerfile
@@ -17,17 +17,13 @@ RUN  go mod download
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 
-
 # Copy the go source
-COPY apis/ apis/
-COPY pkg/v1/sdk/ pkg/v1/sdk/
-COPY cmd/managers/capabilities/main.go main.go
-
+COPY ./ ./
 
 # Build
 ARG LD_FLAGS
 ENV LD_FLAGS="$LD_FLAGS "'-extldflags "-static"'
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "$LD_FLAGS" -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "$LD_FLAGS" -o manager ./cmd/managers/capabilities/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/pkg/v1/sdk/features/Dockerfile
+++ b/pkg/v1/sdk/features/Dockerfile
@@ -17,17 +17,13 @@ RUN  go mod download
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 
-
 # Copy the go source
-COPY apis/ apis/
-COPY pkg/v1/sdk/ pkg/v1/sdk/
-COPY cmd/managers/featuregate/main.go main.go
-
+COPY ./ ./
 
 # Build
 ARG LD_FLAGS
 ENV LD_FLAGS="$LD_FLAGS "'-extldflags "-static"'
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "$LD_FLAGS" -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -ldflags "$LD_FLAGS" -o manager ./cmd/managers/featuregate/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
**What this PR does / why we need it**:

Both these Dockerfiles included specific directories for building
manager binary, but it seems like `pkg/v1/buildinfo` is now required as
it is being passed as a linker flag to all docker builds. This change
just copies all source code for building to prevent future breakages
like this.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #764 

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

```
$ cd pkg/v1/sdk/capabilities
$ make docker-build

$ cd pkg/v1/sdk/features
$ make docker-build
```

Both succeeds.

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
