### PR TITLE
remove the OPTIONAL label from both Username and Filter for LDAP user…

### DIFF
--- a/pkg/v1/tkg/web/src/app/views/landing/wizard/shared/components/steps/identity-step/identity-step.component.html
+++ b/pkg/v1/tkg/web/src/app/views/landing/wizard/shared/components/steps/identity-step/identity-step.component.html
@@ -371,7 +371,7 @@
                 <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
                     <clr-input-container [attr.data-step-metadata]="formName">
                         <label>
-                            FILTER (OPTIONAL)
+                            FILTER
                             <clr-tooltip>
                                 <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                                 <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
@@ -391,6 +391,7 @@
                                name="userSearchFilter"/>
                         <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
                         <clr-control-helper></clr-control-helper>
+                        <clr-control-error>Filter is required</clr-control-error>
                     </clr-input-container>
                 </div>
 
@@ -398,7 +399,7 @@
                 <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
                     <clr-input-container [attr.data-step-metadata]="formName">
                         <label>
-                            USERNAME (OPTIONAL)
+                            USERNAME
                             <clr-tooltip>
                                 <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                                 <clr-tooltip-content clrPosition="top-left" clrSize="lg" *clrIfOpen>
@@ -413,6 +414,7 @@
                                name="userSearchUsername"/>
                         <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
                         <clr-control-helper></clr-control-helper>
+                        <clr-control-error>Username is required</clr-control-error>
                     </clr-input-container>
                 </div>
             </div>

--- a/pkg/v1/tkg/web/src/app/views/landing/wizard/shared/components/steps/identity-step/identity-step.component.ts
+++ b/pkg/v1/tkg/web/src/app/views/landing/wizard/shared/components/steps/identity-step/identity-step.component.ts
@@ -38,13 +38,13 @@ const ldapValidatedFields: Array<string> = [
     'endpointIp',
     'endpointPort',
     'bindPW',
+    'userSearchFilter',
     'userSearchUsername'
 ];
 
 const ldapNonValidatedFields: Array<string> = [
     'bindDN',
     'userSearchBaseDN',
-    'userSearchFilter',
     'groupSearchBaseDN',
     'groupSearchFilter',
     'groupSearchUserAttr',
@@ -175,6 +175,11 @@ export class SharedIdentityStepComponent extends StepFormDirective implements On
         ], this.getSavedValue('endpointPort', ''));
 
         this.resurrectField('bindPW', [], '');
+
+        this.resurrectField('userSearchFilter', [
+            Validators.required
+        ], this.getSavedValue('userSearchFilter', ''));
+
         this.resurrectField('userSearchUsername', [
             Validators.required
         ], this.getSavedValue('userSearchUsername', ''));


### PR DESCRIPTION

![Screen Shot 2021-10-22 at 11 04 13 AM](https://user-images.githubusercontent.com/90293999/138386728-a3c9e4af-e2a1-403d-9bfb-6fc659fe76df.png)

What this PR does / why we need it 
LDAPS User Search Username is a required field, not optional. Once the User Search Username has been added (e.g. userPrincipalName), then the User Search Filter field becomes a requirement for the Validate LDAP Configuration to succeed. So remove the OPTIONAL label from both Username and Filter.

Which issue(s) this PR fixes 
Fixes #637

Describe testing done for PR
 Test passed on UI
