### PR TITLE
Display the latest package version as part of "tanzu package available list" command

### DIFF
--- a/cmd/cli/plugin/package/package_available_list.go
+++ b/cmd/cli/plugin/package/package_available_list.go
@@ -6,10 +6,14 @@ package main
 import (
 	"fmt"
 
+	"github.com/k14s/semver/v4"
 	"github.com/spf13/cobra"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/kappclient"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
+
+	"go.uber.org/multierr"
 )
 
 var packageAvailableListCmd = &cobra.Command{
@@ -51,19 +55,31 @@ func packageAvailableList(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if packageAvailableOp.AllNamespaces {
-			t.SetKeys("NAME", "DISPLAY-NAME", "SHORT-DESCRIPTION", "NAMESPACE")
+			t.SetKeys("NAME", "DISPLAY-NAME", "SHORT-DESCRIPTION", "LATEST-VERSION", "NAMESPACE")
 		} else {
-			t.SetKeys("NAME", "DISPLAY-NAME", "SHORT-DESCRIPTION")
+			t.SetKeys("NAME", "DISPLAY-NAME", "SHORT-DESCRIPTION", "LATEST-VERSION")
 		}
+		var multiGetVerErr error
 		for i := range packageMetadataList.Items {
 			pkg := packageMetadataList.Items[i]
+			latestVersion, getVerErr := getPackageLatestVersion(pkg.Name, pkg.Namespace, kc)
+			// It is safe to use multierr.Append() even when getVerErr is nil. The API handles that case.
+			multiGetVerErr = multierr.Append(multiGetVerErr, getVerErr)
 			if packageAvailableOp.AllNamespaces {
-				t.AddRow(pkg.Name, pkg.Spec.DisplayName, pkg.Spec.ShortDescription, pkg.Namespace)
+				t.AddRow(pkg.Name, pkg.Spec.DisplayName, pkg.Spec.ShortDescription, latestVersion, pkg.Namespace)
 			} else {
-				t.AddRow(pkg.Name, pkg.Spec.DisplayName, pkg.Spec.ShortDescription)
+				t.AddRow(pkg.Name, pkg.Spec.DisplayName, pkg.Spec.ShortDescription, latestVersion)
 			}
 		}
 		t.RenderWithSpinner()
+
+		// If there are any errors when getting the latest package version, we do not want to error out the command and
+		// block user from moving forward. When an error occurs, the latest version will be empty. What we want is to
+		// show a warning message to explain what the empty latest version means.
+		if multiGetVerErr != nil {
+			log.Warning("\nUnable to get the latest version for all packages, some packages' latest version fields" +
+				" are empty. Please try again or use `tanzu package available list <package-name>` to get the version.")
+		}
 		return nil
 	}
 	t, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat,
@@ -91,4 +107,34 @@ func packageAvailableList(cmd *cobra.Command, args []string) error {
 	}
 	t.RenderWithSpinner()
 	return nil
+}
+
+// getPackageLatestVersion returns the latest version of a particular package under a namespace
+func getPackageLatestVersion(packageName, namespace string, kc kappclient.Client) (string, error) {
+	pkgs, listErr := kc.ListPackages(packageName, namespace)
+	if listErr != nil {
+		return "", listErr
+	}
+	var latest *semver.Version
+	var parseErr error
+	for i := range pkgs.Items {
+		pkg := pkgs.Items[i]
+		current, err := semver.Make(pkg.Spec.Version)
+		if err != nil {
+			// If we are not able to parse the version of current package, record the error and continue
+			parseErr = multierr.Append(parseErr, err)
+			continue
+		}
+		if latest == nil {
+			latest = &current
+		} else if latest.LT(current) {
+			latest = &current
+		}
+	}
+
+	// If we are not able to get and compare versions from all packages, latest is nil
+	if latest == nil {
+		return "", parseErr
+	}
+	return latest.String(), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/jinzhu/copier v0.2.8
 	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
 	github.com/k14s/imgpkg v0.6.0
+	github.com/k14s/semver/v4 v4.0.1-0.20210701191048-266d47ac6115
 	github.com/k14s/ytt v0.32.1-0.20210511155130-214258be2519
 	github.com/lithammer/dedent v1.1.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible

--- a/go.sum
+++ b/go.sum
@@ -768,6 +768,7 @@ github.com/k14s/difflib v0.0.0-20201117154628-0c031775bf57 h1:CwBRArr+BWBopnUJhD
 github.com/k14s/difflib v0.0.0-20201117154628-0c031775bf57/go.mod h1:B0xN2MiNBGWOWi9CcfAo9LBI8IU4J1utlbOIJCsmKr4=
 github.com/k14s/imgpkg v0.6.0 h1:o5nfYciVGF53EUdzQhv96sYuqnoplw4oWWvxr8c86d8=
 github.com/k14s/imgpkg v0.6.0/go.mod h1:vFWIWK44PadM7SWJ+AaPieRMUavjRNzfdijG3uHDwkQ=
+github.com/k14s/semver/v4 v4.0.1-0.20210701191048-266d47ac6115 h1:wKSifC/VbCaQMqXYn6/gSFqle82OX4bE3KYALDU9FlU=
 github.com/k14s/semver/v4 v4.0.1-0.20210701191048-266d47ac6115/go.mod h1:mGrnmO5qnhJIaSiwMo05cvRL6Ww9ccYbTgNFcm6RHZQ=
 github.com/k14s/starlark-go v0.0.0-20200720175618-3a5c849cc368 h1:4bcRTTSx+LKSxMWibIwzHnDNmaN1x52oEpvnjCy+8vk=
 github.com/k14s/starlark-go v0.0.0-20200720175618-3a5c849cc368/go.mod h1:lKGj1op99m4GtQISxoD2t+K+WO/q2NzEPKvfXFQfbCA=


### PR DESCRIPTION
### What this PR does / why we need it

With current tanzu package plugin, there is no way to show the latest package version from `tanzu package available list` command. This PR improves the user experiences by adding the latest package version as part of the `tanzu package available list` command.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #769 

### Describe testing done for PR

- Manually build tanzu package plugin on local and verified the latest version is shown from `tanzu package available list` and `tanzu package available list -A` command.

```
 ~  tanzu package available list
| Retrieving available packages...
  NAME                           DISPLAY-NAME  SHORT-DESCRIPTION                                                                                           LATEST-VERSION
  cert-manager.tanzu.vmware.com  cert-manager  Certificate management                                                                                      1.1.0+vmware.1-tkg.2-zshippable
  contour.tanzu.vmware.com       Contour       An ingress controller                                                                                       1.17.1+vmware.1-tkg.1-zshippable
  external-dns.tanzu.vmware.com  external-dns  This package provides DNS synchronization functionality.                                                    0.8.0+vmware.1-tkg.1-zshippable
  fluent-bit.tanzu.vmware.com    fluent-bit    Fluent Bit is a fast Log Processor and Forwarder                                                            1.7.5+vmware.1-tkg.1-zshippable
  grafana.tanzu.vmware.com       grafana       Visualization and analytics software                                                                        7.5.7+vmware.1-tkg.1-zshippable
  harbor.tanzu.vmware.com        Harbor        OCI Registry                                                                                                2.2.3+vmware.1-tkg.1-zshippable
  multus-cni.tanzu.vmware.com    multus-cni    This package provides the ability for enabling attaching multiple network interfaces to pods in Kubernetes  3.7.1+vmware.1-tkg.1-zshippable
  prometheus.tanzu.vmware.com    prometheus    A time series database for your metrics                                                                     2.27.0+vmware.1-tkg.1-zshippable
```

```
 ~  tanzu package available list -A
| Retrieving available packages...
  NAME                                                DISPLAY-NAME                       SHORT-DESCRIPTION                                                                                                                                                                                       LATEST-VERSION                           NAMESPACE
  cert-manager.tanzu.vmware.com                       cert-manager                       Certificate management                                                                                                                                                                                  1.1.0+vmware.1-tkg.2-zshippable   tanzu-package-repo-global
  contour.tanzu.vmware.com                            Contour                            An ingress controller                                                                                                                                                                                   1.17.1+vmware.1-tkg.1-zshippable  tanzu-package-repo-global
  external-dns.tanzu.vmware.com                       external-dns                       This package provides DNS synchronization functionality.                                                                                                                                                0.8.0+vmware.1-tkg.1-zshippable   tanzu-package-repo-global
  fluent-bit.tanzu.vmware.com                         fluent-bit                         Fluent Bit is a fast Log Processor and Forwarder                                                                                                                                                        1.7.5+vmware.1-tkg.1-zshippable   tanzu-package-repo-global
  grafana.tanzu.vmware.com                            grafana                            Visualization and analytics software                                                                                                                                                                    7.5.7+vmware.1-tkg.1-zshippable   tanzu-package-repo-global
  harbor.tanzu.vmware.com                             Harbor                             OCI Registry                                                                                                                                                                                            2.2.3+vmware.1-tkg.1-zshippable   tanzu-package-repo-global
......
```

- Manually introduce error from listing packages, and verified the warning message is shown properly.

```
 ~  tanzu package available list
- Retrieving available packages...
  NAME                           DISPLAY-NAME  SHORT-DESCRIPTION                                                                                           LATEST-VERSION
  cert-manager.tanzu.vmware.com  cert-manager  Certificate management
  contour.tanzu.vmware.com       Contour       An ingress controller
  external-dns.tanzu.vmware.com  external-dns  This package provides DNS synchronization functionality.
  fluent-bit.tanzu.vmware.com    fluent-bit    Fluent Bit is a fast Log Processor and Forwarder
  grafana.tanzu.vmware.com       grafana       Visualization and analytics software
  harbor.tanzu.vmware.com        Harbor        OCI Registry
  multus-cni.tanzu.vmware.com    multus-cni    This package provides the ability for enabling attaching multiple network interfaces to pods in Kubernetes
  prometheus.tanzu.vmware.com    prometheus    A time series database for your metrics

Unable to get the latest version for all packages, some packages' latest version fields are empty. Please try again or use `tanzu package available list <package-name>` to get the version.
```

```
/ Retrieving available packages...
  NAME                           DISPLAY-NAME  SHORT-DESCRIPTION                                                                                           LATEST-VERSION
  cert-manager.tanzu.vmware.com  cert-manager  Certificate management
  contour.tanzu.vmware.com       Contour       An ingress controller                                                                                       1.17.1+vmware.1-tkg.1-zshippable
  external-dns.tanzu.vmware.com  external-dns  This package provides DNS synchronization functionality.                                                    0.8.0+vmware.1-tkg.1-zshippable
  fluent-bit.tanzu.vmware.com    fluent-bit    Fluent Bit is a fast Log Processor and Forwarder                                                            1.7.5+vmware.1-tkg.1-zshippable
  grafana.tanzu.vmware.com       grafana       Visualization and analytics software                                                                        7.5.7+vmware.1-tkg.1-zshippable
  harbor.tanzu.vmware.com        Harbor        OCI Registry                                                                                                2.2.3+vmware.1-tkg.1-zshippable
  multus-cni.tanzu.vmware.com    multus-cni    This package provides the ability for enabling attaching multiple network interfaces to pods in Kubernetes  3.7.1+vmware.1-tkg.1-zshippable
  prometheus.tanzu.vmware.com    prometheus    A time series database for your metrics                                                                     2.27.0+vmware.1-tkg.1-zshippable

Unable to get the latest version for all packages, some packages' latest version fields are empty. Please try again or use `tanzu package available list <package-name>` to get the version.
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
"tanzu package available list" command will show the latest package version from the ouput.
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
