### PR TITLE
Add changes for adding secret for secretgen controller to be deployed by addons manager

### DIFF
--- a/pkg/v1/providers/config_default.yaml
+++ b/pkg/v1/providers/config_default.yaml
@@ -473,6 +473,11 @@ DOCKER_MACHINE_TEMPLATE_IMAGE:
 #! If "none" is specified, pinniped services will not be deployed on the cluster
 IDENTITY_MANAGEMENT_TYPE: "none"
 
+#! ---------------------------------------------------------------------
+#! SecretGen Controller configuration
+#! ---------------------------------------------------------------------
+SECRETGEN_CONTROLLER_ENABLE: true
+
 #! Settings for Pinniped OIDC
 CERT_DURATION: 2160h
 CERT_RENEW_BEFORE: 360h

--- a/pkg/v1/providers/ytt/02_addons/secretgen-controller/add_secretgen-controller.yaml
+++ b/pkg/v1/providers/ytt/02_addons/secretgen-controller/add_secretgen-controller.yaml
@@ -1,0 +1,24 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:template", "template")
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("/lib/helpers.star", "ValuesFormatStr")
+
+#@ if data.values.PROVIDER_TYPE != "tkg-service-vsphere" and data.values.SECRETGEN_CONTROLLER_ENABLE:
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #@ "{}-secretgen-controller-addon".format(data.values.CLUSTER_NAME)
+  namespace: #@ data.values.NAMESPACE
+  labels:
+    tkg.tanzu.vmware.com/addon-name: "secretgen-controller"
+    tkg.tanzu.vmware.com/cluster-name: #@ data.values.CLUSTER_NAME
+    clusterctl.cluster.x-k8s.io/move: ""
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: "addons-management/secretgen-controller"
+type: tkg.tanzu.vmware.com/addon
+stringData:
+  values.yaml: #@ ValuesFormatStr.format(yaml.encode(""))
+
+#@ end

--- a/pkg/v1/providers/ytt/02_addons/secretgen-controller/add_secretgen-controller.yaml
+++ b/pkg/v1/providers/ytt/02_addons/secretgen-controller/add_secretgen-controller.yaml
@@ -3,9 +3,10 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:yaml", "yaml")
 #@ load("/lib/helpers.star", "ValuesFormatStr")
+#@ load("secretgen-controller_addon_data.lib.yaml", "secretgencontrollerdatavalues")
 
 #@ if data.values.PROVIDER_TYPE != "tkg-service-vsphere" and data.values.SECRETGEN_CONTROLLER_ENABLE:
-
+---
 apiVersion: v1
 kind: Secret
 metadata:
@@ -19,6 +20,5 @@ metadata:
     tkg.tanzu.vmware.com/addon-type: "addons-management/secretgen-controller"
 type: tkg.tanzu.vmware.com/addon
 stringData:
-  values.yaml: #@ ValuesFormatStr.format(yaml.encode(""))
-
+  values.yaml: #@ ValuesFormatStr.format(yaml.encode(secretgencontrollerdatavalues()))
 #@ end

--- a/pkg/v1/providers/ytt/02_addons/secretgen-controller/add_secretgen-controller.yaml
+++ b/pkg/v1/providers/ytt/02_addons/secretgen-controller/add_secretgen-controller.yaml
@@ -1,4 +1,3 @@
-#@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:template", "template")
 #@ load("@ytt:data", "data")
 #@ load("@ytt:yaml", "yaml")
@@ -15,7 +14,9 @@ metadata:
   labels:
     tkg.tanzu.vmware.com/addon-name: "secretgen-controller"
     tkg.tanzu.vmware.com/cluster-name: #@ data.values.CLUSTER_NAME
+    #@ if data.values.TKG_CLUSTER_ROLE != "workload":
     clusterctl.cluster.x-k8s.io/move: ""
+    #@ end
   annotations:
     tkg.tanzu.vmware.com/addon-type: "addons-management/secretgen-controller"
 type: tkg.tanzu.vmware.com/addon

