### PR TITLE
Provision dual-stack bootstrap cluster when TKG_IP_FAMILY is `ipv4,ipv6`

### DIFF
--- a/pkg/v1/providers/infrastructure-vsphere/v0.7.10/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v0.7.10/ytt/overlay.yaml
@@ -88,13 +88,11 @@ spec:
     name: #@ "{}-control-plane".format(data.values.CLUSTER_NAME)
   clusterNetwork:
     pods:
-      cidrBlocks:
-      #@overlay/match by=overlay.index(0)
-      - #@ data.values.CLUSTER_CIDR
+      #@overlay/replace
+      cidrBlocks: #@ data.values.CLUSTER_CIDR.split(",")
     services:
-      cidrBlocks:
-      #@overlay/match by=overlay.index(0)
-      - #@ data.values.SERVICE_CIDR
+      #@overlay/replace
+      cidrBlocks: #@ data.values.SERVICE_CIDR.split(",")
 
 #@overlay/match by=overlay.subset({"kind":"VSphereCluster"})
 ---

--- a/pkg/v1/providers/tests/unit/ip_family_test.go
+++ b/pkg/v1/providers/tests/unit/ip_family_test.go
@@ -206,97 +206,182 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 			}
 		})
 
-		It("renders control plane and worker VSphereMachineTemplates with ipv4 single stack settings", func() {
-			values := createDataValues(map[string]string{
-				"CLUSTER_NAME":     "foo",
-				"TKG_CLUSTER_ROLE": "workload",
-				"TKG_IP_FAMILY":    "ipv4",
-			})
-			output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
-			Expect(err).NotTo(HaveOccurred())
+		Describe("cluster cidr blocks", func() {
+			var values string
+			When("cluster cidr and service cidr have multiple values", func() {
+				BeforeEach(func() {
+					values = createDataValues(map[string]string{
+						"CLUSTER_NAME":     "foo",
+						"TKG_CLUSTER_ROLE": "workload",
+						"TKG_IP_FAMILY":    "ipv4,ipv6",
+						"CLUSTER_CIDR":     "100.96.0.0/11,fd00:100:96::/48",
+						"SERVICE_CIDR":     "100.64.0.0/18,fd00:100:64::/108",
+					})
+				})
 
-			vsphereMachineTemplateDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
-				"$.kind": "VSphereMachineTemplate",
-			})
+				It("renders the cluster with the pod and service cidrs with dual stack settings", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
 
-			Expect(err).NotTo(HaveOccurred())
-			Expect(vsphereMachineTemplateDocs).To(HaveLen(2))
-			for _, machineDoc := range vsphereMachineTemplateDocs {
-				Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].dhcp4", "true"))
-				Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].networkName", "VM Network"))
-				Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[0].dhcp6"))
-				Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[1]"))
-			}
+					clusterDoc, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "Cluster",
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(clusterDoc).To(HaveLen(1))
+					Expect(clusterDoc[0]).To(HaveYAMLPathWithValue("$.spec.clusterNetwork.pods.cidrBlocks[0]", "100.96.0.0/11"))
+					Expect(clusterDoc[0]).To(HaveYAMLPathWithValue("$.spec.clusterNetwork.pods.cidrBlocks[1]", "fd00:100:96::/48"))
+					Expect(clusterDoc[0]).To(HaveYAMLPathWithValue("$.spec.clusterNetwork.services.cidrBlocks[0]", "100.64.0.0/18"))
+					Expect(clusterDoc[0]).To(HaveYAMLPathWithValue("$.spec.clusterNetwork.services.cidrBlocks[1]", "fd00:100:64::/108"))
+				})
+			})
+			When("cluster cidr and service cidr have a single value", func() {
+				BeforeEach(func() {
+					values = createDataValues(map[string]string{
+						"CLUSTER_NAME":     "foo",
+						"TKG_CLUSTER_ROLE": "workload",
+						"TKG_IP_FAMILY":    "ipv4",
+						"CLUSTER_CIDR":     "100.96.0.0/11",
+						"SERVICE_CIDR":     "100.64.0.0/18",
+					})
+				})
+
+				It("renders the cluster with the pod and service cidrs with single stack settings", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					clusterDoc, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "Cluster",
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(clusterDoc).To(HaveLen(1))
+					Expect(clusterDoc[0]).To(HaveYAMLPathWithValue("$.spec.clusterNetwork.pods.cidrBlocks[0]", "100.96.0.0/11"))
+					Expect(clusterDoc[0]).NotTo(HaveYAMLPath("$.spec.clusterNetwork.pods.cidrBlocks[1]"))
+					Expect(clusterDoc[0]).To(HaveYAMLPathWithValue("$.spec.clusterNetwork.services.cidrBlocks[0]", "100.64.0.0/18"))
+					Expect(clusterDoc[0]).NotTo(HaveYAMLPath("$.spec.clusterNetwork.services.cidrBlocks[1]"))
+				})
+			})
 		})
 
