### PR TITLE
Add Feature plugin

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,6 +26,7 @@
 /pkg/v1/sdk @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tanzu-framework-api-machinery-owners
 /cmd/managers/capabilities @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tanzu-framework-api-machinery-owners
 /cmd/managers/featuregate @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tanzu-framework-api-machinery-owners
+/cmd/cli/plugin/feature @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tanzu-framework-api-machinery-owners
 /cmd/cli/plugin-admin/codegen @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tanzu-framework-api-machinery-owners
 /pkg/v1/codegen @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tanzu-framework-api-machinery-owners
 /packages/management @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tanzu-framework-api-machinery-owners

--- a/cmd/cli/plugin/feature/README.md
+++ b/cmd/cli/plugin/feature/README.md
@@ -1,0 +1,1 @@
+# feature

--- a/cmd/cli/plugin/feature/README.md
+++ b/cmd/cli/plugin/feature/README.md
@@ -1,1 +1,106 @@
 # feature
+
+Feature plugin lets you operate on Features and FeatureGates
+
+## Usage
+
+Feature plugin has 3 commands
+
+1. list - allows to list the features that are gated by a particular
+   FeatureGate.
+2. activate - allows to activate a feature.
+3. deactivate - allows to deactivate a feature.
+
+By default, Feature plugin operates on Features that are gated by `tkg-system`
+FeatureGate, but that can be changed by specifying `featuregate` flag.
+
+Ex:
+
+```sh
+# list Features associated with tkg-system FeatureGate
+tanzu feature list
+# list Features associated with tkg-system-sample FeatureGate
+tanzu feature list --featuregate=tkg-system-sample
+```
+
+```sh
+>>> tanzu feature --help
+Operate on features and featuregates
+
+Usage:
+  tanzu feature [command]
+
+Available Commands:
+  activate      Activate Features
+  deactivate    Deactivate Features
+  list          List Features
+
+Flags:
+  -h, --help   help for feature
+
+Use "tanzu feature [command] --help" for more information about a command.
+```
+
+### list command
+
+```sh
+>>> tanzu feature list --help
+List Features
+
+Usage:
+  tanzu feature list [flags]
+
+Examples:
+  
+    # List a clusters Features
+    tanzu feature list --activated
+    tanzu feature list --unavailable
+    tanzu feature list --deactivated
+
+Flags:
+  -a, --activated            List only activated Features
+  -d, --deactivated          List only deactivated Features
+  -e, --extended             Include extended output. Higher latency as it requires more API calls.
+  -f, --featuregate string   List Features gated by a particular FeatureGate (default "tkg-system")
+  -h, --help                 help for list
+  -o, --output string        Output format (yaml|json|table)
+  -u, --unavailable          List only Features specified in the gate but missing from cluster
+```
+
+### activate command
+
+```sh
+>>> tanzu feature activate --help
+Activate Features
+
+Usage:
+  tanzu feature activate <feature> [flags]
+
+Examples:
+  
+    # Activate a cluster Feature
+    tanzu feature activate myfeature
+
+Flags:
+  -f, --featuregate string   Activate a Feature gated by a particular FeatureGate (default "tkg-system")
+  -h, --help                 help for activate
+```
+
+### deactivate command
+
+```sh
+>>> tanzu feature deactivate --help
+Deactivate Features
+
+Usage:
+  tanzu feature deactivate <feature> [flags]
+
+Examples:
+  
+    # Deactivate a cluster Feature
+    tanzu feature deactivate myfeature
+
+Flags:
+  -f, --featuregate string   Deactivate Feature gated by a particular FeatureGate (default "tkg-system")
+  -h, --help                 help for deactivate
+```

--- a/cmd/cli/plugin/feature/activate.go
+++ b/cmd/cli/plugin/feature/activate.go
@@ -1,0 +1,45 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/features/client"
+)
+
+// FeatureActivateCmd is for activating Features
+var FeatureActivateCmd = &cobra.Command{
+	Use:   "activate <feature>",
+	Short: "Activate Features",
+	Args:  cobra.ExactArgs(1),
+	Example: `
+	# Activate a cluster Feature
+	tanzu feature activate myfeature`,
+	RunE: featureActivate,
+}
+
+func init() {
+	FeatureActivateCmd.Flags().StringVarP(&featuregate, "featuregate", "f", "tkg-system", "Activate a Feature gated by a particular FeatureGate")
+}
+
+func featureActivate(cmd *cobra.Command, args []string) error {
+	featureName := args[0]
+	featureGateClient, err := client.NewFeatureGateClient()
+	if err != nil {
+		return fmt.Errorf("couldn't get featureGateRunner: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	if err := featureGateClient.ActivateFeature(ctx, featureName, featuregate); err != nil {
+		return fmt.Errorf("couldn't activate feature %s: %w", featureName, err)
+	}
+	cmd.Printf("Feature %s Activated", featureName)
+	return nil
+}

--- a/cmd/cli/plugin/feature/deactivate.go
+++ b/cmd/cli/plugin/feature/deactivate.go
@@ -1,0 +1,43 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/features/client"
+)
+
+// FeatureDeactivateCmd is for deactivating Features
+var FeatureDeactivateCmd = &cobra.Command{
+	Use:   "deactivate <feature>",
+	Short: "Deactivate Features",
+	Args:  cobra.ExactArgs(1),
+	Example: `
+	# Deactivate a cluster Feature
+	tanzu feature deactivate myfeature`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		featureName := args[0]
+		featureGateClient, err := client.NewFeatureGateClient()
+		if err != nil {
+			return fmt.Errorf("couldn't get a featureGateRunner: %w", err)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+		defer cancel()
+
+		if err := featureGateClient.DeactivateFeature(ctx, featureName, featuregate); err != nil {
+			return fmt.Errorf("couldn't deactivate feature %s: %w", featureName, err)
+		}
+		cmd.Printf("Feature %s Deactivated", featureName)
+		return nil
+	},
+}
+
+func init() {
+	FeatureDeactivateCmd.Flags().StringVarP(&featuregate, "featuregate", "f", "tkg-system", "Deactivate Feature gated by a particular FeatureGate")
+}

