### PR TITLE
codeowners: use iam tag instead of individual handles

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,11 @@
 * @vmware-tanzu/tanzu-framework-reviewers
 /addons @vmware-tanzu/tanzu-framework-reviewers @shyaamsn @danniel1205
-/addons/pinniped @vmware-tanzu/tanzu-framework-reviewers @ankeesler @benjaminapetersen @sabbey37
+/addons/pinniped @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-iam-owners
 /cmd/cli @vmware-tanzu/tanzu-framework-reviewers @Anuj2512
 /cmd/cli/plugin/tkr @vmware-tanzu/tanzu-framework-reviewers @prkalle
 /pkg/v1/cli @vmware-tanzu/tanzu-framework-reviewers @miclettej @Anuj2512
 /pkg/v1/providers @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tanzu-framework-lcm-reviewers @Anuj2512
-/pkg/v1/providers/ytt/02_addons/auth @vmware-tanzu/tanzu-framework-reviewers @ankeesler @benjaminapetersen @sabbey37
+/pkg/v1/providers/ytt/02_addons/auth @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-iam-owners
 /pkg/v1/providers/ytt/02_addons/avi @vmware-tanzu/tanzu-framework-reviewers @XudongLiuHarold @iXinqi
 /pkg/v1/providers/ytt/03_customizations/02_avi @vmware-tanzu/tanzu-framework-reviewers @XudongLiuHarold @iXinqi
 /pkg/v1/tkr @vmware-tanzu/tanzu-framework-reviewers @prkalle
@@ -16,5 +16,5 @@
 /pkg/v1/tkg/test/tkgpackageclient @vmware-tanzu/tanzu-framework-reviewers @shyaamsn @danniel1205 @maralavi @shivaani0505 @ggpaue @blc1996
 /cmd/cli/plugin/package @vmware-tanzu/tanzu-framework-reviewers @shyaamsn @danniel1205 @maralavi @shivaani0505 @ggpaue @blc1996
 /cmd/cli/plugin/imagepullsecret @vmware-tanzu/tanzu-framework-reviewers @shyaamsn @danniel1205 @maralavi @shivaani0505 @ggpaue @blc1996
-/cmd/cli/plugin/pinniped-auth @vmware-tanzu/tanzu-framework-reviewers @ankeesler @benjaminapetersen @sabbey37
+/cmd/cli/plugin/pinniped-auth @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-iam-owners
 /pkg/v1/tkg/tkgconfigpaths @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tanzu-framework-release-team


### PR DESCRIPTION
**What this PR does / why we need it**:
Using a team tag instead of individual handles gives us more control over codeowners for Pinniped-related files by allowing us to easily change the codeowners without needing to make a PR.

**Which issue(s) this PR fixes**:
None

**Describe testing done for PR**:
None

**Special notes for your reviewer**:
Feel free to reach out to me with any questions!

**Release note**:

```release-note
None
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [ ] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
