### PR TITLE
Disable WebSocket origin check

### DIFF
--- a/pkg/v1/tkg/web/server/ws/ws.go
+++ b/pkg/v1/tkg/web/server/ws/ws.go
@@ -7,9 +7,7 @@ package ws
 import (
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
-	"net/url"
 	"syscall"
 
 	"github.com/gorilla/websocket"
@@ -24,37 +22,12 @@ var (
 	logs          = [][]byte{}
 )
 
-const (
-	localhostIP = "127.0.0.1"
-	localhost   = "localhost"
-)
-
 // InitWebsocketUpgrader initializes the upgrader and configures the
 // CheckOrigin function using the provided host
 func InitWebsocketUpgrader(hostBind string) {
-	isLocal := hostBind == localhostIP || hostBind == localhost
 	upgrader = websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool {
-			// 1. Get the request origin
-			// 2. Verify the origin is in allowed origins
-			// (Allowed origins are 'localhost' '127.0.0.1' and 'user-specified host with --bind flag')
-			originURL, err := url.Parse(r.Header.Get("Origin"))
-			if err != nil {
-				log.ForceWriteToStdErr([]byte(fmt.Sprintf("Error verifying websocket origin url: %s", err.Error())))
-				return false
-			}
-
-			origin, _, err := net.SplitHostPort(originURL.Host)
-			if err != nil {
-				log.ForceWriteToStdErr([]byte(fmt.Sprintf("Error verifying websocket origin: %s", err.Error())))
-				return false
-			}
-
-			// (Allowed origins are 'localhost' '127.0.0.1' and 'user-specified hostname with --bind flag')
-			if (isLocal && (origin == localhostIP || origin == localhost)) || origin == hostBind {
-				return true
-			}
-			return false
+			return true
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR has disabled the "origin" checks prior to setting up the WebSocket connection between Tanzu UI server and the browser, which would make it much easier for users to connect to the Tanzu UI server remotely if the need has ever arisen.

Tanzu CLI was designed and built as a provisioning tool running on one machine (locally) in the first place. But often times, we've found that people run the UI remotely due to their environment constraints. In order to support this use case, we've introduced the "--bind" option, which allows people to bind the Tanzu UI server to an externally accessible IP/host. This change has definitely made use of "remote UI" much easier.

One thing fell short in the empowerment is: when the change was made, some stringent checks were added to check the "origin" of the request prior to WebSocket channel setup based on a simple networking model assumption underneath. This  overlook has caused issues when the networking model no longer holds, for instance the following use case:  

https://github.com/vmware-tanzu/community-edition/issues/2170

After carefully reviewing the implementation details, we've decided to disable the "origin" checks so as to make it much easier to use the UI remotely.

**Which issue(s) this PR fixes**:
Fixes https://github.com/vmware-tanzu/community-edition/issues/2170

**Describe testing done for PR**:
First starting Tanzu UI server on one machine by binding the server to the public IP. 
then access the UI from another machine
Logs are shown as expected in browser (which indicates that the WebSocket connection is working properly).

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