-		It("renders control plane and worker VSphereMachineTemplates with ipv6 single stack settings", func() {
-			values := createDataValues(map[string]string{
-				"CLUSTER_NAME":     "foo",
-				"TKG_CLUSTER_ROLE": "workload",
-				"TKG_IP_FAMILY":    "ipv6",
-			})
-			output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
-			Expect(err).NotTo(HaveOccurred())
+		Describe("vsphere machine templates", func() {
+			var values string
+			When("data values are set to single stack IPv4 settings", func() {
+				BeforeEach(func() {
+					values = createDataValues(map[string]string{
+						"CLUSTER_NAME":     "foo",
+						"TKG_CLUSTER_ROLE": "workload",
+						"TKG_IP_FAMILY":    "ipv4",
+						"CLUSTER_CIDR":     "100.96.0.0/11",
+						"SERVICE_CIDR":     "100.64.0.0/18",
+					})
+				})
+				It("renders control plane and worker templates each with an ipv4 single stack network device", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
 
-			vsphereMachineTemplateDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
-				"$.kind": "VSphereMachineTemplate",
+					vsphereMachineTemplateDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "VSphereMachineTemplate",
+					})
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(vsphereMachineTemplateDocs).To(HaveLen(2))
+					for _, machineDoc := range vsphereMachineTemplateDocs {
+						Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].dhcp4", "true"))
+						Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].networkName", "VM Network"))
+						Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[0].dhcp6"))
+						Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[1]"))
+					}
+				})
+
 			})
 
-			Expect(err).NotTo(HaveOccurred())
-			Expect(vsphereMachineTemplateDocs).To(HaveLen(2))
-			for _, machineDoc := range vsphereMachineTemplateDocs {
-				Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].dhcp6", "true"))
-				Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].networkName", "VM Network"))
-				Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[0].dhcp4"))
-				Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[1]"))
-			}
+			When("data values are set to single stack IPv6 settings", func() {
+				BeforeEach(func() {
+					values = createDataValues(map[string]string{
+						"CLUSTER_NAME":     "foo",
+						"TKG_CLUSTER_ROLE": "workload",
+						"TKG_IP_FAMILY":    "ipv6",
+						"CLUSTER_CIDR":     "fd00:100:96::/48",
+						"SERVICE_CIDR":     "fd00:100:64::/108",
+					})
+				})
+				It("renders control plane and worker templates each with an ipv6 single stack network device", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					vsphereMachineTemplateDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "VSphereMachineTemplate",
+					})
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(vsphereMachineTemplateDocs).To(HaveLen(2))
+					for _, machineDoc := range vsphereMachineTemplateDocs {
+						Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].dhcp6", "true"))
+						Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].networkName", "VM Network"))
+						Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[0].dhcp4"))
+						Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[1]"))
+					}
+				})
+			})
+
+			When("data values are set to ipv4,ipv6 dual stack settings", func() {
+				BeforeEach(func() {
+					values = createDataValues(map[string]string{
+						"CLUSTER_NAME":     "foo",
+						"TKG_CLUSTER_ROLE": "workload",
+						"TKG_IP_FAMILY":    "ipv4,ipv6",
+						"CLUSTER_CIDR":     "100.96.0.0/11,fd00:100:96::/48",
+						"SERVICE_CIDR":     "100.64.0.0/18,fd00:100:64::/108",
+					})
+				})
+				It("renders control plane and worker templates each with a dual stack network device", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					vsphereMachineTemplateDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "VSphereMachineTemplate",
+					})
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(vsphereMachineTemplateDocs).To(HaveLen(2))
+					for _, machineDoc := range vsphereMachineTemplateDocs {
+						Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].dhcp4", "true"))
+						Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].dhcp6", "true"))
+						Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].networkName", "VM Network"))
+						Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[1]"))
+					}
+				})
+			})
+
+			When("data values are set to ipv6,ipv4 dual stack settings", func() {
+				BeforeEach(func() {
+					values = createDataValues(map[string]string{
+						"CLUSTER_NAME":     "foo",
+						"TKG_CLUSTER_ROLE": "workload",
+						"TKG_IP_FAMILY":    "ipv6,ipv4",
+						"CLUSTER_CIDR":     "fd00:100:96::/48,100.96.0.0/11",
+						"SERVICE_CIDR":     "fd00:100:64::/108,100.64.0.0/18",
+					})
+				})
+				It("renders a control plane and worker template each with a dual stack network device", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					vsphereMachineTemplateDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "VSphereMachineTemplate",
+					})
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(vsphereMachineTemplateDocs).To(HaveLen(2))
+					for _, machineDoc := range vsphereMachineTemplateDocs {
+						Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].dhcp4", "true"))
+						Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].dhcp6", "true"))
+						Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].networkName", "VM Network"))
+						Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[1]"))
+					}
+				})
+			})
 		})
 
