### PR TITLE
[Draft] Addons should upgrade before cluster upgrade

### DIFF
--- a/addons/controllers/addon_reconcilers.go
+++ b/addons/controllers/addon_reconcilers.go
@@ -205,9 +205,9 @@ func (r *AddonReconciler) ReconcileAddonDataValuesSecretNormal(
 			addonDataValuesSecret.Data["imageInfo.yaml"] = imageInfoBytes
 		}
 		// Add kubernetesVersion info
-		TKRVersionBytes, err := util.GetKubernetesVersionInfo(bom)
+		TKRVersionBytes, err := util.GetTKRVersionInfo(bom)
 		if err != nil {
-			log.Error(err, "Error retrieving Kubernetes version info from BOM")
+			log.Error(err, "Error retrieving TKR version info from BOM")
 			return err
 		}
 		addonDataValuesSecret.Data["tanzuKubernetesRelease.yaml"] = TKRVersionBytes

--- a/addons/controllers/addon_reconcilers.go
+++ b/addons/controllers/addon_reconcilers.go
@@ -191,9 +191,7 @@ func (r *AddonReconciler) ReconcileAddonDataValuesSecretNormal(
 
 	addonDataValuesSecretMutateFn := func() error {
 		addonDataValuesSecret.Type = corev1.SecretTypeOpaque
-		if addonDataValuesSecret.Data == nil {
-			addonDataValuesSecret.Data = map[string][]byte{}
-		}
+		addonDataValuesSecret.Data = map[string][]byte{}
 		for k, v := range addonSecret.Data {
 			addonDataValuesSecret.Data[k] = v
 		}
@@ -206,6 +204,13 @@ func (r *AddonReconciler) ReconcileAddonDataValuesSecretNormal(
 			}
 			addonDataValuesSecret.Data["imageInfo.yaml"] = imageInfoBytes
 		}
+		// Add kubernetesVersion info
+		TKRVersionBytes, err := util.GetKubernetesVersionInfo(bom)
+		if err != nil {
+			log.Error(err, "Error retrieving Kubernetes version info from BOM")
+			return err
+		}
+		addonDataValuesSecret.Data["tanzuKubernetesRelease.yaml"] = TKRVersionBytes
 
 		return nil
 	}

--- a/addons/go.sum
+++ b/addons/go.sum
@@ -118,10 +118,12 @@ github.com/Jeffail/gabs v1.4.0/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.0.3/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
+github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/hcsshim v0.8.6/go.mod h1:Op3hHsoHPAvb6lceZHDtd9OkTew38wNoXnJs8iY7rUg=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -162,6 +164,7 @@ github.com/apex/log v1.3.0/go.mod h1:jd8Vpsr46WAe3EZSQ/IUMs2qQD/GOycT5rPWCO1yGcs
 github.com/apex/logs v0.0.4/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
+github.com/apparentlymart/go-cidr v1.1.0 h1:2mAhrMoF+nhXqxTzSZMUzDHkLjmIHC+Zzn4tdgBZjnU=
 github.com/apparentlymart/go-cidr v1.1.0/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/YjEn/vI25Lg7Gwc=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -237,6 +240,7 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/containerd/containerd v1.3.0 h1:xjvXQWABwS2uiv3TWgQt5Uth60Gu86LTGZXMJkjc7rY=
 github.com/containerd/containerd v1.3.0/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/stargz-snapshotter/estargz v0.4.1/go.mod h1:x7Q9dg9QYb4+ELgxmo4gBUeJB0tl5dqH1Sdz0nJU1QM=
 github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
@@ -288,10 +292,13 @@ github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v0.7.3-0.20190327010347-be7ac8be2ae0/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7 h1:Cvj7S8I4Xpx78KAl6TwTmMHuHlZ/0SM60NUneGJQ7IE=
 github.com/docker/docker v1.4.2-0.20190924003213-a8608b5b67c7/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
+github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -685,6 +692,7 @@ github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b h1:FQ7+9fxhyp82ks9vAuyPzG0/vVbWwMwLJ+P6yJI5FN8=
 github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b/go.mod h1:HMcgvsgd0Fjj4XXDkbjdmlbI505rUPBs6WBMYg2pXks=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -860,6 +868,7 @@ github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWEr
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
@@ -987,6 +996,7 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -1597,6 +1607,7 @@ google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d h1:HV9Z9qMhQEsdlvxNFELgQ11RkMzO3CMkjEySjCtuLes=
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -1620,6 +1631,7 @@ google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
+google.golang.org/grpc v1.34.0 h1:raiipEjMOIC/TO2AvyTxP25XFdLxNIBwzDh3FM3XztI=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/addons/pkg/types/addons.go
+++ b/addons/pkg/types/addons.go
@@ -49,9 +49,9 @@ type ImageInfo struct {
 	Images map[string]Image `yaml:"images,omitempty"`
 }
 
