### PR TITLE
append dvs name to the portgroup name when formulating the network pa…

### DIFF
--- a/pkg/v1/tkg/vc/interface.go
+++ b/pkg/v1/tkg/vc/interface.go
@@ -23,6 +23,8 @@ const (
 	TypeDatastore       = "Datastore"
 	TypeHost            = "HostSystem"
 	TypeNetwork         = "Network"
+	TypeDvpg            = "DistributedVirtualPortgroup"
+	TypeDvs             = "VmwareDistributedVirtualSwitch"
 	TypeOpaqueNetwork   = "OpaqueNetwork"
 	TypeVirtualMachine  = "VirtualMachine"
 )


### PR DESCRIPTION
### What this PR does / why we need it
With standard vSphere networking, Portgroups cannot have the same name within the same network folder. With NSX, Portgroups can have the same name, even within the same Switch. 

In this PR when networks paths are formulated, Switch name is appended to the Portgroup name to make the network path unique. This fix only works in formulating correct network paths when Portgroups with the same name exist across different Switches.  

The case to fix the scenario where - Portgroups with the same name exist in the same Switch will be fixed in a different PR.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

TODO: created an issue to track the unit test work - https://github.com/vmware-tanzu/tanzu-framework/issues/926

Fixes #

### Describe testing done for PR
vSphere setup - 
![image](https://user-images.githubusercontent.com/5937425/137823644-8592bb00-61cc-4524-8eae-708409105b51.png)

Tanzu CLI kickstart UI - 
![image](https://user-images.githubusercontent.com/5937425/137823897-332e97a1-33b2-4b79-b871-3132b83fce17.png)

Created a management cluster using network `/kubo-dc/network/DSwitch/management_segment2` and it was successful.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
