### PR TITLE
addons/pinniped/post-deploy: use stable cert-manager v1 APIs

### DIFF
--- a/addons/pinniped/post-deploy/pkg/configure/configure_test.go
+++ b/addons/pinniped/post-deploy/pkg/configure/configure_test.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"testing"
 
-	certmanagerv1beta1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1beta1"
+	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	certmanagerfake "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/fake"
 	"github.com/stretchr/testify/require"
 	authv1alpha1 "go.pinniped.dev/generated/1.19/apis/concierge/authentication/v1alpha1"
@@ -88,13 +88,13 @@ func TestPinniped(t *testing.T) {
 		},
 	}
 
-	certificateGVR := certmanagerv1beta1.SchemeGroupVersion.WithResource("certificates")
-	supervisorCertificate := &certmanagerv1beta1.Certificate{
+	certificateGVR := certmanagerv1.SchemeGroupVersion.WithResource("certificates")
+	supervisorCertificate := &certmanagerv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: supervisorNamespace,
 			Name:      "some-supervisor-certificate-name",
 		},
-		Spec: certmanagerv1beta1.CertificateSpec{
+		Spec: certmanagerv1.CertificateSpec{
 			SecretName: supervisorCertificateSecret.Name,
 			IPAddresses: []string{
 				supervisorService.Status.LoadBalancer.Ingress[0].IP,

--- a/addons/pinniped/post-deploy/pkg/utils/utils.go
+++ b/addons/pinniped/post-deploy/pkg/utils/utils.go
@@ -13,7 +13,7 @@ import (
 	"net/url"
 	"time"
 
-	certmanagerv1beta1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1beta1"
+	certmanagerv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -53,7 +53,7 @@ func RandomHex(n int) (string, error) {
 }
 
 // GetSecretFromCert extracts the secret for the certificate.
-func GetSecretFromCert(ctx context.Context, client kubernetes.Interface, cert *certmanagerv1beta1.Certificate) (*corev1.Secret, error) {
+func GetSecretFromCert(ctx context.Context, client kubernetes.Interface, cert *certmanagerv1.Certificate) (*corev1.Secret, error) {
 	// get secret from cert
 	var secret *corev1.Secret
 	secretNamespace := cert.Namespace


### PR DESCRIPTION
### What this PR does / why we need it

* This PR updates the post-deploy job to use stable v1 cert-manager APIs
* We already moved to cert-manager v1 APIs in the package: https://github.com/vmware-tanzu/community-edition/commit/8223879eb4abcc604a907a2212fcb0519117f467

### Which issue(s) this PR fixes

None

### Describe testing done for PR

I built the post-deploy job from this branch, patched it into a running management cluster, and saw that it worked as it did before.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

None

#### Special notes for your reviewer

None