### PR TITLE
Validate SERVICE_CIDR is small enough to pass kube-apiserver validation

### DIFF
--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -573,6 +573,10 @@ func (c *TkgClient) ConfigureAndValidateManagementClusterConfiguration(options *
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
+	if err = c.validateServiceCIDRNetmask(); err != nil {
+		return NewValidationError(ValidationErrorCode, err.Error())
+	}
+
 	if err = c.ConfigureAndValidateHTTPProxyConfiguration(name); err != nil {
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
@@ -1601,6 +1605,30 @@ func (c *TkgClient) configureAndValidateIPFamilyConfiguration() error {
 	}
 	if err := c.validateIPHostnameForIPFamily(constants.TKGHTTPSProxy, ipFamily); err != nil {
 		return err
+	}
+	return nil
+}
+
+func (c *TkgClient) validateServiceCIDRNetmask() error {
+	// kube-apiserver requires that the service CIDR be of limited size.
+	// This validation avoids a case where the cluster never comes up when
+	// the CIDR is too large.
+	// https://github.com/kubernetes/kubernetes/blob/3c87c43ceff6122637c8d8070601f7271026360e/cmd/kube-apiserver/app/options/validation.go#L52
+	configVariableName := constants.ConfigVariableServiceCIDR
+	serviceCIDRs, _ := c.TKGConfigReaderWriter().Get(configVariableName)
+	cidrSlice := strings.Split(serviceCIDRs, ",")
+	for _, cidrString := range cidrSlice {
+		_, cidr, err := net.ParseCIDR(cidrString)
+		if err != nil {
+			// This should never happen since CIDRs were already validated before
+			return errors.Errorf("invalid %s \"%s\"", configVariableName, serviceCIDRs)
+		}
+		maxCIDRBits := 20
+		var ones, bits = cidr.Mask.Size()
+		if bits-ones > maxCIDRBits {
+			return errors.Errorf("invalid %s \"%s\", expected netmask to be \"/%d\" or greater", configVariableName, cidrString, bits-maxCIDRBits)
+		}
+
 	}
 	return nil
 }

--- a/pkg/v1/tkg/client/validate_test.go
+++ b/pkg/v1/tkg/client/validate_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Validate", func() {
 
 				Context("when SERVICE_CIDR and CLUSTER_CIDR are ipv4", func() {
 					It("should pass validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "192.168.2.1/8")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "192.168.2.1/12")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "192.168.2.1/8")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -132,17 +132,16 @@ var _ = Describe("Validate", func() {
 
 				Context("when SERVICE_CIDR is ipv6", func() {
 					It("should fail validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/8")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/108")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
 						Expect(validationError).To(HaveOccurred())
-						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"::1/8\", expected to be a CIDR of type \"ipv4\" (TKG_IP_FAMILY)"))
+						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"::1/108\", expected to be a CIDR of type \"ipv4\" (TKG_IP_FAMILY)"))
 					})
 				})
 
 				Context("when CLUSTER_CIDR is ipv6", func() {
 					It("should fail validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/16")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "::1/8")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -152,10 +151,6 @@ var _ = Describe("Validate", func() {
 				})
 
 				Context("HTTP(S)_PROXY variables", func() {
-					BeforeEach(func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/8")
-						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "1.2.3.4/8")
-					})
 					Context("when HTTP_PROXY and HTTPS_PROXY are ipv6 with ports", func() {
 						It("should fail validation", func() {
 							tkgConfigReaderWriter.Set(constants.TKGHTTPProxy, "http://[::1]:3128")
@@ -176,7 +171,7 @@ var _ = Describe("Validate", func() {
 
 				Context("when SERVICE_CIDR and CLUSTER_CIDR are ipv4", func() {
 					It("should pass validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "192.168.2.1/8")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "192.168.2.1/12")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "192.168.2.1/8")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -185,16 +180,15 @@ var _ = Describe("Validate", func() {
 				})
 				Context("when SERVICE_CIDR is ipv6", func() {
 					It("should fail validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/8")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/108")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
 						Expect(validationError).To(HaveOccurred())
-						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"::1/8\", expected to be a CIDR of type \"ipv4\" (TKG_IP_FAMILY)"))
+						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"::1/108\", expected to be a CIDR of type \"ipv4\" (TKG_IP_FAMILY)"))
 					})
 				})
 				Context("when CLUSTER_CIDR is ipv6", func() {
 					It("should fail validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/16")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "::1/8")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -213,7 +207,6 @@ var _ = Describe("Validate", func() {
 				})
 				Context("when CLUSTER_CIDR is not an actual CIDR", func() {
 					It("should fail validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/8")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "1.2.3.4")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -248,7 +241,6 @@ var _ = Describe("Validate", func() {
 				})
 				Context("when CLUSTER_CIDR is garbage", func() {
 					It("should fail validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/8")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "aoiwnf")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -258,17 +250,15 @@ var _ = Describe("Validate", func() {
 				})
 				Context("when multiple CIDRs are provided to SERVICE_CIDR", func() {
 					It("should fail validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/8,1.2.3.5/8")
-						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "1.2.3.6/8")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/12,1.2.3.5/12")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
 						Expect(validationError).To(HaveOccurred())
-						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"1.2.3.4/8,1.2.3.5/8\", expected to be a CIDR of type \"ipv4\" (TKG_IP_FAMILY)"))
+						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"1.2.3.4/12,1.2.3.5/12\", expected to be a CIDR of type \"ipv4\" (TKG_IP_FAMILY)"))
 					})
 				})
 				Context("when multiple CIDRs are provided to CLUSTER_CIDR", func() {
 					It("should fail validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/8")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "1.2.3.5/8,1.2.3.6/8")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -277,10 +267,6 @@ var _ = Describe("Validate", func() {
 					})
 				})
 				Context("HTTP(S)_PROXY variables", func() {
-					BeforeEach(func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/8")
-						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "1.2.3.4/8")
-					})
 					Context("when HTTP_PROXY and HTTPS_PROXY are unset", func() {
 						It("should pass validation", func() {
 							validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -353,7 +339,7 @@ var _ = Describe("Validate", func() {
 				})
 				Context("when SERVICE_CIDR and CLUSTER_CIDR are ipv6", func() {
 					It("should pass validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/8")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/108")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "::1/8")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -371,7 +357,6 @@ var _ = Describe("Validate", func() {
 				})
 				Context("when CLUSTER_CIDR is ipv4", func() {
 					It("should fail validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/8")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "1.2.3.4/16")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -390,7 +375,6 @@ var _ = Describe("Validate", func() {
 				})
 				Context("when CLUSTER_CIDR is not an actual CIDR", func() {
 					It("should fail validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/8")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "::1")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -400,7 +384,6 @@ var _ = Describe("Validate", func() {
 				})
 				Context("when SERVICE_CIDR is undefined", func() {
 					It("should set the default CIDR", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "::1/8")
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
 						Expect(validationError).NotTo(HaveOccurred())
 						cidr, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableServiceCIDR)
@@ -426,7 +409,6 @@ var _ = Describe("Validate", func() {
 				})
 				Context("when CLUSTER_CIDR is garbage", func() {
 					It("should fail validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/8")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "aoiwnf")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -436,17 +418,15 @@ var _ = Describe("Validate", func() {
 				})
 				Context("when multiple CIDRs are provided to SERVICE_CIDR", func() {
 					It("should fail validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/8,::2/8")
-						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "::3/8")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/108,::2/108")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
 						Expect(validationError).To(HaveOccurred())
-						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"::1/8,::2/8\", expected to be a CIDR of type \"ipv6\" (TKG_IP_FAMILY)"))
+						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"::1/108,::2/108\", expected to be a CIDR of type \"ipv6\" (TKG_IP_FAMILY)"))
 					})
 				})
 				Context("when multiple CIDRs are provided to CLUSTER_CIDR", func() {
 					It("should fail validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/8")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "::3/8,::4/8")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -455,10 +435,6 @@ var _ = Describe("Validate", func() {
 					})
 				})
 				Context("HTTP(S)_PROXY variables", func() {
-					BeforeEach(func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/8")
-						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "::1/8")
-					})
 					Context("when HTTP_PROXY and HTTPS_PROXY are unset", func() {
 						It("should pass validation", func() {
 							validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -532,7 +508,7 @@ var _ = Describe("Validate", func() {
 
 				Context("when SERVICE_CIDR and CLUSTER_CIDR are ipv4,ipv6", func() {
 					It("should pass validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/16,::1/8")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/16,::1/108")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "1.2.3.5/16,::3/8")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -559,8 +535,6 @@ var _ = Describe("Validate", func() {
 				})
 
 				DescribeTable("HTTP(S)_PROXY variables", func(httpProxy, httpsProxy string) {
-					tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/16,::1/8")
-					tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "1.2.3.5/16,::1/8")
 					tkgConfigReaderWriter.Set(constants.TKGHTTPProxy, httpProxy)
 					tkgConfigReaderWriter.Set(constants.TKGHTTPSProxy, httpsProxy)
 
@@ -582,7 +556,7 @@ var _ = Describe("Validate", func() {
 
 				Context("when SERVICE_CIDR and CLUSTER_CIDR are ipv6,ipv4", func() {
 					It("should pass validation", func() {
-						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/8,1.2.3.4/16")
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/108,1.2.3.4/16")
 						tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "::3/8,1.2.3.5/16")
 
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
@@ -609,8 +583,6 @@ var _ = Describe("Validate", func() {
 				})
 
 				DescribeTable("HTTP(S)_PROXY variables", func(httpProxy, httpsProxy string) {
-					tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/8,1.2.3.4/16")
-					tkgConfigReaderWriter.Set(constants.ConfigVariableClusterCIDR, "::1/8,1.2.3.5/16")
 					tkgConfigReaderWriter.Set(constants.TKGHTTPProxy, httpProxy)
 					tkgConfigReaderWriter.Set(constants.TKGHTTPSProxy, httpsProxy)
 
@@ -652,23 +624,23 @@ var _ = Describe("Validate", func() {
 			},
 				// Primary IPv4:
 				Entry("Primary IPv4: IPv4 CIDR only", dualStackIPv4Primary, "1.2.3.4/16"),
-				Entry("Primary IPv4: IPv6 CIDR only", dualStackIPv4Primary, "::1/8"),
-				Entry("Primary IPv4: IPv4 Address", dualStackIPv4Primary, "1.2.3.4,::1/8"),
+				Entry("Primary IPv4: IPv6 CIDR only", dualStackIPv4Primary, "::1/108"),
+				Entry("Primary IPv4: IPv4 Address", dualStackIPv4Primary, "1.2.3.4,::1/108"),
 				Entry("Primary IPv4: IPv6 Address", dualStackIPv4Primary, "1.2.3.4/16,::1"),
-				Entry("Primary IPv4: Too many CIDRs", dualStackIPv4Primary, "1.2.3.4/16,::1/8,::2/8"),
+				Entry("Primary IPv4: Too many CIDRs", dualStackIPv4Primary, "1.2.3.4/16,::1/108,::2/108"),
 				Entry("Primary IPv4: Two IPv4 CIDRs", dualStackIPv4Primary, "1.2.3.4/16,2.3.4.5/16"),
-				Entry("Primary IPv4: Two IPv6 CIDRs", dualStackIPv4Primary, "::1/8,::2/8"),
-				Entry("Primary IPv4: Out of order", dualStackIPv4Primary, "::1/8,1.2.3.4/16"),
+				Entry("Primary IPv4: Two IPv6 CIDRs", dualStackIPv4Primary, "::1/108,::2/108"),
+				Entry("Primary IPv4: Out of order", dualStackIPv4Primary, "::1/108,1.2.3.4/16"),
 				Entry("Primary IPv4: Garbage", dualStackIPv4Primary, "asdf,fasd"),
 				// Primary Ipv6:
 				Entry("Primary IPv6: IPv4 CIDR only", dualStackIPv6Primary, "1.2.3.4/16"),
-				Entry("Primary IPv6: IPv6 CIDR only", dualStackIPv6Primary, "::1/8"),
-				Entry("Primary IPv6: IPv4 Address", dualStackIPv6Primary, "::1/8,1.2.3.4"),
+				Entry("Primary IPv6: IPv6 CIDR only", dualStackIPv6Primary, "::1/108"),
+				Entry("Primary IPv6: IPv4 Address", dualStackIPv6Primary, "::1/108,1.2.3.4"),
 				Entry("Primary IPv6: IPv6 Address", dualStackIPv6Primary, "::1,1.2.3.4/16"),
-				Entry("Primary IPv6: Too many CIDRs", dualStackIPv6Primary, "::1/8,::2/8,1.2.3.4/16"),
+				Entry("Primary IPv6: Too many CIDRs", dualStackIPv6Primary, "::1/108,::2/108,1.2.3.4/16"),
 				Entry("Primary IPv6: Two IPv4 CIDRs", dualStackIPv6Primary, "1.2.3.4/16,2.3.4.5/16"),
-				Entry("Primary IPv6: Two IPv6 CIDRs", dualStackIPv6Primary, "::1/8,::2/8"),
-				Entry("Primary IPv6: Out of order", dualStackIPv6Primary, "1.2.3.4/16,::1/8"),
+				Entry("Primary IPv6: Two IPv6 CIDRs", dualStackIPv6Primary, "::1/108,::2/108"),
+				Entry("Primary IPv6: Out of order", dualStackIPv6Primary, "1.2.3.4/16,::1/108"),
 				Entry("Primary IPv6: Garbage", dualStackIPv6Primary, "asdf,fasd"),
 			)
 
@@ -714,6 +686,123 @@ var _ = Describe("Validate", func() {
 				Entry("Primary IPv6: Garbage", dualStackIPv6Primary, "asdf,fasd"),
 			)
 		})
+
+		Context("SERVICE_CIDR netmask validation", func() {
+			Context("when SERVICE_CIDR is ipv4", func() {
+				BeforeEach(func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv4")
+				})
+
+				Context("when Service CIDR size is too large", func() {
+					It("should fail validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "192.168.2.1/11")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"192.168.2.1/11\", expected netmask to be \"/12\" or greater"))
+					})
+				})
+				Context("when Service CIDR size is at or below the maximum size", func() {
+					It("should pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "192.168.2.1/12")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+			})
+
+			Context("when SERVICE_CIDR is ipv6", func() {
+				BeforeEach(func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv6")
+				})
+
+				Context("when Service CIDR size is too large", func() {
+					It("should fail validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/107")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"::1/107\", expected netmask to be \"/108\" or greater"))
+					})
+				})
+				Context("when Service CIDR size is at or below the maximum size", func() {
+					It("should pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/108")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+			})
+
+			Context("when IPFamily is ipv4,ipv6 i.e Dual-stack Primary IPv4", func() {
+				BeforeEach(func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv4,ipv6")
+				})
+
+				Context("when the primary ipv4 Service CIDR size is too large", func() {
+					It("should fail validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/11,::1/108")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"1.2.3.4/11\", expected netmask to be \"/12\" or greater"))
+					})
+				})
+				Context("when the secondary ipv6 Service CIDR size is too large", func() {
+					It("should fail validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/12,::1/107")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"::1/107\", expected netmask to be \"/108\" or greater"))
+					})
+				})
+				Context("when Service CIDRs sizes are at or below the maximum size", func() {
+					It("should pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/12,::1/108")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+			})
+
+			Context("when IPFamily is ipv6,ipv4 i.e Dual-stack Primary IPv6", func() {
+				BeforeEach(func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv6,ipv4")
+				})
+
+				Context("when the primary ipv6 Service CIDR size is too large", func() {
+					It("should fail validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/107,1.2.3.4/12")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"::1/107\", expected netmask to be \"/108\" or greater"))
+					})
+				})
+				Context("when the secondary ipv4 Service CIDR size is too large", func() {
+					It("should fail validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/108,1.2.3.4/11")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("invalid SERVICE_CIDR \"1.2.3.4/11\", expected netmask to be \"/12\" or greater"))
+					})
+				})
+				Context("when Service CIDRs sizes are at or below the maximum size", func() {
+					It("pass validation", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/108,1.2.3.4/12")
+
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+					})
+				})
+			})
+		})
+
 		Context("Nameserver configuration and validation", func() {
 			It("should allow empty nameserver configurations", func() {
 				validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)


### PR DESCRIPTION
### What this PR does / why we need it

Kube-apiserver validates the provided service CIDR is not too large.
When provided an invalide service cidr, the kube-apiserver fails
to come up and causes the cluster to hang.

This PR duplicates the service CIDR validation so that cluster creation
with an invalid CIDR fails fast.

The kube-apiserver validation can be seen here:
https://github.com/kubernetes/kubernetes/blob/3c87c43ceff6122637c8d8070601f7271026360e/cmd/kube-apiserver/app/options/validation.go#L52

### Describe testing done for PR

passes unit tests

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
