### PR TITLE
Update scale API to operate on node pools

### DIFF
--- a/cmd/cli/plugin/cluster/scale.go
+++ b/cmd/cli/plugin/cluster/scale.go
@@ -16,6 +16,7 @@ import (
 
 type scaleClustersOptions struct {
 	namespace         string
+	nodePoolName      string
 	workerCount       int32
 	controlPlaneCount int32
 }
@@ -32,6 +33,7 @@ var scaleClusterCmd = &cobra.Command{
 func init() {
 	scaleClusterCmd.Flags().Int32VarP(&sc.workerCount, "worker-machine-count", "w", 0, "The number of worker nodes to scale to. Assumes unchanged if not specified")
 	scaleClusterCmd.Flags().Int32VarP(&sc.controlPlaneCount, "controlplane-machine-count", "c", 0, "The number of control plane nodes to scale to. Assumes unchanged if not specified")
+	scaleClusterCmd.Flags().StringVarP(&sc.nodePoolName, "node-pool-name", "p", "", "The name of the node-pool to scale")
 	scaleClusterCmd.Flags().StringVarP(&sc.namespace, "namespace", "n", "", "The namespace where the workload cluster was created. Assumes 'default' if not specified.")
 }
 
@@ -58,6 +60,7 @@ func scaleCluster(server *v1alpha1.Server, clusterName string) error {
 		ControlPlaneCount: sc.controlPlaneCount,
 		WorkerCount:       sc.workerCount,
 		Namespace:         sc.namespace,
+		NodePoolName:      sc.nodePoolName,
 	}
 
 	return tkgctlClient.ScaleCluster(scaleClusterOptions)

--- a/pkg/v1/tkg/client/machine_deployment.go
+++ b/pkg/v1/tkg/client/machine_deployment.go
@@ -79,7 +79,7 @@ type VSphereNodePool struct {
 	NumCPUs           int32  `yaml:"numCPUs,omitempty"`
 }
 
-// SetMachineDeployment sets a MachineDeployment on a cluster
+// SetMachineDeployment sets a MachineDeployment on a cluster.
 func (c *TkgClient) SetMachineDeployment(options *SetMachineDeploymentOptions) error {
 	clusterClient, err := c.getClusterClient()
 	if err != nil {
@@ -404,6 +404,11 @@ func (c *TkgClient) GetMachineDeployments(options GetMachineDeploymentOptions) (
 		return nil, errors.Wrap(err, "Unable to create clusterclient")
 	}
 
+	return c.DoGetMachineDeployments(clusterClient, &options)
+}
+
+// DoGetMachineDeployments retrieves machine deployments for a cluster given a regional cluster client
+func (c *TkgClient) DoGetMachineDeployments(clusterClient clusterclient.Client, options *GetMachineDeploymentOptions) ([]capi.MachineDeployment, error) {
 	workers, err := clusterClient.GetMDObjectForCluster(options.ClusterName, options.Namespace)
 	if err != nil || len(workers) == 0 {
 		return nil, errors.Wrap(err, "unable to get worker machine deployments")

--- a/pkg/v1/tkg/client/scale.go
+++ b/pkg/v1/tkg/client/scale.go
@@ -19,6 +19,7 @@ type ScaleClusterOptions struct {
 	Kubeconfig        string
 	ClusterName       string
 	Namespace         string
+	NodePoolName      string
 	WorkerCount       int32
 	ControlPlaneCount int32
 }
@@ -53,7 +54,7 @@ func (c *TkgClient) ScaleCluster(options ScaleClusterOptions) error {
 }
 
 // DoScaleCluster performs the scale operation using the given clusterclient.Client
-func (c *TkgClient) DoScaleCluster(clusterClient clusterclient.Client, options *ScaleClusterOptions) error { // nolint:gocyclo
+func (c *TkgClient) DoScaleCluster(clusterClient clusterclient.Client, options *ScaleClusterOptions) error {
 	isPacific, err := clusterClient.IsPacificRegionalCluster()
 	if err != nil {
 		return errors.Wrap(err, "error determining Tanzu Kubernetes Grid service for vSphere management cluster ")
@@ -83,32 +84,10 @@ func (c *TkgClient) DoScaleCluster(clusterClient clusterclient.Client, options *
 	}
 
 	if options.WorkerCount > 0 {
-		// scale nodes across all machine deployments in the cluster
-		workerNodeMachineDeployments, err := clusterClient.GetMDObjectForCluster(options.ClusterName, options.Namespace)
-		if err != nil || len(workerNodeMachineDeployments) == 0 {
-			errList = append(errList, errors.Wrapf(err, "unable to find worker node machine deployment object for cluster %s", options.ClusterName))
+		if options.NodePoolName == "" {
+			errList = append(errList, c.scaleWorkersDefault(clusterClient, options)...)
 		} else {
-			numMachineDeployments := int32(len(workerNodeMachineDeployments))
-			if options.WorkerCount < numMachineDeployments {
-				errList = append(errList, errors.Errorf("new worker count must be greater than or to the number of machine deployments. worker count: %d, machine deployment count: %d", options.WorkerCount, numMachineDeployments))
-			}
-			workersPerMD := options.WorkerCount / numMachineDeployments
-			leftoverWorkers := options.WorkerCount % numMachineDeployments
-			// each machine deployment gets scaled to have an approx equal number of replicas
-			for i := int32(0); i < numMachineDeployments; i++ {
-				workerCount := workersPerMD
-				if leftoverWorkers > 0 {
-					workerCount++
-					leftoverWorkers--
-				}
-				err = clusterClient.UpdateReplicas(&workerNodeMachineDeployments[i], workerNodeMachineDeployments[i].Name, workerNodeMachineDeployments[i].Namespace, workerCount)
-				if err != nil {
-					errList = append(errList, errors.Wrapf(err, "unable to update worker node machine deployment replica count for cluster %s", options.ClusterName))
-				}
-			}
-			if len(errList) == 0 {
-				log.Infof("Successfully updated worker node machine deployment replica count for cluster %s", options.ClusterName)
-			}
+			errList = append(errList, c.scaleWorkersNodePool(clusterClient, options))
 		}
 	}
 
@@ -148,4 +127,87 @@ func (c *TkgClient) ScalePacificCluster(options ScaleClusterOptions, clusterClie
 		return nil
 	}
 	return kerrors.NewAggregate(errList)
+}
+
+func (c *TkgClient) scaleWorkersDefault(clusterClient clusterclient.Client, options *ScaleClusterOptions) []error {
+	// scale nodes across all machine deployments in the cluster
+	workerNodeMachineDeployments, err := clusterClient.GetMDObjectForCluster(options.ClusterName, options.Namespace)
+	if err != nil {
+		return []error{errors.Wrapf(err, "error retrieving worker node machine deployment objects for cluster %s", options.ClusterName)}
+	}
+	if len(workerNodeMachineDeployments) == 0 {
+		return []error{errors.Errorf("no machine deployments found in cluster %s", options.ClusterName)}
+	}
+
+	numMachineDeployments := int32(len(workerNodeMachineDeployments))
+	if options.WorkerCount < numMachineDeployments {
+		return []error{errors.Errorf("new worker count must be greater than or equal to the number of machine deployments. worker count: %d, machine deployment count: %d", options.WorkerCount, numMachineDeployments)}
+	}
+	workersPerMD := options.WorkerCount / numMachineDeployments
+	leftoverWorkers := options.WorkerCount % numMachineDeployments
+	var errList []error
+	// each machine deployment gets scaled to have an approx equal number of replicas
+	for i := int32(0); i < numMachineDeployments; i++ {
+		workerCount := desiredWorkerCount(workersPerMD, leftoverWorkers, i)
+		err := clusterClient.UpdateReplicas(&workerNodeMachineDeployments[i], workerNodeMachineDeployments[i].Name, workerNodeMachineDeployments[i].Namespace, workerCount)
+		if err != nil {
+			errList = append(errList, errors.Wrapf(err, "unable to update worker node replica count for machine deployment %s on cluster %s", workerNodeMachineDeployments[i].Name, options.ClusterName))
+		}
+	}
+
+	if len(errList) == 0 {
+		log.Infof("Successfully updated worker node machine deployment replica count for cluster %s", options.ClusterName)
+	}
+	return errList
+}
+
+func (c *TkgClient) scaleWorkersNodePool(clusterClient clusterclient.Client, options *ScaleClusterOptions) error {
+	mdExists, err := c.mdExists(clusterClient, options)
+	if err != nil {
+		return err
+	}
+	if !mdExists {
+		return errors.Errorf("Could not find node pool with name %s", options.NodePoolName)
+	}
+
+	mdOptions := SetMachineDeploymentOptions{
+		Namespace:   options.Namespace,
+		ClusterName: options.ClusterName,
+		NodePool: NodePool{
+			Name:     options.NodePoolName,
+			Replicas: &options.WorkerCount,
+		},
+	}
+	if err := c.DoSetMachineDeployment(clusterClient, &mdOptions); err != nil {
+		return errors.Wrapf(err, "Unable to scale node pool %s", options.NodePoolName)
+	}
+
+	return nil
+}
+
+func desiredWorkerCount(workersPerMD, leftoverWorkers, i int32) int32 {
+	if i < leftoverWorkers {
+		return workersPerMD + 1
+	}
+	return workersPerMD
+}
+
+func (c *TkgClient) mdExists(clusterClient clusterclient.Client, options *ScaleClusterOptions) (bool, error) {
+	getOptions := GetMachineDeploymentOptions{
+		ClusterName: options.ClusterName,
+		Namespace:   options.Namespace,
+		Name:        options.NodePoolName,
+	}
+	mds, err := c.DoGetMachineDeployments(clusterClient, &getOptions)
+	if err != nil {
+		return false, errors.Wrapf(err, "Failed to get node pools for cluster %s", options.ClusterName)
+	}
+
+	for i := range mds {
+		if mds[i].Name == options.NodePoolName {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/v1/tkg/client/scale_test.go
+++ b/pkg/v1/tkg/client/scale_test.go
@@ -4,11 +4,13 @@
 package client_test
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
@@ -112,6 +114,8 @@ var _ = Describe("Scale API", func() {
 			regionalClusterClient *fakes.ClusterClient
 			tkgClient             *TkgClient
 			scaleClusterOptions   ScaleClusterOptions
+
+			md1, md2, md3 v1alpha3.MachineDeployment
 		)
 
 		const (
@@ -123,86 +127,181 @@ var _ = Describe("Scale API", func() {
 
 		BeforeEach(func() {
 			tkgClient, err = CreateTKGClient("../fakes/config/config.yaml", testingDir, defaultTKGBoMFileForTesting, 2*time.Second)
-			regionalClusterClient = &fakes.ClusterClient{}
-			scaleClusterOptions = ScaleClusterOptions{}
 			Expect(err).NotTo(HaveOccurred())
+			regionalClusterClient = &fakes.ClusterClient{}
+			regionalClusterClient.IsPacificRegionalClusterReturns(false, nil)
+			regionalClusterClient.GetKCPObjectForClusterReturns(nil, nil)
+
+			scaleClusterOptions = ScaleClusterOptions{}
+			scaleClusterOptions.ControlPlaneCount = 0
+			scaleClusterOptions.ClusterName = "test-cluster"
+
+			md1 = v1alpha3.MachineDeployment{}
+			md1.Name = md1Name
+			md1.Namespace = defaultNamespaceName
+			md1.Spec = v1alpha3.MachineDeploymentSpec{
+				Template: v1alpha3.MachineTemplateSpec{
+					Spec: v1alpha3.MachineSpec{
+						Bootstrap: v1alpha3.Bootstrap{
+							ConfigRef: &v1.ObjectReference{
+								Name:      md1Name + "-kct",
+								Namespace: defaultNamespaceName,
+							},
+						},
+						InfrastructureRef: v1.ObjectReference{
+							Name:      md1Name + "-mt",
+							Namespace: defaultNamespaceName,
+						},
+					},
+				},
+			}
+			md2 = v1alpha3.MachineDeployment{}
+			md2.Name = md2Name
+			md2.Namespace = defaultNamespaceName
+			md2.Spec = v1alpha3.MachineDeploymentSpec{
+				Template: v1alpha3.MachineTemplateSpec{
+					Spec: v1alpha3.MachineSpec{
+						Bootstrap: v1alpha3.Bootstrap{
+							ConfigRef: &v1.ObjectReference{
+								Name:      md2Name + "-kct",
+								Namespace: defaultNamespaceName,
+							},
+						},
+						InfrastructureRef: v1.ObjectReference{
+							Name:      md2Name + "-mt",
+							Namespace: defaultNamespaceName,
+						},
+					},
+				},
+			}
+			md3 = v1alpha3.MachineDeployment{}
+			md3.Name = md3Name
+			md3.Namespace = defaultNamespaceName
+			md3.Spec = v1alpha3.MachineDeploymentSpec{
+				Template: v1alpha3.MachineTemplateSpec{
+					Spec: v1alpha3.MachineSpec{
+						Bootstrap: v1alpha3.Bootstrap{
+							ConfigRef: &v1.ObjectReference{
+								Name:      md3Name + "-kct",
+								Namespace: defaultNamespaceName,
+							},
+						},
+						InfrastructureRef: v1.ObjectReference{
+							Name:      md3Name + "-mt",
+							Namespace: defaultNamespaceName,
+						},
+					},
+				},
+			}
 		})
 
 		Context("management cluster is not a Pacific cluster", func() {
-			When("a user scales worker nodes greater than num of machine deployments", func() {
-				It("should update mds with the correct number of workers", func() {
-					regionalClusterClient.IsPacificRegionalClusterReturns(false, nil)
-					regionalClusterClient.GetKCPObjectForClusterReturns(nil, nil)
-					md1 := v1alpha3.MachineDeployment{}
-					md1.Name = md1Name
-					md1.Namespace = defaultNamespaceName
-					md2 := v1alpha3.MachineDeployment{}
-					md2.Name = md2Name
-					md2.Namespace = defaultNamespaceName
-					md3 := v1alpha3.MachineDeployment{}
-					md3.Name = md3Name
-					md3.Namespace = defaultNamespaceName
-					regionalClusterClient.GetMDObjectForClusterReturns([]v1alpha3.MachineDeployment{md1, md2, md3}, nil)
+			Context("and scale is not operating on a specific node pool", func() {
+				When("a user scales worker nodes greater than num of machine deployments", func() {
+					It("should update mds with the correct number of workers", func() {
+						regionalClusterClient.GetMDObjectForClusterReturns([]v1alpha3.MachineDeployment{md1, md2, md3}, nil)
 
-					scaleClusterOptions.ControlPlaneCount = 0
-					scaleClusterOptions.WorkerCount = 4
+						scaleClusterOptions.WorkerCount = 4
 
-					err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
-					Expect(err).ToNot(HaveOccurred())
+						err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
+						Expect(err).ToNot(HaveOccurred())
 
-					Expect(regionalClusterClient.UpdateReplicasCallCount()).To(Equal(3))
-					_, name, namespace, count := regionalClusterClient.UpdateReplicasArgsForCall(0)
-					Expect(name).To(Equal(md1.Name))
-					Expect(namespace).To(Equal(md1.Namespace))
-					Expect(count).To(BeEquivalentTo(2))
+						Expect(regionalClusterClient.UpdateReplicasCallCount()).To(Equal(3))
+						_, name, namespace, count := regionalClusterClient.UpdateReplicasArgsForCall(0)
+						Expect(name).To(Equal(md1.Name))
+						Expect(namespace).To(Equal(md1.Namespace))
+						Expect(count).To(BeEquivalentTo(2))
 
-					_, name, namespace, count = regionalClusterClient.UpdateReplicasArgsForCall(1)
-					Expect(name).To(Equal(md2.Name))
-					Expect(namespace).To(Equal(md2.Namespace))
-					Expect(count).To(BeEquivalentTo(1))
+						_, name, namespace, count = regionalClusterClient.UpdateReplicasArgsForCall(1)
+						Expect(name).To(Equal(md2.Name))
+						Expect(namespace).To(Equal(md2.Namespace))
+						Expect(count).To(BeEquivalentTo(1))
 
-					_, name, namespace, count = regionalClusterClient.UpdateReplicasArgsForCall(2)
-					Expect(name).To(Equal(md3.Name))
-					Expect(namespace).To(Equal(md3.Namespace))
-					Expect(count).To(BeEquivalentTo(1))
+						_, name, namespace, count = regionalClusterClient.UpdateReplicasArgsForCall(2)
+						Expect(name).To(Equal(md3.Name))
+						Expect(namespace).To(Equal(md3.Namespace))
+						Expect(count).To(BeEquivalentTo(1))
+					})
+				})
+				When("a user scales worker nodes less than num of machine deployments", func() {
+					It("should return an error", func() {
+						regionalClusterClient.GetMDObjectForClusterReturns([]v1alpha3.MachineDeployment{md1, md2, md3}, nil)
+
+						scaleClusterOptions.WorkerCount = 2
+
+						err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("worker count must be greater than"))
+					})
+				})
+				When("a user calls ScaleCluster with a worker count less than 1", func() {
+					It("should not update any mds", func() {
+						scaleClusterOptions.WorkerCount = 0
+
+						err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(regionalClusterClient.GetMDObjectForClusterCallCount()).To(Equal(0))
+						Expect(regionalClusterClient.UpdateReplicasCallCount()).To(Equal(0))
+					})
 				})
 			})
-			When("a user scales worker nodes less than num of machine deployments", func() {
-				It("should return an error", func() {
-					regionalClusterClient.IsPacificRegionalClusterReturns(false, nil)
-					regionalClusterClient.GetKCPObjectForClusterReturns(nil, nil)
-					md1 := v1alpha3.MachineDeployment{}
-					md1.Name = md1Name
-					md1.Namespace = defaultNamespaceName
-					md2 := v1alpha3.MachineDeployment{}
-					md2.Name = md2Name
-					md2.Namespace = defaultNamespaceName
-					md3 := v1alpha3.MachineDeployment{}
-					md3.Name = md3Name
-					md3.Namespace = defaultNamespaceName
-					regionalClusterClient.GetMDObjectForClusterReturns([]v1alpha3.MachineDeployment{md1, md2, md3}, nil)
+			Context("and scale is operating on a specific node pool", func() {
+				When("a user scales an existing node pool", func() {
+					It("should update the replicas of that node pool", func() {
+						regionalClusterClient.GetMDObjectForClusterReturnsOnCall(0, []v1alpha3.MachineDeployment{md1, md2, md3}, nil)
+						regionalClusterClient.GetMDObjectForClusterReturnsOnCall(1, []v1alpha3.MachineDeployment{md1, md2, md3}, nil)
 
-					scaleClusterOptions.ControlPlaneCount = 0
-					scaleClusterOptions.WorkerCount = 2
+						scaleClusterOptions.NodePoolName = md1Name
+						scaleClusterOptions.WorkerCount = 3
 
-					err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("worker count must be greater than"))
+						err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
+						Expect(err).ToNot(HaveOccurred())
+
+						Expect(regionalClusterClient.GetMDObjectForClusterCallCount()).To(Equal(2))
+						Expect(regionalClusterClient.UpdateResourceCallCount()).To(Equal(1))
+						mdInterface, _, _, _ := regionalClusterClient.UpdateResourceArgsForCall(0)
+						md := mdInterface.(*v1alpha3.MachineDeployment)
+						Expect(*md.Spec.Replicas).To(Equal(int32(3)))
+					})
 				})
-			})
-			When("a user calls ScaleCluster with a worker count less than 1", func() {
-				It("should not update any mds", func() {
-					regionalClusterClient.IsPacificRegionalClusterReturns(false, nil)
-					regionalClusterClient.GetKCPObjectForClusterReturns(nil, nil)
+				When("an error occurs retrieving machine deployments", func() {
+					It("should throw an error", func() {
+						mdErrString := "failed retrieving mds"
+						regionalClusterClient.GetMDObjectForClusterReturnsOnCall(0, nil, errors.New(mdErrString))
 
-					scaleClusterOptions.ControlPlaneCount = 0
-					scaleClusterOptions.WorkerCount = 0
+						scaleClusterOptions.NodePoolName = md1Name
+						scaleClusterOptions.WorkerCount = 3
 
-					err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
-					Expect(err).ToNot(HaveOccurred())
+						err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
+						Expect(err).Should(MatchError(fmt.Sprintf("Failed to get node pools for cluster %s: unable to get worker machine deployments: %s", scaleClusterOptions.ClusterName, mdErrString)))
+					})
+				})
+				When("the named node pool can't be found", func() {
+					It("should throw an error", func() {
+						regionalClusterClient.GetMDObjectForClusterReturnsOnCall(0, nil, nil)
 
-					Expect(regionalClusterClient.GetMDObjectForClusterCallCount()).To(Equal(0))
-					Expect(regionalClusterClient.UpdateReplicasCallCount()).To(Equal(0))
+						scaleClusterOptions.NodePoolName = md1Name
+						scaleClusterOptions.WorkerCount = 3
+
+						err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
+						Expect(err).Should(MatchError(fmt.Sprintf("Could not find node pool with name %s", scaleClusterOptions.NodePoolName)))
+					})
+				})
+				When("the node pool fails to be updated", func() {
+					It("should throw an error", func() {
+						mdErrString := "failed setting node pool"
+						regionalClusterClient.GetMDObjectForClusterReturnsOnCall(0, []v1alpha3.MachineDeployment{md1, md2, md3}, nil)
+						regionalClusterClient.GetMDObjectForClusterReturnsOnCall(1, nil, errors.New(mdErrString))
+
+						scaleClusterOptions.NodePoolName = md1Name
+						scaleClusterOptions.WorkerCount = 3
+
+						err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
+						Expect(err).Should(MatchError(fmt.Sprintf("Unable to scale node pool %s: unable to get worker machine deployments: %s", scaleClusterOptions.NodePoolName, mdErrString)))
+
+						Expect(regionalClusterClient.GetMDObjectForClusterCallCount()).To(Equal(2))
+					})
 				})
 			})
 		})

--- a/pkg/v1/tkg/tkgctl/scale_cluster.go
+++ b/pkg/v1/tkg/tkgctl/scale_cluster.go
@@ -17,6 +17,7 @@ type ScaleClusterOptions struct {
 	WorkerCount       int32
 	ControlPlaneCount int32
 	Namespace         string
+	NodePoolName      string
 }
 
 // ScaleCluster scales cluster
@@ -35,6 +36,7 @@ func (t *tkgctl) ScaleCluster(options ScaleClusterOptions) error {
 		ClusterName:       options.ClusterName,
 		WorkerCount:       options.WorkerCount,
 		ControlPlaneCount: options.ControlPlaneCount,
+		NodePoolName:      options.NodePoolName,
 	}
 
 	err := t.tkgClient.ScaleCluster(scaleClusterOptions)


### PR DESCRIPTION
This change updates the scale api to accept a node-pool name so that only
that node pool will be scaled. Tests have been added for this new
feature. Updates the cli to support a new flag to pass the node-pool
name.

### What this PR does / why we need it
This PR updates the scale API to support scaling a node pool by name. 
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
Added tests for scale API. 
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Update Scale API to accept a node-pool name, which will scale just the desired node-pool to the desired number of replicas. 
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
