### PR TITLE
TCE 2159 - CLUSTER_PLAN not set in Docker config by /tkgconfig API

### DIFF
--- a/pkg/v1/tkg/tkgconfigproviders/docker.go
+++ b/pkg/v1/tkg/tkgconfigproviders/docker.go
@@ -34,7 +34,7 @@ func (c *client) NewDockerConfig(params *models.DockerRegionalClusterParams) (*D
 	res := &DockerConfig{
 		ClusterName:            params.ClusterName,
 		InfrastructureProvider: constants.InfrastructureProviderDocker,
-		ClusterPlan:            params.ControlPlaneFlavor,
+		ClusterPlan:            constants.PlanDev,
 		TmcRegistrationURL:     params.TmcRegistrationURL,
 		ClusterCIDR:            params.Networking.ClusterPodCIDR,
 		ServiceCIDR:            params.Networking.ClusterServiceCIDR,

--- a/pkg/v1/tkg/web/src/app/views/landing/docker-wizard/docker-wizard.component.ts
+++ b/pkg/v1/tkg/web/src/app/views/landing/docker-wizard/docker-wizard.component.ts
@@ -47,8 +47,6 @@ export class DockerWizardComponent extends WizardBaseDirective implements OnInit
             }),
             dockerNodeSettingForm: this.formBuilder.group({
             })
-            // identityForm: this.formBuilder.group({
-            // })
         });
     }
 
@@ -62,19 +60,6 @@ export class DockerWizardComponent extends WizardBaseDirective implements OnInit
         } else if (stepName === 'nodeSetting') {
             return 'Optional: Specify the management cluster name'
         }
-
-        // else if (stepName === 'identity') {
-        //     if (this.getFieldValue('identityForm', 'identityType') === 'oidc' &&
-        //         this.getFieldValue('identityForm', 'issuerURL')) {
-        //         return 'OIDC configured: ' + this.getFieldValue('identityForm', 'issuerURL')
-        //     } else if (this.getFieldValue('identityForm', 'identityType') === 'ldap' &&
-        //         this.getFieldValue('identityForm', 'endpointIp')) {
-        //         return 'LDAP configured: ' + this.getFieldValue('identityForm', 'endpointIp') + ':' +
-        //         this.getFieldValue('identityForm', 'endpointPort');
-        //     } else {
-        //         return 'Specify identity management'
-        //     }
-        // }
     }
 
     getPayload() {
@@ -126,49 +111,9 @@ export class DockerWizardComponent extends WizardBaseDirective implements OnInit
             });
         }
 
-        // let ldap_url = '';
-        // if (this.getFieldValue('identityForm', 'endpointIp')) {
-        //     ldap_url = this.getFieldValue('identityForm', 'endpointIp') +
-        //         ':' + this.getFieldValue('identityForm', 'endpointPort');
-        // }
-
         payload.identityManagement = {
-            // 'idm_type': this.getFieldValue('identityForm', 'identityType') || 'none'
             'idm_type': 'none'
         }
-
-        // if (this.getFieldValue('identityForm', 'identityType') === 'oidc') {
-        //     payload.identityManagement = Object.assign({
-        //             'oidc_provider_name': '',
-        //             'oidc_provider_url': this.getFieldValue('identityForm', 'issuerURL'),
-        //             'oidc_client_id': this.getFieldValue('identityForm', 'clientId'),
-        //             'oidc_client_secret': this.getFieldValue('identityForm', 'clientSecret'),
-        //             'oidc_scope': this.getFieldValue('identityForm', 'scopes'),
-        //             'oidc_claim_mappings': {
-        //                 'username': this.getFieldValue('identityForm', 'oidcUsernameClaim'),
-        //                 'groups': this.getFieldValue('identityForm', 'oidcGroupsClaim')
-        //             }
-        //
-        //         }
-        //         , payload.identityManagement);
-        // } else if (this.getFieldValue('identityForm', 'identityType') === 'ldap') {
-        //     payload.identityManagement = Object.assign({
-        //             'ldap_url': ldap_url,
-        //             'ldap_bind_dn': this.getFieldValue('identityForm', 'bindDN'),
-        //             'ldap_bind_password': this.getFieldValue('identityForm', 'bindPW'),
-        //             'ldap_user_search_base_dn': this.getFieldValue('identityForm', 'userSearchBaseDN'),
-        //             'ldap_user_search_filter': this.getFieldValue('identityForm', 'userSearchFilter'),
-        //             'ldap_user_search_username': this.getFieldValue('identityForm', 'userSearchUsername'),
-        //             'ldap_user_search_name_attr': this.getFieldValue('identityForm', 'userSearchUsername'),
-        //             'ldap_group_search_base_dn': this.getFieldValue('identityForm', 'groupSearchBaseDN'),
-        //             'ldap_group_search_filter': this.getFieldValue('identityForm', 'groupSearchFilter'),
-        //             'ldap_group_search_user_attr': this.getFieldValue('identityForm', 'groupSearchUserAttr'),
-        //             'ldap_group_search_group_attr': this.getFieldValue('identityForm', 'groupSearchGroupAttr'),
-        //             'ldap_group_search_name_attr': this.getFieldValue('identityForm', 'groupSearchNameAttr'),
-        //             'ldap_root_ca': this.getFieldValue('identityForm', 'ldapRootCAData')
-        //         }
-        //         , payload.identityManagement);
-        // }
 
         return payload;
     }


### PR DESCRIPTION
Resolves issue where Docker workflow CLUSTER_PLAN was not being set by /tkgconfig API. This API is called from the UI to generate the config when user completes the Docker wizard

Also removed some commented code from the UI which is not likely to be used any time in the near future.

Signed-off-by: Justin Miclette <miclettej@vmware.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes # https://github.com/vmware-tanzu/community-edition/issues/2159

**Describe testing done for PR**:
Built CLI locally, verified that CLUSTER_PLAN is getting set to default of "dev." Deployed a management cluster on Docker by pasting and executing the CLI command equivalent generated in the UI.

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
<img width="878" alt="Screen Shot 2021-10-05 at 4 55 03 PM" src="https://user-images.githubusercontent.com/13439013/136119515-703a7de0-87fe-4ece-a294-ee2daefdbc66.png">
