### PR TITLE
Add nodepool operations for TKGS providers

### DIFF
--- a/cmd/cli/plugin/cluster/get_node_pools.go
+++ b/cmd/cli/plugin/cluster/get_node_pools.go
@@ -4,15 +4,21 @@
 package main
 
 import (
-	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/spf13/cobra"
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
+	tkgsv1alpha2 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgctl"
 )
 
 type listNodePoolOptions struct {
@@ -59,11 +65,18 @@ func listNodePoolsInternal(cmd *cobra.Command, server *v1alpha1.Server, clusterN
 		Namespace:   lnp.namespace,
 	}
 
+	isPacific, err := tkgctlClient.IsPacificRegionalCluster()
+	if err != nil {
+		return errors.Wrap(err, "error determining Tanzu Kubernetes Cluster service for vSphere management cluster ")
+	}
+	if isPacific {
+		return listPacificNodePools(cmd, tkgctlClient, mdOptions)
+	}
+
 	machineDeployments, err := tkgctlClient.GetMachineDeployments(mdOptions)
 	if err != nil {
 		return err
 	}
-
 	var t component.OutputWriter
 	if lnp.outputFormat == string(component.JSONOutputType) || lnp.outputFormat == string(component.YAMLOutputType) {
 		t = component.NewObjectWriter(cmd.OutOrStdout(), lnp.outputFormat, machineDeployments)
@@ -76,4 +89,63 @@ func listNodePoolsInternal(cmd *cobra.Command, server *v1alpha1.Server, clusterN
 	t.Render()
 
 	return nil
+}
+
+func listPacificNodePools(cmd *cobra.Command, tkgctlClient tkgctl.TKGClient, mdOptions client.GetMachineDeploymentOptions) error {
+	var tkcObj *tkgsv1alpha2.TanzuKubernetesCluster
+
+	tkcObj, err := tkgctlClient.GetPacificClusterObject(mdOptions.ClusterName, mdOptions.Namespace)
+	if err != nil {
+		return errors.Wrap(err, "unable to get Tanzu Kubernetes Cluster object")
+	}
+	machineDeployments, err := tkgctlClient.GetPacificMachineDeployments(mdOptions)
+	if err != nil {
+		return err
+	}
+	// // Pacific TKC has nodepool names, so update the MD names with nodepool names from TKC object before listing nodepools.
+	// // This is required because the user would want to use the nodepool names from the list output for nodepool set/delete operations
+	err = updateMDsWithTKCNodepoolNames(tkcObj, machineDeployments)
+	if err != nil {
+		return err
+	}
+
+	var t component.OutputWriter
+	if lnp.outputFormat == string(component.JSONOutputType) || lnp.outputFormat == string(component.YAMLOutputType) {
+		t = component.NewObjectWriter(cmd.OutOrStdout(), lnp.outputFormat, machineDeployments)
+	} else {
+		t = component.NewOutputWriter(cmd.OutOrStdout(), lnp.outputFormat, "NAME", "NAMESPACE", "PHASE", "REPLICAS", "READY", "UPDATED", "UNAVAILABLE")
+		for idx := range machineDeployments {
+			md := machineDeployments[idx]
+			t.AddRow(md.Name, md.Namespace, md.Status.Phase, md.Status.Replicas, md.Status.ReadyReplicas, md.Status.UpdatedReplicas, md.Status.UnavailableReplicas)
+		}
+	}
+	t.Render()
+
+	return nil
+}
+
+func updateMDsWithTKCNodepoolNames(tkcObj *tkgsv1alpha2.TanzuKubernetesCluster, machineDeployments []v1alpha3.MachineDeployment) error {
+	nodepools := tkcObj.Spec.Topology.NodePools
+	for mdIdx := range machineDeployments {
+		nodepoolName := getNodePoolNameFromMDName(tkcObj.Name, machineDeployments[mdIdx].Name)
+		for npIdx := range nodepools {
+			if nodepoolName == nodepools[npIdx].Name {
+				machineDeployments[mdIdx].Name = nodepools[npIdx].Name
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func getNodePoolNameFromMDName(clusterName, mdName string) string {
+	// Pacific(TKGS) creates a corresponding MachineDeployment for a nodepool in
+	// the format {tkc-clustername}-{nodepool-name}-{randomstring}
+	trimmedName := strings.TrimPrefix(mdName, fmt.Sprintf("%s-", clusterName))
+	lastHypenIdx := strings.LastIndex(trimmedName, "-")
+	if lastHypenIdx == -1 {
+		return ""
+	}
+	nodepoolName := trimmedName[:lastHypenIdx]
+	return nodepoolName
 }

--- a/pkg/v1/tkg/client/client.go
+++ b/pkg/v1/tkg/client/client.go
@@ -14,6 +14,7 @@ import (
 	clusterctltree "sigs.k8s.io/cluster-api/cmd/clusterctl/client/tree"
 
 	runv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
+	tkgsv1alpha2 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
 
 	clusterctlconfig "sigs.k8s.io/cluster-api/cmd/clusterctl/client/config"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/repository"
@@ -154,6 +155,9 @@ type Client interface {
 	SetMachineHealthCheck(options *SetMachineHealthCheckOptions) error
 	// GetMachineDeployments gets a list of MachineDeployments for a cluster
 	GetMachineDeployments(options GetMachineDeploymentOptions) ([]capi.MachineDeployment, error)
+	// GetPacificMachineDeployments gets machine deployments from a Pacific cluster
+	// Note: This would be soon deprecated after TKGS and TKGm adopt the clusterclass
+	GetPacificMachineDeployments(options GetMachineDeploymentOptions) ([]capi.MachineDeployment, error)
 	// SetMachineDeployment create machine deployment in a cluster
 	SetMachineDeployment(options *SetMachineDeploymentOptions) error
 	// DeleteMachineDeployment deletes a machine deployment in a cluster
@@ -193,6 +197,10 @@ type Client interface {
 	ActivateTanzuKubernetesReleases(tkrName string) error
 	// DeactivateTanzuKubernetesReleases deactivates TanzuKubernetesRelease
 	DeactivateTanzuKubernetesReleases(tkrName string) error
+	// IsPacificRegionalCluster checks if the cluster pointed to by kubeconfig  is Pacific management cluster(supervisor)
+	IsPacificRegionalCluster() (bool, error)
+	// GetPacificClusterObject gets Pacific cluster object
+	GetPacificClusterObject(clusterName, namespace string) (*tkgsv1alpha2.TanzuKubernetesCluster, error)
 }
 
 // TkgClient implements Client.

--- a/pkg/v1/tkg/client/machine_deployment.go
+++ b/pkg/v1/tkg/client/machine_deployment.go
@@ -4,11 +4,14 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	aws "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	azure "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
 	vsphere "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
@@ -16,8 +19,11 @@ import (
 	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
 	docker "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha3"
 
+	tkgsv1alpha2 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
+
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
 )
 
 // GetMachineDeploymentOptions a struct describing options for retrieving MachineDeployments
@@ -43,12 +49,18 @@ type DeleteMachineDeploymentOptions struct {
 
 // NodePool a struct describing a node pool
 type NodePool struct {
-	Name            string            `yaml:"name"`
-	Replicas        *int32            `yaml:"replicas,omitempty"`
-	AZ              string            `yaml:"az,omitempty"`
-	NodeMachineType string            `yaml:"nodeMachineType,omitempty"`
-	Labels          map[string]string `yaml:"labels,omitempty"`
-	VSphere         VSphereNodePool   `yaml:"vsphere,omitempty"`
+	Name             string                    `yaml:"name"`
+	Replicas         *int32                    `yaml:"replicas,omitempty"`
+	AZ               string                    `yaml:"az,omitempty"`
+	NodeMachineType  string                    `yaml:"nodeMachineType,omitempty"`
+	Labels           *map[string]string        `yaml:"labels,omitempty"`
+	VSphere          VSphereNodePool           `yaml:"vsphere,omitempty"`
+	Taints           *[]corev1.Taint           `yaml:"taints,omitempty"`
+	VMClass          string                    `yaml:"vmClass,omitempty"`
+	StorageClass     string                    `yaml:"storageClass,omitempty"`
+	Volumes          *[]tkgsv1alpha2.Volume    `yaml:"volumes,omitempty"`
+	TKR              tkgsv1alpha2.TKRReference `yaml:"tkr,omitempty"`
+	NodeDrainTimeout *metav1.Duration          `yaml:"nodeDrainTimeout,omitempty"`
 }
 
 // VSphereNodePool a struct describing properties necessary for a node pool on vSphere
@@ -67,13 +79,29 @@ type VSphereNodePool struct {
 	NumCPUs           int32  `yaml:"numCPUs,omitempty"`
 }
 
-// SetMachineDeployment sets a MachineDeployment on a cluster.
-func (c *TkgClient) SetMachineDeployment(options *SetMachineDeploymentOptions) error { //nolint:funlen,gocyclo
+// SetMachineDeployment sets a MachineDeployment on a cluster
+func (c *TkgClient) SetMachineDeployment(options *SetMachineDeploymentOptions) error {
 	clusterClient, err := c.getClusterClient()
 	if err != nil {
 		return errors.Wrap(err, "Unable to create clusterclient")
 	}
 
+	isPacific, err := clusterClient.IsPacificRegionalCluster()
+	if err != nil {
+		return errors.Wrap(err, "error determining Tanzu Kubernetes Cluster service for vSphere management cluster ")
+	}
+	if isPacific {
+		err := c.ValidatePacificVersionWithCLI(clusterClient)
+		if err != nil {
+			return err
+		}
+		return c.SetNodePoolsForPacificCluster(clusterClient, options)
+	}
+	return c.DoSetMachineDeployment(clusterClient, options)
+}
+
+// DoSetMachineDeployment sets a MachineDeployment on a cluster
+func (c *TkgClient) DoSetMachineDeployment(clusterClient clusterclient.Client, options *SetMachineDeploymentOptions) error { //nolint:gocyclo
 	workers, err := clusterClient.GetMDObjectForCluster(options.ClusterName, options.Namespace)
 	if err != nil || len(workers) == 0 {
 		return errors.Wrap(err, "unable to get worker machine deployments")
@@ -94,9 +122,11 @@ func (c *TkgClient) SetMachineDeployment(options *SetMachineDeploymentOptions) e
 	if options.Replicas != nil {
 		baseWorker.Spec.Replicas = options.Replicas
 	}
-
-	for k, v := range options.Labels {
-		baseWorker.Spec.Template.Labels[k] = v
+	if options.Labels != nil {
+		labels := *options.Labels
+		for k, v := range labels {
+			baseWorker.Spec.Template.Labels[k] = v
+		}
 	}
 
 	kcTemplate, err := retrieveKubeadmConfigTemplate(clusterClient, baseWorker.Spec.Template.Spec.Bootstrap.ConfigRef)
@@ -149,13 +179,96 @@ func (c *TkgClient) SetMachineDeployment(options *SetMachineDeploymentOptions) e
 	return nil
 }
 
+// SetNodePoolsForPacificCluster sets nodepool for Pacific cluster
+func (c *TkgClient) SetNodePoolsForPacificCluster(clusterClient clusterclient.Client, options *SetMachineDeploymentOptions) error {
+	tkc, err := clusterClient.GetPacificClusterObject(options.ClusterName, options.Namespace)
+	if err != nil {
+		return errors.Wrapf(err, "unable to get TKC object %q in namespace %q", options.ClusterName, options.Namespace)
+	}
+
+	nodePools := tkc.Spec.Topology.NodePools
+	update := false
+	nodePool := tkgsv1alpha2.NodePool{}
+	for idx := range nodePools {
+		if nodePools[idx].Name == options.Name {
+			nodePool = nodePools[idx]
+			update = true
+		}
+	}
+	setTKCNodePool(options, &nodePool)
+	if update {
+		for idx := range tkc.Spec.Topology.NodePools {
+			if tkc.Spec.Topology.NodePools[idx].Name == options.Name {
+				tkc.Spec.Topology.NodePools[idx] = nodePool
+				break
+			}
+		}
+		err = clusterClient.UpdateResource(tkc, tkc.Name, options.Namespace)
+		if err != nil {
+			return errors.Wrapf(err, "failed to update the nodepool %q of TKC %q in namespace %q", options.Name, tkc.Name, options.Namespace)
+		}
+	} else {
+		tkc.Spec.Topology.NodePools = append(tkc.Spec.Topology.NodePools, nodePool)
+		err = clusterClient.UpdateResource(tkc, tkc.Name, options.Namespace)
+		if err != nil {
+			return errors.Wrapf(err, "failed to add the nodepool %q of TKC %q in namespace %q", options.Name, tkc.Name, options.Namespace)
+		}
+	}
+
+	return nil
+}
+
+func setTKCNodePool(options *SetMachineDeploymentOptions, nodepool *tkgsv1alpha2.NodePool) {
+	nodepool.Name = options.Name
+	if options.Labels != nil {
+		nodepool.Labels = *options.Labels
+	}
+	if options.Taints != nil {
+		nodepool.Taints = *options.Taints
+	}
+	if options.Replicas != nil {
+		nodepool.Replicas = options.Replicas
+	}
+	if options.StorageClass != "" {
+		nodepool.StorageClass = options.StorageClass
+	}
+	if options.VMClass != "" {
+		nodepool.VMClass = options.VMClass
+	}
+	if options.TKR.Reference != nil && options.TKR.Reference.Name != "" {
+		nodepool.TKR = options.TKR
+	}
+	if options.Volumes != nil {
+		nodepool.Volumes = *options.Volumes
+	}
+	if options.NodeDrainTimeout != nil {
+		nodepool.NodeDrainTimeout = options.NodeDrainTimeout
+	}
+}
+
 // DeleteMachineDeployment deletes a machine deployment
-func (c *TkgClient) DeleteMachineDeployment(options DeleteMachineDeploymentOptions) error { //nolint:funlen,gocyclo
+func (c *TkgClient) DeleteMachineDeployment(options DeleteMachineDeploymentOptions) error {
 	clusterClient, err := c.getClusterClient()
 	if err != nil {
 		return errors.Wrap(err, "Unable to create clusterclient")
 	}
 
+	isPacific, err := clusterClient.IsPacificRegionalCluster()
+	if err != nil {
+		return errors.Wrap(err, "error determining Tanzu Kubernetes Cluster service for vSphere management cluster ")
+	}
+	if isPacific {
+		err := c.ValidatePacificVersionWithCLI(clusterClient)
+		if err != nil {
+			return err
+		}
+		return c.DeleteNodePoolForPacificCluster(clusterClient, options)
+	}
+	return c.DoDeleteMachineDeployment(clusterClient, options)
+}
+
+// DoDeleteMachineDeployment deletes a machine deployment
+func (c *TkgClient) DoDeleteMachineDeployment(clusterClient clusterclient.Client, options DeleteMachineDeploymentOptions) error { //nolint:funlen,gocyclo
 	workers, err := clusterClient.GetMDObjectForCluster(options.ClusterName, options.Namespace)
 	if err != nil {
 		return errors.Wrap(err, "unable to get worker machine deployments")
@@ -236,6 +349,50 @@ func (c *TkgClient) DeleteMachineDeployment(options DeleteMachineDeploymentOptio
 	if err != nil {
 		return errors.Wrap(err, "unable to delete kubeadmconfigtemplate")
 	}
+	return nil
+}
+
+// DeleteNodePoolForPacificCluster deletes a machine deployment
+func (c *TkgClient) DeleteNodePoolForPacificCluster(clusterClient clusterclient.Client, options DeleteMachineDeploymentOptions) error {
+	tkc, err := clusterClient.GetPacificClusterObject(options.ClusterName, options.Namespace)
+	if err != nil {
+		return errors.Wrapf(err, "unable to get TKC object %q in namespace %q", options.ClusterName, options.Namespace)
+	}
+
+	nodePools := tkc.Spec.Topology.NodePools
+	matched := false
+	toDeleteNodepolIndex := -1
+	for idx := range nodePools {
+		if nodePools[idx].Name == options.Name {
+			toDeleteNodepolIndex = idx
+			matched = true
+		}
+	}
+
+	if !matched {
+		return errors.Errorf("could not find node pool %q to delete", options.Name)
+	}
+
+	if len(nodePools) < 2 {
+		return errors.New("cannot delete last worker node pool in cluster")
+	}
+
+	nodepoolPatch := []clusterclient.JSONPatch{
+		{
+			Op:   "remove",
+			Path: fmt.Sprintf("/spec/topology/nodePools/%d", toDeleteNodepolIndex),
+		},
+	}
+
+	payloadBytes, err := json.Marshal(nodepoolPatch)
+	if err != nil {
+		return errors.Wrap(err, "unable to generate json patch")
+	}
+	log.V(3).Infof("Applying TanzuKubernetesCluster node pool delete patch: %s", string(payloadBytes))
+	err = clusterClient.PatchResource(tkc, options.ClusterName, options.Namespace, string(payloadBytes), types.JSONPatchType, nil)
+	if err != nil {
+		return errors.Wrap(err, "unable to apply node pool delete patch for tkc object")
+	}
 
 	return nil
 }
@@ -253,6 +410,25 @@ func (c *TkgClient) GetMachineDeployments(options GetMachineDeploymentOptions) (
 	}
 
 	return workers, nil
+}
+
+// GetPacificMachineDeployments retrieves machine deployments for a Pacific(TKGS) cluster
+// This is defined separately for Pacific (TKGS) provider because the TKGS and TKGm CAPI versions could be different
+// and this should be deprecated after clusterclass is adopted by both TKGm and TKGS
+func (c *TkgClient) GetPacificMachineDeployments(options GetMachineDeploymentOptions) ([]capi.MachineDeployment, error) {
+	clusterClient, err := c.getClusterClient()
+	if err != nil {
+		return nil, errors.Wrap(err, "Unable to create clusterclient")
+	}
+
+	mdList := &capi.MachineDeploymentList{}
+	if err := clusterClient.GetResourceList(mdList, options.ClusterName, options.Namespace, nil, nil); err != nil {
+		return nil, errors.Wrap(err, "unable to get machine deployment for the given cluster")
+	}
+	if len(mdList.Items) == 0 {
+		return nil, errors.New("no machine deployment objects found for the given cluster")
+	}
+	return mdList.Items, nil
 }
 
 func createVSphereMachineTemplate(clusterClient clusterclient.Client, infraTemplate *corev1.ObjectReference, machineTemplateName string, options *SetMachineDeploymentOptions) error {

--- a/pkg/v1/tkg/client/machine_deployment_test.go
+++ b/pkg/v1/tkg/client/machine_deployment_test.go
@@ -1,0 +1,315 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	tkgsv1alpha2 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
+	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+)
+
+var _ = Describe("GetMachineDeployments", func() {
+	var (
+		err                   error
+		regionalClusterClient *fakes.ClusterClient
+		tkgClient             *TkgClient
+		setDeploymentOptions  *SetMachineDeploymentOptions
+		replicas              int32
+		tkc                   tkgsv1alpha2.TanzuKubernetesCluster
+		gotTkc                *tkgsv1alpha2.TanzuKubernetesCluster
+		testClusterName       string = "my-cluster"
+	)
+
+	BeforeEach(func() {
+		tkgClient, err = CreateTKGClient("../fakes/config/config.yaml", testingDir, defaultTKGBoMFileForTesting, 2*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		regionalClusterClient = &fakes.ClusterClient{}
+	})
+	Context("When the regional cluster is Pacific", func() {
+		var retError error
+		JustBeforeEach(func() {
+			regionalClusterClient.GetPacificClusterObjectReturns(&tkc, retError)
+			err = tkgClient.SetNodePoolsForPacificCluster(regionalClusterClient, setDeploymentOptions)
+		})
+
+		Context("When the TKC cluster doesn't exist", func() {
+			BeforeEach(func() {
+				retError = errors.Errorf("fake-tkg-get-error")
+				tkc = GetDummyPacificCluster()
+
+				replicas = 1
+				setDeploymentOptions = &SetMachineDeploymentOptions{
+					ClusterName: testClusterName,
+					Namespace:   "dummy-namespace",
+					NodePool: NodePool{
+						Name:         "fake-nodepool",
+						Replicas:     &replicas,
+						VMClass:      "fake-vm-class",
+						StorageClass: "fake-storage-class",
+						TKR: tkgsv1alpha2.TKRReference{
+							Reference: &corev1.ObjectReference{
+								Name: "dummy-tkr",
+							},
+						},
+					}}
+			})
+			It("should return error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(`unable to get TKC object "my-cluster" in namespace "dummy-namespace": fake-tkg-get-error`))
+			})
+		})
+		Context("When the TKC cluster exist and TKC resource update failed when new node-pool is to be added", func() {
+			BeforeEach(func() {
+				retError = nil
+				tkc = GetDummyPacificCluster()
+				tkc.Name = testClusterName
+
+				replicas = 1
+				setDeploymentOptions = &SetMachineDeploymentOptions{
+					ClusterName: testClusterName,
+					Namespace:   "dummy-namespace",
+					NodePool: NodePool{
+						Name:         "fake-new-nodepool",
+						Replicas:     &replicas,
+						VMClass:      "fake-vm-class",
+						StorageClass: "fake-storage-class",
+						TKR: tkgsv1alpha2.TKRReference{
+							Reference: &corev1.ObjectReference{
+								Name: "dummy-tkr",
+							},
+						},
+					}}
+				regionalClusterClient.UpdateResourceCalls(func(obj interface{}, objName string, namespace string, opts ...client.UpdateOption) error {
+					return errors.Errorf("fake-update-resource-error")
+				})
+			})
+			It("should return error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(`failed to add the nodepool "fake-new-nodepool" of TKC "my-cluster" in namespace "dummy-namespace": fake-update-resource-error`))
+			})
+		})
+		Context("When the TKC cluster exist and a new node-pool is added successfully", func() {
+			BeforeEach(func() {
+				retError = nil
+				tkc = GetDummyPacificCluster()
+
+				replicas = 1
+				setDeploymentOptions = &SetMachineDeploymentOptions{
+					ClusterName: testClusterName,
+					Namespace:   "dummy-namespace",
+					NodePool: NodePool{
+						Name:         "fake-new-nodepool",
+						Replicas:     &replicas,
+						VMClass:      "fake-vm-class",
+						StorageClass: "fake-storage-class",
+						TKR: tkgsv1alpha2.TKRReference{
+							Reference: &corev1.ObjectReference{
+								Name: "dummy-tkr",
+							},
+						},
+					}}
+				regionalClusterClient.UpdateResourceCalls(func(obj interface{}, objName string, namespace string, opts ...client.UpdateOption) error {
+					gotTkc = obj.(*tkgsv1alpha2.TanzuKubernetesCluster)
+					return nil
+				})
+			})
+			It("should not return error and TKC should show newly added nodepool", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(gotTkc.Spec.Topology.NodePools)).To(Equal(3))
+				Expect(gotTkc.Spec.Topology.NodePools[2].Name).To(Equal("fake-new-nodepool"))
+			})
+		})
+		Context("When the TKC cluster exist and a node-pool is to be updated", func() {
+			BeforeEach(func() {
+				retError = nil
+				tkc = GetDummyPacificCluster()
+
+				replicas = 3
+				setDeploymentOptions = &SetMachineDeploymentOptions{
+					ClusterName: testClusterName,
+					Namespace:   "dummy-namespace",
+					NodePool: NodePool{
+						Name:         "nodepool-1",
+						Replicas:     &replicas,
+						VMClass:      "fake-vm-class",
+						StorageClass: "fake-storage-class",
+						TKR: tkgsv1alpha2.TKRReference{
+							Reference: &corev1.ObjectReference{
+								Name: "dummy-tkr",
+							},
+						},
+					}}
+				regionalClusterClient.UpdateResourceCalls(func(obj interface{}, objName string, namespace string, opts ...client.UpdateOption) error {
+					gotTkc = obj.(*tkgsv1alpha2.TanzuKubernetesCluster)
+					return nil
+				})
+			})
+			It("should update the existing node pool of TKC", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(gotTkc.Spec.Topology.NodePools)).To(Equal(2))
+				Expect(gotTkc.Spec.Topology.NodePools[0].Name).To(Equal("nodepool-1"))
+				Expect(*gotTkc.Spec.Topology.NodePools[0].Replicas).To(Equal(int32(3)))
+				Expect(gotTkc.Spec.Topology.NodePools[0].VMClass).To(Equal("fake-vm-class"))
+
+			})
+		})
+	})
+})
+
+var _ = Describe("DeleteMachineDeployments", func() {
+	var (
+		err                     error
+		regionalClusterClient   *fakes.ClusterClient
+		tkgClient               *TkgClient
+		deleteDeploymentOptions DeleteMachineDeploymentOptions
+		tkc                     tkgsv1alpha2.TanzuKubernetesCluster
+		testClusterName         string = "my-cluster"
+	)
+
+	BeforeEach(func() {
+		tkgClient, err = CreateTKGClient("../fakes/config/config.yaml", testingDir, defaultTKGBoMFileForTesting, 2*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		regionalClusterClient = &fakes.ClusterClient{}
+	})
+	Context("When the regional cluster is Pacific", func() {
+		var retError error
+		JustBeforeEach(func() {
+			regionalClusterClient.GetPacificClusterObjectReturns(&tkc, retError)
+			err = tkgClient.DeleteNodePoolForPacificCluster(regionalClusterClient, deleteDeploymentOptions)
+		})
+
+		Context("When the TKC cluster doesn't exist", func() {
+			BeforeEach(func() {
+				retError = errors.Errorf("fake-tkg-get-error")
+				tkc = GetDummyPacificCluster()
+
+				deleteDeploymentOptions = DeleteMachineDeploymentOptions{
+					ClusterName: testClusterName,
+					Namespace:   "dummy-namespace",
+					Name:        "fake-nodepool",
+				}
+			})
+			It("should return error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(`unable to get TKC object "my-cluster" in namespace "dummy-namespace": fake-tkg-get-error`))
+			})
+		})
+		Context("When the TKC cluster exist and node-pool to be deleted doesn't exist", func() {
+			BeforeEach(func() {
+				retError = nil
+				tkc = GetDummyPacificCluster()
+				tkc.Name = testClusterName
+
+				deleteDeploymentOptions = DeleteMachineDeploymentOptions{
+					ClusterName: testClusterName,
+					Namespace:   "dummy-namespace",
+					Name:        "invalid-nodepool",
+				}
+				regionalClusterClient.PatchResourceReturns(nil)
+			})
+			It("should return error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(`could not find node pool "invalid-nodepool" to delete`))
+			})
+		})
+		Context("When the TKC cluster exist, and updating the TKC object failed", func() {
+			BeforeEach(func() {
+				retError = nil
+				tkc = GetDummyPacificCluster()
+				tkc.Name = "my-cluster"
+
+				deleteDeploymentOptions = DeleteMachineDeploymentOptions{
+					ClusterName: "my-cluster",
+					Namespace:   "dummy-namespace",
+					Name:        "nodepool-1",
+				}
+				regionalClusterClient.PatchResourceReturns(errors.Errorf("fake-patch-error"))
+			})
+			It("should return error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(`unable to apply node pool delete patch for tkc object: fake-patch-error`))
+			})
+		})
+		Context("When the TKC cluster exist and nodepool is successfully deleted", func() {
+			gotJSONPatchString := ""
+			gotTKCName := ""
+			gotNameSpace := ""
+			BeforeEach(func() {
+				retError = nil
+				tkc = GetDummyPacificCluster()
+				tkc.Name = testClusterName
+
+				deleteDeploymentOptions = DeleteMachineDeploymentOptions{
+					ClusterName: testClusterName,
+					Namespace:   "dummy-namespace",
+					Name:        "nodepool-1",
+				}
+				regionalClusterClient.PatchResourceCalls(func(obj interface{}, resourceName string, namespace string, patchJSONString string, patchType types.PatchType, pollOptions *clusterclient.PollOptions) error {
+					gotJSONPatchString = patchJSONString
+					gotTKCName = resourceName
+					gotNameSpace = namespace
+					return nil
+				})
+			})
+			It("should not return error", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(gotTKCName).To(Equal("my-cluster"))
+				Expect(gotNameSpace).To(Equal("dummy-namespace"))
+				wantJSONPatchStrig := `{"op":"remove","path":"/spec/topology/nodePools/0","value":""}`
+				Expect(gotJSONPatchString).To(ContainSubstring(wantJSONPatchStrig))
+			})
+		})
+	})
+})
+
+func GetDummyPacificCluster() tkgsv1alpha2.TanzuKubernetesCluster {
+	var controlPlaneReplicas int32 = 1
+	var nodepoolReplicase int32 = 2
+	controlPlane := tkgsv1alpha2.TopologySettings{
+		Replicas: &controlPlaneReplicas,
+		TKR: tkgsv1alpha2.TKRReference{
+			Reference: &corev1.ObjectReference{
+				Name: "dummy-tkr",
+			},
+		},
+	}
+	nodepools := []tkgsv1alpha2.NodePool{
+		{Name: "nodepool-1",
+			TopologySettings: tkgsv1alpha2.TopologySettings{
+				Replicas: &nodepoolReplicase,
+				TKR: tkgsv1alpha2.TKRReference{
+					Reference: &corev1.ObjectReference{
+						Name: "dummy-tkr",
+					},
+				},
+			},
+		},
+		{Name: "nodepool-2",
+			TopologySettings: tkgsv1alpha2.TopologySettings{
+				Replicas: &nodepoolReplicase,
+				TKR: tkgsv1alpha2.TKRReference{
+					Reference: &corev1.ObjectReference{
+						Name: "dummy-tkr",
+					},
+				},
+			},
+		},
+	}
+
+	tkc := tkgsv1alpha2.TanzuKubernetesCluster{}
+	tkc.ClusterName = "DummyTKC"
+	tkc.Spec.Topology.ControlPlane = controlPlane
+	tkc.Spec.Topology.NodePools = nodepools
+	return tkc
+}

--- a/pkg/v1/tkg/client/pacific_cluster.go
+++ b/pkg/v1/tkg/client/pacific_cluster.go
@@ -1,0 +1,61 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+
+	tkgsv1alpha2 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
+)
+
+// GetPacificClusterObject return Pacific cluster object
+func (c *TkgClient) GetPacificClusterObject(clusterName, namespace string) (*tkgsv1alpha2.TanzuKubernetesCluster, error) {
+	currentRegion, err := c.GetCurrentRegionContext()
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot get current management cluster context")
+	}
+	clusterclientOptions := clusterclient.Options{
+		GetClientInterval: 1 * time.Second,
+		GetClientTimeout:  3 * time.Second,
+	}
+	regionalClusterClient, err := clusterclient.NewClient(currentRegion.SourceFilePath, currentRegion.ContextName, clusterclientOptions)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get cluster client")
+	}
+
+	isPacific, err := regionalClusterClient.IsPacificRegionalCluster()
+	if err != nil {
+		return nil, errors.Wrap(err, "error determining 'Tanzu Kubernetes Cluster service for vSphere' management cluster")
+	}
+	if !isPacific {
+		return nil, errors.New("the management cluster is not 'Tanzu Kubernetes Cluster service for vSphere' management cluster")
+	}
+
+	err = c.ValidatePacificVersionWithCLI(regionalClusterClient)
+	if err != nil {
+		return nil, err
+	}
+	return regionalClusterClient.GetPacificClusterObject(clusterName, namespace)
+}
+
+// IsPacificRegionalCluster checks if the cluster pointed to by kubeconfig  is Pacific management cluster(supervisor)
+func (c *TkgClient) IsPacificRegionalCluster() (bool, error) {
+	currentRegion, err := c.GetCurrentRegionContext()
+	if err != nil {
+		return false, errors.Wrap(err, "cannot get current management cluster context")
+	}
+	clusterclientOptions := clusterclient.Options{
+		GetClientInterval: 1 * time.Second,
+		GetClientTimeout:  3 * time.Second,
+	}
+	regionalClusterClient, err := clusterclient.NewClient(currentRegion.SourceFilePath, currentRegion.ContextName, clusterclientOptions)
+	if err != nil {
+		return false, errors.Wrap(err, "unable to get cluster client")
+	}
+
+	return regionalClusterClient.IsPacificRegionalCluster()
+}

--- a/pkg/v1/tkg/fakes/client.go
+++ b/pkg/v1/tkg/fakes/client.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/client/tree"
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/region"
@@ -290,6 +291,33 @@ type Client struct {
 		result1 []client.MachineHealthCheck
 		result2 error
 	}
+	GetPacificClusterObjectStub        func(string, string) (*v1alpha2.TanzuKubernetesCluster, error)
+	getPacificClusterObjectMutex       sync.RWMutex
+	getPacificClusterObjectArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	getPacificClusterObjectReturns struct {
+		result1 *v1alpha2.TanzuKubernetesCluster
+		result2 error
+	}
+	getPacificClusterObjectReturnsOnCall map[int]struct {
+		result1 *v1alpha2.TanzuKubernetesCluster
+		result2 error
+	}
+	GetPacificMachineDeploymentsStub        func(client.GetMachineDeploymentOptions) ([]v1alpha3.MachineDeployment, error)
+	getPacificMachineDeploymentsMutex       sync.RWMutex
+	getPacificMachineDeploymentsArgsForCall []struct {
+		arg1 client.GetMachineDeploymentOptions
+	}
+	getPacificMachineDeploymentsReturns struct {
+		result1 []v1alpha3.MachineDeployment
+		result2 error
+	}
+	getPacificMachineDeploymentsReturnsOnCall map[int]struct {
+		result1 []v1alpha3.MachineDeployment
+		result2 error
+	}
 	GetRegionContextsStub        func(string) ([]region.RegionContext, error)
 	getRegionContextsMutex       sync.RWMutex
 	getRegionContextsArgsForCall []struct {
@@ -390,6 +418,18 @@ type Client struct {
 		result2 error
 	}
 	isPacificManagementClusterReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
+	IsPacificRegionalClusterStub        func() (bool, error)
+	isPacificRegionalClusterMutex       sync.RWMutex
+	isPacificRegionalClusterArgsForCall []struct {
+	}
+	isPacificRegionalClusterReturns struct {
+		result1 bool
+		result2 error
+	}
+	isPacificRegionalClusterReturnsOnCall map[int]struct {
 		result1 bool
 		result2 error
 	}
@@ -1952,6 +1992,135 @@ func (fake *Client) GetMachineHealthChecksReturnsOnCall(i int, result1 []client.
 	}{result1, result2}
 }
 
+func (fake *Client) GetPacificClusterObject(arg1 string, arg2 string) (*v1alpha2.TanzuKubernetesCluster, error) {
+	fake.getPacificClusterObjectMutex.Lock()
+	ret, specificReturn := fake.getPacificClusterObjectReturnsOnCall[len(fake.getPacificClusterObjectArgsForCall)]
+	fake.getPacificClusterObjectArgsForCall = append(fake.getPacificClusterObjectArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.GetPacificClusterObjectStub
+	fakeReturns := fake.getPacificClusterObjectReturns
+	fake.recordInvocation("GetPacificClusterObject", []interface{}{arg1, arg2})
+	fake.getPacificClusterObjectMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *Client) GetPacificClusterObjectCallCount() int {
+	fake.getPacificClusterObjectMutex.RLock()
+	defer fake.getPacificClusterObjectMutex.RUnlock()
+	return len(fake.getPacificClusterObjectArgsForCall)
+}
+
+func (fake *Client) GetPacificClusterObjectCalls(stub func(string, string) (*v1alpha2.TanzuKubernetesCluster, error)) {
+	fake.getPacificClusterObjectMutex.Lock()
+	defer fake.getPacificClusterObjectMutex.Unlock()
+	fake.GetPacificClusterObjectStub = stub
+}
+
+func (fake *Client) GetPacificClusterObjectArgsForCall(i int) (string, string) {
+	fake.getPacificClusterObjectMutex.RLock()
+	defer fake.getPacificClusterObjectMutex.RUnlock()
+	argsForCall := fake.getPacificClusterObjectArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *Client) GetPacificClusterObjectReturns(result1 *v1alpha2.TanzuKubernetesCluster, result2 error) {
+	fake.getPacificClusterObjectMutex.Lock()
+	defer fake.getPacificClusterObjectMutex.Unlock()
+	fake.GetPacificClusterObjectStub = nil
+	fake.getPacificClusterObjectReturns = struct {
+		result1 *v1alpha2.TanzuKubernetesCluster
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *Client) GetPacificClusterObjectReturnsOnCall(i int, result1 *v1alpha2.TanzuKubernetesCluster, result2 error) {
+	fake.getPacificClusterObjectMutex.Lock()
+	defer fake.getPacificClusterObjectMutex.Unlock()
+	fake.GetPacificClusterObjectStub = nil
+	if fake.getPacificClusterObjectReturnsOnCall == nil {
+		fake.getPacificClusterObjectReturnsOnCall = make(map[int]struct {
+			result1 *v1alpha2.TanzuKubernetesCluster
+			result2 error
+		})
+	}
+	fake.getPacificClusterObjectReturnsOnCall[i] = struct {
+		result1 *v1alpha2.TanzuKubernetesCluster
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *Client) GetPacificMachineDeployments(arg1 client.GetMachineDeploymentOptions) ([]v1alpha3.MachineDeployment, error) {
+	fake.getPacificMachineDeploymentsMutex.Lock()
+	ret, specificReturn := fake.getPacificMachineDeploymentsReturnsOnCall[len(fake.getPacificMachineDeploymentsArgsForCall)]
+	fake.getPacificMachineDeploymentsArgsForCall = append(fake.getPacificMachineDeploymentsArgsForCall, struct {
+		arg1 client.GetMachineDeploymentOptions
+	}{arg1})
+	stub := fake.GetPacificMachineDeploymentsStub
+	fakeReturns := fake.getPacificMachineDeploymentsReturns
+	fake.recordInvocation("GetPacificMachineDeployments", []interface{}{arg1})
+	fake.getPacificMachineDeploymentsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *Client) GetPacificMachineDeploymentsCallCount() int {
+	fake.getPacificMachineDeploymentsMutex.RLock()
+	defer fake.getPacificMachineDeploymentsMutex.RUnlock()
+	return len(fake.getPacificMachineDeploymentsArgsForCall)
+}
+
+func (fake *Client) GetPacificMachineDeploymentsCalls(stub func(client.GetMachineDeploymentOptions) ([]v1alpha3.MachineDeployment, error)) {
+	fake.getPacificMachineDeploymentsMutex.Lock()
+	defer fake.getPacificMachineDeploymentsMutex.Unlock()
+	fake.GetPacificMachineDeploymentsStub = stub
+}
+
+func (fake *Client) GetPacificMachineDeploymentsArgsForCall(i int) client.GetMachineDeploymentOptions {
+	fake.getPacificMachineDeploymentsMutex.RLock()
+	defer fake.getPacificMachineDeploymentsMutex.RUnlock()
+	argsForCall := fake.getPacificMachineDeploymentsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *Client) GetPacificMachineDeploymentsReturns(result1 []v1alpha3.MachineDeployment, result2 error) {
+	fake.getPacificMachineDeploymentsMutex.Lock()
+	defer fake.getPacificMachineDeploymentsMutex.Unlock()
+	fake.GetPacificMachineDeploymentsStub = nil
+	fake.getPacificMachineDeploymentsReturns = struct {
+		result1 []v1alpha3.MachineDeployment
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *Client) GetPacificMachineDeploymentsReturnsOnCall(i int, result1 []v1alpha3.MachineDeployment, result2 error) {
+	fake.getPacificMachineDeploymentsMutex.Lock()
+	defer fake.getPacificMachineDeploymentsMutex.Unlock()
+	fake.GetPacificMachineDeploymentsStub = nil
+	if fake.getPacificMachineDeploymentsReturnsOnCall == nil {
+		fake.getPacificMachineDeploymentsReturnsOnCall = make(map[int]struct {
+			result1 []v1alpha3.MachineDeployment
+			result2 error
+		})
+	}
+	fake.getPacificMachineDeploymentsReturnsOnCall[i] = struct {
+		result1 []v1alpha3.MachineDeployment
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *Client) GetRegionContexts(arg1 string) ([]region.RegionContext, error) {
 	fake.getRegionContextsMutex.Lock()
 	ret, specificReturn := fake.getRegionContextsReturnsOnCall[len(fake.getRegionContextsArgsForCall)]
@@ -2451,6 +2620,62 @@ func (fake *Client) IsPacificManagementClusterReturnsOnCall(i int, result1 bool,
 		})
 	}
 	fake.isPacificManagementClusterReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *Client) IsPacificRegionalCluster() (bool, error) {
+	fake.isPacificRegionalClusterMutex.Lock()
+	ret, specificReturn := fake.isPacificRegionalClusterReturnsOnCall[len(fake.isPacificRegionalClusterArgsForCall)]
+	fake.isPacificRegionalClusterArgsForCall = append(fake.isPacificRegionalClusterArgsForCall, struct {
+	}{})
+	stub := fake.IsPacificRegionalClusterStub
+	fakeReturns := fake.isPacificRegionalClusterReturns
+	fake.recordInvocation("IsPacificRegionalCluster", []interface{}{})
+	fake.isPacificRegionalClusterMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *Client) IsPacificRegionalClusterCallCount() int {
+	fake.isPacificRegionalClusterMutex.RLock()
+	defer fake.isPacificRegionalClusterMutex.RUnlock()
+	return len(fake.isPacificRegionalClusterArgsForCall)
+}
+
+func (fake *Client) IsPacificRegionalClusterCalls(stub func() (bool, error)) {
+	fake.isPacificRegionalClusterMutex.Lock()
+	defer fake.isPacificRegionalClusterMutex.Unlock()
+	fake.IsPacificRegionalClusterStub = stub
+}
+
+func (fake *Client) IsPacificRegionalClusterReturns(result1 bool, result2 error) {
+	fake.isPacificRegionalClusterMutex.Lock()
+	defer fake.isPacificRegionalClusterMutex.Unlock()
+	fake.IsPacificRegionalClusterStub = nil
+	fake.isPacificRegionalClusterReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *Client) IsPacificRegionalClusterReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.isPacificRegionalClusterMutex.Lock()
+	defer fake.isPacificRegionalClusterMutex.Unlock()
+	fake.IsPacificRegionalClusterStub = nil
+	if fake.isPacificRegionalClusterReturnsOnCall == nil {
+		fake.isPacificRegionalClusterReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.isPacificRegionalClusterReturnsOnCall[i] = struct {
 		result1 bool
 		result2 error
 	}{result1, result2}
@@ -3455,6 +3680,10 @@ func (fake *Client) Invocations() map[string][][]interface{} {
 	defer fake.getMachineDeploymentsMutex.RUnlock()
 	fake.getMachineHealthChecksMutex.RLock()
 	defer fake.getMachineHealthChecksMutex.RUnlock()
+	fake.getPacificClusterObjectMutex.RLock()
+	defer fake.getPacificClusterObjectMutex.RUnlock()
+	fake.getPacificMachineDeploymentsMutex.RLock()
+	defer fake.getPacificMachineDeploymentsMutex.RUnlock()
 	fake.getRegionContextsMutex.RLock()
 	defer fake.getRegionContextsMutex.RUnlock()
 	fake.getTanzuKubernetesReleasesMutex.RLock()
@@ -3471,6 +3700,8 @@ func (fake *Client) Invocations() map[string][][]interface{} {
 	defer fake.isManagementClusterAKindClusterMutex.RUnlock()
 	fake.isPacificManagementClusterMutex.RLock()
 	defer fake.isPacificManagementClusterMutex.RUnlock()
+	fake.isPacificRegionalClusterMutex.RLock()
+	defer fake.isPacificRegionalClusterMutex.RUnlock()
 	fake.listTKGClustersMutex.RLock()
 	defer fake.listTKGClustersMutex.RUnlock()
 	fake.parseHiddenArgsAsFeatureFlagsMutex.RLock()

--- a/pkg/v1/tkg/fakes/clusterclient.go
+++ b/pkg/v1/tkg/fakes/clusterclient.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/azure"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgconfigbom"
@@ -352,6 +353,20 @@ type ClusterClient struct {
 	}
 	getManagementClusterTKGVersionReturnsOnCall map[int]struct {
 		result1 string
+		result2 error
+	}
+	GetPacificClusterObjectStub        func(string, string) (*v1alpha2.TanzuKubernetesCluster, error)
+	getPacificClusterObjectMutex       sync.RWMutex
+	getPacificClusterObjectArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	getPacificClusterObjectReturns struct {
+		result1 *v1alpha2.TanzuKubernetesCluster
+		result2 error
+	}
+	getPacificClusterObjectReturnsOnCall map[int]struct {
+		result1 *v1alpha2.TanzuKubernetesCluster
 		result2 error
 	}
 	GetPacificTKCAPIVersionStub        func() (string, error)
@@ -2658,6 +2673,70 @@ func (fake *ClusterClient) GetManagementClusterTKGVersionReturnsOnCall(i int, re
 	}
 	fake.getManagementClusterTKGVersionReturnsOnCall[i] = struct {
 		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ClusterClient) GetPacificClusterObject(arg1 string, arg2 string) (*v1alpha2.TanzuKubernetesCluster, error) {
+	fake.getPacificClusterObjectMutex.Lock()
+	ret, specificReturn := fake.getPacificClusterObjectReturnsOnCall[len(fake.getPacificClusterObjectArgsForCall)]
+	fake.getPacificClusterObjectArgsForCall = append(fake.getPacificClusterObjectArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("GetPacificClusterObject", []interface{}{arg1, arg2})
+	fake.getPacificClusterObjectMutex.Unlock()
+	if fake.GetPacificClusterObjectStub != nil {
+		return fake.GetPacificClusterObjectStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getPacificClusterObjectReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ClusterClient) GetPacificClusterObjectCallCount() int {
+	fake.getPacificClusterObjectMutex.RLock()
+	defer fake.getPacificClusterObjectMutex.RUnlock()
+	return len(fake.getPacificClusterObjectArgsForCall)
+}
+
+func (fake *ClusterClient) GetPacificClusterObjectCalls(stub func(string, string) (*v1alpha2.TanzuKubernetesCluster, error)) {
+	fake.getPacificClusterObjectMutex.Lock()
+	defer fake.getPacificClusterObjectMutex.Unlock()
+	fake.GetPacificClusterObjectStub = stub
+}
+
+func (fake *ClusterClient) GetPacificClusterObjectArgsForCall(i int) (string, string) {
+	fake.getPacificClusterObjectMutex.RLock()
+	defer fake.getPacificClusterObjectMutex.RUnlock()
+	argsForCall := fake.getPacificClusterObjectArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *ClusterClient) GetPacificClusterObjectReturns(result1 *v1alpha2.TanzuKubernetesCluster, result2 error) {
+	fake.getPacificClusterObjectMutex.Lock()
+	defer fake.getPacificClusterObjectMutex.Unlock()
+	fake.GetPacificClusterObjectStub = nil
+	fake.getPacificClusterObjectReturns = struct {
+		result1 *v1alpha2.TanzuKubernetesCluster
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ClusterClient) GetPacificClusterObjectReturnsOnCall(i int, result1 *v1alpha2.TanzuKubernetesCluster, result2 error) {
+	fake.getPacificClusterObjectMutex.Lock()
+	defer fake.getPacificClusterObjectMutex.Unlock()
+	fake.GetPacificClusterObjectStub = nil
+	if fake.getPacificClusterObjectReturnsOnCall == nil {
+		fake.getPacificClusterObjectReturnsOnCall = make(map[int]struct {
+			result1 *v1alpha2.TanzuKubernetesCluster
+			result2 error
+		})
+	}
+	fake.getPacificClusterObjectReturnsOnCall[i] = struct {
+		result1 *v1alpha2.TanzuKubernetesCluster
 		result2 error
 	}{result1, result2}
 }
@@ -6035,6 +6114,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.getMachineObjectsForClusterMutex.RUnlock()
 	fake.getManagementClusterTKGVersionMutex.RLock()
 	defer fake.getManagementClusterTKGVersionMutex.RUnlock()
+	fake.getPacificClusterObjectMutex.RLock()
+	defer fake.getPacificClusterObjectMutex.RUnlock()
 	fake.getPacificTKCAPIVersionMutex.RLock()
 	defer fake.getPacificTKCAPIVersionMutex.RUnlock()
 	fake.getPacificTanzuKubernetesReleasesMutex.RLock()

--- a/pkg/v1/tkg/tkgctl/interface.go
+++ b/pkg/v1/tkg/tkgctl/interface.go
@@ -8,6 +8,7 @@ import (
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 
 	runv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
+	tkgsv1alpha2 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/region"
 )
@@ -80,4 +81,11 @@ type TKGClient interface {
 	ActivateTanzuKubernetesReleases(tkrName string) error
 	// DeactivateTanzuKubernetesReleases deactivates TanzuKubernetesRelease
 	DeactivateTanzuKubernetesReleases(tkrName string) error
+	// IsPacificRegionalCluster checks if the cluster pointed to by kubeconfig  is Pacific management cluster(supervisor)
+	IsPacificRegionalCluster() (bool, error)
+	// GetPacificClusterObject gets Pacific cluster object
+	GetPacificClusterObject(clusterName, namespace string) (*tkgsv1alpha2.TanzuKubernetesCluster, error)
+	// GetPacificMachineDeployments gets machine deployments from a Pacific cluster
+	// Note: This would be soon deprecated after TKGS and TKGm adopt the clusterclass
+	GetPacificMachineDeployments(options client.GetMachineDeploymentOptions) ([]capi.MachineDeployment, error)
 }

--- a/pkg/v1/tkg/tkgctl/machine_deployment.go
+++ b/pkg/v1/tkg/tkgctl/machine_deployment.go
@@ -13,6 +13,13 @@ func (c *tkgctl) GetMachineDeployments(options client.GetMachineDeploymentOption
 	return c.tkgClient.GetMachineDeployments(options)
 }
 
+// GetPacificMachineDeployments returns the MachineDeployments of Pacific(TKGS) TKC cluster
+// This is defined separately for Pacific (TKGS) provider because the TKGS and TKGm CAPI versions could be different
+// and this should be deprecated after clusterclass is adopted by both TKGm and TKGS
+func (c *tkgctl) GetPacificMachineDeployments(options client.GetMachineDeploymentOptions) ([]capi.MachineDeployment, error) {
+	return c.tkgClient.GetPacificMachineDeployments(options)
+}
+
 func (c *tkgctl) SetMachineDeployment(options *client.SetMachineDeploymentOptions) error {
 	if err := c.tkgClient.SetMachineDeployment(options); err != nil {
 		return err

--- a/pkg/v1/tkg/tkgctl/pacific_cluster.go
+++ b/pkg/v1/tkg/tkgctl/pacific_cluster.go
@@ -1,0 +1,18 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgctl
+
+import (
+	tkgsv1alpha2 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
+)
+
+// GetPacificClusterObject return Pacific cluster object
+func (t *tkgctl) GetPacificClusterObject(clusterName, namespace string) (*tkgsv1alpha2.TanzuKubernetesCluster, error) {
+	return t.tkgClient.GetPacificClusterObject(clusterName, namespace)
+}
+
+// GetPacificClusterObject checks if the cluster pointed to by kubeconfig  is Pacific management cluster(supervisor)
+func (t *tkgctl) IsPacificRegionalCluster() (bool, error) {
+	return t.tkgClient.IsPacificRegionalCluster()
+}


### PR DESCRIPTION
Signed-off-by: PremKumar Kalle <pkalle@vmware.com>

### What this PR does / why we need it
This PR adds nodepool CRUD operation support for TKGS provider. User can add/update/delete/list the node pools in TKGS Tanzu kubernetes cluster
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Created a new nodepool in TKC cluster using `tanzu cluster nodepool set` operation and it was successful. Sample file used for set operation is as below
```
name: workers-1
labels:
 wlabel1: vlabel1
 wlabel2: vlabel2
replicas: 1
storageClass: gc-storage-profile
tkr:
  reference:
    name: v1.20.9---vmware.1-tkg.1.a4cee5b
vmClass: best-effort-xsmall
```

Deleted the nodepool added in the previous set operation and it was success

Created few TKC clusters and added some extra nodepools for some of the TKC clusters and later used `tanzu cluster nodepool list test-wc-t3-tkgs --namespace test-gc-e2e-demo-ns` command to list the node pools of a cluster and it was success
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Added nodepool CRUD operation support for TKGS(vSphere with Kubernetes service) provider
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
