### PR TITLE
Adds clarifying comment that the context has not been switched by default

### DIFF
--- a/pkg/v1/tkg/client/init.go
+++ b/pkg/v1/tkg/client/init.go
@@ -342,7 +342,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 		log.Warningf("Warning: Management cluster is created successfully, but some packages are failing. %v", err)
 	}
 
-	log.Infof("Context set for management cluster %s as '%s'.", options.ClusterName, kubeContext)
+	log.Infof("You can now access the management cluster %s by running 'kubectl config use-context %s'", options.ClusterName, kubeContext)
 	isSuccessful = true
 	return nil
 }


### PR DESCRIPTION
Adds clarifying comment that the context has not been switched by default

Signed-off-by: Sudarshan <asudarshan@vmware.com>

### What this PR does / why we need it
The message `Context set for management cluster` is misleading. We don't actually set the context to the default kubeconfig. We set the context for the management cluster in tkg's kubeconfig. 

This PR changes the message being logged so as to not mislead the user that the context is being switched.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #852 

### Describe testing done for PR
1. Ran make build-cli-local successfully
2. I didn't do any other testing because this is a logging change

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
