### PR TITLE
Do addons upgrade before node upgrade

### DIFF
--- a/addons/controllers/addon_reconcilers.go
+++ b/addons/controllers/addon_reconcilers.go
@@ -191,9 +191,7 @@ func (r *AddonReconciler) ReconcileAddonDataValuesSecretNormal(
 
 	addonDataValuesSecretMutateFn := func() error {
 		addonDataValuesSecret.Type = corev1.SecretTypeOpaque
-		if addonDataValuesSecret.Data == nil {
-			addonDataValuesSecret.Data = map[string][]byte{}
-		}
+		addonDataValuesSecret.Data = map[string][]byte{}
 		for k, v := range addonSecret.Data {
 			addonDataValuesSecret.Data[k] = v
 		}

--- a/pkg/v1/tkg/client/upgrade_cluster.go
+++ b/pkg/v1/tkg/client/upgrade_cluster.go
@@ -170,14 +170,25 @@ func (c *TkgClient) UpgradeCluster(options *UpgradeClusterOptions) error { // no
 		}
 	}
 
-	err = c.DoClusterUpgrade(regionalClusterClient, currentClusterClient, options)
-	if err != nil {
-		return err
-	}
-
 	err = c.addKubernetesReleaseLabel(regionalClusterClient, options)
 	if err != nil {
 		return errors.Wrapf(err, "unable to patch the cluster object with TanzuKubernetesRelease label")
+	}
+
+	// Upgrade/Add certain addons on old clusters during upgrade
+	// The addons should upgrade prior to cluster upgrade to account for forward compatibility
+	// i.e. some old addons may not run on the nodes with new k8s version
+	// We will ensure backward compatibility when shipping packages going forward
+	if !options.SkipAddonUpgrade {
+		err = c.upgradeAddons(regionalClusterClient, currentClusterClient, options.ClusterName, options.Namespace, options.IsRegionalCluster, options.Edition)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = c.DoClusterUpgrade(regionalClusterClient, currentClusterClient, options)
+	if err != nil {
+		return err
 	}
 
 	if !options.IsRegionalCluster {
@@ -186,11 +197,18 @@ func (c *TkgClient) UpgradeCluster(options *UpgradeClusterOptions) error { // no
 		if err != nil {
 			return errors.Wrapf(err, "failed to upgrade autoscaler for cluster '%s'", options.ClusterName)
 		}
+	}
 
-		log.Info("Waiting for packages to be up and running...")
-		if err := c.WaitForPackages(regionalClusterClient, currentClusterClient, options.ClusterName, options.Namespace); err != nil {
-			log.Warningf("Warning: Cluster is upgraded successfully, but some packages are failing. %v", err)
+	if options.IsRegionalCluster {
+		log.Info("Waiting for additional components to be up and running...")
+		if err := c.WaitForAddonsDeployments(regionalClusterClient); err != nil {
+			return err
 		}
+	}
+
+	log.Info("Waiting for packages to be up and running...")
+	if err := c.WaitForPackages(regionalClusterClient, currentClusterClient, options.ClusterName, options.Namespace); err != nil {
+		log.Warningf("Warning: Cluster is upgraded successfully, but some packages are failing. %v", err)
 	}
 
 	return nil
@@ -288,14 +306,6 @@ func (c *TkgClient) DoClusterUpgrade(regionalClusterClient clusterclient.Client,
 		return err
 	}
 
-	// Upgrade/Add certain addons on old clusters during upgrade
-	// apply this only for workload clusters, Upgrading the addons
-	// for the management cluster is done as part of management cluster upgrade
-	// once we update the TKG version in cluster object
-	if !options.IsRegionalCluster && !options.SkipAddonUpgrade {
-		return c.upgradeAddons(regionalClusterClient, currentClusterClient, upgradeClusterConfig.ClusterName,
-			upgradeClusterConfig.ClusterNamespace, options.IsRegionalCluster, options.Edition)
-	}
 	return nil
 }
 

--- a/pkg/v1/tkg/client/upgrade_region.go
+++ b/pkg/v1/tkg/client/upgrade_region.go
@@ -83,7 +83,7 @@ type providersUpgradeInfo struct {
 // 	d) Call the clusterctl ApplyUpgrade() to upgrade providers
 //  e) Wait for providers to be up and running
 // 2. call the UpgradeCluster() for upgrading the k8s version of the Management cluster
-func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) error { //nolint:gocyclo
+func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) error {
 	contexts, err := c.GetRegionContexts(options.ClusterName)
 	if err != nil || len(contexts) == 0 {
 		return errors.Errorf("management cluster %s not found", options.ClusterName)
@@ -147,27 +147,6 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 	err = regionalClusterClient.PatchClusterObjectWithTKGVersion(options.ClusterName, options.Namespace, c.tkgBomClient.GetCurrentTKGVersion())
 	if err != nil {
 		return err
-	}
-
-	// Upgrade/Add certain addons to the old clusters during upgrade
-	// This is done after we patch the management cluster object with new TKG version
-	// so, while generating cluster template with new tkg and k8s version, it does not
-	// throw version incompatibility validation error.
-	if !options.SkipAddonUpgrade {
-		err = c.upgradeAddons(regionalClusterClient, regionalClusterClient, options.ClusterName, options.Namespace, true, options.Edition)
-		if err != nil {
-			return err
-		}
-	}
-
-	log.Info("Waiting for additional components to be up and running...")
-	if err := c.WaitForAddonsDeployments(regionalClusterClient); err != nil {
-		return err
-	}
-
-	log.Info("Waiting for packages to be up and running...")
-	if err := c.WaitForPackages(regionalClusterClient, regionalClusterClient, options.ClusterName, options.Namespace); err != nil {
-		log.Warningf("Warning: Management cluster is upgraded successfully, but some packages are failing. %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

### What this PR does / why we need it
#966 

The addons should upgrade prior to cluster upgrade to account for forward compatibility.
i.e. some old addons may not run on the nodes with new k8s version. (Calico: The CRD definitions are using apiextensions.k8s.io/v1beta1 API version. This will make the CRD unusable once the cluster is upgraded to 1.22.0.)

Backward compatibility will be ensured when we ship addon packages with each release.

the original cluster upgrade process
1. Upgrades cluster-api resources
1. Some special pre upgrade handling
1. Updates management cluster node by patching the version of KubeadmControlPlane cluster-api resource. Once this is patched, a machine and a node with the new version will be reconciled. The CLI wait's for cluster-api's Ready condition before proceeds.
1. Updates workload cluster node by patching the version of MachineDeployment cluster-api resource. It will create a new worker node. CLI waits on MachineDeployment until it's successfully reconciled.
1. Upgrade addons. Including patching kapp-controller, TKR, addons manager.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes # Fixes N+1 compatibility of Core addons with k8s 1.22

### Describe testing done for PR
Clusters successfully upgraded in manual upgrade testing.
Created Bolt integration MR to run the testing pipeline.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Optimize cluster upgrade to reduce addons compatibility issues
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