--- a/cmd/cli/plugin/feature/list.go
+++ b/cmd/cli/plugin/feature/list.go
@@ -1,0 +1,193 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	crClient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/features/client"
+)
+
+var featuregate, outputFormat string
+var activated, deactivated, unavailable, extended bool
+
+// FeatureListCmd is for activating Features
+var FeatureListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List Features",
+	Args:  cobra.NoArgs,
+	Example: `
+	# List a clusters Features
+	tanzu feature list --activated
+	tanzu feature list --unavailable
+	tanzu feature list --deactivated`,
+	RunE: featureList,
+}
+
+func init() {
+	FeatureListCmd.Flags().BoolVarP(&extended, "extended", "e", false, "Include extended output. Higher latency as it requires more API calls.")
+	FeatureListCmd.Flags().StringVarP(&featuregate, "featuregate", "f", "tkg-system", "List Features gated by a particular FeatureGate")
+	FeatureListCmd.Flags().BoolVarP(&activated, "activated", "a", false, "List only activated Features")
+	FeatureListCmd.Flags().BoolVarP(&deactivated, "deactivated", "d", false, "List only deactivated Features")
+	FeatureListCmd.Flags().BoolVarP(&unavailable, "unavailable", "u", false, "List only Features specified in the gate but missing from cluster")
+	FeatureListCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
+}
+
+// FeatureInfo is a struct that holds Feature information
+type FeatureInfo struct {
+	Name        string
+	Maturity    string
+	Description string
+	Activated   bool
+	Available   bool
+	Immutable   bool
+}
+
+func featureList(cmd *cobra.Command, _ []string) error {
+	featureGateClient, err := client.NewFeatureGateClient()
+	if err != nil {
+		return fmt.Errorf("couldn't get featureGateRunner: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	gate, err := featureGateClient.GetFeatureGate(ctx, featuregate)
+	if crClient.IgnoreNotFound(err) != nil {
+		return err
+	}
+	if err != nil {
+		return fmt.Errorf("featuregate %s not found: %w", featuregate, err)
+	}
+
+	var features []*FeatureInfo
+	switch {
+	case activated:
+		for _, a := range gate.Status.ActivatedFeatures {
+			features = append(features, &FeatureInfo{
+				Name:      a,
+				Activated: true,
+				Available: true,
+			})
+		}
+	case deactivated:
+		for _, a := range gate.Status.DeactivatedFeatures {
+			features = append(features, &FeatureInfo{
+				Name:      a,
+				Activated: false,
+				Available: true,
+			})
+		}
+	case unavailable:
+		for _, a := range gate.Status.UnavailableFeatures {
+			features = append(features, &FeatureInfo{
+				Name:      a,
+				Activated: false,
+				Available: false,
+			})
+		}
+	default:
+		for _, a := range gate.Status.ActivatedFeatures {
+			features = append(features, &FeatureInfo{
+				Name:      a,
+				Activated: true,
+				Available: true,
+			})
+		}
+		for _, a := range gate.Status.DeactivatedFeatures {
+			features = append(features, &FeatureInfo{
+				Name:      a,
+				Activated: false,
+				Available: true,
+			})
+		}
+		for _, a := range gate.Status.UnavailableFeatures {
+			features = append(features, &FeatureInfo{
+				Name:      a,
+				Activated: false,
+				Available: false,
+			})
+		}
+	}
+	if extended {
+		err := joinFeatures(ctx, featureGateClient, features)
+		if err != nil {
+			return fmt.Errorf("couldn't get extended information about features: %w", err)
+		}
+
+		// Many API calls to gather and join on Features
+		return listExtended(cmd, features)
+	}
+
+	return listBasic(cmd, features)
+}
+
+// listExtended renders the output with extended feature information
+func listExtended(cmd *cobra.Command, features []*FeatureInfo) error {
+	var t component.OutputWriterSpinner
+	t, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat,
+		"Retrieving Features...", true, "NAME", "ACTIVATION STATE", "AVAILABLE", "MATURITY", "DESCRIPTION", "IMMUTABLE")
+	if err != nil {
+		return fmt.Errorf("couldn't get OutputWriterSpinner: %w", err)
+	}
+
+	for _, info := range features {
+		t.AddRow(
+			info.Name,
+			info.Activated,
+			info.Available,
+			info.Maturity,
+			info.Description,
+			info.Immutable)
+	}
+	t.RenderWithSpinner()
+
+	return nil
+}
+
+// listBasic renders the output with basic feature information
+func listBasic(cmd *cobra.Command, features []*FeatureInfo) error {
+	var t component.OutputWriterSpinner
+	t, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat,
+		"Retrieving Features...", true, "NAME", "ACTIVATION STATE", "AVAILABLE")
+	if err != nil {
+		return fmt.Errorf("couldn't get OutputWriterSpinner: %w", err)
+	}
+
+	for _, info := range features {
+		t.AddRow(
+			info.Name,
+			info.Activated,
+			info.Available)
+	}
+	t.RenderWithSpinner()
+
+	return nil
+}
+
+// joinFeatures retrieves additional information of a Feature and merges it with existing information.
+func joinFeatures(ctx context.Context, featureGateClient *client.FeatureGateClient, features []*FeatureInfo) error {
+	for _, info := range features {
+		feature, err := featureGateClient.GetFeature(ctx, info.Name)
+		if err != nil {
+			// skip returning the error for unavailable feature when not found
+			// to fetch others
+			if !info.Available && apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+		info.Maturity = feature.Spec.Maturity
+		info.Description = feature.Spec.Description
+		info.Immutable = feature.Spec.Immutable
+	}
+	return nil
+}

--- a/cmd/cli/plugin/feature/list_test.go
+++ b/cmd/cli/plugin/feature/list_test.go
@@ -1,0 +1,68 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/features/client"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/features/client/fake"
+)
+
+func TestJoinFeatures(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	objs, _, _ := fake.GetTestObjects()
+	s := scheme.Scheme
+	if err := configv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("Unable to add config scheme: (%v)", err)
+	}
+	cl := crclient.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+	featureGateClient, err := client.NewFeatureGateClient(client.WithClient(cl))
+
+	if err != nil {
+		t.Fatalf("Unable to get FeatureGateClient: (%v)", err)
+	}
+
+	joinFeaturesTestCases := []struct {
+		description string
+		features    []*FeatureInfo
+		exists      bool
+	}{
+		{
+			description: "should successfully fetch additional information of an available feature",
+			features:    []*FeatureInfo{{Name: "foo", Available: true}},
+			exists:      true,
+		},
+		{
+			description: "should successfully fetch additional information of an unavailable feature",
+			features:    []*FeatureInfo{{Name: "baz", Available: false}},
+			exists:      true,
+		},
+		{
+			description: "should not fetch additional information of an unavailable feature that doesn't exist",
+			features:    []*FeatureInfo{{Name: "xyz", Available: false}},
+			exists:      false,
+		},
+	}
+
+	for _, tc := range joinFeaturesTestCases {
+		t.Run(tc.description, func(t *testing.T) {
+			_ = joinFeatures(ctx, featureGateClient, tc.features)
+			if tc.exists && tc.features[0].Available && tc.features[0].Maturity == "" {
+				t.Errorf("expected to fetch available %s feature information", tc.features[0].Name)
+			} else if tc.exists && !tc.features[0].Available && tc.features[0].Maturity == "" {
+				t.Errorf("expected to fetch unavailable %s feature information", tc.features[0].Name)
+			} else if !tc.exists && !tc.features[0].Available && tc.features[0].Maturity != "" {
+				t.Errorf("expected not to fetch information of unavailable %s feature that doesn't exist", tc.features[0].Name)
+			}
+		})
+	}
+}

