### PR TITLE
Node pool redux

### DIFF
--- a/pkg/v1/tkg/client/machine_deployment_test.go
+++ b/pkg/v1/tkg/client/machine_deployment_test.go
@@ -4,18 +4,30 @@
 package client_test
 
 import (
+	"fmt"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	aws "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	azure "sigs.k8s.io/cluster-api-provider-azure/api/v1alpha3"
+	vsphere "sigs.k8s.io/cluster-api-provider-vsphere/api/v1alpha3"
+	capi "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/v1beta1"
+	docker "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha3"
 
 	tkgsv1alpha2 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
 	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
 )
 
@@ -313,3 +325,1253 @@ func GetDummyPacificCluster() tkgsv1alpha2.TanzuKubernetesCluster {
 	tkc.Spec.Topology.NodePools = nodepools
 	return tkc
 }
+
+const (
+	prependMDName1 = "test-cluster-md-0"
+	prependMDName2 = "test-cluster-md-1"
+	md1Name        = "md-0"
+	md2Name        = "md-1"
+	clusterName    = "test-cluster"
+)
+
+func Test_NormalizeNodePoolName_WithPrepend(t *testing.T) {
+	mds := []capi.MachineDeployment{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: prependMDName1,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: prependMDName2,
+			},
+		},
+	}
+
+	workers, _ := NormalizeNodePoolName(mds, clusterName)
+
+	if err != nil {
+		t.Fatal("Unexpected error normalzing node pool names")
+	}
+
+	if workers[0].Name != md1Name {
+		t.Errorf("Expected first machine deployment name to be %s, was %s", md1Name, workers[0].Name)
+	}
+
+	if workers[1].Name != md2Name {
+		t.Errorf("Expected second machine deployment name to be %s, was %s", md2Name, workers[1].Name)
+	}
+}
+
+func Test_NormalizeNodePoolName_WithoutPrepend(t *testing.T) {
+	mds := []capi.MachineDeployment{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: md1Name,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: md2Name,
+			},
+		},
+	}
+
+	workers, _ := NormalizeNodePoolName(mds, clusterName)
+
+	if err != nil {
+		t.Fatal("Unexpected error normalzing node pool names")
+	}
+
+	if workers[0].Name != md1Name {
+		t.Errorf("Expected first machine deployment name to be %s, was %s", md1Name, workers[0].Name)
+	}
+
+	if workers[1].Name != md2Name {
+		t.Errorf("Expected second machine deployment name to be %s, was %s", md2Name, workers[1].Name)
+	}
+}
+
+var _ = Describe("Machine Deployment", func() {
+	const (
+		clusterName = "test-cluster"
+		np1Name     = "np-1"
+		md1Name     = "test-cluster-np-1"
+		md2Name     = "test-cluster-np-2"
+		md3Name     = "test-cluster-np-3"
+	)
+	var (
+		clusterClient fakes.ClusterClient
+		err           error
+		md1           capi.MachineDeployment
+		md2           capi.MachineDeployment
+		md3           capi.MachineDeployment
+	)
+	BeforeEach(func() {
+		clusterClient = fakes.ClusterClient{}
+
+	})
+	Context("DoDeleteMachineDeployment", func() {
+		var options DeleteMachineDeploymentOptions
+		BeforeEach(func() {
+			options = DeleteMachineDeploymentOptions{
+				ClusterName: clusterName,
+				Name:        np1Name,
+			}
+		})
+		JustBeforeEach(func() {
+			err = DoDeleteMachineDeployment(&clusterClient, &options)
+		})
+		When("there is an error retrieving machine deployments", func() {
+			BeforeEach(func() {
+				clusterClient.GetMDObjectForClusterReturns(nil, errors.New(""))
+			})
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Context("machine deployments exist", func() {
+			BeforeEach(func() {
+				md1 = capi.MachineDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: md1Name,
+					},
+					Spec: capi.MachineDeploymentSpec{
+						Template: capi.MachineTemplateSpec{
+							Spec: capi.MachineSpec{
+								Bootstrap: capi.Bootstrap{
+									ConfigRef: &corev1.ObjectReference{
+										Name: "test-cluster-np-1-kct",
+									},
+								},
+								InfrastructureRef: corev1.ObjectReference{
+									Kind: constants.VSphereMachineTemplate,
+									Name: "test-cluster-np-1-mt",
+								},
+							},
+						},
+					},
+				}
+				md2 = capi.MachineDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: md2Name,
+					},
+					Spec: capi.MachineDeploymentSpec{
+						Template: capi.MachineTemplateSpec{
+							Spec: capi.MachineSpec{
+								Bootstrap: capi.Bootstrap{
+									ConfigRef: &corev1.ObjectReference{
+										Name: "test-cluster-np-2-kct",
+									},
+								},
+								InfrastructureRef: corev1.ObjectReference{
+									Kind: constants.VSphereMachineTemplate,
+									Name: "test-cluster-np-2-mt",
+								},
+							},
+						},
+					},
+				}
+				md3 = capi.MachineDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: md3Name,
+					},
+					Spec: capi.MachineDeploymentSpec{
+						Template: capi.MachineTemplateSpec{
+							Spec: capi.MachineSpec{
+								Bootstrap: capi.Bootstrap{
+									ConfigRef: &corev1.ObjectReference{
+										Name: "test-cluster-np-3-kct",
+									},
+								},
+								InfrastructureRef: corev1.ObjectReference{
+									Kind: constants.VSphereMachineTemplate,
+									Name: "test-cluster-np-3-mt",
+								},
+							},
+						},
+					},
+				}
+			})
+			When("there is only one machine deployment", func() {
+				BeforeEach(func() {
+					clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1}, nil)
+				})
+				It("should throw an error", func() {
+					Expect(err).To(HaveOccurred())
+					Expect(err).Should(MatchError("cannot delete last worker node pool in cluster"))
+				})
+			})
+			When("the named machine deployment is not found", func() {
+				BeforeEach(func() {
+					options.Name = "not-found"
+					clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+				})
+				It("should throw an error", func() {
+					Expect(err).To(HaveOccurred())
+					Expect(err).Should(MatchError(fmt.Sprintf("could not find node pool %s to delete", options.Name)))
+				})
+			})
+			When("the kubeadmconfigtemplate is not found", func() {
+				BeforeEach(func() {
+					clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+					clusterClient.GetResourceReturns(errors.New(""))
+				})
+				It("should return an error", func() {
+					Expect(err).To(HaveOccurred())
+					Expect(err).Should(MatchError(fmt.Sprintf("unable to retrieve kubeadmconfigtemplate %s-%s-kct: ", options.ClusterName, options.Name)))
+
+					_, name, namespace, _, _ := clusterClient.GetResourceArgsForCall(0)
+					Expect(name).To(Equal("test-cluster-np-1-kct"))
+					Expect(namespace).To(Equal(""))
+				})
+			})
+			Context("with vSphere Machine Templates", func() {
+				When("the vsphere machine template can't be found", func() {
+					BeforeEach(func() {
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								callIndex++
+								return errors.New("")
+							}
+							return nil
+						}
+					})
+					It("should return an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to retrieve machine template %s-%s-mt: ", options.ClusterName, options.Name)))
+					})
+				})
+				When("there is an error deleting the machine deployment", func() {
+					BeforeEach(func() {
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								mt := obj.(*vsphere.VSphereMachineTemplate)
+								*mt = vsphere.VSphereMachineTemplate{}
+								callIndex++
+								return nil
+							}
+							return nil
+						}
+						clusterClient.DeleteResourceReturns(errors.New(""))
+					})
+					It("should throw an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to delete machine deployment %s-%s: ", options.ClusterName, options.Name)))
+					})
+					When("there is an error deleting the machine template", func() {
+						BeforeEach(func() {
+							clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+							callIndex := 0
+							clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+								if callIndex == 0 {
+									kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+									*kct = v1alpha3.KubeadmConfigTemplate{}
+									callIndex++
+									return nil
+								}
+								if callIndex == 1 {
+									mt := obj.(*vsphere.VSphereMachineTemplate)
+									*mt = vsphere.VSphereMachineTemplate{}
+									callIndex++
+									return nil
+								}
+								return nil
+							}
+							clusterClient.DeleteResourceReturnsOnCall(0, nil)
+							clusterClient.DeleteResourceReturnsOnCall(1, errors.New(""))
+						})
+						It("should throw an error", func() {
+							Expect(err).To(HaveOccurred())
+							Expect(err).Should(MatchError(fmt.Sprintf("unable to delete machine template %s-%s-mt: ", options.ClusterName, options.Name)))
+						})
+					})
+					When("there is an error deleting the kubeadmconfig template", func() {
+						BeforeEach(func() {
+							clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+							callIndex := 0
+							clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+								if callIndex == 0 {
+									kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+									*kct = v1alpha3.KubeadmConfigTemplate{}
+									callIndex++
+									return nil
+								}
+								if callIndex == 1 {
+									mt := obj.(*vsphere.VSphereMachineTemplate)
+									*mt = vsphere.VSphereMachineTemplate{}
+									callIndex++
+									return nil
+								}
+								return nil
+							}
+							clusterClient.DeleteResourceReturnsOnCall(0, nil)
+							clusterClient.DeleteResourceReturnsOnCall(1, nil)
+							clusterClient.DeleteResourceReturnsOnCall(2, errors.New(""))
+						})
+						It("should throw an error", func() {
+							Expect(err).To(HaveOccurred())
+							Expect(err).Should(MatchError(fmt.Sprintf("unable to delete kubeadmconfigtemplate %s-%s-kct: ", options.ClusterName, options.Name)))
+						})
+					})
+					When("the node pool deletes successfully", func() {
+						BeforeEach(func() {
+							clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+							callIndex := 0
+							clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+								if callIndex == 0 {
+									kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+									*kct = v1alpha3.KubeadmConfigTemplate{}
+									callIndex++
+									return nil
+								}
+								if callIndex == 1 {
+									mt := obj.(*vsphere.VSphereMachineTemplate)
+									*mt = vsphere.VSphereMachineTemplate{}
+									callIndex++
+									return nil
+								}
+								return nil
+							}
+							clusterClient.DeleteResourceReturnsOnCall(0, nil)
+							clusterClient.DeleteResourceReturnsOnCall(1, nil)
+							clusterClient.DeleteResourceReturnsOnCall(2, nil)
+						})
+						It("should return successfully", func() {
+							Expect(err).NotTo(HaveOccurred())
+						})
+					})
+				})
+			})
+			Context("with AWS Machine Templates", func() {
+				When("the AWS machine template can't be found", func() {
+					BeforeEach(func() {
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								callIndex++
+								return errors.New("")
+							}
+							return nil
+						}
+					})
+					It("should return an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to retrieve machine template %s-%s-mt: ", options.ClusterName, options.Name)))
+					})
+				})
+				When("there is an error deleting the machine deployment", func() {
+					BeforeEach(func() {
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AWSMachineTemplate
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								mt := obj.(*aws.AWSMachineTemplate)
+								*mt = aws.AWSMachineTemplate{}
+								callIndex++
+								return nil
+							}
+							return nil
+						}
+						clusterClient.DeleteResourceReturns(errors.New(""))
+					})
+					It("should throw an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to delete machine deployment %s-%s: ", options.ClusterName, options.Name)))
+					})
+				})
+				When("there is an error deleting the machine template", func() {
+					BeforeEach(func() {
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AWSMachineTemplate
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								mt := obj.(*aws.AWSMachineTemplate)
+								*mt = aws.AWSMachineTemplate{}
+								callIndex++
+								return nil
+							}
+							return nil
+						}
+						clusterClient.DeleteResourceReturnsOnCall(0, nil)
+						clusterClient.DeleteResourceReturnsOnCall(1, errors.New(""))
+					})
+					It("should throw an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to delete machine template %s-%s-mt: ", options.ClusterName, options.Name)))
+					})
+				})
+				When("there is an error deleting the kubeadmconfig template", func() {
+					BeforeEach(func() {
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AWSMachineTemplate
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								mt := obj.(*aws.AWSMachineTemplate)
+								*mt = aws.AWSMachineTemplate{}
+								callIndex++
+								return nil
+							}
+							return nil
+						}
+						clusterClient.DeleteResourceReturnsOnCall(0, nil)
+						clusterClient.DeleteResourceReturnsOnCall(1, nil)
+						clusterClient.DeleteResourceReturnsOnCall(2, errors.New(""))
+					})
+					It("should throw an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to delete kubeadmconfigtemplate %s-%s-kct: ", options.ClusterName, options.Name)))
+					})
+				})
+				When("the node pool is deleted successfully", func() {
+					BeforeEach(func() {
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AWSMachineTemplate
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								mt := obj.(*aws.AWSMachineTemplate)
+								*mt = aws.AWSMachineTemplate{}
+								callIndex++
+								return nil
+							}
+							return nil
+						}
+						clusterClient.DeleteResourceReturnsOnCall(0, nil)
+						clusterClient.DeleteResourceReturnsOnCall(1, nil)
+						clusterClient.DeleteResourceReturnsOnCall(2, nil)
+					})
+					It("should return successfully", func() {
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+			Context("with Azure Machine Templates", func() {
+				When("the Azure machine template can't be found", func() {
+					BeforeEach(func() {
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								callIndex++
+								return errors.New("")
+							}
+							return nil
+						}
+					})
+					It("should return an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to retrieve machine template %s-%s-mt: ", options.ClusterName, options.Name)))
+					})
+				})
+				When("there is an error deleting the machine deployment", func() {
+					BeforeEach(func() {
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AzureMachineTemplate
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								mt := obj.(*azure.AzureMachineTemplate)
+								*mt = azure.AzureMachineTemplate{}
+								callIndex++
+								return nil
+							}
+							return nil
+						}
+						clusterClient.DeleteResourceReturns(errors.New(""))
+					})
+					It("should throw an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to delete machine deployment %s-%s: ", options.ClusterName, options.Name)))
+					})
+				})
+				When("there is an error deleting the machine template", func() {
+					BeforeEach(func() {
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AzureMachineTemplate
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								mt := obj.(*azure.AzureMachineTemplate)
+								*mt = azure.AzureMachineTemplate{}
+								callIndex++
+								return nil
+							}
+							return nil
+						}
+						clusterClient.DeleteResourceReturnsOnCall(0, nil)
+						clusterClient.DeleteResourceReturnsOnCall(1, errors.New(""))
+					})
+					It("should throw an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to delete machine template %s-%s-mt: ", options.ClusterName, options.Name)))
+					})
+				})
+				When("there is an error deleting the kubeadmconfig template", func() {
+					BeforeEach(func() {
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AzureMachineTemplate
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								mt := obj.(*azure.AzureMachineTemplate)
+								*mt = azure.AzureMachineTemplate{}
+								callIndex++
+								return nil
+							}
+							return nil
+						}
+						clusterClient.DeleteResourceReturnsOnCall(0, nil)
+						clusterClient.DeleteResourceReturnsOnCall(1, nil)
+						clusterClient.DeleteResourceReturnsOnCall(2, errors.New(""))
+					})
+					It("should throw an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to delete kubeadmconfigtemplate %s-%s-kct: ", options.ClusterName, options.Name)))
+					})
+				})
+				When("the node pool is deleted successfully", func() {
+					BeforeEach(func() {
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AzureMachineTemplate
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								mt := obj.(*azure.AzureMachineTemplate)
+								*mt = azure.AzureMachineTemplate{}
+								callIndex++
+								return nil
+							}
+							return nil
+						}
+						clusterClient.DeleteResourceReturnsOnCall(0, nil)
+						clusterClient.DeleteResourceReturnsOnCall(1, nil)
+						clusterClient.DeleteResourceReturnsOnCall(2, nil)
+					})
+					It("should return successfully", func() {
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+			Context("with Docker Machine Templates", func() {
+				When("the docker machine template can't be found", func() {
+					BeforeEach(func() {
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								callIndex++
+								return errors.New("")
+							}
+							return nil
+						}
+					})
+					It("should return an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to retrieve machine template %s-%s-mt: ", options.ClusterName, options.Name)))
+					})
+				})
+				When("there is an error deleting the machine deployment", func() {
+					BeforeEach(func() {
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.DockerMachineTemplate
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								mt := obj.(*docker.DockerMachineTemplate)
+								*mt = docker.DockerMachineTemplate{}
+								callIndex++
+								return nil
+							}
+							return nil
+						}
+						clusterClient.DeleteResourceReturns(errors.New(""))
+					})
+					It("should throw an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to delete machine deployment %s-%s: ", options.ClusterName, options.Name)))
+					})
+				})
+				When("there is an error deleting the machine template", func() {
+					BeforeEach(func() {
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.DockerMachineTemplate
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								mt := obj.(*docker.DockerMachineTemplate)
+								*mt = docker.DockerMachineTemplate{}
+								callIndex++
+								return nil
+							}
+							return nil
+						}
+						clusterClient.DeleteResourceReturnsOnCall(0, nil)
+						clusterClient.DeleteResourceReturnsOnCall(1, errors.New(""))
+					})
+					It("should throw an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to delete machine template %s-%s-mt: ", options.ClusterName, options.Name)))
+					})
+				})
+				When("there is an error deleting the kubeadmconfig template", func() {
+					BeforeEach(func() {
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.DockerMachineTemplate
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								mt := obj.(*docker.DockerMachineTemplate)
+								*mt = docker.DockerMachineTemplate{}
+								callIndex++
+								return nil
+							}
+							return nil
+						}
+						clusterClient.DeleteResourceReturnsOnCall(0, nil)
+						clusterClient.DeleteResourceReturnsOnCall(1, nil)
+						clusterClient.DeleteResourceReturnsOnCall(2, errors.New(""))
+					})
+					It("should throw an error", func() {
+						Expect(err).To(HaveOccurred())
+						Expect(err).Should(MatchError(fmt.Sprintf("unable to delete kubeadmconfigtemplate %s-%s-kct: ", options.ClusterName, options.Name)))
+					})
+				})
+				When("the node pool is deleted successfully", func() {
+					BeforeEach(func() {
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.DockerMachineTemplate
+						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+						callIndex := 0
+						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
+							if callIndex == 0 {
+								kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+								*kct = v1alpha3.KubeadmConfigTemplate{}
+								callIndex++
+								return nil
+							}
+							if callIndex == 1 {
+								mt := obj.(*docker.DockerMachineTemplate)
+								*mt = docker.DockerMachineTemplate{}
+								callIndex++
+								return nil
+							}
+							return nil
+						}
+						clusterClient.DeleteResourceReturnsOnCall(0, nil)
+						clusterClient.DeleteResourceReturnsOnCall(1, nil)
+						clusterClient.DeleteResourceReturnsOnCall(2, nil)
+					})
+					It("should return successfully", func() {
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+		})
+	})
+	Context("DoGetMachineDeployment", func() {
+		var (
+			options            GetMachineDeploymentOptions
+			machineDeployments []capi.MachineDeployment
+		)
+		BeforeEach(func() {
+			options = GetMachineDeploymentOptions{
+				ClusterName: clusterName,
+				Name:        np1Name,
+			}
+		})
+		JustBeforeEach(func() {
+			machineDeployments, err = DoGetMachineDeployments(&clusterClient, &options)
+		})
+		When("there is an error retrieving machine deployments", func() {
+			BeforeEach(func() {
+				clusterClient.GetMDObjectForClusterReturns(nil, errors.New(""))
+			})
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		When("machine deployments are found", func() {
+			BeforeEach(func() {
+				md1 = capi.MachineDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-cluster-np-1",
+					},
+				}
+				md2 = capi.MachineDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "np-2",
+					},
+				}
+				clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2}, nil)
+			})
+			It("normalize the node pool names", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(machineDeployments)).To(Equal(2))
+				Expect(machineDeployments[0].Name).To(Equal("np-1"))
+				Expect(machineDeployments[1].Name).To(Equal("np-2"))
+			})
+		})
+	})
+	Context("DoSetMachineDeployment", func() {
+		var (
+			options SetMachineDeploymentOptions
+		)
+		BeforeEach(func() {
+			newReplicas := int32(3)
+			options = SetMachineDeploymentOptions{
+				ClusterName: clusterName,
+				NodePool: NodePool{
+					Name:     np1Name,
+					Replicas: &newReplicas,
+					Labels: &map[string]string{
+						"key1": "value1",
+						"key2": "value2",
+					},
+				},
+			}
+		})
+		JustBeforeEach(func() {
+			err = DoSetMachineDeployment(&clusterClient, &options)
+		})
+		When("there is an error retrieving machine deployments", func() {
+			BeforeEach(func() {
+				clusterClient.GetMDObjectForClusterReturns(nil, errors.New(""))
+			})
+			It("should throw an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err).Should(MatchError("error retrieving worker machine deployments: "))
+			})
+		})
+		When("no machine deployments are found", func() {
+			BeforeEach(func() {
+				clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{}, nil)
+			})
+			It("should throw an error", func() {
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Context("Update Existing MachineDeployment", func() {
+			BeforeEach(func() {
+				existingReplicas := int32(1)
+				md1 = capi.MachineDeployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-cluster-np-1",
+						Annotations: map[string]string{
+							"key1": "value1",
+							"key2": "value2",
+						},
+					},
+					Spec: capi.MachineDeploymentSpec{
+						Replicas: &existingReplicas,
+						Template: capi.MachineTemplateSpec{
+							ObjectMeta: capi.ObjectMeta{
+								Labels: map[string]string{
+									"oldkey": "oldvalue",
+								},
+							},
+						},
+					},
+				}
+				clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1}, nil)
+			})
+			When("updating the machine deployment hits an error", func() {
+				BeforeEach(func() {
+					clusterClient.UpdateResourceReturns(errors.New(""))
+				})
+				It("should throw an error", func() {
+					Expect(err).To(HaveOccurred())
+					Expect(err).Should(MatchError("failed to update machinedeployment: "))
+				})
+			})
+			When("the machine deployment updates successfully", func() {
+				BeforeEach(func() {
+					clusterClient.UpdateResourceReturns(nil)
+				})
+				It("should update replicas and labels", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(clusterClient.UpdateResourceCallCount()).To(Equal(1))
+					obj, name, namespace, _ := clusterClient.UpdateResourceArgsForCall(0)
+					Expect(name).To(Equal("test-cluster-np-1"))
+					Expect(namespace).To(Equal(""))
+					md := obj.(*capi.MachineDeployment)
+
+					Expect(md.Name).To(Equal("test-cluster-np-1"))
+					Expect(md.Annotations).To(Equal(map[string]string{}))
+					Expect(*md.Spec.Replicas).To(Equal(int32(3)))
+					Expect(md.Spec.Template.Labels).To(HaveKeyWithValue("oldkey", "oldvalue"))
+					Expect(md.Spec.Template.Labels).To(HaveKeyWithValue("key1", "value1"))
+					Expect(md.Spec.Template.Labels).To(HaveKeyWithValue("key2", "value2"))
+				})
+			})
+		})
+		Context("Create MachineDeployment", func() {
+			var (
+				kubeadmConfigTemplate v1alpha3.KubeadmConfigTemplate
+				joinConfig            v1beta1.JoinConfiguration
+			)
+			BeforeEach(func() {
+				options.Name = "np-2"
+				joinConfig = v1beta1.JoinConfiguration{
+					NodeRegistration: v1beta1.NodeRegistrationOptions{
+						KubeletExtraArgs: map[string]string{},
+					},
+				}
+				kubeadmConfigTemplate = v1alpha3.KubeadmConfigTemplate{
+					Spec: v1alpha3.KubeadmConfigTemplateSpec{
+						Template: v1alpha3.KubeadmConfigTemplateResource{
+							Spec: v1alpha3.KubeadmConfigSpec{
+								JoinConfiguration: &joinConfig,
+							},
+						},
+					},
+				}
+			})
+			Context("vSphere machine deployment", func() {
+				var vSphereMachineTemplate vsphere.VSphereMachineTemplate
+				BeforeEach(func() {
+					existingReplicas := int32(1)
+					md1 = capi.MachineDeployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-cluster-np-1",
+							Annotations: map[string]string{
+								"key1": "value1",
+								"key2": "value2",
+							},
+						},
+						Spec: capi.MachineDeploymentSpec{
+							Replicas: &existingReplicas,
+							Template: capi.MachineTemplateSpec{
+								ObjectMeta: capi.ObjectMeta{
+									Labels: map[string]string{
+										"oldkey": "oldvalue",
+									},
+								},
+								Spec: capi.MachineSpec{
+									Bootstrap: capi.Bootstrap{
+										ConfigRef: &corev1.ObjectReference{
+											Name: "test-cluster-np-1-kct",
+										},
+									},
+									InfrastructureRef: corev1.ObjectReference{
+										Name: "test-cluster-np-1-mt",
+										Kind: constants.VSphereMachineTemplate,
+									},
+								},
+							},
+							Selector: metav1.LabelSelector{
+								MatchLabels: map[string]string{},
+							},
+						},
+					}
+					clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1}, nil)
+					vSphereMachineTemplate = vsphere.VSphereMachineTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-cluster-np-1-mt",
+						},
+						Spec: vsphere.VSphereMachineTemplateSpec{
+							Template: vsphere.VSphereMachineTemplateResource{
+								Spec: vsphere.VSphereMachineSpec{
+									VirtualMachineCloneSpec: vsphere.VirtualMachineCloneSpec{
+										Template:          "template0",
+										CloneMode:         "old",
+										Datacenter:        "dc0",
+										Folder:            "folder0",
+										Datastore:         "ds0",
+										StoragePolicyName: "policy0",
+										ResourcePool:      "rp0",
+										NumCPUs:           4,
+										MemoryMiB:         4096,
+										DiskGiB:           16384,
+									},
+								},
+							},
+						},
+					}
+					options.NodePool.VSphere = VSphereNodePool{
+						CloneMode:         "new",
+						Datacenter:        "dc1",
+						Datastore:         "ds1",
+						StoragePolicyName: "policy1",
+						Folder:            "folder1",
+						Network:           "network1",
+						ResourcePool:      "rp1",
+						VCIP:              "0.0.0.2",
+						Template:          "template1",
+						MemoryMiB:         8192,
+						DiskGiB:           65536,
+						NumCPUs:           8,
+					}
+
+					callIndex := 0
+					clusterClient.GetResourceStub = func(i interface{}, s1, s2 string, pvf clusterclient.PostVerifyrFunc, po *clusterclient.PollOptions) error {
+						if callIndex == 0 {
+							kct := i.(*v1alpha3.KubeadmConfigTemplate)
+							*kct = kubeadmConfigTemplate
+							callIndex++
+							return nil
+						}
+						if callIndex == 1 {
+							mt := i.(*vsphere.VSphereMachineTemplate)
+							*mt = vSphereMachineTemplate
+							callIndex++
+							return nil
+						}
+						return nil
+					}
+				})
+				clusterClient.CreateResourceReturnsOnCall(0, nil)
+				clusterClient.CreateResourceReturnsOnCall(1, nil)
+				clusterClient.CreateNamespaceReturnsOnCall(2, nil)
+				When("Machine Deployment creates successfully", func() {
+					It("should properly set all values for created resources", func() {
+						Expect(err).ToNot(HaveOccurred())
+						Expect(clusterClient.CreateResourceCallCount()).To(Equal(3))
+
+						obj, _, _, _ := clusterClient.CreateResourceArgsForCall(0)
+						kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+						Expect(kct.Annotations).To(Equal(map[string]string{}))
+						Expect(kct.ResourceVersion).To(Equal(""))
+						Expect(kct.Name).To(Equal("test-cluster-np-2-kct"))
+						Expect(kct.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs["node-labels"]).To(Equal("key1=value1,key2=value2"))
+
+						obj, _, _, _ = clusterClient.CreateResourceArgsForCall(1)
+						mt := obj.(*vsphere.VSphereMachineTemplate)
+						Expect(mt.Name).To(Equal("test-cluster-np-2-mt"))
+						Expect(mt.Annotations).To(Equal(map[string]string{}))
+						Expect(mt.ResourceVersion).To(Equal(""))
+						Expect(mt.Spec.Template.Spec.CloneMode).To(Equal(vsphere.CloneMode(options.VSphere.CloneMode)))
+						Expect(mt.Spec.Template.Spec.Datacenter).To(Equal(options.VSphere.Datacenter))
+						Expect(mt.Spec.Template.Spec.Datastore).To(Equal(options.VSphere.Datastore))
+						Expect(mt.Spec.Template.Spec.DiskGiB).To(Equal(options.VSphere.DiskGiB))
+						Expect(mt.Spec.Template.Spec.Folder).To(Equal(options.VSphere.Folder))
+						Expect(mt.Spec.Template.Spec.MemoryMiB).To(Equal(options.VSphere.MemoryMiB))
+						Expect(mt.Spec.Template.Spec.NumCPUs).To(Equal(options.VSphere.NumCPUs))
+						Expect(mt.Spec.Template.Spec.ResourcePool).To(Equal(options.VSphere.ResourcePool))
+						Expect(mt.Spec.Template.Spec.Server).To(Equal(options.VSphere.VCIP))
+						Expect(mt.Spec.Template.Spec.Template).To(Equal(options.VSphere.Template))
+						Expect(mt.Spec.Template.Spec.Network.Devices[0].NetworkName).To(Equal(options.VSphere.Network))
+
+						obj, _, _, _ = clusterClient.CreateResourceArgsForCall(2)
+						md := obj.(*capi.MachineDeployment)
+						Expect(md.Name).To(Equal("test-cluster-np-2"))
+						Expect(md.Annotations).To(Equal(map[string]string{}))
+						Expect(md.ResourceVersion).To(Equal(""))
+						Expect(md.Spec.Replicas).To(Equal(options.Replicas))
+					})
+				})
+			})
+			Context("AWS machine deployment", func() {
+				var awsMachineTemplate aws.AWSMachineTemplate
+				BeforeEach(func() {
+					az := "us-west-1"
+					existingReplicas := int32(1)
+					md1 = capi.MachineDeployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-cluster-np-1",
+							Annotations: map[string]string{
+								"key1": "value1",
+								"key2": "value2",
+							},
+						},
+						Spec: capi.MachineDeploymentSpec{
+							Replicas: &existingReplicas,
+							Template: capi.MachineTemplateSpec{
+								ObjectMeta: capi.ObjectMeta{
+									Labels: map[string]string{
+										"oldkey": "oldvalue",
+									},
+								},
+								Spec: capi.MachineSpec{
+									Bootstrap: capi.Bootstrap{
+										ConfigRef: &corev1.ObjectReference{
+											Name: "test-cluster-np-1-kct",
+										},
+									},
+									InfrastructureRef: corev1.ObjectReference{
+										Name: "test-cluster-np-1-mt",
+										Kind: constants.AWSMachineTemplate,
+									},
+									FailureDomain: &az,
+								},
+							},
+							Selector: metav1.LabelSelector{
+								MatchLabels: map[string]string{},
+							},
+						},
+					}
+					clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1}, nil)
+					awsMachineTemplate = aws.AWSMachineTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-cluster-np-1-mt",
+						},
+						Spec: aws.AWSMachineTemplateSpec{
+							Template: aws.AWSMachineTemplateResource{
+								Spec: aws.AWSMachineSpec{
+									InstanceType: "t3.large",
+								},
+							},
+						},
+					}
+					options.AZ = "us-west-2"
+					options.NodeMachineType = "t3.xlarge"
+
+					callIndex := 0
+					clusterClient.GetResourceStub = func(i interface{}, s1, s2 string, pvf clusterclient.PostVerifyrFunc, po *clusterclient.PollOptions) error {
+						if callIndex == 0 {
+							kct := i.(*v1alpha3.KubeadmConfigTemplate)
+							*kct = kubeadmConfigTemplate
+							callIndex++
+							return nil
+						}
+						if callIndex == 1 {
+							mt := i.(*aws.AWSMachineTemplate)
+							*mt = awsMachineTemplate
+							callIndex++
+							return nil
+						}
+						return nil
+					}
+				})
+				clusterClient.CreateResourceReturnsOnCall(0, nil)
+				clusterClient.CreateResourceReturnsOnCall(1, nil)
+				clusterClient.CreateNamespaceReturnsOnCall(2, nil)
+				When("Machine Deployment creates successfully", func() {
+					It("should properly set all values for created resources", func() {
+						Expect(err).ToNot(HaveOccurred())
+						Expect(clusterClient.CreateResourceCallCount()).To(Equal(3))
+
+						obj, _, _, _ := clusterClient.CreateResourceArgsForCall(0)
+						kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+						Expect(kct.Annotations).To(Equal(map[string]string{}))
+						Expect(kct.ResourceVersion).To(Equal(""))
+						Expect(kct.Name).To(Equal("test-cluster-np-2-kct"))
+						Expect(kct.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs["node-labels"]).To(Equal("key1=value1,key2=value2"))
+
+						obj, _, _, _ = clusterClient.CreateResourceArgsForCall(1)
+						mt := obj.(*aws.AWSMachineTemplate)
+						Expect(mt.Name).To(Equal("test-cluster-np-2-mt"))
+						Expect(mt.Annotations).To(Equal(map[string]string{}))
+						Expect(mt.ResourceVersion).To(Equal(""))
+						Expect(mt.Spec.Template.Spec.InstanceType).To(Equal(options.NodeMachineType))
+
+						obj, _, _, _ = clusterClient.CreateResourceArgsForCall(2)
+						md := obj.(*capi.MachineDeployment)
+						Expect(md.Name).To(Equal("test-cluster-np-2"))
+						Expect(md.Annotations).To(Equal(map[string]string{}))
+						Expect(md.ResourceVersion).To(Equal(""))
+						Expect(*md.Spec.Template.Spec.FailureDomain).To(Equal(options.AZ))
+						Expect(md.Spec.Replicas).To(Equal(options.Replicas))
+					})
+				})
+			})
+			Context("Azure machine deployment", func() {
+				var azureMachineTemplate azure.AzureMachineTemplate
+				BeforeEach(func() {
+					az := "1"
+					existingReplicas := int32(1)
+					md1 = capi.MachineDeployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-cluster-np-1",
+							Annotations: map[string]string{
+								"key1": "value1",
+								"key2": "value2",
+							},
+						},
+						Spec: capi.MachineDeploymentSpec{
+							Replicas: &existingReplicas,
+							Template: capi.MachineTemplateSpec{
+								ObjectMeta: capi.ObjectMeta{
+									Labels: map[string]string{
+										"oldkey": "oldvalue",
+									},
+								},
+								Spec: capi.MachineSpec{
+									Bootstrap: capi.Bootstrap{
+										ConfigRef: &corev1.ObjectReference{
+											Name: "test-cluster-np-1-kct",
+										},
+									},
+									InfrastructureRef: corev1.ObjectReference{
+										Name: "test-cluster-np-1-mt",
+										Kind: constants.AzureMachineTemplate,
+									},
+									FailureDomain: &az,
+								},
+							},
+							Selector: metav1.LabelSelector{
+								MatchLabels: map[string]string{},
+							},
+						},
+					}
+					clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1}, nil)
+					azureMachineTemplate = azure.AzureMachineTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-cluster-np-1-mt",
+						},
+						Spec: azure.AzureMachineTemplateSpec{
+							Template: azure.AzureMachineTemplateResource{
+								Spec: azure.AzureMachineSpec{
+									VMSize: "Standard_D3s",
+								},
+							},
+						},
+					}
+					options.AZ = "2"
+					options.NodeMachineType = "Standard_B2s"
+
+					callIndex := 0
+					clusterClient.GetResourceStub = func(i interface{}, s1, s2 string, pvf clusterclient.PostVerifyrFunc, po *clusterclient.PollOptions) error {
+						if callIndex == 0 {
+							kct := i.(*v1alpha3.KubeadmConfigTemplate)
+							*kct = kubeadmConfigTemplate
+							callIndex++
+							return nil
+						}
+						if callIndex == 1 {
+							mt := i.(*azure.AzureMachineTemplate)
+							*mt = azureMachineTemplate
+							callIndex++
+							return nil
+						}
+						return nil
+					}
+				})
+				clusterClient.CreateResourceReturnsOnCall(0, nil)
+				clusterClient.CreateResourceReturnsOnCall(1, nil)
+				clusterClient.CreateNamespaceReturnsOnCall(2, nil)
+				When("Machine Deployment creates successfully", func() {
+					It("should properly set all values for created resources", func() {
+						Expect(err).ToNot(HaveOccurred())
+						Expect(clusterClient.CreateResourceCallCount()).To(Equal(3))
+
+						obj, _, _, _ := clusterClient.CreateResourceArgsForCall(0)
+						kct := obj.(*v1alpha3.KubeadmConfigTemplate)
+						Expect(kct.Annotations).To(Equal(map[string]string{}))
+						Expect(kct.ResourceVersion).To(Equal(""))
+						Expect(kct.Name).To(Equal("test-cluster-np-2-kct"))
+						Expect(kct.Spec.Template.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs["node-labels"]).To(Equal("key1=value1,key2=value2"))
+
+						obj, _, _, _ = clusterClient.CreateResourceArgsForCall(1)
+						mt := obj.(*azure.AzureMachineTemplate)
+						Expect(mt.Name).To(Equal("test-cluster-np-2-mt"))
+						Expect(mt.Annotations).To(Equal(map[string]string{}))
+						Expect(mt.ResourceVersion).To(Equal(""))
+						Expect(mt.Spec.Template.Spec.VMSize).To(Equal(options.NodeMachineType))
+
+						obj, _, _, _ = clusterClient.CreateResourceArgsForCall(2)
+						md := obj.(*capi.MachineDeployment)
+						Expect(md.Name).To(Equal("test-cluster-np-2"))
+						Expect(md.Annotations).To(Equal(map[string]string{}))
+						Expect(md.ResourceVersion).To(Equal(""))
+						Expect(*md.Spec.Template.Spec.FailureDomain).To(Equal(options.AZ))
+						Expect(md.Spec.Replicas).To(Equal(options.Replicas))
+					})
+				})
+			})
+		})
+	})
+})

