### PR TITLE
increase default poll timeout value

### DIFF
--- a/pkg/v1/tkg/tkgpackagedatamodel/constants.go
+++ b/pkg/v1/tkg/tkgpackagedatamodel/constants.go
@@ -11,7 +11,7 @@ const (
 	ClusterRoleName                     = "%s-%s-cluster-role"
 	DefaultAPIVersion                   = "install.package.carvel.dev/v1alpha1"
 	DefaultPollInterval                 = 1 * time.Second
-	DefaultPollTimeout                  = 5 * time.Minute
+	DefaultPollTimeout                  = 15 * time.Minute
 	DefaultRepositoryImageTag           = "latest"
 	DefaultRepositoryImageTagConstraint = ">0.0.0"
 	ErrPackageNotInstalled              = "package install does not exist in the namespace"


### PR DESCRIPTION
**What this PR does / why we need it:**
- This PR is to increase default poll timeout value to accommodate better default timeout for packages that install many other packages

**Describe testing done for PR:**
Existing UT and integration tests

**Does this PR introduce a user-facing change?:**
None

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
increases default poll timeout value to prevent failure in package installation (due to time out) when a package installs many other packages
```

**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