-// KubernetesVersionInfo contains tanzuKubernetesRelease version info
-type KubernetesVersionInfo struct {
-	KubernetesVersion string `yaml:"kubernetesVersion"`
+// TKRVersionInfo contains tanzuKubernetesRelease version info
+type TKRVersionInfo struct {
+	TKRVersionInfo string `yaml:"tanzuKubernetesRelease"`
 }
 
 // Image contains the image information

--- a/addons/pkg/types/addons.go
+++ b/addons/pkg/types/addons.go
@@ -49,6 +49,11 @@ type ImageInfo struct {
 	Images map[string]Image `yaml:"images,omitempty"`
 }
 
+// KubernetesVersionInfo contains tanzuKubernetesRelease version info
+type KubernetesVersionInfo struct {
+	KubernetesVersion string `yaml:"kubernetesVersion"`
+}
+
 // Image contains the image information
 type Image struct {
 	ImagePath string `yaml:"imagePath"`

--- a/addons/pkg/util/bom_util.go
+++ b/addons/pkg/util/bom_util.go
@@ -9,13 +9,13 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	addontypes "github.com/vmware-tanzu/tanzu-framework/addons/pkg/types"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
+	addontypes "github.com/vmware-tanzu/tanzu-framework/addons/pkg/types"
+	tkgutils "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/utils"
 	bomtypes "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/types"
 )
 
@@ -54,13 +54,14 @@ func GetTKRNameFromBOMConfigMap(bomConfigMap *corev1.ConfigMap) string {
 	return bomConfigMap.Labels[constants.TKRLabel]
 }
 
-// GetTKGVersionInfo returns kubernetes version info given a BOM
-func GetKubernetesVersionInfo(bom *bomtypes.Bom) ([]byte, error) {
-	kubeadmConfig, err := bom.GetKubeadmConfigSpec()
+// GetTKRVersionInfo returns TKR version info given a BOM
+func GetTKRVersionInfo(bom *bomtypes.Bom) ([]byte, error) {
+	TKRVersion, err := bom.GetReleaseVersion()
 	if err != nil {
 		return nil, err
 	}
-	TKRVersionInfo := &addontypes.KubernetesVersionInfo{KubernetesVersion: kubeadmConfig.KubernetesVersion}
+
+	TKRVersionInfo := &addontypes.TKRVersionInfo{TKRVersionInfo: tkgutils.GetTkrNameFromTkrVersion(TKRVersion)}
 
 	TKRVersionBytes, err := yaml.Marshal(TKRVersionInfo)
 	if err != nil {

--- a/addons/pkg/util/bom_util.go
+++ b/addons/pkg/util/bom_util.go
@@ -7,6 +7,10 @@ import (
 	"context"
 	"fmt"
 
+	"gopkg.in/yaml.v2"
+
+	addontypes "github.com/vmware-tanzu/tanzu-framework/addons/pkg/types"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,6 +52,24 @@ func GetBOMByTKRName(ctx context.Context, c client.Client, tkrName string) (*bom
 // GetTKRNameFromBOMConfigMap returns tkr name given a bom configmap
 func GetTKRNameFromBOMConfigMap(bomConfigMap *corev1.ConfigMap) string {
 	return bomConfigMap.Labels[constants.TKRLabel]
+}
+
+// GetTKGVersionInfo returns kubernetes version info given a BOM
+func GetKubernetesVersionInfo(bom *bomtypes.Bom) ([]byte, error) {
+	kubeadmConfig, err := bom.GetKubeadmConfigSpec()
+	if err != nil {
+		return nil, err
+	}
+	TKRVersionInfo := &addontypes.KubernetesVersionInfo{KubernetesVersion: kubeadmConfig.KubernetesVersion}
+
+	TKRVersionBytes, err := yaml.Marshal(TKRVersionInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	outputBytes := append([]byte(constants.TKGDataValueFormatString), TKRVersionBytes...)
+
+	return outputBytes, nil
 }
 
 // GetAddonImageRepository returns imageRepository from configMap `tkr-controller-config` in namespace `tkr-system` if exists else use BOM

--- a/pkg/v1/tkg/client/upgrade_cluster.go
+++ b/pkg/v1/tkg/client/upgrade_cluster.go
@@ -183,16 +183,6 @@ func (c *TkgClient) UpgradeCluster(options *UpgradeClusterOptions) error { // no
 		}
 	}
 
-	log.Info("Waiting for additional components to be up and running...")
-	if err := c.WaitForAddonsDeployments(regionalClusterClient); err != nil {
-		return err
-	}
-
-	log.Info("Waiting for packages to be up and running...")
-	if err := c.WaitForPackages(regionalClusterClient, currentClusterClient, options.ClusterName, options.Namespace); err != nil {
-		log.Warningf("Warning: Management cluster is upgraded successfully, but some packages are failing. %v", err)
-	}
-
 	err = c.DoClusterUpgrade(regionalClusterClient, currentClusterClient, options)
 	if err != nil {
 		return err
@@ -204,6 +194,16 @@ func (c *TkgClient) UpgradeCluster(options *UpgradeClusterOptions) error { // no
 		if err != nil {
 			return errors.Wrapf(err, "failed to upgrade autoscaler for cluster '%s'", options.ClusterName)
 		}
+	}
+
+	log.Info("Waiting for additional components to be up and running...")
+	if err := c.WaitForAddonsDeployments(regionalClusterClient); err != nil {
+		return err
+	}
+
+	log.Info("Waiting for packages to be up and running...")
+	if err := c.WaitForPackages(regionalClusterClient, currentClusterClient, options.ClusterName, options.Namespace); err != nil {
+		log.Warningf("Warning: Management cluster is upgraded successfully, but some packages are failing. %v", err)
 	}
 
 	return nil

--- a/pkg/v1/tkg/client/upgrade_region.go
+++ b/pkg/v1/tkg/client/upgrade_region.go
@@ -149,27 +149,6 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 		return err
 	}
 
-	// Upgrade/Add certain addons to the old clusters during upgrade
-	// This is done after we patch the management cluster object with new TKG version
-	// so, while generating cluster template with new tkg and k8s version, it does not
-	// throw version incompatibility validation error.
-	if !options.SkipAddonUpgrade {
-		err = c.upgradeAddons(regionalClusterClient, regionalClusterClient, options.ClusterName, options.Namespace, true, options.Edition)
-		if err != nil {
-			return err
-		}
-	}
-
-	log.Info("Waiting for additional components to be up and running...")
-	if err := c.WaitForAddonsDeployments(regionalClusterClient); err != nil {
-		return err
-	}
-
-	log.Info("Waiting for packages to be up and running...")
-	if err := c.WaitForPackages(regionalClusterClient, regionalClusterClient, options.ClusterName, options.Namespace); err != nil {
-		log.Warningf("Warning: Management cluster is upgraded successfully, but some packages are failing. %v", err)
-	}
-
 	return nil
 }
 

--- a/pkg/v1/tkr/pkg/types/bom.go
+++ b/pkg/v1/tkr/pkg/types/bom.go
@@ -103,24 +103,15 @@ type Addon struct {
 	PackageName          string               `yaml:"packageName,omitempty"`
 }
 
-// KubeadmConfigSpec contains kubeadm config info
-type KubeadmConfigSpec struct {
-	ApiVersion        string `yaml:"apiVersion,omitempty"`
-	Kind              string `yaml:"kind,omitempty"`
-	ImageRepository   string `yaml:"imageRepository,omitempty"`
-	KubernetesVersion string `yaml:"kubernetesVersion,omitempty"`
-}
-
 // BomContent contains the content of a BOM file
 type BomContent struct {
-	Release           Release                    `yaml:"release"`
-	Components        map[string][]ComponentInfo `yaml:"components"`
-	KubeadmConfigSpec KubeadmConfigSpec          `yaml:"kubeadmConfigSpec"`
-	ImageConfig       ImageConfig                `yaml:"imageConfig"`
-	OVA               OVAInfos                   `yaml:"ova"`
-	AMI               AMIInfos                   `yaml:"ami,omitempty"`
-	Azure             AzureInfos                 `yaml:"azure,omitempty"`
-	Addons            Addons                     `yaml:"addons,omitempty"`
+	Release     Release                    `yaml:"release"`
+	Components  map[string][]ComponentInfo `yaml:"components"`
+	ImageConfig ImageConfig                `yaml:"imageConfig"`
+	OVA         OVAInfos                   `yaml:"ova"`
+	AMI         AMIInfos                   `yaml:"ami,omitempty"`
+	Azure       AzureInfos                 `yaml:"azure,omitempty"`
+	Addons      Addons                     `yaml:"addons,omitempty"`
 }
 
 // Bom represents a BOM file
@@ -208,14 +199,6 @@ func (b *Bom) Components() (map[string][]ComponentInfo, error) {
 		return nil, errors.New("the BOM is not initialized")
 	}
 	return b.bom.Components, nil
-}
-
-// Components gets all release components in the BOM file
-func (b *Bom) GetKubeadmConfigSpec() (KubeadmConfigSpec, error) {
-	if !b.initialzed {
-		return KubeadmConfigSpec{}, errors.New("the BOM is not initialized")
-	}
-	return b.bom.KubeadmConfigSpec, nil
 }
 
 // GetImageRepository gets the image repository

--- a/pkg/v1/tkr/pkg/types/bom.go
+++ b/pkg/v1/tkr/pkg/types/bom.go
@@ -103,15 +103,24 @@ type Addon struct {
 	PackageName          string               `yaml:"packageName,omitempty"`
 }
 
+// KubeadmConfigSpec contains kubeadm config info
+type KubeadmConfigSpec struct {
+	ApiVersion        string `yaml:"apiVersion,omitempty"`
+	Kind              string `yaml:"kind,omitempty"`
+	ImageRepository   string `yaml:"imageRepository,omitempty"`
+	KubernetesVersion string `yaml:"kubernetesVersion,omitempty"`
+}
+
 // BomContent contains the content of a BOM file
 type BomContent struct {
-	Release     Release                    `yaml:"release"`
-	Components  map[string][]ComponentInfo `yaml:"components"`
-	ImageConfig ImageConfig                `yaml:"imageConfig"`
-	OVA         OVAInfos                   `yaml:"ova"`
-	AMI         AMIInfos                   `yaml:"ami,omitempty"`
-	Azure       AzureInfos                 `yaml:"azure,omitempty"`
-	Addons      Addons                     `yaml:"addons,omitempty"`
+	Release           Release                    `yaml:"release"`
+	Components        map[string][]ComponentInfo `yaml:"components"`
+	KubeadmConfigSpec KubeadmConfigSpec          `yaml:"kubeadmConfigSpec"`
+	ImageConfig       ImageConfig                `yaml:"imageConfig"`
+	OVA               OVAInfos                   `yaml:"ova"`
+	AMI               AMIInfos                   `yaml:"ami,omitempty"`
+	Azure             AzureInfos                 `yaml:"azure,omitempty"`
+	Addons            Addons                     `yaml:"addons,omitempty"`
 }
 
 // Bom represents a BOM file
@@ -199,6 +208,14 @@ func (b *Bom) Components() (map[string][]ComponentInfo, error) {
 		return nil, errors.New("the BOM is not initialized")
 	}
 	return b.bom.Components, nil
+}
+
+// Components gets all release components in the BOM file
+func (b *Bom) GetKubeadmConfigSpec() (KubeadmConfigSpec, error) {
+	if !b.initialzed {
+		return KubeadmConfigSpec{}, errors.New("the BOM is not initialized")
+	}
+	return b.bom.KubeadmConfigSpec, nil
 }
 
 // GetImageRepository gets the image repository


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

**What this PR does / why we need it**:
The addons should upgrade prior to cluster upgrade to account for forward compatibility.
i.e. some old addons may not run on the nodes with new k8s version. The new addons will be only scheduled on new nodes, so we don't need to worry about backward compatibility as it's a rolling upgrade

the cluster upgrade process
1. Upgrades cluster-api resources
1. Some special pre upgrade handling
1. Updates management cluster node by patching the version of KubeadmControlPlane cluster-api resource. Once this is patched, a machine and a node with the new version will be reconciled. The CLI wait's for cluster-api's Ready condition before proceeds.
1. Updates workload cluster node by patching the version of MachineDeployment cluster-api resource. It will create a new worker node. CLI waits on MachineDeployment until it's successfully reconciled.
1. Upgrade addons. Including patching kapp-controller, TKR, addons manager.
 
Calico:  The CRD definitions are using **apiextensions.k8s.io/v1beta1** API version. This will make the CRD unusable once the cluster is upgraded to 1.22.0. 
The CLI will wait for the old CNI package running on the new node to mark the node as ready, it will block waits on Calico which will never come up.
Due to the issue of Calico, the process will be stuck at step 3. KubeadmControlPlane will never be ready because it is missing CNI.


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes N+1 compatibility of Core addons with k8s 1.22

**Describe testing done for PR**:
<!--
Example: Created vSphere workload cluster to verify change.
-->
POC
Manually replicated the same upgrade situation, the upgrade was successful with this order change.

**Special notes for your reviewer**:

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note

```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
