### PR TITLE
Change precedence of image repo settings in `get_image_repo_for_component`

### DIFF
--- a/pkg/v1/providers/ytt/lib/helpers.star
+++ b/pkg/v1/providers/ytt/lib/helpers.star
@@ -79,15 +79,13 @@ def tkg_image_repo():
 end
 
 def get_image_repo_for_component(image):
-  # if custom image repo is specified use that repo
-  if data.values.TKG_CUSTOM_IMAGE_REPOSITORY:
-    return data.values.TKG_CUSTOM_IMAGE_REPOSITORY
-  end
-
   # if imageRepo is specified for the component with image.imageRepository
   # than use image.imageRepository else use default imageRepo from BoM file
   if hasattr(image, 'imageRepository'):
     return image.imageRepository
+  # if custom image repo is specified use that repo
+  elif data.values.TKG_CUSTOM_IMAGE_REPOSITORY:
+    return data.values.TKG_CUSTOM_IMAGE_REPOSITORY
   else:
     return tkgBomData.imageConfig.imageRepository
   end


### PR DESCRIPTION
### What this PR does / why we need it

The ordering of the `get_image_repo_for_component` seems wrong to me. The way it is now the `TKG_CUSTOM_IMAGE_REPOSITORY` takes precedence over the more specific `imageRepository` field on individual images in the BOM. My current workflow requires me to override the global image repository using `TKG_CUSTOM_IMAGE_REPOSITORY`, which I imagine is pretty common if you don't want to use the standard image repository. However, this prevents you from using the `imageRepository` field to override individual image repositories, which you may want to do to push and test individual images in a separate location.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
No issue.

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Ran `tanzu management-cluster create --dry-run` with...
* nothing set and saw the default image repository.
* `TKG_CUSTOM_IMAGE_REPOSITORY` set and saw the custom image repository.
* `TKG_CUSTOM_IMAGE_REPOSITORY` set and an individual `imageRepository` field set and saw the `imageRepository` used.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Bom field no longer ignores imageRepository field when using TKG_CUSTOM_IMAGE_REPOSITORY field.
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
