### PR TITLE
addons/pinniped/post-deploy: trigger test with addons

### DIFF
--- a/addons/Makefile
+++ b/addons/Makefile
@@ -42,6 +42,7 @@ help: ## Display this help
 test: fmt vet ## Run Tests
 	$(MAKE) kubebuilder -C ${ROOT_DIR}$(TOOLS_DIR)
 	KUBEBUILDER_ASSETS=${ROOT_DIR}$(KUBEBUILDER_BIN_DIR) go test ./... -coverprofile cover.out -v 2
+	$(MAKE) test -C pinniped/post-deploy
 
 .PHONY: test-verbose
 test-verbose: ## Verbose tests with streaming output for debugging

--- a/addons/pinniped/post-deploy/Makefile
+++ b/addons/pinniped/post-deploy/Makefile
@@ -6,18 +6,22 @@
 
 .DEFAULT_GOAL:=help
 
-export GOPROXY ?= https://build-artifactory.eng.vmware.com/gocenter.io/
-export GOSUMDB ?= off
-
 GIT_VERSION ?= $(shell git describe --always --tags)
 GIT_REF_LONG = $(shell git rev-parse --verify HEAD)
 # Release version
 VERSION ?= $(GIT_VERSION)
 
+.PHONY: test
+test: fmt vet ## Run tests
+	go test ./... -coverprofile cover.out -v 2
+
 .PHONY: fmt
 fmt: ## Format the code base
-	gofmt -w ./pkg ./main.go
-	goimports -w ./pkg ./main.go
+	go fmt ./...
+
+.PHONY: vet
+vet: ## Vet codebase
+	go vet ./...
 
 native: ## Build binary
 	CGO_ENABLED=0 go build -o tkg-pinniped-post-deploy -ldflags="-s -w -X $(GOTARGET)/pkg/buildinfo.Version=$(GIT_VERSION) -X github.com/vmware-tanzu/tanzu-framework/addons/pinniped/post-deploy/pkg/buildinfo.GitSHA=$(GIT_REF_LONG)" github.com/vmware-tanzu/tanzu-framework/addons/pinniped/post-deploy


### PR DESCRIPTION
**What this PR does / why we need it**:

* Context: we (area/iam) are in the process of updating the Pinniped package and related components to support Pinniped being run in a non-default API group so that the Tanzu version of Pinniped running on the cluster will not conflict with any other version of Pinniped
* This PR should trigger the post-deploy job tests to run whenever the rest of the addons tests are run

**Which issue(s) this PR fixes**:

None

**Describe testing done for PR**:

`make test` from the root of the repo passes.

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [X] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
