### PR TITLE
Update cluster name validation

### DIFF
--- a/pkg/v1/tkg/client/cluster.go
+++ b/pkg/v1/tkg/client/cluster.go
@@ -63,7 +63,7 @@ var TKGSupportedClusterOptions string
 
 // CreateCluster create workload cluster
 func (c *TkgClient) CreateCluster(options *CreateClusterOptions, waitForCluster bool) error { //nolint:gocyclo,funlen
-	if err := checkClusterNameFormat(options.ClusterName); err != nil {
+	if err := CheckClusterNameFormat(options.ClusterName, options.ProviderRepositorySource.InfrastructureProvider); err != nil {
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 	log.Info("Validating configuration...")

--- a/pkg/v1/tkg/client/validate_test.go
+++ b/pkg/v1/tkg/client/validate_test.go
@@ -871,3 +871,44 @@ var _ = Describe("Validate", func() {
 		})
 	})
 })
+
+var _ = Describe("Cluster Name Validation", func() {
+	var (
+		infrastructureProvider string
+		err                    error
+	)
+	Context("Azure Cluster", func() {
+		BeforeEach(func() {
+			infrastructureProvider = "azure"
+		})
+		When("cluster name starts with lowercase alpha and is less than 45 characters", func() {
+			It("should validate successfully", func() {
+				err = client.CheckClusterNameFormat("azure-test-cluster", infrastructureProvider)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		When("cluster name does not start with lowercase alpha and is more than 44 characters", func() {
+			It("should throw an error", func() {
+				err = client.CheckClusterNameFormat("1-azure-test-cluster-with-a-really-long-name-that-is-excessive", infrastructureProvider)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+	Context("AWS/vSphere Cluster", func() {
+		BeforeEach(func() {
+			infrastructureProvider = "aws"
+		})
+		When("cluster name starts with lowercase alphanumeric and is less than 64 characters", func() {
+			It("should validate successfully", func() {
+				err = client.CheckClusterNameFormat("1aws-test-cluster", infrastructureProvider)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		When("cluster name does not start with lowercase alphanumeric and is more than 63 characters", func() {
+			It("should throw an error", func() {
+				err = client.CheckClusterNameFormat("-aws-test-cluster-with-a-really-long-name-that-is-excessive-and-still-needs-to-be-longer", infrastructureProvider)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})


### PR DESCRIPTION
Updates cluster name validation so that the more restrictive Azure
naming limits are only applied to Azure clusters. Other clusters use
regular k8s dns naming limitations.

**What this PR does / why we need it**:
Validation was added for Azure clusters, which has a stricter naming requirement than other IaaSes. This validation was applied to all IaaSes, which it doesn't need to be.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
