### PR TITLE
addons/pinniped/post-deploy: plumb --concierge-is-cluster-scoped

### DIFF
--- a/addons/pinniped/post-deploy/pkg/configure/configure.go
+++ b/addons/pinniped/post-deploy/pkg/configure/configure.go
@@ -42,21 +42,22 @@ type Clients struct {
 
 // Parameters contains the settings used.
 type Parameters struct {
-	ClusterName             string
-	ClusterType             string
-	SupervisorSvcName       string
-	SupervisorSvcNamespace  string
-	SupervisorSvcEndpoint   string
-	FederationDomainName    string
-	JWTAuthenticatorName    string
-	SupervisorCertName      string
-	SupervisorCertNamespace string
-	SupervisorCABundleData  string
-	DexNamespace            string
-	DexSvcName              string
-	DexCertName             string
-	DexConfigMapName        string
-	PinnipedAPIGroupSuffix  string
+	ClusterName              string
+	ClusterType              string
+	SupervisorSvcName        string
+	SupervisorSvcNamespace   string
+	SupervisorSvcEndpoint    string
+	FederationDomainName     string
+	JWTAuthenticatorName     string
+	SupervisorCertName       string
+	SupervisorCertNamespace  string
+	SupervisorCABundleData   string
+	DexNamespace             string
+	DexSvcName               string
+	DexCertName              string
+	DexConfigMapName         string
+	PinnipedAPIGroupSuffix   string
+	ConciergeIsClusterScoped bool
 }
 
 func ensureDeploymentReady(ctx context.Context, c Clients, namespace, deploymentTypeName string) error {
@@ -188,21 +189,22 @@ func TKGAuthentication(c Clients) error {
 	}
 
 	if err := Pinniped(ctx, c, inspector, &Parameters{
-		ClusterName:             tkgMetadata.Cluster.Name,
-		ClusterType:             tkgMetadata.Cluster.Type,
-		SupervisorSvcName:       vars.SupervisorSvcName,
-		SupervisorSvcNamespace:  vars.SupervisorNamespace,
-		SupervisorSvcEndpoint:   vars.SupervisorSvcEndpoint,
-		FederationDomainName:    vars.FederationDomainName,
-		JWTAuthenticatorName:    vars.JWTAuthenticatorName,
-		SupervisorCertName:      vars.SupervisorCertName,
-		SupervisorCertNamespace: vars.SupervisorNamespace,
-		SupervisorCABundleData:  vars.SupervisorCABundleData,
-		DexNamespace:            vars.DexNamespace,
-		DexSvcName:              vars.DexSvcName,
-		DexCertName:             vars.DexCertName,
-		DexConfigMapName:        vars.DexConfigMapName,
-		PinnipedAPIGroupSuffix:  vars.PinnipedAPIGroupSuffix,
+		ClusterName:              tkgMetadata.Cluster.Name,
+		ClusterType:              tkgMetadata.Cluster.Type,
+		SupervisorSvcName:        vars.SupervisorSvcName,
+		SupervisorSvcNamespace:   vars.SupervisorNamespace,
+		SupervisorSvcEndpoint:    vars.SupervisorSvcEndpoint,
+		FederationDomainName:     vars.FederationDomainName,
+		JWTAuthenticatorName:     vars.JWTAuthenticatorName,
+		SupervisorCertName:       vars.SupervisorCertName,
+		SupervisorCertNamespace:  vars.SupervisorNamespace,
+		SupervisorCABundleData:   vars.SupervisorCABundleData,
+		DexNamespace:             vars.DexNamespace,
+		DexSvcName:               vars.DexSvcName,
+		DexCertName:              vars.DexCertName,
+		DexConfigMapName:         vars.DexConfigMapName,
+		PinnipedAPIGroupSuffix:   vars.PinnipedAPIGroupSuffix,
+		ConciergeIsClusterScoped: vars.ConciergeIsClusterScoped,
 	}); err != nil {
 		// logging has been done inside the function
 		return err
@@ -303,7 +305,7 @@ func Pinniped(ctx context.Context, c Clients, inspector inspect.Inspector, p *Pa
 			Issuer:                           &supervisorSvcEndpoint,
 			IssuerCABundleData:               &caData,
 			PinnipedAPIGroupSuffix:           p.PinnipedAPIGroupSuffix,
-			PinnipedConciergeIsClusterScoped: false,
+			PinnipedConciergeIsClusterScoped: p.ConciergeIsClusterScoped,
 		}, c.K8SClientset); err != nil {
 			return err
 		}
@@ -320,7 +322,7 @@ func Pinniped(ctx context.Context, c Clients, inspector inspect.Inspector, p *Pa
 		// create configmap for Pinniped info
 		if err := createOrUpdatePinnipedInfo(ctx, supervisor.PinnipedInfo{
 			PinnipedAPIGroupSuffix:           p.PinnipedAPIGroupSuffix,
-			PinnipedConciergeIsClusterScoped: false,
+			PinnipedConciergeIsClusterScoped: p.ConciergeIsClusterScoped,
 		}, c.K8SClientset); err != nil {
 			return err
 		}

--- a/addons/pinniped/post-deploy/pkg/configure/configure_test.go
+++ b/addons/pinniped/post-deploy/pkg/configure/configure_test.go
@@ -83,7 +83,7 @@ func TestPinniped(t *testing.T) {
 			"issuer":                               serviceHTTPSEndpoint(supervisorService),
 			"issuer_ca_bundle_data":                base64.StdEncoding.EncodeToString(supervisorCertificateSecret.Data["ca.crt"]),
 			"pinniped_api_group_suffix":            apiGroupSuffix,
-			"pinniped_concierge_is_cluster_scoped": "false",
+			"pinniped_concierge_is_cluster_scoped": "true",
 		},
 	}
 
@@ -94,7 +94,7 @@ func TestPinniped(t *testing.T) {
 		},
 		Data: map[string]string{
 			"pinniped_api_group_suffix":            apiGroupSuffix,
-			"pinniped_concierge_is_cluster_scoped": "false",
+			"pinniped_concierge_is_cluster_scoped": "true",
 		},
 	}
 
@@ -190,15 +190,16 @@ func TestPinniped(t *testing.T) {
 				return kubedynamicfake.NewSimpleDynamicClient(scheme, defaultJWTAuthenticator)
 			},
 			parameters: Parameters{
-				ClusterType:             "management",
-				ClusterName:             pinnipedInfoConfigMap.Data["cluster_name"],
-				SupervisorSvcNamespace:  supervisorService.Namespace,
-				SupervisorSvcName:       supervisorService.Name,
-				FederationDomainName:    federationDomain.Name,
-				SupervisorCertNamespace: supervisorCertificate.Namespace,
-				SupervisorCertName:      supervisorCertificate.Name,
-				JWTAuthenticatorName:    jwtAuthenticator.Name,
-				PinnipedAPIGroupSuffix:  apiGroupSuffix,
+				ClusterType:              "management",
+				ClusterName:              pinnipedInfoConfigMap.Data["cluster_name"],
+				SupervisorSvcNamespace:   supervisorService.Namespace,
+				SupervisorSvcName:        supervisorService.Name,
+				FederationDomainName:     federationDomain.Name,
+				SupervisorCertNamespace:  supervisorCertificate.Namespace,
+				SupervisorCertName:       supervisorCertificate.Name,
+				JWTAuthenticatorName:     jwtAuthenticator.Name,
+				PinnipedAPIGroupSuffix:   apiGroupSuffix,
+				ConciergeIsClusterScoped: true,
 			},
 			wantKubeClientActions: []kubetesting.Action{
 				// 1. Get the supervisor service endpoint to create the correct issuer
@@ -247,13 +248,14 @@ func TestPinniped(t *testing.T) {
 				return kubedynamicfake.NewSimpleDynamicClient(scheme, defaultJWTAuthenticator)
 			},
 			parameters: Parameters{
-				ClusterType:            "workload",
-				ClusterName:            jwtAuthenticator.Spec.Audience,
-				SupervisorSvcNamespace: supervisorService.Namespace,
-				SupervisorSvcEndpoint:  jwtAuthenticator.Spec.Issuer,
-				SupervisorCABundleData: jwtAuthenticator.Spec.TLS.CertificateAuthorityData,
-				JWTAuthenticatorName:   jwtAuthenticator.Name,
-				PinnipedAPIGroupSuffix: apiGroupSuffix,
+				ClusterType:              "workload",
+				ClusterName:              jwtAuthenticator.Spec.Audience,
+				SupervisorSvcNamespace:   supervisorService.Namespace,
+				SupervisorSvcEndpoint:    jwtAuthenticator.Spec.Issuer,
+				SupervisorCABundleData:   jwtAuthenticator.Spec.TLS.CertificateAuthorityData,
+				JWTAuthenticatorName:     jwtAuthenticator.Name,
+				PinnipedAPIGroupSuffix:   apiGroupSuffix,
+				ConciergeIsClusterScoped: true,
 			},
 			wantKubeClientActions: []kubetesting.Action{
 				// 2. Create the Pinniped info configmap


### PR DESCRIPTION
### What this PR does / why we need it

* This commit plumbs through a flag passed to the post-deploy job so that it is actually used by the business logic
* See https://github.com/vmware-tanzu/tanzu-framework/pull/949 and https://github.com/vmware-tanzu/tanzu-framework/pull/934

### Which issue(s) this PR fixes

Related to #835

### Describe testing done for PR

Built the post-deploy job, patched it into a running environment with Pinniped 0.12.0, ensured that I could generate a kubeconfig and use it

### Release note

```release-note
NONE
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