-		It("renders control plane and worker VSphereMachineTemplates with ipv4,ipv6 dual stack settings", func() {
-			values := createDataValues(map[string]string{
-				"CLUSTER_NAME":     "foo",
-				"TKG_CLUSTER_ROLE": "workload",
-				"TKG_IP_FAMILY":    "ipv4,ipv6",
-			})
-			output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
-			Expect(err).NotTo(HaveOccurred())
-
-			vsphereMachineTemplateDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
-				"$.kind": "VSphereMachineTemplate",
-			})
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(vsphereMachineTemplateDocs).To(HaveLen(2))
-			for _, machineDoc := range vsphereMachineTemplateDocs {
-				Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].dhcp4", "true"))
-				Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].dhcp6", "true"))
-				Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].networkName", "VM Network"))
-				Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[1]"))
-			}
-		})
-
-		It("renders control plane and worker VSphereMachineTemplates with ipv6,ipv4 dual stack settings", func() {
-			values := createDataValues(map[string]string{
-				"CLUSTER_NAME":     "foo",
-				"TKG_CLUSTER_ROLE": "workload",
-				"TKG_IP_FAMILY":    "ipv6,ipv4",
-			})
-			output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
-			Expect(err).NotTo(HaveOccurred())
-
-			vsphereMachineTemplateDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
-				"$.kind": "VSphereMachineTemplate",
-			})
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(vsphereMachineTemplateDocs).To(HaveLen(2))
-			for _, machineDoc := range vsphereMachineTemplateDocs {
-				Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].dhcp4", "true"))
-				Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].dhcp6", "true"))
-				Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].networkName", "VM Network"))
-				Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[1]"))
-			}
-		})
 	})
 
 	Describe("vsphere cpi", func() {

--- a/pkg/v1/tkg/client/upgrade_addon.go
+++ b/pkg/v1/tkg/client/upgrade_addon.go
@@ -6,6 +6,7 @@ package client
 import (
 	"encoding/base64"
 	"fmt"
+	"net"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -378,6 +379,16 @@ func (c *TkgClient) setNetworkingConfiguration(regionalClusterClient clusterclie
 			c.TKGConfigReaderWriter().Set(constants.ConfigVariableIPFamily, constants.IPv4Family)
 		case IPv6IPFamily:
 			c.TKGConfigReaderWriter().Set(constants.ConfigVariableIPFamily, constants.IPv6Family)
+		case DualStackIPFamily:
+			ip, _, err := net.ParseCIDR(cluster.Spec.ClusterNetwork.Services.CIDRBlocks[0])
+			if err != nil {
+				return fmt.Errorf("unable to detect valid IPFamily, could not parse CIDR: %s", err.Error())
+			}
+			if ip.To4() == nil {
+				c.TKGConfigReaderWriter().Set(constants.ConfigVariableIPFamily, constants.DualStackPrimaryIPv6Family)
+			} else {
+				c.TKGConfigReaderWriter().Set(constants.ConfigVariableIPFamily, constants.DualStackPrimaryIPv4Family)
+			}
 		default:
 			return fmt.Errorf("unable to detect valid IPFamily, found %s", ipFamily)
 		}

--- a/pkg/v1/tkg/fakes/config/config_ipv4_ipv6.yaml
+++ b/pkg/v1/tkg/fakes/config/config_ipv4_ipv6.yaml
@@ -1,0 +1,20 @@
+providers:
+  - name: cluster-api
+    url: providers/cluster-api/v0.0.0/core-components.yaml
+    type: CoreProvider
+  - name: aws
+    url: providers/infrastructure-aws/v0.5.1/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere
+    url: providers/infrastructure-vsphere/v0.6.2/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere-pacific
+    url: providers/infrastructure-tkg-service-vsphere/v1.0.0/unused.yaml
+    type: InfrastructureProvider
+  - name: kubeadm
+    url: providers/bootstrap-kubeadm/v0.3.2/bootstrap-components.yaml
+    type: BootstrapProvider
+  - name: kubeadm
+    url: providers/control-plane-kubeadm/v0.3.2/control-plane-components.yaml
+    type: ControlPlaneProvider
+TKG_IP_FAMILY: "ipv4,ipv6"

--- a/pkg/v1/tkg/kind/client.go
+++ b/pkg/v1/tkg/kind/client.go
@@ -352,20 +352,30 @@ type criRegistryTLSConfig struct {
 // set the podSubnet and serviceSubnet fields
 // if TKG_IP_FAMILY is set then set the ipFamily field
 func (k *KindClusterProxy) getKindNetworkingConfig() kindv1.Networking {
-	ipFamily, _ := k.getIPFamily()
+	ipFamily, err := k.options.Readerwriter.Get(constants.ConfigVariableIPFamily)
+	if err != nil {
+		// ignore this error as TKG_IP_FAMILY is optional
+		ipFamily = ""
+	}
 	podSubnet, err := k.options.Readerwriter.Get(constants.ConfigVariableClusterCIDR)
 	if err != nil {
-		if ipFamily == constants.IPv6Family {
+		switch ipFamily {
+		case constants.DualStackPrimaryIPv4Family:
+			podSubnet = constants.DefaultDualStackPrimaryIPv4ClusterCIDR
+		case constants.IPv6Family:
 			podSubnet = constants.DefaultIPv6ClusterCIDR
-		} else {
+		default:
 			podSubnet = constants.DefaultIPv4ClusterCIDR
 		}
 	}
 	serviceSubnet, err := k.options.Readerwriter.Get(constants.ConfigVariableServiceCIDR)
 	if err != nil {
-		if ipFamily == constants.IPv6Family {
+		switch ipFamily {
+		case constants.DualStackPrimaryIPv4Family:
+			serviceSubnet = constants.DefaultDualStackPrimaryIPv4ServiceCIDR
+		case constants.IPv6Family:
 			serviceSubnet = constants.DefaultIPv6ServiceCIDR
-		} else {
+		default:
 			serviceSubnet = constants.DefaultIPv4ServiceCIDR
 		}
 	}
@@ -373,24 +383,28 @@ func (k *KindClusterProxy) getKindNetworkingConfig() kindv1.Networking {
 	networkConfig := kindv1.Networking{
 		PodSubnet:     podSubnet,
 		ServiceSubnet: serviceSubnet,
-		IPFamily:      ipFamily,
+		IPFamily:      k.getKindIPFamily(),
 	}
 
 	return networkConfig
 }
 
 // if TKG_IP_FAMILY is set then set the networking field
-func (k *KindClusterProxy) getIPFamily() (kindv1.ClusterIPFamily, error) {
+func (k *KindClusterProxy) getKindIPFamily() kindv1.ClusterIPFamily {
 	ipFamily, err := k.options.Readerwriter.Get(constants.ConfigVariableIPFamily)
 	if err != nil {
 		// ignore this error as TKG_IP_FAMILY is optional
 		ipFamily = ""
 	}
-	normalisedIPFamily := kindv1.ClusterIPFamily(strings.ToLower(ipFamily))
-	switch normalisedIPFamily {
-	case kindv1.IPv4Family, kindv1.IPv6Family, kindv1.DualStackFamily, kindv1.ClusterIPFamily(""):
-		return normalisedIPFamily, nil
+
+	switch strings.ToLower(ipFamily) {
+	case constants.IPv4Family:
+		return kindv1.IPv4Family
+	case constants.IPv6Family:
+		return kindv1.IPv6Family
+	case constants.DualStackPrimaryIPv4Family:
+		return kindv1.DualStackFamily
 	default:
-		return "", fmt.Errorf("TKG_IP_FAMILY should be one of %s, %s, %s, got %s", kindv1.IPv4Family, kindv1.IPv6Family, kindv1.DualStackFamily, normalisedIPFamily)
+		return ""
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows the tanzu cli to automatically provision dual-stack bootstrap clusters when the TKG_IP_FAMILY is ipv4,ipv6 so a user doesn't have to create their own externally and pass it to the tanzu cli using the -e flag. This also enables a user to delete a management cluster without creating a bootstrap cluster as well.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Part of #616 

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->

Created a cluster with TKG_IP_FAMILY `ipv4,ipv6` with `tanzu management-cluster create`, without creating my own bootstrap cluster, and saw it successfully create a management cluster.

Note: This does require the kind version to be 0.11.1 in the BOM. Currently this is not the case and will be required for this to work. I believe there is some parallel work happening to make this true.

I also deleted the same cluster with `tanzu management-cluster delete`, without creating my own bootstrap cluster, and saw it successfully delete the management cluster.

**Special notes for your reviewer**:

This replaces an earlier closed PR: #729

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Bootstrap clusters will be dual-stack when deploying a dual-stack management-cluster.
```

**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
