### PR TITLE
Make Capability GVR query's group field optional

### DIFF
--- a/apis/run/v1alpha1/capability_types.go
+++ b/apis/run/v1alpha1/capability_types.go
@@ -65,8 +65,7 @@ type QueryGVR struct {
 	// +kubebuilder:validation:MinLength:=1
 	Name string `json:"name"`
 	// Group is the API group to check for in the cluster.
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinLength:=1
+	// +optional
 	Group string `json:"group"`
 	// Versions is the slice of versions to check for in the specified API group.
 	// +optional

--- a/config/crd/bases/run.tanzu.vmware.com_capabilities.yaml
+++ b/config/crd/bases/run.tanzu.vmware.com_capabilities.yaml
@@ -52,7 +52,6 @@ spec:
                           group:
                             description: Group is the API group to check for in the
                               cluster.
-                            minLength: 1
                             type: string
                           name:
                             description: Name is the unique name of the query.
@@ -71,7 +70,6 @@ spec:
                               type: string
                             type: array
                         required:
-                        - group
                         - name
                         type: object
                       type: array


### PR DESCRIPTION
### What this PR does / why we need it

Changes GVR query's `group` field to be optional. Optional field lets you query core k8s resources as they don't have an
API group name.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #882 

### Describe testing done for PR

Apply new CRD and create a Capability CR:

```
apiVersion: run.tanzu.vmware.com/v1alpha1
kind: Capability
metadata:
  name: capability-sample
spec:
  queries:
    - name: "q1"
      groupVersionResources:
        - name: "fooGVR"
          group: ""
          versions:
            - v1
          resource: "pods"
```

Verify CR is successfully created and controller reconciles result.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The Capability CRD now allows specifying an empty group name in the GVR query to check for core Kubernetes resources.
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
