### PR TITLE
remove triage/accepted from support process flow

### DIFF
--- a/docs/community/support-process.md
+++ b/docs/community/support-process.md
@@ -51,13 +51,15 @@ The point person will use the following process for each issue:
 
 * Feature request
   * Label the issue with `kind/feature`.
-  * Remove `needs-triage` label and add `triage/accepted` label.
-  * Determine the area of the Framework the issue belongs to and add appropriate area label.
+  * Determine the area of the Framework the issue belongs to and add appropriate
+    [area](https://github.com/vmware-tanzu/tanzu-framework/labels?q=area) label.
+  * Remove `needs-triage` label.
 * Bug
   * Label the issue with `kind/bug`.
-  * Remove `needs-triage` label and add `triage/accepted`.
-  * Determine the area of the Framework the issue belongs to and add appropriate area label.
+  * Determine the area of the Framework the issue belongs to and add appropriate
+    [area](https://github.com/vmware-tanzu/tanzu-framework/labels?q=area) label.
   * If the issue is critical urgent, it should be labeled as `severity-1`.
+  * Remove `needs-triage` label.
 * User question/problem that does not fall into one of the previous categories
   * Assign the issue to yourself.
   * When you start investigating/responding, label the issue with `investigating`.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes triage/accepted from support process flow to make the flow simpler

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
