### PR TITLE
Updates the kube-vip params in the overlay file

### DIFF
--- a/pkg/v1/providers/infrastructure-vsphere/v0.7.10/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v0.7.10/ytt/overlay.yaml
@@ -35,11 +35,11 @@ spec:
     - name: vip_interface
       value:  #@ data.values.VIP_NETWORK_INTERFACE
     - name: vip_leaseduration
-      value: "15"
+      value: "30"
     - name: vip_renewdeadline
-      value: "10"
+      value: "20"
     - name: vip_retryperiod
-      value: "2"
+      value: "4"
     image: #@ "{}/{}:{}".format(get_image_repo_for_component(bomData.components["kube-vip"][0].images.kubeVipImage), bomData.components["kube-vip"][0].images.kubeVipImage.imagePath, bomData.components["kube-vip"][0].images.kubeVipImage.tag)
     imagePullPolicy: IfNotPresent
     name: kube-vip
@@ -109,7 +109,7 @@ spec:
   #@ else:
   #@overlay/remove
   controlPlaneEndpoint:
-  #@ end  
+  #@ end
   thumbprint: #@ get_vsphere_thumbprint()
   server: #@ data.values.VSPHERE_SERVER
   identityRef:
@@ -216,7 +216,7 @@ spec:
     #@overlay/match by=overlay.index(0)
     - content: #@ yaml.encode(kube_vip_pod())
     #@ else:
-    #@overlay/match by=overlay.index(0)  
+    #@overlay/match by=overlay.index(0)
     #@overlay/remove
     - content:
     #@ end


### PR DESCRIPTION
### What this PR does / why we need it
This patch updates the kube-vip parameter values in the overlay for infra-vsphere provider.

### Which issue(s) this PR fixes
Fixes # n/a

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
kube-vips pamameters in vsphere overlay updated to match new recommended values.
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