--- a/pkg/v1/providers/ytt/02_addons/secretgen-controller/secretgen-controller_addon_data.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/secretgen-controller/secretgen-controller_addon_data.lib.yaml
@@ -1,0 +1,8 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+
+#@ def secretgencontrollerdatavalues():
+secretgenController:
+  namespace: tanzu-system
+  createNamespace: true
+#@ end

--- a/pkg/v1/providers/ytt/02_addons/secretgen-controller/secretgen-controller_addon_data.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/secretgen-controller/secretgen-controller_addon_data.lib.yaml
@@ -1,4 +1,3 @@
-#@ load("@ytt:data", "data")
 #@ load("@ytt:yaml", "yaml")
 
 #@ def secretgencontrollerdatavalues():


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds changes for deploying secret gen controller by add ons manager
Namespace is "tanzu-system" for deploying secretgen-controller for TKG clusters

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #758

**Describe testing done for PR**:

1. Tested by deploying a cluster and using imagepullsecret plugin to test different commands
```
NAMESPACE                           NAME                                                                READY   STATUS    RESTARTS   AGE
...
kube-system                         kube-apiserver-ip-10-0-27-127.us-west-2.compute.internal            1/1     Running   0          18h
kube-system                         kube-controller-manager-ip-10-0-27-127.us-west-2.compute.internal   1/1     Running   0          18h
kube-system                         kube-proxy-cgpr8                                                    1/1     Running   0          18h
kube-system                         kube-proxy-kvfz8                                                    1/1     Running   0          18h
kube-system                         kube-scheduler-ip-10-0-27-127.us-west-2.compute.internal            1/1     Running   0          18h
kube-system                         metrics-server-57bfcd6886-rh9wm                                     1/1     Running   0          18h
tanzu-system                        secretgen-controller-7496778f79-tlw6q                               1/1     Running   0          18h
tkg-system                          kapp-controller-654fbdc88f-qp8kn                                    1/1     Running   2          18h
...
```
2. Added the secret
3. Add the repository
```
tanzu package repository add private-repo -n test-ns --url us-east4-docker.pkg.dev/cf-sandbox-dkalinin/test-areg-private/example-pkg-repo@sha256:a80e9b512b9eff76ab638cce50a3c4541a12673d9b698103314f32c93f1deb61 --create-namespace
| Adding package repository 'private-repo' 
/ Validating provided settings for the package repository 
| Creating namespace 'test-ns' 
| Creating package repository resource 
- Waiting for 'PackageRepository' reconciliation for 'private-repo' 
| Resource install status: Reconciling
```
4. List the secrets
```
tanzu imagepullsecret list -A   
| Retrieving image pull secrets... 
  NAME                          REGISTRY                 EXPORTED           AGE    NAMESPACE                  
  tanzu-standard-fetch-0        us-east4-docker.pkg.dev  not exported       25h    tanzu-package-repo-global  
  private-repo-fetch-0          us-east4-docker.pkg.dev  not exported       3m36s  test-ns                    
  antrea-fetch-0                us-east4-docker.pkg.dev  not exported       25h    tkg-system                 
  metrics-server-fetch-0        us-east4-docker.pkg.dev  not exported       25h    tkg-system                 
  pkg-dev-reg                   us-east4-docker.pkg.dev  to all namespaces  6h53m  tkg-system                 
  secretgen-controller-fetch-0  us-east4-docker.pkg.dev  not exported       25h    tkg-system                 
  tanzu-addons-manager-fetch-0  us-east4-docker.pkg.dev  not exported       25h    tkg-system                 
  tanzu-core-fetch-0            us-east4-docker.pkg.dev  not exported       25h    tkg-system
  ```
**Special notes for your reviewer**:

1. Default for the variable is chosen as true, but can be changed once the default value is decided
2. SecretGen controller is running in namespace => secretgen-controller for now.

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
Deploy secretgen controller as new core addon in tanzu-system namespace when creating or upgrading clusters

```
**New PR Checklist**

- [ ] Ensure PR contains only public links or terms
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
