### PR TITLE
CLI feature flag support for default values

### DIFF
--- a/apis/config/v1alpha1/clientconfig.go
+++ b/apis/config/v1alpha1/clientconfig.go
@@ -3,7 +3,12 @@
 
 package v1alpha1
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 const (
 	// AllUnstableVersions allows all plugin versions
@@ -59,4 +64,40 @@ func (c *ClientConfig) SetUnstableVersionSelector(f VersionSelectorLevel) {
 		return
 	}
 	c.ClientOptions.CLI.UnstableVersionSelector = AllUnstableVersions
+}
+
+func (c *ClientConfig) IsConfigFeatureActivated(featureName string) (bool, error) {
+	plugin, flag, err := c.SplitFeaturePath(featureName)
+	if err != nil {
+		return false, err
+	}
+
+	if c.ClientOptions == nil || c.ClientOptions.Features == nil ||
+		c.ClientOptions.Features[plugin] == nil || c.ClientOptions.Features[plugin][flag] == "" {
+		return false, nil
+	}
+
+	booleanValue, err := strconv.ParseBool(c.ClientOptions.Features[plugin][flag])
+	if err != nil {
+		errMsg := "error converting " + featureName + " entry '" + c.ClientOptions.Features[plugin][flag] + "' to boolean value: " + err.Error()
+		return false, errors.New(errMsg)
+	}
+	return booleanValue, nil
+}
+
+func (c *ClientConfig) SplitFeaturePath(featurePath string) (string, string, error) {
+	// parse the param
+	paramArray := strings.Split(featurePath, ".")
+	if len(paramArray) != 3 {
+		return "", "", errors.New("unable to parse feature name config parameter into three parts [" + featurePath + "]  (was expecting features.<plugin>.<feature>)")
+	}
+
+	featuresLiteral := paramArray[0]
+	plugin := paramArray[1]
+	flag := paramArray[2]
+
+	if featuresLiteral != "features" {
+		return "", "", errors.New("unsupported feature config path parameter [" + featuresLiteral + "] (was expecting 'features.<plugin>.<feature>')")
+	}
+	return plugin, flag, nil
 }

--- a/pkg/v1/config/clientconfig.go
+++ b/pkg/v1/config/clientconfig.go
@@ -8,12 +8,24 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/aunum/log"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 
 	configv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