--- a/cmd/cli/plugin/feature/main.go
+++ b/cmd/cli/plugin/feature/main.go
@@ -1,0 +1,41 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/aunum/log"
+
+	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
+)
+
+var descriptor = cliv1alpha1.PluginDescriptor{
+	Name:        "feature",
+	Description: "Operate on features and featuregates",
+	Version:     buildinfo.Version,
+	Group:       cliv1alpha1.RunCmdGroup,
+}
+
+const contextTimeout = 30 * time.Second
+
+func main() {
+	p, err := plugin.NewPlugin(&descriptor)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p.AddCommands(
+		FeatureListCmd,
+		FeatureActivateCmd,
+		FeatureDeactivateCmd,
+	)
+
+	if err := p.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/cli/plugin/feature/test/main.go
+++ b/cmd/cli/plugin/feature/test/main.go
@@ -1,0 +1,31 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
+)
+
+var descriptor = cli.NewTestFor("feature")
+
+func main() {
+	p, err := plugin.NewPlugin(descriptor)
+	if err != nil {
+		log.Fatal(err)
+	}
+	p.Cmd.RunE = test
+	if err := p.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func test(c *cobra.Command, _ []string) error {
+	return nil
+}

--- a/common.mk
+++ b/common.mk
@@ -42,7 +42,7 @@ LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.Version
 # Add supported OS-ARCHITECTURE combinations here
 ENVS ?= linux-amd64 windows-amd64 darwin-amd64
 STANDALONE_PLUGINS ?= login management-cluster package pinniped-auth secret
-CONTEXTAWARE_PLUGINS ?= cluster kubernetes-release
+CONTEXTAWARE_PLUGINS ?= cluster kubernetes-release feature
 ADMIN_PLUGINS ?= builder codegen test
 PLUGINS ?= $(STANDALONE_PLUGINS) $(CONTEXTAWARE_PLUGINS)
 

--- a/pkg/v1/sdk/features/client/client.go
+++ b/pkg/v1/sdk/features/client/client.go
@@ -1,0 +1,174 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8sconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	configv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
+)
+
+// FeatureGateClient defines methods to interact with FeatureGate resources
+type FeatureGateClient struct {
+	c client.Client
+}
+
+// NewFeatureGateClient returns an instance of FeatureGateClient.
+func NewFeatureGateClient(options ...Option) (*FeatureGateClient, error) {
+	featureGateClient := &FeatureGateClient{}
+	// Apply options
+	for _, option := range options {
+		featureGateClient = option(featureGateClient)
+	}
+	if featureGateClient.c == nil {
+		c, err := getFeatureGateClient()
+		if err != nil {
+			return nil, err
+		}
+		featureGateClient.c = c
+	}
+	return featureGateClient, nil
+}
+
+// Option is FeatureGateClient Option definition
+type Option func(*FeatureGateClient) *FeatureGateClient
+
+// WithClient function is for setting the passed in client when creating FeatureGateClient
+func WithClient(cl client.Client) Option {
+	return func(featureGateClient *FeatureGateClient) *FeatureGateClient {
+		featureGateClient.c = cl
+		return featureGateClient
+	}
+}
+
+// getFeatureGateClient returns a new FeatureGate client
+func getFeatureGateClient() (client.Client, error) {
+	var restConfig *rest.Config
+	var err error
+
+	scheme := runtime.NewScheme()
+	if err := configv1alpha1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+
+	if restConfig, err = k8sconfig.GetConfig(); err != nil {
+		return nil, err
+	}
+	crClient, err := client.New(restConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, fmt.Errorf("unable to create cluster client: %w", err)
+	}
+	return crClient, nil
+}
+
+// GetFeatureGate fetches the FeatureGate
+func (f *FeatureGateClient) GetFeatureGate(ctx context.Context, featureGateName string) (*configv1alpha1.FeatureGate, error) {
+	gate := &configv1alpha1.FeatureGate{}
+
+	if err := f.c.Get(ctx, client.ObjectKey{
+		Name: featureGateName,
+	}, gate); err != nil {
+		return nil, fmt.Errorf("couldn't get featuregate %s: %w", featureGateName, err)
+	}
+	return gate, nil
+}
+
+// GetFeature fetches the Feature
+func (f *FeatureGateClient) GetFeature(ctx context.Context, featureName string) (*configv1alpha1.Feature, error) {
+	feature := &configv1alpha1.Feature{}
+
+	if err := f.c.Get(ctx, client.ObjectKey{Name: featureName}, feature); err != nil {
+		return nil, err
+	}
+	return feature, nil
+}
+
+// ActivateFeature activates a Feature
+func (f *FeatureGateClient) ActivateFeature(ctx context.Context, featureName, featureGateName string) error {
+	feature, err := f.GetFeature(ctx, featureName)
+	if err != nil {
+		return fmt.Errorf("couldn't get feature %s: %w", featureName, err)
+	}
+	if !feature.Spec.Discoverable {
+		return fmt.Errorf("feature not found %s", featureName)
+	} else if feature.Spec.Immutable {
+		return fmt.Errorf("cannot activate an immutable feature %s", featureName)
+	}
+	gate, err := f.GetFeatureGate(ctx, featureGateName)
+	if err != nil {
+		return err
+	}
+	return f.setActivated(ctx, gate, featureName)
+}
+
+// setActivated sets the Feature to activate in FeatureGate
+func (f *FeatureGateClient) setActivated(ctx context.Context, gate *configv1alpha1.FeatureGate, featureName string) error {
+	for i, featureRef := range gate.Spec.Features {
+		if featureRef.Name == featureName {
+			gate.Spec.Features[i].Activate = true
+			return f.c.Update(ctx, gate)
+		}
+	}
+
+	ref := configv1alpha1.FeatureReference{
+		Name:     featureName,
+		Activate: true,
+	}
+	gate.Spec.Features = append(gate.Spec.Features, ref)
+	if err := f.c.Update(ctx, gate); err != nil {
+		return fmt.Errorf("couldn't update featurgate %s: %w", gate.Name, err)
+	}
+	return nil
+}
+
+// DeactivateFeature deactivates a Feature
+func (f *FeatureGateClient) DeactivateFeature(ctx context.Context, featureName, featureGateName string) error {
+	feature, err := f.GetFeature(ctx, featureName)
+	if err != nil {
+		return fmt.Errorf("couldn't get feature %s: %w", featureName, err)
+	}
+	if !feature.Spec.Discoverable {
+		return fmt.Errorf("feature not found %s", featureName)
+	} else if feature.Spec.Immutable {
+		return fmt.Errorf("cannot deactivate an immutable feature %s", featureName)
+	}
+	gate, err := f.GetFeatureGate(ctx, featureGateName)
+	if err != nil {
+		return err
+	}
+	return f.setDeactivated(ctx, gate, featureName)
+}
+
+// setDeactivated sets the Feature to deactivate in FeatureGate
+func (f *FeatureGateClient) setDeactivated(ctx context.Context, gate *configv1alpha1.FeatureGate, featureName string) error {
+	for i, featureRef := range gate.Spec.Features {
+		if featureRef.Name == featureName {
+			if !featureRef.Activate {
+				return nil
+			}
+			gate.Spec.Features[i].Activate = false
+			return f.c.Update(ctx, gate)
+		}
+	}
+
+	ref := configv1alpha1.FeatureReference{
+		Name:     featureName,
+		Activate: false,
+	}
+	gate.Spec.Features = append(gate.Spec.Features, ref)
+	if err := f.c.Update(ctx, gate); err != nil {
+		return fmt.Errorf("couldn't update featurgate %s: %w", gate.Name, err)
+	}
+	return nil
+}

