### PR TITLE
Ignore pinniped dir in license check

### DIFF
--- a/hack/check-license.sh
+++ b/hack/check-license.sh
@@ -17,7 +17,8 @@ verify_license() {
   local result
   result=$(mktemp /tmp/tf-licence-check.XXXXXX)
   for ext in "${file_patterns_to_check[@]}"; do
-    find . -type d \( -path ./vendor -o -name node_modules \) -prune -o -name "$ext" -type f -print0 |
+    # ignore ./vendor dir, ./pinniped dir ( the dir is cloned while building CLI) and node_modules dir
+    find . -type d \( -path ./vendor -o -path ./pinniped -o -name node_modules \) -prune -o -name "$ext" -type f -print0 |
       while IFS= read -r -d '' path; do
         for rword in "${required_keywords[@]}"; do
           if ! grep -q "$rword" "$path"; then


### PR DESCRIPTION
**What this PR does / why we need it**:
pinniped dir is cloned while building the CLI,
ignore the `./pinniped` dir while checking licenses
for shell scripts and Makefile.

Signed-off-by: Navid Shaikh <navids@vmware.com>

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #740 

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
- build cli locally / clone pinniped dir at the root
- run  license check 
```
./hack/check-license.sh
Checking License in shell scripts and Makefiles ...
License check passed!`
```
**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
