### PR TITLE
Update pinniped-auth login command to adjust concierge credentials cache path

### DIFF
--- a/cmd/cli/plugin/pinniped-auth/login.go
+++ b/cmd/cli/plugin/pinniped-auth/login.go
@@ -35,6 +35,7 @@ type loginOIDCOptions struct {
 	conciergeEndpoint          string
 	conciergeCABundle          string
 	conciergeAPIGroupSuffix    string
+	credentialCachePath        string
 	listenPort                 uint16
 	skipBrowser                bool
 	debugSessionCache          bool
@@ -104,6 +105,8 @@ func loginOIDCCommand(
 
 		if !loginOptions.conciergeIsClusterScoped {
 			oidcLoginArgs = append(oidcLoginArgs, fmt.Sprintf("--concierge-namespace=%s", loginOptions.conciergeNamespace))
+		} else {
+			oidcLoginArgs = append(oidcLoginArgs, fmt.Sprintf("--credential-cache=%s", loginOptions.credentialCachePath))
 		}
 
 		pinnipedCliCmd, err := getPinnipedCLICmdFunc(oidcLoginArgs, loginOptions, cli.DefaultPluginRoot, buildinfo.Version, buildinfo.SHA)
@@ -174,6 +177,7 @@ func setLoginCommandFlags() {
 	loginCommand.Flags().StringVar(&loginOptions.conciergeEndpoint, "concierge-endpoint", "", "API base for the Pinniped concierge endpoint")
 	loginCommand.Flags().StringVar(&loginOptions.conciergeCABundle, "concierge-ca-bundle-data", "", "CA bundle to use when connecting to the concierge")
 	loginCommand.Flags().StringVar(&loginOptions.conciergeAPIGroupSuffix, "concierge-api-group-suffix", defaultPinnipedAPIGroupSuffix, "Concierge API group suffix")
+	loginCommand.Flags().StringVar(&loginOptions.credentialCachePath, "credential-cache", filepath.Join(mustGetConfigDir(), "credentials.yaml"), "Path to cluster-specific credentials cache (\"\" disables the cache)")
 	loginCommand.Flags().BoolVar(&loginOptions.conciergeIsClusterScoped, "concierge-is-cluster-scoped", false, "Is concierge cluster scoped")
 	loginCommand.Flags().MarkHidden("debug-session-cache") //nolint
 	loginCommand.MarkFlagRequired("issuer")                //nolint

--- a/cmd/cli/plugin/pinniped-auth/login_test.go
+++ b/cmd/cli/plugin/pinniped-auth/login_test.go
@@ -30,6 +30,7 @@ const (
 //nolint:funlen
 func TestLoginOIDCCommand(t *testing.T) {
 	sessionsCacheFilePath := filepath.Join(mustGetConfigDir(), "sessions.yaml")
+	credentialCacheFilePath := filepath.Join(mustGetConfigDir(), "credentials.yaml")
 	tests := []struct {
 		name                 string
 		args                 []string
@@ -174,7 +175,8 @@ func TestLoginOIDCCommand(t *testing.T) {
 				"--skip-browser", "true",
 				"--debug-session-cache", "true",
 				"--scopes", "openid",
-				"--session-cache", "/some/path",
+				"--session-cache", "/path/to/session",
+				"--credential-cache", "/path/to/cred",
 				"--ca-bundle", "/some/path",
 				"--ca-bundle-data", "somebase64encodeddata",
 				"--request-audience", "alternateaudience",
@@ -194,7 +196,7 @@ func TestLoginOIDCCommand(t *testing.T) {
 				"--client-id=test-client",
 				"--listen-port=3737",
 				"--skip-browser=true",
-				"--session-cache=/some/path",
+				"--session-cache=/path/to/session",
 				"--debug-session-cache=true",
 				"--scopes=openid",
 				"--ca-bundle=/some/path",
@@ -205,6 +207,7 @@ func TestLoginOIDCCommand(t *testing.T) {
 				"--concierge-authenticator-name=concierge-authenticator",
 				"--concierge-endpoint=test-endpoint",
 				"--concierge-ca-bundle-data=test-bundle",
+				"--credential-cache=/path/to/cred",
 			},
 		},
 		{
@@ -231,6 +234,7 @@ func TestLoginOIDCCommand(t *testing.T) {
 				"--concierge-authenticator-name=",
 				"--concierge-endpoint=",
 				"--concierge-ca-bundle-data=",
+				fmt.Sprintf("--credential-cache=%s", credentialCacheFilePath),
 			},
 		},
 	}

--- a/docs/cli/commands/tanzu_pinniped-auth_login.md
+++ b/docs/cli/commands/tanzu_pinniped-auth_login.md
@@ -35,6 +35,7 @@ tanzu pinniped-auth login [flags]
       --request-audience string               Request a token with an alternate audience using RFC8693 token exchange
       --scopes strings                        OIDC scopes to request during login. (default ["offline_access, openid, pinniped:request-audience"])
       --session-cache string                  Path to session cache file. (default "~/.config/tanzu/pinniped/sessions.yaml")
+      --credential-cache string               Path to cluster-specific credentials cache file. (default "~/.config/tanzu/pinniped/credentials.yaml")
       --skip-browser                          Skip opening the browser (just print the URL).
 ```
 


### PR DESCRIPTION
Signed-off-by: Benjamin A. Petersen <ben@benjaminapetersen.me>

### What this PR does / why we need it

We have recently updated the Pinniped package to 0.12.0. 
During our testing, we noticed that:
- `sessions.yaml` (supervisor cache) was in `/.config/tanzu/pinniped`
- but my `credentials.yaml` (concierge cache) was in `/.config/pinniped`

This PR solves this by declaring the correct location for the credentials file as well.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

N/A, this will be part of the 0.4 -> 0.12 upgrade and therefore the "bug" will never be seen by a customer in a release.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
