### PR TITLE
.github/ISSUE_TEMPLATE: add IAM product area

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -12,6 +12,7 @@ labels: needs-triage, kind/bug
 - [ ] Addons
 - [ ] CLI
 - [ ] Docs
+- [ ] IAM
 - [ ] Installation
 - [ ] Plugin
 - [ ] Security

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,6 +15,7 @@ labels: needs-triage, kind/feature
 - [ ] Addons
 - [ ] CLI
 - [ ] Docs
+- [ ] IAM
 - [ ] Installation
 - [ ] Plugin
 - [ ] Security


### PR DESCRIPTION
### What this PR does / why we need it

* It seems like our list of "product areas" in our issue template roughly follows the `area/*` labels
* We have an `area/iam`, but no IAM "product area" in our issue template, so I am wondering if we should add it
* I think adding IAM as a "product area" would get contributors thinking about the authentication/authorization experience, which would help feedback get funneled to the correct `area/iam` folks

### Which issue(s) this PR fixes

None

### Describe testing done for PR

None

### Release note

NONE

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

None

#### Special notes for your reviewer

 None