--- a/pkg/v1/sdk/features/client/client_test.go
+++ b/pkg/v1/sdk/features/client/client_test.go
@@ -1,0 +1,264 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/features/client/fake"
+)
+
+const contextTimeout = 30 * time.Second
+
+func TestGetFeature(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	objs, features, _ := fake.GetTestObjects()
+	s := scheme.Scheme
+	if err := configv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("Unable to add config scheme: (%v)", err)
+	}
+	cl := crclient.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+	featureGateClient, err := NewFeatureGateClient(WithClient(cl))
+	if err != nil {
+		t.Fatalf("Unable to get FeatureGateClient: (%v)", err)
+	}
+
+	getFeatureTestCases := []struct {
+		description string
+		featureName string
+		returnErr   bool
+	}{
+		{
+			description: "should successfully return feature",
+			featureName: "cloud-event-listener",
+			returnErr:   false,
+		},
+		{
+			description: "should return an error when querying for feature that doesn't exist",
+			featureName: "xyz",
+			returnErr:   true,
+		},
+	}
+
+	for _, tc := range getFeatureTestCases {
+		t.Run(tc.description, func(t *testing.T) {
+			feature, err := featureGateClient.GetFeature(ctx, tc.featureName)
+			if err != nil {
+				if !tc.returnErr {
+					t.Errorf("error not expected, but got error: %v", err)
+				}
+			} else if tc.returnErr {
+				if err == nil {
+					t.Errorf("error expected, but got nothing")
+				}
+			}
+			if feature != nil && (feature.Name != features[tc.featureName].Name ||
+				feature.Spec.Immutable != features[tc.featureName].Spec.Immutable ||
+				feature.Spec.Discoverable != features[tc.featureName].Spec.Discoverable ||
+				feature.Spec.Activated != features[tc.featureName].Spec.Activated ||
+				feature.Spec.Maturity != features[tc.featureName].Spec.Maturity ||
+				feature.Spec.Description != features[tc.featureName].Spec.Description) {
+				t.Errorf("feature returned is not the correct feature, Expected: %v, Got: %v", features[tc.featureName], feature)
+			}
+		})
+	}
+}
+
+func TestGetFeaturegate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	objs, _, featureGates := fake.GetTestObjects()
+	s := scheme.Scheme
+	if err := configv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("Unable to add config scheme: (%v)", err)
+	}
+	cl := crclient.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+	featureGateClient, err := NewFeatureGateClient(WithClient(cl))
+	if err != nil {
+		t.Fatalf("Unable to get FeatureGateClient: (%v)", err)
+	}
+
+	getFeatureGateTestCases := []struct {
+		description     string
+		featureGateName string
+		returnErr       bool
+	}{
+		{
+			description:     "should successfully return featuregate",
+			featureGateName: "tkg-system",
+			returnErr:       false,
+		},
+		{
+			description:     "should return an error when querying for feature that doesn't exist",
+			featureGateName: "bar",
+			returnErr:       true,
+		},
+	}
+
+	for _, tc := range getFeatureGateTestCases {
+		t.Run(tc.description, func(t *testing.T) {
+			featureGate, err := featureGateClient.GetFeatureGate(ctx, tc.featureGateName)
+			if err != nil {
+				if !tc.returnErr {
+					t.Errorf("error not expected, but got error: %v", err)
+				}
+			} else if tc.returnErr {
+				if err == nil {
+					t.Errorf("error expected, but got nothing")
+				}
+			}
+			if featureGate != nil && (featureGate.Name != featureGates[tc.featureGateName].Name ||
+				len(featureGate.Spec.Features) != len(featureGates[tc.featureGateName].Spec.Features)) {
+				t.Errorf("featuregate returned is not the correct featuregate, Expected: %v, Got: %v", featureGates[tc.featureGateName], featureGate)
+			}
+		})
+	}
+}
+
+func TestActivateFeature(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	objs, _, _ := fake.GetTestObjects()
+	s := scheme.Scheme
+	if err := configv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("Unable to add config scheme: (%v)", err)
+	}
+	cl := crclient.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+	featureGateClient, err := NewFeatureGateClient(WithClient(cl))
+	if err != nil {
+		t.Fatalf("Unable to get FeatureGateClient: (%v)", err)
+	}
+
+	activateFeatureTestCases := []struct {
+		description     string
+		featureName     string
+		featureGateName string
+		returnErr       bool
+	}{
+		{
+			description:     "should successfully activate the feature",
+			featureName:     "foo",
+			featureGateName: "tkg-system",
+			returnErr:       false,
+		},
+		{
+			description:     "should throw an error when changing immutable feature",
+			featureName:     "bar",
+			featureGateName: "tkg-system",
+			returnErr:       true,
+		},
+		{
+			description:     "should throw an error when changing undiscoverable feature",
+			featureName:     "baz",
+			featureGateName: "tkg-system",
+			returnErr:       true,
+		},
+		{
+			description:     "should throw an error when the feature doesn't exist",
+			featureName:     "bax",
+			featureGateName: "tkg-system",
+			returnErr:       true,
+		},
+		{
+			description:     "should throw an error when the featuregate doesn't exist",
+			featureName:     "foo",
+			featureGateName: "tkg-system-test",
+			returnErr:       true,
+		},
+	}
+
+	for _, tc := range activateFeatureTestCases {
+		t.Run(tc.description, func(t *testing.T) {
+			err := featureGateClient.ActivateFeature(ctx, tc.featureName, tc.featureGateName)
+			if err != nil {
+				if !tc.returnErr {
+					t.Errorf("error not expected, but got error: %v", err)
+				}
+			} else if tc.returnErr {
+				if err == nil {
+					t.Errorf("error expected, but got nothing")
+				}
+			}
+		})
+	}
+}
+
+func TestDeactivateFeature(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	defer cancel()
+
+	objs, _, _ := fake.GetTestObjects()
+	s := scheme.Scheme
+	if err := configv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("Unable to add config scheme: (%v)", err)
+	}
+	cl := crclient.NewClientBuilder().WithRuntimeObjects(objs...).Build()
+	featureGateClient, err := NewFeatureGateClient(WithClient(cl))
+	if err != nil {
+		t.Fatalf("Unable to get FeatureGateClient: (%v)", err)
+	}
+
+	deactivateFeatureTestCases := []struct {
+		description     string
+		featureName     string
+		featureGateName string
+		returnErr       bool
+	}{
+		{
+			description:     "should successfully deactivate the feature",
+			featureName:     "foo",
+			featureGateName: "tkg-system",
+			returnErr:       false,
+		},
+		{
+			description:     "should throw an error when changing immutable feature",
+			featureName:     "bar",
+			featureGateName: "tkg-system",
+			returnErr:       true,
+		},
+		{
+			description:     "should throw an error when changing undiscoverable feature",
+			featureName:     "baz",
+			featureGateName: "tkg-system",
+			returnErr:       true,
+		},
+		{
+			description:     "should throw an error when the feature doesn't exist",
+			featureName:     "bax",
+			featureGateName: "tkg-system",
+			returnErr:       true,
+		},
+		{
+			description:     "should throw an error when the featuregate doesn't exist",
+			featureName:     "foo",
+			featureGateName: "tkg-system-test",
+			returnErr:       true,
+		},
+	}
+
+	for _, tc := range deactivateFeatureTestCases {
+		t.Run(tc.description, func(t *testing.T) {
+			err := featureGateClient.DeactivateFeature(ctx, tc.featureName, tc.featureGateName)
+			if err != nil {
+				if !tc.returnErr {
+					t.Errorf("error not expected, but got error: %v", err)
+				}
+			} else if tc.returnErr {
+				if err == nil {
+					t.Errorf("error expected, but got nothing")
+				}
+			}
+		})
+	}
+}

