### PR TITLE
Codeowners update: Use github group @vmware-tanzu/tkg-addons-owners for addons code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 * @vmware-tanzu/tanzu-framework-reviewers
-/addons @vmware-tanzu/tanzu-framework-reviewers @shyaamsn @danniel1205
+/addons @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-addons-owners
 /addons/pinniped @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-iam-owners
 /cmd/cli @vmware-tanzu/tanzu-framework-reviewers @Anuj2512
 /cmd/cli/plugin/tkr @vmware-tanzu/tanzu-framework-reviewers @prkalle
@@ -10,11 +10,11 @@
 /pkg/v1/providers/ytt/03_customizations/02_avi @vmware-tanzu/tanzu-framework-reviewers @XudongLiuHarold @iXinqi
 /pkg/v1/tkr @vmware-tanzu/tanzu-framework-reviewers @prkalle
 /pkg/v1/tkg @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tanzu-framework-lcm-reviewers
-/pkg/v1/tkg/tkgpackagedatamodel @vmware-tanzu/tanzu-framework-reviewers @shyaamsn @danniel1205 @maralavi @shivaani0505 @ggpaue @blc1996
-/pkg/v1/tkg/kappclient @vmware-tanzu/tanzu-framework-reviewers @shyaamsn @danniel1205 @maralavi @shivaani0505 @ggpaue @blc1996
-/pkg/v1/tkg/tkgpackageclient @vmware-tanzu/tanzu-framework-reviewers @shyaamsn @danniel1205 @maralavi @shivaani0505 @ggpaue @blc1996
-/pkg/v1/tkg/test/tkgpackageclient @vmware-tanzu/tanzu-framework-reviewers @shyaamsn @danniel1205 @maralavi @shivaani0505 @ggpaue @blc1996
-/cmd/cli/plugin/package @vmware-tanzu/tanzu-framework-reviewers @shyaamsn @danniel1205 @maralavi @shivaani0505 @ggpaue @blc1996
-/cmd/cli/plugin/imagepullsecret @vmware-tanzu/tanzu-framework-reviewers @shyaamsn @danniel1205 @maralavi @shivaani0505 @ggpaue @blc1996
+/pkg/v1/tkg/tkgpackagedatamodel @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-addons-owners
+/pkg/v1/tkg/kappclient @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-addons-owners
+/pkg/v1/tkg/tkgpackageclient @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-addons-owners
+/pkg/v1/tkg/test/tkgpackageclient @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-addons-owners
+/cmd/cli/plugin/package @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-addons-owners
+/cmd/cli/plugin/imagepullsecret @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-addons-owners
 /cmd/cli/plugin/pinniped-auth @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-iam-owners
 /pkg/v1/tkg/tkgconfigpaths @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tanzu-framework-release-team


### PR DESCRIPTION
Signed-off-by: Vijay Katam <vkatam@vmware.com>

**What this PR does / why we need it**:
Use github group for addons instead of individual handles.

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
NONE
```

