### PR TITLE
Adds default feature flags (when missing) to config file

### DIFF
--- a/config/crd/bases/config.tanzu.vmware.com_clientconfigs.yaml
+++ b/config/crd/bases/config.tanzu.vmware.com_clientconfigs.yaml
@@ -166,6 +166,14 @@ spec:
                     Plugin API based plugin discovery mechanism
                   type: boolean
               type: object
+            features:
+              additionalProperties:
+                additionalProperties:
+                  type: string
+                description: FeatureMap is simply a hash table, but needs an explicit
+                  type to be an object in another hash map (cf ClientOptions.Features)
+                type: object
+              type: object
           type: object
         current:
           description: CurrentServer in use.

--- a/pkg/v1/config/clientconfig.go
+++ b/pkg/v1/config/clientconfig.go
@@ -133,7 +133,7 @@ func populateDefaultCliFeatureValues(c *configv1alpha1.ClientConfig, defaultCliF
 
 func addFeatureFlag(c *configv1alpha1.ClientConfig, plugin, flag string, flagValue bool) {
 	if c.ClientOptions.Features[plugin] == nil {
-		c.ClientOptions.Features[plugin] = configv1alpha1.FeatureMap{}
+		c.ClientOptions.Features[plugin] = make(map[string]string)
 	}
 	c.ClientOptions.Features[plugin][flag] = strconv.FormatBool(flagValue)
 }

--- a/pkg/v1/config/clientconfig.go
+++ b/pkg/v1/config/clientconfig.go
@@ -120,7 +120,6 @@ func NewClientConfig() (*configv1alpha1.ClientConfig, error) {
 }
 
 func populateDefaultCliFeatureValues(c *configv1alpha1.ClientConfig, defaultCliFeatureFlags map[string]bool) error {
-	c.ClientOptions.Features = make(map[string]configv1alpha1.FeatureMap)
 	for featureName, flagValue := range defaultCliFeatureFlags {
 		plugin, flag, err := c.SplitFeaturePath(featureName)
 		if err != nil {
@@ -132,6 +131,9 @@ func populateDefaultCliFeatureValues(c *configv1alpha1.ClientConfig, defaultCliF
 }
 
 func addFeatureFlag(c *configv1alpha1.ClientConfig, plugin, flag string, flagValue bool) {
+	if c.ClientOptions.Features == nil {
+		c.ClientOptions.Features = make(map[string]configv1alpha1.FeatureMap)
+	}
 	if c.ClientOptions.Features[plugin] == nil {
 		c.ClientOptions.Features[plugin] = make(map[string]string)
 	}

--- a/pkg/v1/config/clientconfig.go
+++ b/pkg/v1/config/clientconfig.go
@@ -131,6 +131,9 @@ func populateDefaultCliFeatureValues(c *configv1alpha1.ClientConfig, defaultCliF
 }
 
 func addFeatureFlag(c *configv1alpha1.ClientConfig, plugin, flag string, flagValue bool) {
+	if c.ClientOptions == nil {
+		c.ClientOptions = &configv1alpha1.ClientOptions{}
+	}
 	if c.ClientOptions.Features == nil {
 		c.ClientOptions.Features = make(map[string]configv1alpha1.FeatureMap)
 	}


### PR DESCRIPTION
### What this PR does / why we need it
The current implementation of configuration feature gates is that when there is no config file, we use the defaults hard-coded in the release. However, if there exists a configuration file, we use whatever values are in that file. This means a newly-added hard-coded feature (value of true) would not be activated for a user with a pre-existing config file.
To handle this, we intend to add all default feature gate values to the user's configuration file, unless they already have an entry.

Fixes #933 

### Describe testing done for PR
Testing locally to see that default values populate config file

### PR Checklist
- [X] Squash the commits into one or a small number of logical commits
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access