+)
+
+// DefaultCliFeatureFlags is used to populate an initially empty config file with default values for feature flags.
+// If a developer expects that their feature will be ready to release, they should create an entry here with a true
+// value. If a developer has a beta feature they want to expose, but leave turned off by default, they should create
+// an entry here with a false value. The keys MUST be in the format "features.<plugin>.<feature>" or initialization
+// will fail. Note that "global" is a special value for <plugin> to be used for CLI-wide features.
+var (
+	DefaultCliFeatureFlags = map[string]bool{
+		"features.management-cluster.import": true,
+	}
 )
 
 const (
@@ -98,7 +110,27 @@ func NewClientConfig() (*configv1alpha1.ClientConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	err = populateDefaultCliFeatureValues(c, DefaultCliFeatureFlags)
+	if err != nil {
+		return nil, err
+	}
 	return c, nil
+}
+
+func populateDefaultCliFeatureValues(c *configv1alpha1.ClientConfig, defaultCliFeatureFlags map[string]bool) error {
+	c.ClientOptions.Features = make(map[string]configv1alpha1.FeatureMap)
+	for featureName, flagValue := range defaultCliFeatureFlags {
+		plugin, flag, err := c.SplitFeaturePath(featureName)
+		if err != nil {
+			return err
+		}
+		if c.ClientOptions.Features[plugin] == nil {
+			c.ClientOptions.Features[plugin] = configv1alpha1.FeatureMap{}
+		}
+		c.ClientOptions.Features[plugin][flag] = strconv.FormatBool(flagValue)
+	}
+	return nil
 }
 
 // ClientConfigNotExistError is thrown when a tanzu config cannot be found.

--- a/pkg/v1/config/clientconfig_test.go
+++ b/pkg/v1/config/clientconfig_test.go
@@ -164,3 +164,139 @@ func TestConfigLegacyDir(t *testing.T) {
 	err = DeleteClientConfig()
 	require.NoError(t, err)
 }
+
+func TestConfigFeatures(t *testing.T) {
+	const pluginName = "management-cluster"
+	const featureName = "foo"
+	const featurePath = "features." + pluginName + "." + featureName
+	cliFeatureFlags := configv1alpha1.FeatureMap{
+		featureName: "true",
+	}
+	cliFeatureMap := make(map[string]configv1alpha1.FeatureMap)
+	cliFeatureMap[pluginName] = cliFeatureFlags
+	cfg := &configv1alpha1.ClientConfig{
+		ClientOptions: &configv1alpha1.ClientOptions{
+			CLI: &configv1alpha1.CLIOptions{
+				Repositories:            DefaultRepositories,
+				UnstableVersionSelector: DefaultVersionSelector,
+			},
+			Features: cliFeatureMap,
+		},
+	}
+	activated, err := cfg.IsConfigFeatureActivated(featurePath)
+	require.True(t, activated, "IsConfigFeatureActivated should report true for feature "+featurePath)
+	require.NoError(t, err)
+}
+
+func TestConfigFeaturesDefault(t *testing.T) {
+	cfg := &configv1alpha1.ClientConfig{
+		ClientOptions: &configv1alpha1.ClientOptions{
+			CLI: &configv1alpha1.CLIOptions{
+				Repositories:            DefaultRepositories,
+				UnstableVersionSelector: DefaultVersionSelector,
+			},
+		},
+	}
+	const featureFoo = "features.management-cluster.foo"
+	activated, err := cfg.IsConfigFeatureActivated(featureFoo)
+	require.False(t, activated, "feature reported true before defaults are  set")
+	require.NoError(t, err)
+
+	cliFeatureFlags := map[string]bool{
+		featureFoo: true,
+	}
+	err = populateDefaultCliFeatureValues(cfg, cliFeatureFlags)
+
+	require.NoError(t, err)
+	activated, err = cfg.IsConfigFeatureActivated(featureFoo)
+	require.True(t, activated, "feature "+featureFoo+" should report true after defaults are set")
+	require.NoError(t, err)
+
+	const featureBar = "features.management-cluster.bar"
+	activated, err = cfg.IsConfigFeatureActivated(featureBar)
+	require.False(t, activated, "feature "+featureBar+" should report false after defaults are set")
+	require.NoError(t, err)
+}
+
+func TestConfigFeaturesDefaultInvalid(t *testing.T) {
+	const featureFoo = "invalid.foo"
+	cliFeatureFlags := map[string]bool{
+		featureFoo: true,
+	}
+	cfg := &configv1alpha1.ClientConfig{
+		ClientOptions: &configv1alpha1.ClientOptions{
+			CLI: &configv1alpha1.CLIOptions{
+				Repositories:            DefaultRepositories,
+				UnstableVersionSelector: DefaultVersionSelector,
+			},
+		},
+	}
+	err := populateDefaultCliFeatureValues(cfg, cliFeatureFlags)
+	require.Error(t, err, "invalid default feature should generate error")
+}
+
+func TestConfigFeaturesInvalidName(t *testing.T) {
+	const featureFoo = "invalid.foo"
+	cfg := &configv1alpha1.ClientConfig{
+		ClientOptions: &configv1alpha1.ClientOptions{
+			CLI: &configv1alpha1.CLIOptions{
+				Repositories:            DefaultRepositories,
+				UnstableVersionSelector: DefaultVersionSelector,
+			},
+		},
+	}
+	result, err := cfg.IsConfigFeatureActivated(featureFoo)
+	require.False(t, result, "invalid feature name '"+featureFoo+"' should generate false return value")
+	require.Error(t, err, "invalid feature name '"+featureFoo+"' should generate error")
+}
+
+func TestConfigFeaturesInvalidValue(t *testing.T) {
+	const featureFoo = "features.management-cluster.foo"
+	cliFeatureFlags := configv1alpha1.FeatureMap{
+		"foo": "INVALID",
+	}
+	cliFeatureMap := make(map[string]configv1alpha1.FeatureMap)
+	cliFeatureMap["management-cluster"] = cliFeatureFlags
+	cfg := &configv1alpha1.ClientConfig{
+		ClientOptions: &configv1alpha1.ClientOptions{
+			CLI: &configv1alpha1.CLIOptions{
+				Repositories:            DefaultRepositories,
+				UnstableVersionSelector: DefaultVersionSelector,
+			},
+			Features: cliFeatureMap,
+		},
+	}
+	activated, err := cfg.IsConfigFeatureActivated(featureFoo)
+	require.False(t, activated, "IsConfigFeatureActivated should report false given invalid value")
+	require.Error(t, err, "IsConfigFeatureActivated should return error given invalid value")
+}
+
+func TestConfigFeaturesSplitName(t *testing.T) {
+	const featureValid = "features.valid-plugin.foo"
+	cfg := &configv1alpha1.ClientConfig{
+		ClientOptions: &configv1alpha1.ClientOptions{
+			CLI: &configv1alpha1.CLIOptions{
+				Repositories:            DefaultRepositories,
+				UnstableVersionSelector: DefaultVersionSelector,
+			},
+		},
+	}
+	pluginName, featureName, err := cfg.SplitFeaturePath(featureValid)
+	require.Equal(t, pluginName, "valid-plugin", "failed to parse '"+featureValid+"' correctly")
+	require.Equal(t, featureName, "foo", "failed to parse '"+featureValid+"' correctly")
+	require.NoError(t, err, "valid feature name '"+featureValid+"' should not generate error")
+}
+
+func TestConfigFeaturesSplitNameInvalid(t *testing.T) {
+	const featureInvalid = "invalid.foo"
+	cfg := &configv1alpha1.ClientConfig{
+		ClientOptions: &configv1alpha1.ClientOptions{
+			CLI: &configv1alpha1.CLIOptions{
+				Repositories:            DefaultRepositories,
+				UnstableVersionSelector: DefaultVersionSelector,
+			},
+		},
+	}
+	_, _, err := cfg.SplitFeaturePath(featureInvalid)
+	require.Error(t, err, "invalid feature name '"+featureInvalid+"' should generate error")
+}


### PR DESCRIPTION
### What this PR does / why we need it
The feature flag support recently introduced needs to provide default values in the configuration file. This is done
with a Map in pkg/v1/config/clientconfig.go.

### Describe testing done for PR
Local testing with config file and unit tests


### PR Checklist
- [X] Squash the commits into one or a small number of logical commits
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access

### Additional information
See comments in pkg/v1/config/clientconfig.go. Related to #767 
