### PR TITLE
improve warning message when values schema is empty

### DIFF
--- a/cmd/cli/plugin/package/package_available_get.go
+++ b/cmd/cli/plugin/package/package_available_get.go
@@ -132,6 +132,11 @@ func getValuesSchema(cmd *cobra.Command, args []string, kc kappclient.Client) er
 	}
 
 	var parseErr error
+	if len(pkg.Spec.ValuesSchema.OpenAPIv3.Raw) == 0 {
+		t.StopSpinner()
+		log.Warningf("package '%s/%s' does not have any user configurable values in the '%s' namespace", pkgName, pkgVersion, packageAvailableOp.Namespace)
+		return nil
+	}
 	dataValuesSchemaParser, parseErr := tkgpackageclient.NewValuesSchemaParser(pkg.Spec.ValuesSchema)
 	if parseErr != nil {
 		return parseErr

--- a/pkg/v1/tkg/tkgpackageclient/utils.go
+++ b/pkg/v1/tkg/tkgpackageclient/utils.go
@@ -36,9 +36,6 @@ type PackageValuesSchemaParser struct {
 
 // NewValuesSchemaParser instantiate a new PackageValuesSchemaParser
 func NewValuesSchemaParser(valuesSchema kapppkg.ValuesSchema) (*PackageValuesSchemaParser, error) {
-	if len(valuesSchema.OpenAPIv3.Raw) == 0 {
-		return nil, fmt.Errorf("data value schema is empty")
-	}
 	loader := openapi3.NewLoader()
 	doc, loadErr := loader.LoadFromData(valuesSchema.OpenAPIv3.Raw)
 	if loadErr != nil {


### PR DESCRIPTION
### What this PR does / why we need it
improve error message when values schema is empty
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #703 

### Describe testing done for PR
manually test on cluster

now if user want to get values schema of a package which which does not have any user configurable values:

tanzu package available get pkg.test.carvel.dev/3.0.0-rc.1 --values-schema -n test-ns --kubeconfig mgmt.config

package 'pkg.test.carvel.dev/3.0.0-rc.1' does not have any user configurable values in the 'test-ns' namespace
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
