### PR TITLE
Fix strict ordering check in catalog unit tests

### DIFF
--- a/pkg/v1/cli/catalog/catalog_test.go
+++ b/pkg/v1/cli/catalog/catalog_test.go
@@ -6,7 +6,6 @@ package catalog
 import (
 	"os"
 	"path/filepath"
-	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -57,12 +56,9 @@ func Test_ContextCatalog_With_Empty_Context(t *testing.T) {
 
 	pds := cc.List()
 	assert.Equal(len(pds), 2)
-	assert.Equal(pds[0].Name, "fakeplugin1")
-	assert.Equal(pds[0].InstallationPath, "/path/to/plugin/fakeplugin1")
-	assert.Equal(pds[0].Version, "1.0.0")
-	assert.Equal(pds[1].Name, "fakeplugin2")
-	assert.Equal(pds[1].InstallationPath, "/path/to/plugin/fakeplugin2")
-	assert.Equal(pds[1].Version, "2.0.0")
+	assert.ElementsMatch([]string{pds[0].Name, pds[1].Name}, []string{"fakeplugin1", "fakeplugin2"})
+	assert.ElementsMatch([]string{pds[0].InstallationPath, pds[1].InstallationPath}, []string{"/path/to/plugin/fakeplugin1", "/path/to/plugin/fakeplugin2"})
+	assert.ElementsMatch([]string{pds[0].Version, pds[1].Version}, []string{"1.0.0", "2.0.0"})
 
 	err = cc.Delete("fakeplugin2")
 	assert.Nil(err)
@@ -92,7 +88,7 @@ func Test_ContextCatalog_With_Empty_Context(t *testing.T) {
 	os.RemoveAll(common.DefaultPluginRoot)
 }
 
-func Test_ContextCatalog_With_Context(t *testing.T) { //nolint:funlen
+func Test_ContextCatalog_With_Context(t *testing.T) {
 	common.DefaultCacheDir = filepath.Join(os.TempDir(), "test")
 
 	assert := assert.New(t)
@@ -131,14 +127,10 @@ func Test_ContextCatalog_With_Context(t *testing.T) { //nolint:funlen
 	assert.Equal(pd.Version, "2.0.0")
 
 	pds := cc.List()
-	sortarray(pds)
 	assert.Equal(len(pds), 2)
-	assert.Equal(pds[0].Name, "fakeplugin1")
-	assert.Equal(pds[0].InstallationPath, "/path/to/plugin/fakeplugin1")
-	assert.Equal(pds[0].Version, "1.0.0")
-	assert.Equal(pds[1].Name, "fakeplugin2")
-	assert.Equal(pds[1].InstallationPath, "/path/to/plugin/fakeplugin2")
-	assert.Equal(pds[1].Version, "2.0.0")
+	assert.ElementsMatch([]string{pds[0].Name, pds[1].Name}, []string{"fakeplugin1", "fakeplugin2"})
+	assert.ElementsMatch([]string{pds[0].InstallationPath, pds[1].InstallationPath}, []string{"/path/to/plugin/fakeplugin1", "/path/to/plugin/fakeplugin2"})
+	assert.ElementsMatch([]string{pds[0].Version, pds[1].Version}, []string{"1.0.0", "2.0.0"})
 
 	err = cc.Delete("fakeplugin2")
 	assert.Nil(err)
@@ -148,7 +140,6 @@ func Test_ContextCatalog_With_Context(t *testing.T) { //nolint:funlen
 	assert.NotEqual(pd.Name, "fakeplugin2")
 
 	pds = cc.List()
-	sortarray(pds)
 	assert.Equal(len(pds), 1)
 
 	// Create another catalog with same context
@@ -176,12 +167,6 @@ func Test_ContextCatalog_With_Context(t *testing.T) { //nolint:funlen
 	assert.False(exists)
 
 	os.RemoveAll(common.DefaultPluginRoot)
-}
-
-func sortarray(pds []cliv1alpha1.PluginDescriptor) {
-	sort.Slice(pds, func(i, j int) bool {
-		return pds[i].Name < pds[j].Name
-	})
 }
 
 // Test_CatalogCacheFileName tests we default to catalog.yaml file when


### PR DESCRIPTION
### What this PR does / why we need it
- Fixes strict ordering check present in catalog_test.go unit tests file
- This fixes occasional failures happening in our test pipeline
- Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/999

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #998

### Describe testing done for PR
- Manually tested the unit test locally
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