--- a/pkg/v1/sdk/features/client/doc.go
+++ b/pkg/v1/sdk/features/client/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package client provides methods to interact with Feature and FeatureGate resources
+package client

--- a/pkg/v1/sdk/features/client/fake/doc.go
+++ b/pkg/v1/sdk/features/client/fake/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package fake provides data needed for testing
+package fake

--- a/pkg/v1/sdk/features/client/fake/objects.go
+++ b/pkg/v1/sdk/features/client/fake/objects.go
@@ -1,0 +1,162 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package fake
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	configv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
+)
+
+// GetTestObjects returns objects to initialize the fake client
+//nolint:funlen
+func GetTestObjects() ([]runtime.Object, map[string]*configv1alpha1.Feature, map[string]*configv1alpha1.FeatureGate) {
+	cloudEventListener := &configv1alpha1.Feature{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cloud-event-listener",
+		},
+		Spec: configv1alpha1.FeatureSpec{
+			Description:  "Open a port to listen for cloudevents. Highly experimental!",
+			Immutable:    false,
+			Discoverable: true,
+			Activated:    true,
+			Maturity:     "alpha",
+		},
+	}
+	dodgyExperimentalPeriscope := &configv1alpha1.Feature{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "dodgy-experimental-periscope",
+		},
+		Spec: configv1alpha1.FeatureSpec{
+			Description:  "experimental support for deploying a periscope. doesnt work very often!",
+			Immutable:    false,
+			Discoverable: true,
+			Activated:    true,
+			Maturity:     "dev",
+		},
+	}
+
+	superToaster := &configv1alpha1.Feature{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "super-toaster",
+		},
+		Spec: configv1alpha1.FeatureSpec{
+			Description:  "An old reliable toaster",
+			Immutable:    false,
+			Discoverable: true,
+			Activated:    true,
+			Maturity:     "dev",
+		},
+	}
+
+	bar := &configv1alpha1.Feature{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bar",
+		},
+		Spec: configv1alpha1.FeatureSpec{
+			Description:  "Bar support",
+			Immutable:    true,
+			Discoverable: true,
+			Activated:    false,
+			Maturity:     "beta",
+		},
+	}
+
+	foo := &configv1alpha1.Feature{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		Spec: configv1alpha1.FeatureSpec{
+			Description:  "Foo support",
+			Immutable:    false,
+			Discoverable: true,
+			Activated:    false,
+			Maturity:     "dev",
+		},
+	}
+
+	baz := &configv1alpha1.Feature{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "baz",
+		},
+		Spec: configv1alpha1.FeatureSpec{
+			Description:  "Baz support",
+			Immutable:    false,
+			Discoverable: false,
+			Activated:    false,
+			Maturity:     "dev",
+		},
+	}
+
+	features := map[string]*configv1alpha1.Feature{
+		"cloud-event-listener":         cloudEventListener,
+		"dodgy-experimental-periscope": dodgyExperimentalPeriscope,
+		"super-toaster":                superToaster,
+		"foo":                          foo,
+		"bar":                          bar,
+		"baz":                          baz,
+	}
+
+	tkgSystemNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+		},
+	}
+
+	kubeSystemNamespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kube-system",
+		},
+	}
+
+	systemFeatureGate := &configv1alpha1.FeatureGate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tkg-system",
+		},
+		Spec: configv1alpha1.FeatureGateSpec{
+			NamespaceSelector: metav1.LabelSelector{},
+			Features: []configv1alpha1.FeatureReference{
+				configv1alpha1.FeatureReference{
+					Activate: true,
+					Name:     "cloud-event-listener",
+				},
+				configv1alpha1.FeatureReference{
+					Name:     "dodgy-experimental-periscope",
+					Activate: false,
+				},
+				configv1alpha1.FeatureReference{
+					Name:     "bar",
+					Activate: false,
+				},
+				configv1alpha1.FeatureReference{
+					Name:     "super-toaster",
+					Activate: false,
+				},
+				configv1alpha1.FeatureReference{
+					Name:     "foo",
+					Activate: false,
+				},
+			},
+		},
+	}
+
+	featureGates := map[string]*configv1alpha1.FeatureGate{
+		"tkg-system": systemFeatureGate,
+	}
+
+	// Objects to track in the fake client.
+	return []runtime.Object{
+		cloudEventListener,
+		dodgyExperimentalPeriscope,
+		superToaster,
+		bar,
+		foo,
+		baz,
+		systemFeatureGate,
+		tkgSystemNamespace,
+		kubeSystemNamespace,
+	}, features, featureGates
+}

