### PR TITLE
Makefile: build pinniped CLI correctly for release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ release-%:
 	$(eval OS = $(word 1,$(subst -, ,$*)))
 
 	$(GO) run ./cmd/cli/plugin-admin/builder/main.go cli compile --version $(BUILD_VERSION) --ldflags "$(LD_FLAGS)" --tags "${BUILD_TAGS}" --path ./cmd/cli/plugin-admin --artifacts artifacts-admin/${OS}/${ARCH}/cli --target ${OS}_${ARCH}
-	./hack/embed-pinniped-binary.sh go ${OS} ${ARCH}
+	./hack/embed-pinniped-binary.sh go ${OS} ${ARCH} ${PINNIPED_VERSIONS}
 	$(GO) run ./cmd/cli/plugin-admin/builder/main.go cli compile --version $(BUILD_VERSION) --ldflags "$(LD_FLAGS)" --tags "${BUILD_TAGS}" --corepath "cmd/cli/tanzu" --artifacts artifacts/${OS}/${ARCH}/cli --target  ${OS}_${ARCH}
 
 ## --------------------------------------


### PR DESCRIPTION
### What this PR does / why we need it

* Context: we (`area/iam`) are in the process of updating the Pinniped package to a newer version (0.12.0)
* We want to make sure the pinniped CLI is correctly built for the target platform during `make release`
* See https://github.com/vmware-tanzu/tanzu-framework/pull/931 for when I should have remembered to update this line

### Which issue(s) this PR fixes

Related to #835

### Describe testing done for PR

* Built with `make release` and validated that `linux` `pinniped-auth` plugin ran correctly on a linux box

### Release note

```release-note
NONE
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

None

#### Special notes for your reviewer

None