### PR TITLE
add secret plugin to the default plugin list

### DIFF
--- a/pkg/v1/cli/defaults.go
+++ b/pkg/v1/cli/defaults.go
@@ -4,4 +4,4 @@
 package cli
 
 // DefaultDistro is the core set of plugins that should be included with the CLI.
-var DefaultDistro = []string{"login", "pinniped-auth", "cluster", "management-cluster", "kubernetes-release", "package"}
+var DefaultDistro = []string{"login", "pinniped-auth", "cluster", "management-cluster", "kubernetes-release", "package", "secret"}


### PR DESCRIPTION
**What this PR does / why we need it:**
- This PR is to add secret plugin to the default plugin list

**Describe testing done for PR:**
Added integration tests as part of the PR

**Does this PR introduce a user-facing change?:**
None

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
adds secret plugin to the default plugin list
```

**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
