### PR TITLE
Add templating to support dualstack ipv6 primary

### DIFF
--- a/pkg/v1/providers/infrastructure-vsphere/v1.0.1/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.0.1/ytt/overlay.yaml
@@ -223,6 +223,19 @@ spec:
         #@ end
         bindPort: #@ data.values.CLUSTER_API_SERVER_PORT
       #@ end
+      #@ if data.values.TKG_IP_FAMILY == "ipv6,ipv4":
+      nodeRegistration:
+        kubeletExtraArgs:
+          #@overlay/match missing_ok=True
+          node-ip: "::"
+      #@ end
+    #@ if data.values.TKG_IP_FAMILY == "ipv6,ipv4":
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          #@overlay/match missing_ok=True
+          node-ip: "::"
+    #@ end
     clusterConfiguration:
       imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.imageRepository)
       etcd:
@@ -232,6 +245,22 @@ spec:
       dns:
         imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.dns.imageRepository)
         imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag
+      #@ if data.values.TKG_IP_FAMILY == "ipv6,ipv4":
+      apiServer:
+        extraArgs:
+          #@overlay/match missing_ok=True
+          advertise-address: #@ data.values.VSPHERE_CONTROL_PLANE_ENDPOINT
+          #@overlay/match missing_ok=True
+          bind-address: "::"
+      controllerManager:
+        extraArgs:
+          #@overlay/match missing_ok=True
+          bind-address: "::"
+      scheduler:
+        extraArgs:
+          #@overlay/match missing_ok=True
+          bind-address: "::"
+      #@ end
     files:
     #@ if not data.values.AVI_CONTROL_PLANE_HA_PROVIDER:
     #@overlay/match by=overlay.index(0)
@@ -267,6 +296,13 @@ metadata:
 spec:
   template:
     spec:
+      #@ if data.values.TKG_IP_FAMILY == "ipv6,ipv4":
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            #@overlay/match missing_ok=True
+            node-ip: "::"
+      #@ end
       users:
       #@overlay/match by=overlay.index(0)
       #@overlay/replace

--- a/pkg/v1/providers/ytt/03_customizations/ip_family.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/ip_family.yaml
@@ -4,11 +4,11 @@
 
 #! Validate TKG_IP_FAMILY values
 
-#@ if data.values.TKG_IP_FAMILY not in ["ipv6", "ipv4", "ipv4,ipv6", "", None]:
-#@ assert.fail("TKG_IP_FAMILY value must be \"ipv6\", \"ipv4\", \"ipv4,ipv6\", or unset")
+#@ if data.values.TKG_IP_FAMILY not in ["ipv6", "ipv4", "ipv4,ipv6", "ipv6,ipv4", "", None]:
+#@ assert.fail("TKG_IP_FAMILY value must be \"ipv6\", \"ipv4\", \"ipv4,ipv6\", \"ipv6,ipv4\", or unset")
 #@ end
 
-#@ if data.values.TKG_IP_FAMILY in ["ipv6", "ipv4,ipv6"] and data.values.PROVIDER_TYPE != "vsphere":
+#@ if data.values.TKG_IP_FAMILY in ["ipv6", "ipv4,ipv6", "ipv6,ipv4"] and data.values.PROVIDER_TYPE != "vsphere":
 #@ assert.fail("TKG_IP_FAMILY value contains \"ipv6\". IPv6 is only compatible with PROVIDER_TYPE \"vsphere\". Please set INFRASTRUCTURE_PROVIDER to a compatible value.")
 #@ end
 


### PR DESCRIPTION
### What this PR does / why we need it
This PR makes it possible to deploy dualstack, primary ipv6 management clusters. 

- Various Kuberntes components don't bind to the correct address in the
  case ipv6 primary dualstack i.e it doesn't bind to the ipv6 interface.
  This will make it explictly bind to the ipv6 interface.
- The apiServer doesn't set the advertise address correctly in the case
  of ipv6 primary dualstack. This will explicitly advertise the
  VSPHERE_CONTROL_PLANE_ENDPOINT.
- Set the node-ip to '::' to make kubelet prefer the ipv6 address on the node.

### Which issue(s) this PR fixes

Related to #616

### Describe testing done for PR

Created vSphere management cluster to verify change.
Unit test coverage for ytt templating overlays.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Experimental support for dualstack primary ipv6 (TKG_IP_FAMILY "ipv6,ipv4")
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
