### PR TITLE
cmd/cli/plugin/pinniped-auth: add group suffix and cluster scoped flags

### DIFF
--- a/cmd/cli/plugin/pinniped-auth/login.go
+++ b/cmd/cli/plugin/pinniped-auth/login.go
@@ -34,18 +34,20 @@ type loginOIDCOptions struct {
 	conciergeAuthenticatorName string
 	conciergeEndpoint          string
 	conciergeCABundle          string
+	conciergeAPIGroupSuffix    string
 	listenPort                 uint16
 	skipBrowser                bool
 	debugSessionCache          bool
 	conciergeEnabled           bool
+	conciergeIsClusterScoped   bool
 }
 
 //go:embed asset/pinniped
 var pinnipedBinary []byte
 
-var lo = &loginOIDCOptions{}
+var loginOptions = &loginOIDCOptions{}
 
-var loCmd = &cobra.Command{
+var loginCommand = &cobra.Command{
 	Use:          "login",
 	Short:        "Login using an OpenID Connect provider",
 	SilenceUsage: true,
@@ -58,58 +60,41 @@ var loCmd = &cobra.Command{
 }
 
 func init() {
-	loCmd.Flags().StringVar(&lo.issuer, "issuer", "", "OpenID Connect issuer URL.")
-	loCmd.Flags().StringVar(&lo.clientID, "client-id", "pinniped-cli", "OpenID Connect client ID.")
-	loCmd.Flags().Uint16Var(&lo.listenPort, "listen-port", 0, "TCP port for localhost listener (authorization code flow only).")
-	loCmd.Flags().StringSliceVar(&lo.scopes, "scopes", []string{"offline_access, openid, pinniped:request-audience"}, "OIDC scopes to request during login.")
-	loCmd.Flags().BoolVar(&lo.skipBrowser, "skip-browser", false, "Skip opening the browser (just print the URL).")
-	loCmd.Flags().StringVar(&lo.sessionCachePath, "session-cache", filepath.Join(mustGetConfigDir(), "sessions.yaml"), "Path to session cache file.")
-	loCmd.Flags().StringSliceVar(&lo.caBundlePaths, "ca-bundle", nil, "Path to TLS certificate authority bundle (PEM format, optional, can be repeated).")
-	loCmd.Flags().StringSliceVar(&lo.caBundleData, "ca-bundle-data", nil, "Base64 endcoded TLS certificate authority bundle (base64 encoded PEM format, optional, can be repeated)")
-	loCmd.Flags().BoolVar(&lo.debugSessionCache, "debug-session-cache", false, "Print debug logs related to the session cache.")
-	loCmd.Flags().StringVar(&lo.requestAudience, "request-audience", "", "Request a token with an alternate audience using RFC8693 token exchange")
-	loCmd.Flags().BoolVar(&lo.conciergeEnabled, "enable-concierge", false, "Exchange the OIDC ID token with the Pinniped concierge during login")
-	loCmd.Flags().StringVar(&lo.conciergeNamespace, "concierge-namespace", "pinniped-concierge", "Namespace in which the concierge was installed")
-	loCmd.Flags().StringVar(&lo.conciergeAuthenticatorType, "concierge-authenticator-type", "", "Concierge authenticator type (e.g., 'webhook', 'jwt')")
-	loCmd.Flags().StringVar(&lo.conciergeAuthenticatorName, "concierge-authenticator-name", "", "Concierge authenticator name")
-	loCmd.Flags().StringVar(&lo.conciergeEndpoint, "concierge-endpoint", "", "API base for the Pinniped concierge endpoint")
-	loCmd.Flags().StringVar(&lo.conciergeCABundle, "concierge-ca-bundle-data", "", "CA bundle to use when connecting to the concierge")
-	loCmd.Flags().MarkHidden("debug-session-cache") //nolint
-	loCmd.MarkFlagRequired("issuer")                //nolint
+	setLoginCommandFlags()
 }
 
-func loginoidcCmd(pinnipedloginCliExec func(args []string) error) *cobra.Command {
-	loCmd.RunE = func(cmd *cobra.Command, args []string) error {
+func loginOIDCCommand(pinnipedLoginCliExec func(args []string) error) *cobra.Command {
+	loginCommand.RunE = func(cmd *cobra.Command, args []string) error {
 		oidcLoginArgs := []string{
 			"login", "oidc",
-			fmt.Sprintf("--issuer=%s", lo.issuer),
-			fmt.Sprintf("--client-id=%s", lo.clientID),
-			fmt.Sprintf("--listen-port=%d", lo.listenPort),
-			fmt.Sprintf("--skip-browser=%s", strconv.FormatBool(lo.skipBrowser)),
-			fmt.Sprintf("--session-cache=%s", lo.sessionCachePath),
-			fmt.Sprintf("--debug-session-cache=%s", strconv.FormatBool(lo.debugSessionCache)),
-			fmt.Sprintf("--scopes=%s", strings.Join(lo.scopes, ",")),
-			fmt.Sprintf("--ca-bundle=%s", strings.Join(lo.caBundlePaths, ",")),
-			fmt.Sprintf("--ca-bundle-data=%s", strings.Join(lo.caBundleData, ",")),
-			fmt.Sprintf("--request-audience=%s", lo.requestAudience),
-			fmt.Sprintf("--enable-concierge=%s", strconv.FormatBool(lo.conciergeEnabled)),
-			fmt.Sprintf("--concierge-namespace=%s", lo.conciergeNamespace),
-			fmt.Sprintf("--concierge-authenticator-type=%s", lo.conciergeAuthenticatorType),
-			fmt.Sprintf("--concierge-authenticator-name=%s", lo.conciergeAuthenticatorName),
-			fmt.Sprintf("--concierge-endpoint=%s", lo.conciergeEndpoint),
-			fmt.Sprintf("--concierge-ca-bundle-data=%s", lo.conciergeCABundle),
+			fmt.Sprintf("--issuer=%s", loginOptions.issuer),
+			fmt.Sprintf("--client-id=%s", loginOptions.clientID),
+			fmt.Sprintf("--listen-port=%d", loginOptions.listenPort),
+			fmt.Sprintf("--skip-browser=%s", strconv.FormatBool(loginOptions.skipBrowser)),
+			fmt.Sprintf("--session-cache=%s", loginOptions.sessionCachePath),
+			fmt.Sprintf("--debug-session-cache=%s", strconv.FormatBool(loginOptions.debugSessionCache)),
+			fmt.Sprintf("--scopes=%s", strings.Join(loginOptions.scopes, ",")),
+			fmt.Sprintf("--ca-bundle=%s", strings.Join(loginOptions.caBundlePaths, ",")),
+			fmt.Sprintf("--ca-bundle-data=%s", strings.Join(loginOptions.caBundleData, ",")),
+			fmt.Sprintf("--request-audience=%s", loginOptions.requestAudience),
+			fmt.Sprintf("--enable-concierge=%s", strconv.FormatBool(loginOptions.conciergeEnabled)),
+			fmt.Sprintf("--concierge-namespace=%s", loginOptions.conciergeNamespace),
+			fmt.Sprintf("--concierge-authenticator-type=%s", loginOptions.conciergeAuthenticatorType),
+			fmt.Sprintf("--concierge-authenticator-name=%s", loginOptions.conciergeAuthenticatorName),
+			fmt.Sprintf("--concierge-endpoint=%s", loginOptions.conciergeEndpoint),
+			fmt.Sprintf("--concierge-ca-bundle-data=%s", loginOptions.conciergeCABundle),
 		}
 
-		err := pinnipedloginCliExec(oidcLoginArgs)
+		err := pinnipedLoginCliExec(oidcLoginArgs)
 		if err != nil {
 			return errors.Wrapf(err, "pinniped-auth login failed")
 		}
 		return nil
 	}
-	return loCmd
+	return loginCommand
 }
 
-// pinnipedLoginExec executes embedded pinniped cli binary
+// pinnipedLoginExec executes embedded Pinniped CLI binary
 func pinnipedLoginExec(oidcLoginArgs []string) error {
 	buildSHA := strings.ReplaceAll(buildinfo.SHA, "-dirty", "")
 	pinnipedCLIBinFile := fmt.Sprintf("tanzu-pinniped-client-%s-%s", buildinfo.Version, buildSHA)
@@ -137,6 +122,29 @@ func pinnipedLoginExec(oidcLoginArgs []string) error {
 		return err
 	}
 	return nil
+}
+
+func setLoginCommandFlags() {
+	loginCommand.Flags().StringVar(&loginOptions.issuer, "issuer", "", "OpenID Connect issuer URL.")
+	loginCommand.Flags().StringVar(&loginOptions.clientID, "client-id", "pinniped-cli", "OpenID Connect client ID.")
+	loginCommand.Flags().Uint16Var(&loginOptions.listenPort, "listen-port", 0, "TCP port for localhost listener (authorization code flow only).")
+	loginCommand.Flags().StringSliceVar(&loginOptions.scopes, "scopes", []string{"offline_access, openid, pinniped:request-audience"}, "OIDC scopes to request during login.")
+	loginCommand.Flags().BoolVar(&loginOptions.skipBrowser, "skip-browser", false, "Skip opening the browser (just print the URL).")
+	loginCommand.Flags().StringVar(&loginOptions.sessionCachePath, "session-cache", filepath.Join(mustGetConfigDir(), "sessions.yaml"), "Path to session cache file.")
+	loginCommand.Flags().StringSliceVar(&loginOptions.caBundlePaths, "ca-bundle", nil, "Path to TLS certificate authority bundle (PEM format, optional, can be repeated).")
+	loginCommand.Flags().StringSliceVar(&loginOptions.caBundleData, "ca-bundle-data", nil, "Base64 endcoded TLS certificate authority bundle (base64 encoded PEM format, optional, can be repeated)")
+	loginCommand.Flags().BoolVar(&loginOptions.debugSessionCache, "debug-session-cache", false, "Print debug logs related to the session cache.")
+	loginCommand.Flags().StringVar(&loginOptions.requestAudience, "request-audience", "", "Request a token with an alternate audience using RFC8693 token exchange")
+	loginCommand.Flags().BoolVar(&loginOptions.conciergeEnabled, "enable-concierge", false, "Exchange the OIDC ID token with the Pinniped concierge during login")
+	loginCommand.Flags().StringVar(&loginOptions.conciergeNamespace, "concierge-namespace", "pinniped-concierge", "Namespace in which the concierge was installed")
+	loginCommand.Flags().StringVar(&loginOptions.conciergeAuthenticatorType, "concierge-authenticator-type", "", "Concierge authenticator type (e.g., 'webhook', 'jwt')")
+	loginCommand.Flags().StringVar(&loginOptions.conciergeAuthenticatorName, "concierge-authenticator-name", "", "Concierge authenticator name")
+	loginCommand.Flags().StringVar(&loginOptions.conciergeEndpoint, "concierge-endpoint", "", "API base for the Pinniped concierge endpoint")
+	loginCommand.Flags().StringVar(&loginOptions.conciergeCABundle, "concierge-ca-bundle-data", "", "CA bundle to use when connecting to the concierge")
+	loginCommand.Flags().StringVar(&loginOptions.conciergeAPIGroupSuffix, "concierge-api-group-suffix", "pinniped.dev", "Concierge API group suffix")
+	loginCommand.Flags().BoolVar(&loginOptions.conciergeIsClusterScoped, "concierge-is-cluster-scoped", false, "Is concierge cluster scoped")
+	loginCommand.Flags().MarkHidden("debug-session-cache") //nolint
+	loginCommand.MarkFlagRequired("issuer")                //nolint
 }
 
 // mustGetConfigDir returns the pinniped config directory

--- a/cmd/cli/plugin/pinniped-auth/main.go
+++ b/cmd/cli/plugin/pinniped-auth/main.go
@@ -26,7 +26,7 @@ func main() {
 		log.Fatal(err)
 	}
 	p.AddCommands(
-		loginoidcCmd(pinnipedLoginExec),
+		loginOIDCCommand(pinnipedLoginExec),
 	)
 	if err := p.Execute(); err != nil {
 		os.Exit(1)


### PR DESCRIPTION
Add concierge-api-group-suffix and concierge-is-cluster-scoped flags to
the pinniped-auth CLI plugin so the plugin can be configured to connect 
with any Pinniped API group and concierge APIs that are cluster-scoped or 
namespace-scoped.

**What this PR does / why we need it**:

- Context: we (`area/iam`) are in the process of updating the Pinniped package and related components to support Pinniped being run in a non-default API group so that the Tanzu version of Pinniped running on the cluster will not conflict with any other version of Pinniped
- This PR adds 2 flags to the pinniped-auth CLI plugin:
     - --concierge-api-group-suffix
     - --concierge-is-cluster-scoped

**Which issue(s) this PR fixes**:
None

**Describe testing done for PR**:
- Added unit tests
- Ran `make build-install-cli-all`

**Special notes for your reviewer**:
Feel free to reach out to me with any questions!

**Release note**:
```release-note
NONE
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
