### PR TITLE
CLI configuration holds edition value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ OCI_REGISTRY ?= projects.registry.vmware.com/tanzu_framework
 
 .DEFAULT_GOAL:=help
 
-LD_FLAGS += -X 'main.BuildEdition=$(BUILD_EDITION)'
 LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.IsOfficialBuild=$(IS_OFFICIAL_BUILD)'
 
 ifneq ($(strip $(TANZU_CORE_BUCKET)),)

--- a/apis/config/v1alpha1/clientconfig.go
+++ b/apis/config/v1alpha1/clientconfig.go
@@ -24,7 +24,13 @@ const (
 const (
 	// FeatureCli allows a feature to be set at the CLI level (globally) rather than for a single plugin
 	FeatureCli string = "cli"
+	// Edition value (in config) affects branding and cluster creation
+	EditionStandard  = "tkg"
+	EditionCommunity = "tce"
 )
+
+// EditionSelector allows selecting edition versions based on config file
+type EditionSelector string
 
 // VersionSelectorLevel allows selecting plugin versions based on semver properties
 type VersionSelectorLevel string
@@ -118,4 +124,22 @@ func (c *ClientConfig) SplitFeaturePath(featurePath string) (string, string, err
 		return "", "", errors.New("unsupported feature config path parameter [" + featuresLiteral + "] (was expecting 'features.<plugin>.<feature>')")
 	}
 	return plugin, flag, nil
+}
+
+// SetEditionSelector indicates the edition of tanzu to be run
+// EditionStandard is the default, EditionCommunity is also available.
+// These values affect branding and cluster creation
+func (c *ClientConfig) SetEditionSelector(edition EditionSelector) {
+	if c.ClientOptions == nil {
+		c.ClientOptions = &ClientOptions{}
+	}
+	if c.ClientOptions.CLI == nil {
+		c.ClientOptions.CLI = &CLIOptions{}
+	}
+	switch edition {
+	case EditionCommunity, EditionStandard:
+		c.ClientOptions.CLI.Edition = edition
+		return
+	}
+	c.ClientOptions.CLI.UnstableVersionSelector = EditionStandard
 }

--- a/apis/config/v1alpha1/clientconfig_types.go
+++ b/apis/config/v1alpha1/clientconfig_types.go
@@ -110,6 +110,8 @@ type CLIOptions struct {
 	DiscoverySources []PluginDiscovery `json:"discoverySources,omitempty" yaml:"discoverySources"`
 	// UnstableVersionSelector determined which version tags are allowed
 	UnstableVersionSelector VersionSelectorLevel `json:"unstableVersionSelector,omitempty" yaml:"unstableVersionSelector"`
+	// Edition
+	Edition string `json:"edition,omitempty" yaml:"edition"`
 }
 
 // PluginDiscovery contains a specific distribution mechanism. Only one of the

--- a/apis/config/v1alpha1/clientconfig_types.go
+++ b/apis/config/v1alpha1/clientconfig_types.go
@@ -111,7 +111,7 @@ type CLIOptions struct {
 	// UnstableVersionSelector determined which version tags are allowed
 	UnstableVersionSelector VersionSelectorLevel `json:"unstableVersionSelector,omitempty" yaml:"unstableVersionSelector"`
 	// Edition
-	Edition string `json:"edition,omitempty" yaml:"edition"`
+	Edition EditionSelector `json:"edition,omitempty" yaml:"edition"`
 }
 
 // PluginDiscovery contains a specific distribution mechanism. Only one of the

--- a/cmd/cli/plugin/cluster/create.go
+++ b/cmd/cli/plugin/cluster/create.go
@@ -147,6 +147,11 @@ func createCluster(clusterName string, server *v1alpha1.Server) error {
 		}
 	}
 
+	edition, err := config.GetEdition()
+	if err != nil {
+		return err
+	}
+
 	ccOptions := tkgctl.CreateClusterOptions{
 		ClusterConfigFile:           cc.clusterConfigFile,
 		TkrVersion:                  tkrVersion,
@@ -165,7 +170,7 @@ func createCluster(clusterName string, server *v1alpha1.Server) error {
 		VsphereControlPlaneEndpoint: cc.vsphereControlPlaneEndpoint,
 		SkipPrompt:                  cc.unattended,
 		Timeout:                     cc.timeout,
-		Edition:                     BuildEdition,
+		Edition:                     edition,
 	}
 
 	return tkgctlClient.CreateCluster(ccOptions)

--- a/cmd/cli/plugin/cluster/main.go
+++ b/cmd/cli/plugin/cluster/main.go
@@ -16,11 +16,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgctl"
 )
 
