### PR TITLE
addons/pinniped/post-deploy: support cluster-scoped concierge

### DIFF
--- a/addons/pinniped/post-deploy/main.go
+++ b/addons/pinniped/post-deploy/main.go
@@ -25,6 +25,9 @@ func main() {
 	flag.StringVar(&vars.PinnipedAPIGroupSuffix, "pinniped-api-group-suffix", vars.PinnipedAPIGroupSuffix, "The API group suffix used to talk to Pinniped APIs")
 
 	// optional
+	flag.BoolVar(&vars.ConciergeIsClusterScoped, "concierge-is-cluster-scoped", vars.ConciergeIsClusterScoped, "Whether the Pinniped Concierge APIs are cluster-scoped")
+
+	// optional
 	flag.StringVar(&vars.SupervisorNamespace, "supervisor-namespace", vars.SupervisorNamespace, "The namespace of Pinniped supervisor")
 
 	// required for management cluster: yes
@@ -117,7 +120,7 @@ func initClients() (configure.Clients, error) {
 	return configure.Clients{
 		K8SClientset:         kubernetes.NewForConfigOrDie(cfg),
 		SupervisorClientset:  pinnipedclientset.NewSupervisor(dynamicClient, vars.PinnipedAPIGroupSuffix),
-		ConciergeClientset:   pinnipedclientset.NewConcierge(dynamicClient, vars.PinnipedAPIGroupSuffix),
+		ConciergeClientset:   pinnipedclientset.NewConcierge(dynamicClient, vars.PinnipedAPIGroupSuffix, vars.ConciergeIsClusterScoped),
 		CertmanagerClientset: certmanagerclientset.NewForConfigOrDie(cfg),
 	}, nil
 }

--- a/addons/pinniped/post-deploy/pkg/configure/concierge/concierge_test.go
+++ b/addons/pinniped/post-deploy/pkg/configure/concierge/concierge_test.go
@@ -137,7 +137,7 @@ func TestCreateOrUpdateJWTAuthenticator(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			kubeDynamicClient := test.newKubeDynamicClient()
 			err := Configurator{
-				Clientset: pinnipedclientset.NewConcierge(kubeDynamicClient, apiGroupSuffix),
+				Clientset: pinnipedclientset.NewConcierge(kubeDynamicClient, apiGroupSuffix, false),
 			}.CreateOrUpdateJWTAuthenticator(
 				context.Background(),
 				jwtAuthenticator.Namespace,

--- a/addons/pinniped/post-deploy/pkg/configure/configure_test.go
+++ b/addons/pinniped/post-deploy/pkg/configure/configure_test.go
@@ -266,7 +266,7 @@ func TestPinniped(t *testing.T) {
 				K8SClientset:         fakeKubeClient,
 				CertmanagerClientset: fakeCertManagerClient,
 				SupervisorClientset:  pinnipedclientset.NewSupervisor(fakeKubeDynamicClient, apiGroupSuffix),
-				ConciergeClientset:   pinnipedclientset.NewConcierge(fakeKubeDynamicClient, apiGroupSuffix),
+				ConciergeClientset:   pinnipedclientset.NewConcierge(fakeKubeDynamicClient, apiGroupSuffix, false),
 			}
 			inspector := inspect.Inspector{K8sClientset: fakeKubeClient, Context: context.Background()}
 			err := Pinniped(context.Background(), clients, inspector, &test.parameters)

--- a/addons/pinniped/post-deploy/pkg/pinnipedclientset/concierge_test.go
+++ b/addons/pinniped/post-deploy/pkg/pinnipedclientset/concierge_test.go
@@ -1,0 +1,117 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package pinnipedclientset
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	authv1alpha1 "go.pinniped.dev/generated/1.19/apis/concierge/authentication/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubedynamicfake "k8s.io/client-go/dynamic/fake"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+func TestConciergeIsClusterScoped(t *testing.T) {
+	const (
+		apiGroupSuffix = "some.mackerel.api.group.suffix.com"
+	)
+
+	authv1alpha1GV := authv1alpha1.SchemeGroupVersion
+	authv1alpha1GV.Group = "authentication.concierge." + apiGroupSuffix
+
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypes(authv1alpha1GV, &authv1alpha1.JWTAuthenticator{}, &authv1alpha1.JWTAuthenticatorList{})
+
+	jwtAuthenticatorGVR := authv1alpha1GV.WithResource("jwtauthenticators")
+
+	namespaceScopedJWTAuthenticator := &authv1alpha1.JWTAuthenticator{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "some-namespace",
+			Name:      "some-name",
+		},
+		Spec: authv1alpha1.JWTAuthenticatorSpec{
+			Issuer:   "some-issuer",
+			Audience: "some-audience",
+			TLS: &authv1alpha1.TLSSpec{
+				CertificateAuthorityData: "some-ca-data",
+			},
+		},
+	}
+	clusterScopedJWTAuthenticator := namespaceScopedJWTAuthenticator.DeepCopy()
+	clusterScopedJWTAuthenticator.Namespace = ""
+
+	tests := []struct {
+		name                     string
+		conciergeIsClusterScoped bool
+		jwtAuthenticator         *authv1alpha1.JWTAuthenticator
+		wantActions              []kubetesting.Action
+	}{
+		{
+			name:                     "namespace scoped",
+			conciergeIsClusterScoped: false,
+			jwtAuthenticator:         namespaceScopedJWTAuthenticator,
+			wantActions: []kubetesting.Action{
+				kubetesting.NewCreateAction(
+					jwtAuthenticatorGVR,
+					namespaceScopedJWTAuthenticator.Namespace,
+					toUnstructured(namespaceScopedJWTAuthenticator, false),
+				),
+				kubetesting.NewGetAction(
+					jwtAuthenticatorGVR,
+					namespaceScopedJWTAuthenticator.Namespace,
+					namespaceScopedJWTAuthenticator.Name,
+				),
+			},
+		},
+		{
+			name:                     "cluster scoped",
+			conciergeIsClusterScoped: true,
+			jwtAuthenticator:         clusterScopedJWTAuthenticator,
+			wantActions: []kubetesting.Action{
+				kubetesting.NewRootCreateAction(jwtAuthenticatorGVR, toUnstructured(clusterScopedJWTAuthenticator, false)),
+				kubetesting.NewRootGetAction(jwtAuthenticatorGVR, clusterScopedJWTAuthenticator.Name),
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			kubeDynamicClient := kubedynamicfake.NewSimpleDynamicClient(scheme)
+
+			jwtAuthenticators := NewConcierge(kubeDynamicClient, apiGroupSuffix, test.conciergeIsClusterScoped).
+				AuthenticationV1alpha1().
+				JWTAuthenticators(test.jwtAuthenticator.Namespace)
+
+			createdJWTAuthenticator, err := jwtAuthenticators.
+				Create(context.Background(), test.jwtAuthenticator, metav1.CreateOptions{})
+			require.NoError(t, err)
+			require.Equal(t, createdJWTAuthenticator, test.jwtAuthenticator)
+
+			gotJWTAuthenticator, err := jwtAuthenticators.
+				Get(context.Background(), test.jwtAuthenticator.Name, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.Equal(t, gotJWTAuthenticator, createdJWTAuthenticator)
+
+			require.Equal(t, test.wantActions, kubeDynamicClient.Actions())
+		})
+	}
+}
+
+func toUnstructured(obj runtime.Object, removeTypeMeta bool) runtime.Object {
+	unstructuredObjData, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		panic(err)
+	}
+
+	if removeTypeMeta {
+		delete(unstructuredObjData, "apiVersion")
+		delete(unstructuredObjData, "kind")
+	}
+
+	return &unstructured.Unstructured{Object: unstructuredObjData}
+}

--- a/addons/pinniped/post-deploy/pkg/vars/vars.go
+++ b/addons/pinniped/post-deploy/pkg/vars/vars.go
@@ -12,6 +12,10 @@ var (
 	// "config.supervisor.tuna.io".
 	PinnipedAPIGroupSuffix = constants.PinnipedDefaultAPIGroupSuffix
 
+	// ConciergeIsClusterScoped indicates whether the Pinniped Concierge APIs are
+	// cluster-scoped (as opposed to namespace-scoped).
+	ConciergeIsClusterScoped = false
+
 	// SupervisorNamespace is the supervisor service namespace.
 	SupervisorNamespace = "pinniped-supervisor"
 


### PR DESCRIPTION
### What this PR does / why we need it

* Context: we (`area/iam`) are in the process of updating the Pinniped package to a newer version (0.12.0)
* From the comment message:
```
Pinniped v0.6.0 changes Concierge APIs to be cluster-scoped. We want this
post-deploy job to work with v0.12.0, so we need to change the Concierge client
to be cluster-scoped. However, we don't want to immediately update the Concierge
client until the new v0.12.0 package is shipped, so we will do this dynamically
via a command line flag for now. Eventually, after we no longer need to support
any Pinniped versions before v0.6.0, we can hardcode the Concierge client to be
cluster-scoped.
```

### Which issue(s) this PR fixes

Related to #835

### Describe testing done for PR

* I added some more unit test coverage in `pkg/pinnipedclientset` for the new dynamic resource scoping logic
* I built the post-deploy job from this branch and ran 4 tests:
1. With a management cluster running Pinniped v0.4.4, I deployed the post-deploy job and ensured that it ran successfully and that I could continue to authenticate to the cluster
2. With a management cluster running Pinniped v0.4.4, I deployed the post-deploy job with `--concierge-is-cluster-scoped=true` and made sure the post-deploy job failed (because it couldn't talk to the Concierge APIs)
3. With a management cluster running Pinniped v0.12.0, I deployed the post-deploy job and made sure the post-deploy job failed (because it couldn't talk to the Concierge APIs)
4. With a management cluster running Pinniped v0.12.0, I deployed the post-deploy job with `--concierge-is-cluster-scoped=true` and ensured that it ran successfully and that I could continue to authenticate to the cluster

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

None

#### Special notes for your reviewer

None
