### PR TITLE
Mark skipped steps grey in LDAP verification

### DIFF
--- a/pkg/v1/tkg/ldap/client.go
+++ b/pkg/v1/tkg/ldap/client.go
@@ -98,6 +98,10 @@ func (c *client) LdapBind() (*tkg_models.LdapTestResult, error) {
 
 // LdapUserSearch verifies user search function is able to locate the user
 func (c *client) LdapUserSearch() (*tkg_models.LdapTestResult, error) {
+	if c.params.LdapTestUser == "" {
+		return resultSkipped, nil
+	}
+
 	baseDn := strings.TrimSpace(c.params.LdapUserSearchBaseDn)
 	filter := strings.TrimSpace(c.params.LdapUserSearchFilter)
 	uid := strings.TrimSpace(c.params.LdapUserSearchUsername)
@@ -148,6 +152,10 @@ func (c *client) LdapUserSearch() (*tkg_models.LdapTestResult, error) {
 
 // LdapGroupSearch verifies group search is able to locate group
 func (c *client) LdapGroupSearch() (*tkg_models.LdapTestResult, error) {
+	if c.params.LdapTestGroup == "" {
+		return resultSkipped, nil
+	}
+
 	attrs := []string{}
 	if len(c.params.LdapGroupSearchNameAttr) > 0 {
 		attrs = append(attrs, c.params.LdapGroupSearchNameAttr)


### PR DESCRIPTION
### What this PR does / why we need it
Currently in LDAP test, all skipped test steps are marked successful. The change is to mark them grey (meaning skipped/not started).

### Describe testing done for PR
End to end testing was done with a local build with live LDAP server (VMWare LDAP).

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowlege by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