--- a/pkg/v1/sdk/features/config/tanzu-featuregates-manager.yaml
+++ b/pkg/v1/sdk/features/config/tanzu-featuregates-manager.yaml
@@ -16,7 +16,7 @@ spec:
         app: tanzu-featuregates-manager
     spec:
       containers:
-        - image:  featuregates-controller-manager:latest
+        - image: featuregates-controller-manager:latest
           imagePullPolicy: IfNotPresent
           name: manager
           resources:


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds Feature plugin

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/527

### Describe testing done for PR
1. Install FeatureGate controller

a. Apply Features CRD
https://github.com/vmware-tanzu/tanzu-framework/blob/main/config/crd/bases/config.tanzu.vmware.com_features.yaml

b. Apply FeatureGate CRD
https://github.com/vmware-tanzu/tanzu-framework/blob/main/config/crd/bases/config.tanzu.vmware.com_featuregates.yaml

c. Install cert-manager
kubectl apply -f https://github.com/jetstack/cert-manager/releases/latest/download/cert-manager.yaml

d. Create tkg-system namespace
kubectl create ns tkg-system

e. Apply below config to install FeatureGate controller
```
---
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: selfsigned-issuer
  namespace: tkg-system
spec:
  selfSigned: {}
---
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: tanzu-featuregates-serving-cert
  namespace: tkg-system
spec:
  dnsNames:
  - tanzu-featuregates-webhook-service.tkg-system.svc
  - tanzu-featuregates-webhook-service-cert.tkg-system.svc.cluster.local
  issuerRef:
    kind: Issuer
    name: selfsigned-issuer
  secretName: tanzu-featuregates-webhook-server-cert
---
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    app: tanzu-featuregates-manager
  name: tanzu-featuregates-manager-sa
  namespace: tkg-system
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: tanzu-featuregates-manager-clusterrole
rules:
  - apiGroups:
      - config.tanzu.vmware.com
    resources:
      - featuregates
    verbs:
      - create
      - delete
      - get
      - list
      - patch
      - update
      - watch
  - apiGroups:
      - config.tanzu.vmware.com
    resources:
      - featuregates/status
    verbs:
      - get
      - patch
      - update
  - apiGroups:
      - config.tanzu.vmware.com
    resources:
      - features
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - config.tanzu.vmware.com
    resources:
      - features/status
    verbs:
      - get
      - patch
      - update
  - apiGroups:
      - ""
    resources:
      - namespaces
    verbs:
      - get
      - list
      - watch
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: tanzu-featuregates-manager-clusterrolebinding
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: tanzu-featuregates-manager-clusterrole
subjects:
  - kind: ServiceAccount
    name: tanzu-featuregates-manager-sa
    namespace: tkg-system
---
apiVersion: admissionregistration.k8s.io/v1
kind: ValidatingWebhookConfiguration
metadata:
  creationTimestamp: null
  name: tanzu-featuregates-validating-webhook
  annotations:
    cert-manager.io/inject-ca-from: tkg-system/tanzu-featuregates-serving-cert
webhooks:
  - admissionReviewVersions:
      - v1beta1
    clientConfig:
      service:
        name: tanzu-featuregates-webhook-service
        namespace: tkg-system
        path: /validate-config-tanzu-vmware-com-v1alpha1-featuregate
    failurePolicy: Fail
    name: featuregate.config.tanzu.vmware.com
    rules:
      - apiGroups:
          - config.tanzu.vmware.com
        apiVersions:
          - v1alpha1
        operations:
          - CREATE
          - UPDATE
        resources:
          - featuregates
    sideEffects: None
---
apiVersion: v1
kind: Service
metadata:
  name: tanzu-featuregates-webhook-service
  namespace: tkg-system
spec:
  ports:
    - port: 443
      targetPort: 9443
  selector:
      app: tanzu-featuregates-manager
---
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: tanzu-featuregates-manager
  name: tanzu-featuregates-controller-manager
  namespace: tkg-system
spec:
  replicas: 1
  selector:
    matchLabels:
      app: tanzu-featuregates-manager
  template:
    metadata:
      labels:
        app: tanzu-featuregates-manager
    spec:
      containers:
        - image: harishyayi/features:1
          imagePullPolicy: IfNotPresent
          name: manager
          resources:
            limits:
              cpu: 100m
              memory: 30Mi
            requests:
              cpu: 100m
              memory: 20Mi
          ports:
            - containerPort: 9443
              name: webhook-server
              protocol: TCP
          volumeMounts:
            - mountPath: /tmp/k8s-webhook-server/serving-certs
              name: cert
              readOnly: true
      volumes:
        - name: cert
          secret:
            defaultMode: 420
            secretName: tanzu-featuregates-webhook-server-cert
      serviceAccount: tanzu-featuregates-manager-sa
      terminationGracePeriodSeconds: 10
      tolerations:
        - effect: NoSchedule
          key: node-role.kubernetes.io/master
---
```
2. Create Features
```
---
apiVersion: config.tanzu.vmware.com/v1alpha1
kind: Feature
metadata:
  name: cloud-event-listener
spec:
  description: "Open a port to listen for cloudevents. Highly experimental!"
  immutable: false
  discoverable: true
  maturity: "alpha"
  activated: false
---
apiVersion: config.tanzu.vmware.com/v1alpha1
kind: Feature
metadata:
  name: dodgy-experimental-periscope
spec:
  description: "experimental support for deploying a periscope. doesnt work very often!"
  immutable: false
  discoverable: true
  maturity: "dev"
  activated: false
---
apiVersion: config.tanzu.vmware.com/v1alpha1
kind: Feature
metadata:
  name: super-toaster
spec:
  description: "An old reliable toaster"
  immutable: true
  discoverable: true
  maturity: "ga"
  activated: true
---
apiVersion: config.tanzu.vmware.com/v1alpha1
kind: Feature
metadata:
  name: ipv6
spec:
  description: "Optional ipv6 support"
  immutable: true
  discoverable: true
  maturity: "beta"
  activated: true
---
apiVersion: config.tanzu.vmware.com/v1alpha1
kind: Feature
metadata:
  name: fortan
spec:
  description: "Fortran support"
  immutable: true
  discoverable: false
  maturity: "dev"
  activated: false
```
3. Create Featuregate CR
```
apiVersion: config.tanzu.vmware.com/v1alpha1
kind: FeatureGate
metadata:
  name: tkg-system
spec:
  features:
  - activate: true
    name: cloud-event-listener
  namespaceSelector: {}
```
4. Test the feature plugin
   a. tanzu feature list
   b. tanzu feature activate dodgy-experimental-periscope
   c. tanzu feature deactivate dodgy-experimental-periscope
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Added Feature plugin to operate on Features and FeatureGates
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
