### PR TITLE
Package repository URL should be able to use sha256 digest

### DIFF
--- a/pkg/v1/tkg/tkgpackageclient/image_utils.go
+++ b/pkg/v1/tkg/tkgpackageclient/image_utils.go
@@ -17,13 +17,13 @@ import (
 
 // parseRegistryImageURL parses the registry image URL to get repository and tag, tag is empty if not specified
 func parseRegistryImageURL(imgURL string) (repository, tag string, err error) {
-	ref, err := name.NewTag(imgURL)
+	ref, err := name.ParseReference(imgURL, name.WeakValidation)
 	if err != nil {
 		return "", "", err
 	}
 
 	repository = ref.Context().String()
-	tag = ref.TagStr()
+	tag = ref.Identifier()
 	// the parser function sets the tag to "latest" if not specified, however we want it to be empty
 	if tag == tkgpackagedatamodel.DefaultRepositoryImageTag && !strings.HasSuffix(imgURL, ":"+tkgpackagedatamodel.DefaultRepositoryImageTag) {
 		tag = ""

--- a/pkg/v1/tkg/tkgpackageclient/image_utils_test.go
+++ b/pkg/v1/tkg/tkgpackageclient/image_utils_test.go
@@ -53,6 +53,20 @@ var _ = Describe("Test image utils", func() {
 			Expect(repository).To(Equal("localhost.localdomain:5000/foo/bar"))
 			Expect(tag).To(Equal(""))
 		})
+
+		It("should give the digest when sha256 is specified", func() {
+			// case 1
+			repository, tag, err := parseRegistryImageURL("us-east4-docker.pkg.dev/cf-sandbox-dkalinin/test-areg-private/example-pkg-repo@sha256:a80e9b512b9eff76ab638cce50a3c4541a12673d9b698103314f32c93f1deb61")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(repository).To(Equal("us-east4-docker.pkg.dev/cf-sandbox-dkalinin/test-areg-private/example-pkg-repo"))
+			Expect(tag).To(Equal("sha256:a80e9b512b9eff76ab638cce50a3c4541a12673d9b698103314f32c93f1deb61"))
+
+			// case 2
+			repository, tag, err = parseRegistryImageURL("projects-stg.registry.vmware.com/tkg/packages/standard/repo@sha256:dce0b8e03a2a2f8b7ddb732def271f50435b490875c9e90ce3df51cae8af68e5")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(repository).To(Equal("projects-stg.registry.vmware.com/tkg/packages/standard/repo"))
+			Expect(tag).To(Equal("sha256:dce0b8e03a2a2f8b7ddb732def271f50435b490875c9e90ce3df51cae8af68e5"))
+		})
 	})
 
 	Context("get current repository and tag", func() {


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

**What this PR does / why we need it**:
We should be able to successfully add repository which has digest without giving error

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #828 

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
Manually rerun the steps listed in #828 and had no issue adding repos with sha256 digest.
Added some unit tests for sha256 digest urls.

**Special notes for your reviewer**:
`tanzu package list/get` command will show both tag and digest now. If it's digest, it will start with `sha256`

```
$ tanzu package repository list -A
- Retrieving repositories...
  NAME            REPOSITORY                                                                      TAG                                                                      STATUS                   DETAILS                  NAMESPACE
  tanzu-standard  projects-stg.registry.vmware.com/tkg/packages/standard/repo                     (>0.0.0)                                                                 Reconcile succeeded                               tanzu-package-repo-global
  test-repo1      projects-stg.registry.vmware.com/tkg/packages/standard/repo                     (>0.0.0)                                                                 Reconcile succeeded                               tanzu-test
  private-repo    us-east4-docker.pkg.dev/cf-sandbox-dkalinin/test-areg-private/example-pkg-repo  sha256:a80e9b512b9eff76ab638cce50a3c4541a12673d9b698103314f32c93f1deb61  Reconcile failed: Fe...  vendir: Error: Synci...  test-ns
  tanzu-core      projects-stg.registry.vmware.com/tkg/packages/core/repo                         v1.21.2_vmware.1-tkg.2-framework-v0.3.0                                  Reconcile succeeded                               tkg-system
```

```
 tanzu package repository get private-repo -n test-ns
- Retrieving repository private-repo...
NAME:          private-repo
VERSION:       12899649
REPOSITORY:    us-east4-docker.pkg.dev/cf-sandbox-dkalinin/test-areg-private/example-pkg-repo
TAG:           sha256:a80e9b512b9eff76ab638cce50a3c4541a12673d9b698103314f32c93f1deb61
STATUS:        Reconcile failed: Fetching resources: Error (see .status.usefulErrorMessage for details)
REASON:        vendir: Error: Syncing directory '0':
  Syncing directory '.' with imgpkgBundle contents:
    Imgpkg: exit status 1 (stderr: imgpkg: Error: Checking if image is bundle:
  Fetching image:
    GET https://us-east4-docker.pkg.dev/v2/token?scope=repository%3Acf-sandbox-dkalinin%2Ftest-areg-private%2Fexample-pkg-repo%3Apull&service=us-east4-docker.pkg.dev:
      DENIED:
        Permission "artifactregistry.repositories.downloadArtifacts" denied on resource "projects/cf-sandbox-dkalinin/locations/us-east4/repositories/test-areg-private" (or it may not exist)
)
```

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
