### PR TITLE
udpate namespace usage in package install cmd

### DIFF
--- a/cmd/cli/plugin/package/package_install.go
+++ b/cmd/cli/plugin/package/package_install.go
@@ -33,7 +33,7 @@ func init() {
 	packageInstallCmd.Flags().StringVarP(&packageInstallOp.PackageName, "package-name", "p", "", "Name of the package to be installed")
 	packageInstallCmd.Flags().StringVarP(&packageInstallOp.Version, "version", "v", "", "Version of the package to be installed")
 	packageInstallCmd.Flags().BoolVarP(&packageInstallOp.CreateNamespace, "create-namespace", "", false, "Create namespace if the target namespace does not exist, optional")
-	packageInstallCmd.Flags().StringVarP(&packageInstallOp.Namespace, "namespace", "n", "default", "Target namespace to install the package, optional")
+	packageInstallCmd.Flags().StringVarP(&packageInstallOp.Namespace, "namespace", "n", "default", "Namespace indicates the location of the repository from which the package is retrieved")
 	packageInstallCmd.Flags().StringVarP(&packageInstallOp.ServiceAccountName, "service-account-name", "", "", "Name of an existing service account used to install underlying package contents, optional")
 	packageInstallCmd.Flags().StringVarP(&packageInstallOp.ValuesFile, "values-file", "f", "", "The path to the configuration values file, optional")
 	packageInstallCmd.Flags().StringVarP(&packageInstallOp.KubeConfig, "kubeconfig", "", "", "The path to the kubeconfig file, optional")
@@ -64,7 +64,7 @@ func packageInstall(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Infof("\n %s", fmt.Sprintf("Added installed package '%s' in namespace '%s'",
-		packageInstallOp.PkgInstallName, packageInstallOp.Namespace))
+	log.Infof("\n %s", fmt.Sprintf("Added installed package '%s'",
+		packageInstallOp.PkgInstallName))
 	return nil
 }


### PR DESCRIPTION
### What this PR does / why we need it
udpate namespace usage in package install cmd
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #698 

### Describe testing done for PR
manually test on cluster

tanzu package install certmgr -p cert-manager.tanzu.vmware.com --namespace tanzu-package-repo-global -v 1.1.0+vmware.1-tkg.2

| Installing package 'cert-manager.tanzu.vmware.com'
/ Getting package metadata for 'cert-manager.tanzu.vmware.com'
| Creating service account 'certmgr-tanzu-package-repo-global-sa'
| Creating cluster admin role 'certmgr-tanzu-package-repo-global-cluster-role'
| Creating cluster role binding 'certmgr-tanzu-package-repo-global-cluster-rolebinding'
| Creating package resource
- Waiting for 'PackageInstall' reconciliation for 'certmgr'
- 'PackageInstall' resource install status: Reconciling


 Added installed package 'certmgr'

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