--- a/pkg/v1/tkg/client/scale.go
+++ b/pkg/v1/tkg/client/scale.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -178,7 +179,7 @@ func (c *TkgClient) scaleWorkersNodePool(clusterClient clusterclient.Client, opt
 			Replicas: &options.WorkerCount,
 		},
 	}
-	if err := c.DoSetMachineDeployment(clusterClient, &mdOptions); err != nil {
+	if err := DoSetMachineDeployment(clusterClient, &mdOptions); err != nil {
 		return errors.Wrapf(err, "Unable to scale node pool %s", options.NodePoolName)
 	}
 
@@ -198,13 +199,15 @@ func (c *TkgClient) mdExists(clusterClient clusterclient.Client, options *ScaleC
 		Namespace:   options.Namespace,
 		Name:        options.NodePoolName,
 	}
-	mds, err := c.DoGetMachineDeployments(clusterClient, &getOptions)
+	mds, err := DoGetMachineDeployments(clusterClient, &getOptions)
 	if err != nil {
 		return false, errors.Wrapf(err, "Failed to get node pools for cluster %s", options.ClusterName)
 	}
 
+	npName := strings.Replace(options.NodePoolName, options.ClusterName+"-", "", -1)
+
 	for i := range mds {
-		if mds[i].Name == options.NodePoolName {
+		if mds[i].Name == npName {
 			return true, nil
 		}
 	}

--- a/pkg/v1/tkg/client/scale_test.go
+++ b/pkg/v1/tkg/client/scale_test.go
@@ -274,7 +274,7 @@ var _ = Describe("Scale API", func() {
 						scaleClusterOptions.WorkerCount = 3
 
 						err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
-						Expect(err).Should(MatchError(fmt.Sprintf("Failed to get node pools for cluster %s: unable to get worker machine deployments: %s", scaleClusterOptions.ClusterName, mdErrString)))
+						Expect(err).Should(MatchError(fmt.Sprintf("Failed to get node pools for cluster %s: error retrieving machine deployments: %s", scaleClusterOptions.ClusterName, mdErrString)))
 					})
 				})
 				When("the named node pool can't be found", func() {
@@ -298,7 +298,7 @@ var _ = Describe("Scale API", func() {
 						scaleClusterOptions.WorkerCount = 3
 
 						err = tkgClient.DoScaleCluster(regionalClusterClient, &scaleClusterOptions)
-						Expect(err).Should(MatchError(fmt.Sprintf("Unable to scale node pool %s: unable to get worker machine deployments: %s", scaleClusterOptions.NodePoolName, mdErrString)))
+						Expect(err).Should(MatchError(fmt.Sprintf("Unable to scale node pool %s: error retrieving worker machine deployments: %s", scaleClusterOptions.NodePoolName, mdErrString)))
 
 						Expect(regionalClusterClient.GetMDObjectForClusterCallCount()).To(Equal(2))
 					})


### PR DESCRIPTION
### What this PR does / why we need it
This PR fixes a number of issues with node pool support in 1.4.0. Fixes issue with k8s resource naming to ensure uniqueness, fixes issue with node pools in non default namespaces, fixes issue with labels not propagating to the nodes, fixes issue where deleting the 'source' node pool causes future node pool failures. Adds loads of unit tests for node pool functionality.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
Tested all IaaSes by creating and updating node pools, deleting the original node pool and creating/updating again. Tested using custom namespaces and tested node pools names with a cluster name prepend and without.
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixes several node pool related bugs and increases stability of node pool feature.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