-var (
-	// BuildEdition is the edition the CLI was built for. This variable will be set during the build.
-	BuildEdition string
-)
-
 var descriptor = cliv1alpha1.PluginDescriptor{
 	Name:        "cluster",
 	Description: "Kubernetes cluster operations",

--- a/cmd/cli/plugin/cluster/upgrade.go
+++ b/cmd/cli/plugin/cluster/upgrade.go
@@ -118,6 +118,11 @@ func upgradeCluster(server *v1alpha1.Server, clusterName string) error {
 		}
 	}
 
+	edition, err := config.GetEdition()
+	if err != nil {
+		return err
+	}
+
 	upgradeClusterOptions := tkgctl.UpgradeClusterOptions{
 		ClusterName:         clusterName,
 		Namespace:           uc.namespace,
@@ -128,7 +133,7 @@ func upgradeCluster(server *v1alpha1.Server, clusterName string) error {
 		OSVersion:           uc.osVersion,
 		OSArch:              uc.osArch,
 		VSphereTemplateName: uc.vSphereTemplateName,
-		Edition:             BuildEdition,
+		Edition:             edition,
 	}
 
 	return tkgctlClient.UpgradeCluster(upgradeClusterOptions)

--- a/cmd/cli/plugin/managementcluster/create.go
+++ b/cmd/cli/plugin/managementcluster/create.go
@@ -105,8 +105,10 @@ func init() {
 
 	// commercial Tanzu editions turn CEIP on by default.
 	// community edition turns it off
+
+	edition, _ := config.GetEdition()
 	defaultCeip := DefaultCEIPSetting
-	if BuildEdition == TCEBuildEditionName {
+	if edition == TCEBuildEditionName {
 		defaultCeip = DefaultCEIPTCESetting
 	}
 	createCmd.Flags().StringVarP(&iro.ceipOptIn, "ceip-participation", "", defaultCeip, "Specify if this management cluster should participate in VMware CEIP. (See [*])")
@@ -153,6 +155,11 @@ func runInit() error {
 		return err
 	}
 
+	edition, err := config.GetEdition()
+	if err != nil {
+		return err
+	}
+
 	options := tkgctl.InitRegionOptions{
 		ClusterConfigFile:           iro.clusterConfigFile,
 		Plan:                        iro.plan,
@@ -178,7 +185,7 @@ func runInit() error {
 		VsphereControlPlaneEndpoint: iro.vsphereControlPlaneEndpoint,
 		SkipPrompt:                  iro.unattended,
 		Timeout:                     iro.timeout,
-		Edition:                     BuildEdition,
+		Edition:                     edition,
 		GenerateOnly:                iro.dryRun,
 	}
 

--- a/cmd/cli/plugin/managementcluster/main.go
+++ b/cmd/cli/plugin/managementcluster/main.go
@@ -13,11 +13,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
 )
 
-var (
-	// BuildEdition is the edition the CLI was built for.
-	BuildEdition string
-)
-
 var descriptor = cliv1alpha1.PluginDescriptor{
 	Name:            "management-cluster",
 	Description:     "Kubernetes management cluster operations",

--- a/cmd/cli/plugin/managementcluster/upgrade.go
+++ b/cmd/cli/plugin/managementcluster/upgrade.go
@@ -80,6 +80,11 @@ func runUpgradeRegion(server *v1alpha1.Server) error {
 		return err
 	}
 
+	edition, err := config.GetEdition()
+	if err != nil {
+		return err
+	}
+
 	options := tkgctl.UpgradeRegionOptions{
 		ClusterName:         server.Name,
 		VSphereTemplateName: ur.vSphereTemplateName,
@@ -88,7 +93,7 @@ func runUpgradeRegion(server *v1alpha1.Server) error {
 		OSName:              ur.osName,
 		OSVersion:           ur.osVersion,
 		OSArch:              ur.osArch,
-		Edition:             BuildEdition,
+		Edition:             edition,
 	}
 
 	err = tkgClient.UpgradeRegion(options)

--- a/pkg/v1/cli/command/core/config_test.go
+++ b/pkg/v1/cli/command/core/config_test.go
@@ -137,12 +137,12 @@ func TestConfigIncorrectConfigLiteral(t *testing.T) {
 func TestConfigEnv(t *testing.T) {
 	cfg := &configv1alpha1.ClientConfig{}
 	value := "baarr"
-	err := setConfiguration(cfg, "env.any-plugin.foo", value)
+	err := setConfiguration(cfg, "env.any-plugin", value)
 	if err != nil {
 		t.Errorf("Unexpected error returned for any-plugin env path argument: %s", err.Error())
 	}
 
-	if cfg.ClientOptions.Env["any-plugin"]["foo"] != value {
+	if cfg.ClientOptions.Env["any-plugin"] != value {
 		t.Error("cfg.ClientOptions.Features[\"any-plugin\"][\"foo\"] was not assigned the value \"" + value + "\"")
 	}
 }

--- a/pkg/v1/cli/command/core/config_test.go
+++ b/pkg/v1/cli/command/core/config_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Test_config_MalformedPathArg validates functionality when an invalid argument is provided.
-func Test_config_MalformedPathArg(t *testing.T) {
+func TestConfigMalformedPathArg(t *testing.T) {
 	err := setConfiguration(nil, "invalid-arg", "")
 	if err == nil {
 		t.Error("Malformed path argument should have resulted in an error")
@@ -25,7 +25,7 @@ func Test_config_MalformedPathArg(t *testing.T) {
 }
 
 // Test_config_InvalidPathArg validates functionality when an invalid argument is provided.
-func Test_config_InvalidPathArg(t *testing.T) {
+func TestConfigInvalidPathArg(t *testing.T) {
 	err := setConfiguration(nil, "shouldbefeatures.plugin.feature", "")
 	if err == nil {
 		t.Error("Invalid path argument should have resulted in an error")
@@ -36,21 +36,38 @@ func Test_config_InvalidPathArg(t *testing.T) {
 	}
 }
 
-// Test_config_UnstableVersions validates functionality when path argument unstable-versions is provided.
-func Test_config_UnstableVersions(t *testing.T) {
+// TestConfigUnstableVersions validates functionality when path argument unstable-versions is provided.
+func TestConfigUnstableVersions(t *testing.T) {
 	cfg := &configv1alpha1.ClientConfig{}
-	err := setConfiguration(cfg, "unstable-versions", "experimental")
+	const path = "unstable-versions"
+	const value = "experimental"
+	err := setConfiguration(cfg, path, value)
 	if err != nil {
-		t.Errorf("Unexpected error returned for unstable-versions path argument: %s", err.Error())
+		t.Errorf("Unexpected error returned for %s path argument: %s", path, err.Error())
 	}
 
-	if cfg.ClientOptions.CLI.UnstableVersionSelector != "experimental" {
+	if cfg.ClientOptions.CLI.UnstableVersionSelector != value {
 		t.Error("Unstable version was not set correctly for valid value")
 	}
 }
 
-// Test_config_InvalidUnstableVersions validates functionality when invalid unstable-versions is provided.
-func Test_config_InvalidUnstableVersions(t *testing.T) {
+// TestConfigUnstableVersions validates functionality when path argument cli.unstable-versions is provided.
+func TestConfigCliUnstableVersions(t *testing.T) {
+	cfg := &configv1alpha1.ClientConfig{}
+	const path = "cli.unstable-versions"
+	const value = "all"
+	err := setConfiguration(cfg, path, value)
+	if err != nil {
+		t.Errorf("Unexpected error returned for %s path argument: %s", path, err.Error())
+	}
+
+	if cfg.ClientOptions.CLI.UnstableVersionSelector != value {
+		t.Error("Unstable version was not set correctly for valid value")
+	}
+}
+
+// TestConfigInvalidUnstableVersions validates functionality when invalid unstable-versions is provided.
+func TestConfigInvalidUnstableVersions(t *testing.T) {
 	cfg := &configv1alpha1.ClientConfig{}
 	err := setConfiguration(cfg, "unstable-versions", "invalid-unstable-versions-value")
 	if err == nil {
@@ -62,8 +79,8 @@ func Test_config_InvalidUnstableVersions(t *testing.T) {
 	}
 }
 
-// Test_config_GlobalFeature validates functionality when global feature path argument is provided.
-func Test_config_GlobalFeature(t *testing.T) {
+// TestConfigGlobalFeature validates functionality when global feature path argument is provided.
+func TestConfigGlobalFeature(t *testing.T) {
 	cfg := &configv1alpha1.ClientConfig{}
 	value := "bar"
 	err := setConfiguration(cfg, "features.global.foo", value)
@@ -76,8 +93,8 @@ func Test_config_GlobalFeature(t *testing.T) {
 	}
 }
 
-// Test_config_Feature validates functionality when normal feature path argument is provided.
-func Test_config_Feature(t *testing.T) {
+// TestConfigFeature validates functionality when normal feature path argument is provided.
+func TestConfigFeature(t *testing.T) {
 	cfg := &configv1alpha1.ClientConfig{}
 	value := "barr"
 	err := setConfiguration(cfg, "features.any-plugin.foo", value)
@@ -90,8 +107,8 @@ func Test_config_Feature(t *testing.T) {
 	}
 }
 
-// Test_config_SetUnsetEnv validates set and unset functionality when env config path argument is provided.
-func Test_config_SetUnsetEnv(t *testing.T) {
+// TestConfigSetUnsetEnv validates set and unset functionality when env config path argument is provided.
+func TestConfigSetUnsetEnv(t *testing.T) {
 	assert := assert.New(t)
 
 	cfg := &configv1alpha1.ClientConfig{}
@@ -105,8 +122,8 @@ func Test_config_SetUnsetEnv(t *testing.T) {
 	assert.Equal(cfg.ClientOptions.Env["foo"], "")
 }
 
-// Test_config_IncorrectConfigLiteral validates incorrect config literal
-func Test_config_IncorrectConfigLiteral(t *testing.T) {
+// TestConfigIncorrectConfigLiteral validates incorrect config literal
+func TestConfigIncorrectConfigLiteral(t *testing.T) {
 	assert := assert.New(t)
 
 	cfg := &configv1alpha1.ClientConfig{}
@@ -114,4 +131,53 @@ func Test_config_IncorrectConfigLiteral(t *testing.T) {
 	err := setConfiguration(cfg, "fake.any-plugin.foo", value)
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "unsupported config path parameter [fake] (was expecting 'features.<plugin>.<feature>' or 'env.<env_variable>')")
+}
+
+// TestConfigEnv validates functionality when normal env path argument is provided.
+func TestConfigEnv(t *testing.T) {
+	cfg := &configv1alpha1.ClientConfig{}
+	value := "baarr"
+	err := setConfiguration(cfg, "env.any-plugin.foo", value)
+	if err != nil {
+		t.Errorf("Unexpected error returned for any-plugin env path argument: %s", err.Error())
+	}
+
+	if cfg.ClientOptions.Env["any-plugin"]["foo"] != value {
+		t.Error("cfg.ClientOptions.Features[\"any-plugin\"][\"foo\"] was not assigned the value \"" + value + "\"")
+	}
+}
+
+func TestConfigEditionCommunity(t *testing.T) {
+	cfg := &configv1alpha1.ClientConfig{}
+	value := configv1alpha1.EditionCommunity
+	err := setConfiguration(cfg, "cli.edition", value)
+	if err != nil {
+		t.Errorf("Unexpected error returned for cli.edition argument: %s", err.Error())
+	}
+
+	if cfg.ClientOptions.CLI.Edition != configv1alpha1.EditionCommunity {
+		t.Error("cfg.ClientOptions.CLI.Edition was not assigned the value \"" + value + "\"")
+	}
+}
+
+func TestConfigEditionStandard(t *testing.T) {
+	cfg := &configv1alpha1.ClientConfig{}
+	value := configv1alpha1.EditionStandard
+	err := setConfiguration(cfg, "cli.edition", value)
+	if err != nil {
+		t.Errorf("Unexpected error returned for cli.edition argument: %s", err.Error())
+	}
+
+	if cfg.ClientOptions.CLI.Edition != configv1alpha1.EditionStandard {
+		t.Error("cfg.ClientOptions.CLI.Edition was not assigned the value \"" + value + "\"")
+	}
+}
+
+func TestConfigEditionInvalid(t *testing.T) {
+	cfg := &configv1alpha1.ClientConfig{}
+	value := "invalidEdition"
+	err := setConfiguration(cfg, "cli.edition", value)
+	if err == nil {
+		t.Errorf("Expected error returned for cli.edition argument: %s", value)
+	}
 }

--- a/pkg/v1/config/clientconfig.go
+++ b/pkg/v1/config/clientconfig.go
@@ -585,3 +585,14 @@ func ConfigureEnvVariables() {
 		}
 	}
 }
+
+func GetEdition() (string, error) {
+	cfg, err := GetClientConfig()
+	if err != nil {
+		return "", err
+	}
+	if cfg != nil && cfg.ClientOptions != nil && cfg.ClientOptions.CLI != nil {
+		return cfg.ClientOptions.CLI.Edition, nil
+	}
+	return "", nil
+}

--- a/pkg/v1/config/clientconfig.go
+++ b/pkg/v1/config/clientconfig.go
@@ -147,6 +147,7 @@ func NewClientConfig() (*configv1alpha1.ClientConfig, error) {
 			CLI: &configv1alpha1.CLIOptions{
 				Repositories:            DefaultRepositories,
 				UnstableVersionSelector: DefaultVersionSelector,
+				Edition:                 DefaultEdition,
 			},
 		},
 	}
@@ -586,6 +587,7 @@ func ConfigureEnvVariables() {
 	}
 }
 
+// GetEdition returns the edition from the local configuration file
 func GetEdition() (string, error) {
 	cfg, err := GetClientConfig()
 	if err != nil {

--- a/pkg/v1/config/clientconfig_test.go
+++ b/pkg/v1/config/clientconfig_test.go
@@ -327,12 +327,12 @@ func TestConfigFeaturesDefaultsAdded(t *testing.T) {
 		},
 	}
 
-	added := addMissingDefaultFeatureFlags(cfg, defaultFeatureFlags)
-	require.True(t, added, "addMissingDefaultFeatureFlags should have added missing default values")
-	require.Equal(t, cfg.ClientOptions.Features["existing"]["truthy"], "false", "addMissingDefaultFeatureFlags should have left existing FALSE value for truthy")
-	require.Equal(t, cfg.ClientOptions.Features["existing"]["falsey"], "true", "addMissingDefaultFeatureFlags should have left existing TRUE value for falsey")
-	require.Equal(t, cfg.ClientOptions.Features["global"]["truthy"], "true", "addMissingDefaultFeatureFlags should have added global TRUE value for truthy")
-	require.Equal(t, cfg.ClientOptions.Features["global"]["falsey"], "false", "addMissingDefaultFeatureFlags should have added global FALSE value for falsey")
+	added := addDefaultFeatureFlagsIfMissing(cfg, defaultFeatureFlags)
+	require.True(t, added, "addDefaultFeatureFlagsIfMissing should have added missing default values")
+	require.Equal(t, cfg.ClientOptions.Features["existing"]["truthy"], "false", "addDefaultFeatureFlagsIfMissing should have left existing FALSE value for truthy")
+	require.Equal(t, cfg.ClientOptions.Features["existing"]["falsey"], "true", "addDefaultFeatureFlagsIfMissing should have left existing TRUE value for falsey")
+	require.Equal(t, cfg.ClientOptions.Features["global"]["truthy"], "true", "addDefaultFeatureFlagsIfMissing should have added global TRUE value for truthy")
+	require.Equal(t, cfg.ClientOptions.Features["global"]["falsey"], "false", "addDefaultFeatureFlagsIfMissing should have added global FALSE value for falsey")
 }
 
 func TestConfigFeaturesDefaultsNoneAdded(t *testing.T) {
@@ -357,10 +357,43 @@ func TestConfigFeaturesDefaultsNoneAdded(t *testing.T) {
 		},
 	}
 
-	added := addMissingDefaultFeatureFlags(cfg, defaultFeatureFlags)
-	require.False(t, added, "addMissingDefaultFeatureFlags should NOT have added any default values")
-	require.Equal(t, cfg.ClientOptions.Features["existing"]["truthy"], "false", "addMissingDefaultFeatureFlags should have left existing FALSE value for truthy")
-	require.Equal(t, cfg.ClientOptions.Features["existing"]["falsey"], "true", "addMissingDefaultFeatureFlags should have left existing TRUE value for falsey")
+	added := addDefaultFeatureFlagsIfMissing(cfg, defaultFeatureFlags)
+	require.False(t, added, "addDefaultFeatureFlagsIfMissing should NOT have added any default values")
+	require.Equal(t, cfg.ClientOptions.Features["existing"]["truthy"], "false", "addDefaultFeatureFlagsIfMissing should have left existing FALSE value for truthy")
+	require.Equal(t, cfg.ClientOptions.Features["existing"]["falsey"], "true", "addDefaultFeatureFlagsIfMissing should have left existing TRUE value for falsey")
+}
+
+func TestConfigFeaturesDefaultEditionAdded(t *testing.T) {
+	cfg := &configv1alpha1.ClientConfig{
+		ClientOptions: &configv1alpha1.ClientOptions{
+			CLI: &configv1alpha1.CLIOptions{
+				Repositories:            DefaultRepositories,
+				UnstableVersionSelector: DefaultVersionSelector,
+			},
+		},
+	}
+
+	added := addDefaultEditionIfMissing(cfg)
+	require.True(t, added, "addDefaultEditionIfMissing should have returned true (having added missing default edition value)")
+	errMsg := "addDefaultEditionIfMissing should have added default edition (" + configv1alpha1.EditionStandard + ") instead of " + cfg.ClientOptions.CLI.Edition
+	require.Equal(t, cfg.ClientOptions.CLI.Edition, configv1alpha1.EditionStandard, errMsg)
+}
+
+func TestConfigFeaturesDefaultEditionNotAdded(t *testing.T) {
+	cfg := &configv1alpha1.ClientConfig{
+		ClientOptions: &configv1alpha1.ClientOptions{
+			CLI: &configv1alpha1.CLIOptions{
+				Repositories:            DefaultRepositories,
+				UnstableVersionSelector: DefaultVersionSelector,
+				Edition:                 "tce",
+			},
+		},
+	}
+
+	added := addDefaultEditionIfMissing(cfg)
+	require.False(t, added, "addDefaultEditionIfMissing should have returned false (without adding default edition value)")
+	errMsg := "addDefaultEditionIfMissing should have left existing edition value intact instead of replacing with [" + cfg.ClientOptions.CLI.Edition + "]"
+	require.Equal(t, cfg.ClientOptions.CLI.Edition, configv1alpha1.EditionCommunity, errMsg)
 }
 
 func TestConfigPopulateDefaultStandaloneDiscovery(t *testing.T) {

--- a/pkg/v1/config/clientconfig_test.go
+++ b/pkg/v1/config/clientconfig_test.go
@@ -376,7 +376,7 @@ func TestConfigFeaturesDefaultEditionAdded(t *testing.T) {
 	added := addDefaultEditionIfMissing(cfg)
 	require.True(t, added, "addDefaultEditionIfMissing should have returned true (having added missing default edition value)")
 	errMsg := "addDefaultEditionIfMissing should have added default edition (" + configv1alpha1.EditionStandard + ") instead of " + cfg.ClientOptions.CLI.Edition
-	require.Equal(t, cfg.ClientOptions.CLI.Edition, configv1alpha1.EditionStandard, errMsg)
+	require.Equal(t, cfg.ClientOptions.CLI.Edition, configv1alpha1.EditionSelector(configv1alpha1.EditionStandard), errMsg)
 }
 
 func TestConfigFeaturesDefaultEditionNotAdded(t *testing.T) {
@@ -393,7 +393,7 @@ func TestConfigFeaturesDefaultEditionNotAdded(t *testing.T) {
 	added := addDefaultEditionIfMissing(cfg)
 	require.False(t, added, "addDefaultEditionIfMissing should have returned false (without adding default edition value)")
 	errMsg := "addDefaultEditionIfMissing should have left existing edition value intact instead of replacing with [" + cfg.ClientOptions.CLI.Edition + "]"
-	require.Equal(t, cfg.ClientOptions.CLI.Edition, configv1alpha1.EditionCommunity, errMsg)
+	require.Equal(t, cfg.ClientOptions.CLI.Edition, configv1alpha1.EditionSelector(configv1alpha1.EditionCommunity), errMsg)
 }
 
 func TestConfigPopulateDefaultStandaloneDiscovery(t *testing.T) {

--- a/pkg/v1/config/defaults.go
+++ b/pkg/v1/config/defaults.go
@@ -33,6 +33,9 @@ var CoreBucketName = "tanzu-cli-framework"
 // DefaultVersionSelector is to only use stable versions of plugins
 const DefaultVersionSelector = configv1alpha1.NoUnstableVersions
 
+// DefaultEdition is the edition assumed when there is no value in the local config file
+const DefaultEdition = "tkg"
+
 // CoreGCPBucketRepository is the default GCP bucket repository.
 var CoreGCPBucketRepository = configv1alpha1.GCPPluginRepository{
 	BucketName: CoreBucketName,

--- a/pkg/v1/tkg/client/cluster.go
+++ b/pkg/v1/tkg/client/cluster.go
@@ -552,7 +552,7 @@ func (c *TkgClient) ConfigureAndValidateWorkloadClusterConfiguration(options *Cr
 	// BUILD_EDITION is the Tanzu Edition, the plugin should be built for. Its value is supposed be constructed from
 	// cmd/cli/plugin/managementcluster/create.go. So empty value at this point is not expected.
 	if options.Edition == "" {
-		return NewValidationError(ValidationErrorCode, "required config variable 'BUILD_EDITION' is not set")
+		return NewValidationError(ValidationErrorCode, "required config variable 'edition' is not set")
 	}
 	c.SetBuildEdition(options.Edition)
 	c.SetTKGClusterRole(options.ClusterType)

--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -542,7 +542,7 @@ func (c *TkgClient) ConfigureAndValidateManagementClusterConfiguration(options *
 	// BUILD_EDITION is the Tanzu Edition, the plugin should be built for. Its value is supposed be constructed from
 	// cmd/cli/plugin/managementcluster/create.go. So empty value at this point is not expected.
 	if options.Edition == "" {
-		return NewValidationError(ValidationErrorCode, "required config variable 'BUILD_EDITION' is not set")
+		return NewValidationError(ValidationErrorCode, "required config variable 'edition' is not set")
 	}
 	c.SetBuildEdition(options.Edition)
 

--- a/pkg/v1/tkg/cmd/config_cluster.go
+++ b/pkg/v1/tkg/cmd/config_cluster.go
@@ -83,7 +83,7 @@ func runGenerateClusterConfig(name string, options *createClusterOptions) error 
 }
 
 func buildCreateClusterOption(name, tkrVersion string, options *createClusterOptions) tkgctl.CreateClusterOptions {
-	cfg, _ := config.GetClientConfig()
+	edition, _ := config.GetEdition()
 	return tkgctl.CreateClusterOptions{
 		ClusterConfigFile:           options.clusterConfigFile,
 		ClusterName:                 name,
@@ -102,6 +102,6 @@ func buildCreateClusterOption(name, tkrVersion string, options *createClusterOpt
 		VsphereControlPlaneEndpoint: options.vsphereControlPlaneEndpoint,
 		SkipPrompt:                  options.unattended || skipPrompt,
 		Timeout:                     options.timeout,
-		Edition:                     cfg.ClientOptions.CLI.Edition,
+		Edition:                     edition,
 	}
 }

--- a/pkg/v1/tkg/cmd/config_cluster.go
+++ b/pkg/v1/tkg/cmd/config_cluster.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgctl"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/utils"
@@ -82,6 +83,7 @@ func runGenerateClusterConfig(name string, options *createClusterOptions) error 
 }
 
 func buildCreateClusterOption(name, tkrVersion string, options *createClusterOptions) tkgctl.CreateClusterOptions {
+	cfg, _ := config.GetClientConfig()
 	return tkgctl.CreateClusterOptions{
 		ClusterConfigFile:           options.clusterConfigFile,
 		ClusterName:                 name,
@@ -100,5 +102,6 @@ func buildCreateClusterOption(name, tkrVersion string, options *createClusterOpt
 		VsphereControlPlaneEndpoint: options.vsphereControlPlaneEndpoint,
 		SkipPrompt:                  options.unattended || skipPrompt,
 		Timeout:                     options.timeout,
+		Edition:                     cfg.ClientOptions.CLI.Edition,
 	}
 }

--- a/pkg/v1/tkg/tkgctl/create_cluster.go
+++ b/pkg/v1/tkg/tkgctl/create_cluster.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	clusterctl "sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
@@ -311,9 +310,9 @@ func (t *tkgctl) configureCreateClusterOptionsFromConfigFile(cc *CreateClusterOp
 
 	// set BuildEdition from config variable
 	if cc.Edition == "" {
-		cfg, err := config.GetClientConfig()
+		edition, err := t.TKGConfigReaderWriter().Get(constants.ConfigVariableBuildEdition)
 		if err == nil {
-			cc.Edition = cfg.ClientOptions.CLI.Edition
+			cc.Edition = edition
 		}
 	}
 

--- a/pkg/v1/tkg/tkgctl/create_cluster.go
+++ b/pkg/v1/tkg/tkgctl/create_cluster.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	clusterctl "sigs.k8s.io/cluster-api/cmd/clusterctl/client"
 
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
@@ -310,9 +311,9 @@ func (t *tkgctl) configureCreateClusterOptionsFromConfigFile(cc *CreateClusterOp
 
 	// set BuildEdition from config variable
 	if cc.Edition == "" {
-		edition, err := t.TKGConfigReaderWriter().Get(constants.ConfigVariableBuildEdition)
+		cfg, err := config.GetClientConfig()
 		if err == nil {
-			cc.Edition = edition
+			cc.Edition = cfg.ClientOptions.CLI.Edition
 		}
 	}
 

--- a/pkg/v1/tkg/tkgctl/init.go
+++ b/pkg/v1/tkg/tkgctl/init.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/skratchdot/open-golang/open"
 
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
@@ -277,9 +276,9 @@ func (t *tkgctl) configureInitManagementClusterOptionsFromConfigFile(iro *InitRe
 
 	// set BuildEdition from config variable
 	if iro.Edition == "" {
-		cfg, err := config.GetClientConfig()
+		edition, err := t.TKGConfigReaderWriter().Get(constants.ConfigVariableBuildEdition)
 		if err == nil {
-			iro.Edition = cfg.ClientOptions.CLI.Edition
+			iro.Edition = edition
 		}
 	}
 

--- a/pkg/v1/tkg/tkgctl/init.go
+++ b/pkg/v1/tkg/tkgctl/init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/skratchdot/open-golang/open"
 
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
@@ -276,9 +277,9 @@ func (t *tkgctl) configureInitManagementClusterOptionsFromConfigFile(iro *InitRe
 
 	// set BuildEdition from config variable
 	if iro.Edition == "" {
-		edition, err := t.TKGConfigReaderWriter().Get(constants.ConfigVariableBuildEdition)
+		cfg, err := config.GetClientConfig()
 		if err == nil {
-			iro.Edition = edition
+			iro.Edition = cfg.ClientOptions.CLI.Edition
 		}
 	}
 

--- a/pkg/v1/tkg/web/server/handlers/features.go
+++ b/pkg/v1/tkg/web/server/handlers/features.go
@@ -6,7 +6,6 @@ package handlers
 import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/pkg/errors"
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"

--- a/pkg/v1/tkg/web/server/handlers/features.go
+++ b/pkg/v1/tkg/web/server/handlers/features.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
-	featuresclient "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/features"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/web/server/models"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/web/server/restapi/operations/edition"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/web/server/restapi/operations/features"

--- a/pkg/v1/tkg/web/server/handlers/features.go
+++ b/pkg/v1/tkg/web/server/handlers/features.go
@@ -6,6 +6,7 @@ package handlers
 import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/pkg/errors"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
@@ -39,15 +40,9 @@ func convertFeatureMap(featureMap v1alpha1.FeatureMap) models.FeatureMap {
 
 // GetTanzuEdition returns the Tanzu edition
 func (app *App) GetTanzuEdition(params edition.GetTanzuEditionParams) middleware.Responder {
-	featuresClient, err := featuresclient.New(app.AppConfig.TKGConfigDir, "")
+	result, err := config.GetEdition()
 	if err != nil {
-		return edition.NewGetTanzuEditionInternalServerError().WithPayload(Err(errors.Wrap(err, "unable to get feature flags client")))
+		return edition.NewGetTanzuEditionInternalServerError().WithPayload(Err(errors.Wrap(err, "unable to get configuration to determine edition")))
 	}
-
-	tanzuEdition, err := featuresClient.GetFeatureFlag("edition")
-	if err != nil {
-		return edition.NewGetTanzuEditionInternalServerError().WithPayload(Err(errors.Wrap(err, "unable to get tanzu edition")))
-	}
-
-	return edition.NewGetTanzuEditionOK().WithPayload(tanzuEdition)
+	return edition.NewGetTanzuEditionOK().WithPayload(result)
 }

--- a/pkg/v1/tkg/web/src/app/shared/components/header-bar/header-bar.component.ts
+++ b/pkg/v1/tkg/web/src/app/shared/components/header-bar/header-bar.component.ts
@@ -5,6 +5,7 @@ import { Router } from '@angular/router';
 import { takeUntil } from "rxjs/operators";
 // App imports
 import { APP_ROUTES } from '../../constants/routes.constants';
+import { AppEdition } from "../../constants/branding.constants";
 import AppServices from "../../service/appServices";
 import { BasicSubscriber } from "../../abstracts/basic-subscriber";
 import { EditionData } from "../../service/branding.service";
@@ -34,7 +35,7 @@ export class HeaderBarComponent extends BasicSubscriber implements OnInit {
             .subscribe((data: TkgEvent) => {
                 const content: EditionData = data.payload;
                 this.edition = content.edition;
-                this.docsUrl = (this.edition === 'tkg') ? 'https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html' :
+                this.docsUrl = (this.edition === AppEdition.TKG) ? 'https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/index.html' :
                     'http://tanzucommunityedition.io/docs';
             });
     }


### PR DESCRIPTION
This PR changes the "edition" (community, standard, advanced) from a build-time parameter value to a run-time configuration value.

**Which issue(s) this PR fixes**:
Fixes #569 

**Describe testing done for PR**:
Deployed the CLI locally and verified that (a) the "tanzu config set edition" command works, (b) the help usage texts are correct, and (c) different values for the edition were pulled from the configuration file and returned from the /edition endpoint

**Special notes for your reviewer**:

**Release note**:
```release-note
The CLI edition can now be set using the command "tanzu config set edition xxx", or manually in the configuration file using "edition: xxx" under the "cli" section. Valid values are "tkg", "tce" and "tce-standalone"
```
**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [X] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
