### PR TITLE
remove deprecated config show command

### DIFF
--- a/pkg/v1/cli/command/core/config.go
+++ b/pkg/v1/cli/command/core/config.go
@@ -22,7 +22,6 @@ import (
 func init() {
 	configCmd.SetUsageFunc(cli.SubCmdUsageFunc)
 	configCmd.AddCommand(
-		showConfigCmd,
 		getConfigCmd,
 		initConfigCmd,
 		setConfigCmd,
@@ -31,7 +30,6 @@ func init() {
 	setConfigCmd.AddCommand(setUnstableVersionsOptionCmd)
 	serversCmd.AddCommand(listServersCmd)
 	addDeleteServersCmd()
-	cli.DeprecateCommandWithAlternative(showConfigCmd, "1.5.0", "get")
 }
 
 var unattended bool
@@ -47,23 +45,6 @@ var configCmd = &cobra.Command{
 	Short: "Configuration for the CLI",
 	Annotations: map[string]string{
 		"group": string(cliv1alpha1.SystemCmdGroup),
-	},
-}
-
-var showConfigCmd = &cobra.Command{
-	Use:   "show",
-	Short: "Show the current configuration",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfgPath, err := config.ClientConfigPath()
-		if err != nil {
-			return err
-		}
-		b, err := os.ReadFile(cfgPath)
-		if err != nil {
-			return err
-		}
-		fmt.Println(string(b))
-		return nil
 	},
 }
 


### PR DESCRIPTION
### What this PR does / why we need it
This PR removes the deprecated config show command.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/963

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Removed the deprecated "config show" command. Use `config get` as an alternative.
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
