### PR TITLE
Tweaks ContextAwareDiscovery to allow more generic feature flags to u…

### DIFF
--- a/pkg/v1/cli/catalog/catalog_test.go
+++ b/pkg/v1/cli/catalog/catalog_test.go
@@ -13,6 +13,7 @@ import (
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/common"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 )
 
 func Test_ContextCatalog_With_Empty_Context(t *testing.T) {
@@ -187,7 +188,7 @@ func sortarray(pds []cliv1alpha1.PluginDescriptor) {
 // the featuregate is configured to true by default
 func Test_CatalogCacheFileName(t *testing.T) {
 	assert := assert.New(t)
-	if common.IsContextAwareDiscoveryEnabled {
+	if config.IsFeatureActivated(config.FeatureContextAwareDiscovery) {
 		assert.Equal(catalogCacheFileName, "catalog.yaml")
 	}
 }

--- a/pkg/v1/cli/command/core/plugin_manager.go
+++ b/pkg/v1/cli/command/core/plugin_manager.go
@@ -56,7 +56,7 @@ var listPluginCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List available plugins",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if config.IsContextAwareDiscoveryEnabled() {
+		if config.IsFeatureActivated(config.FeatureContextAwareDiscovery) {
 			server, err := config.GetCurrentServer()
 			if err != nil {
 				return err
@@ -175,7 +175,7 @@ var describePluginCmd = &cobra.Command{
 		}
 		name := args[0]
 
-		if config.IsContextAwareDiscoveryEnabled() {
+		if config.IsFeatureActivated(config.FeatureContextAwareDiscovery) {
 			server, err := config.GetCurrentServer()
 			if err != nil {
 				return err
@@ -224,7 +224,7 @@ var installPluginCmd = &cobra.Command{
 		}
 		name := args[0]
 
-		if config.IsContextAwareDiscoveryEnabled() {
+		if config.IsFeatureActivated(config.FeatureContextAwareDiscovery) {
 			server, err := config.GetCurrentServer()
 			if err != nil {
 				return err
@@ -267,7 +267,7 @@ var upgradePluginCmd = &cobra.Command{
 		}
 		name := args[0]
 
-		if config.IsContextAwareDiscoveryEnabled() {
+		if config.IsFeatureActivated(config.FeatureContextAwareDiscovery) {
 			return errors.New("context-aware discovery is enabled but function is not yet implemented")
 		}
 
@@ -297,7 +297,7 @@ var deletePluginCmd = &cobra.Command{
 		}
 		name := args[0]
 
-		if config.IsContextAwareDiscoveryEnabled() {
+		if config.IsFeatureActivated(config.FeatureContextAwareDiscovery) {
 			return errors.New("context-aware discovery is enabled but function is not yet implemented")
 		}
 
@@ -311,7 +311,7 @@ var cleanPluginCmd = &cobra.Command{
 	Use:   "clean",
 	Short: "Clean the plugins",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		if config.IsContextAwareDiscoveryEnabled() {
+		if config.IsFeatureActivated(config.FeatureContextAwareDiscovery) {
 			return errors.New("context-aware discovery is enabled but function is not yet implemented")
 		}
 


### PR DESCRIPTION
### What this PR does / why we need it
The global feature flag context-aware-discovery gives us an opportunity to create convenience methods that can be used with other global feature flags

### Describe testing done for PR
Ran tests locally

### PR Checklist
- [X] Squash the commits into one or a small number of logical commits
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access

### Additional information
Related to #767 
