### PR TITLE
increase poll timeout for package plugin integration tests

### DIFF
--- a/pkg/v1/tkg/test/tkgpackageclient/package_plugin_integration_test.go
+++ b/pkg/v1/tkg/test/tkgpackageclient/package_plugin_integration_test.go
@@ -88,7 +88,7 @@ var (
 	resultImgPullSecret         secretlib.SecretPluginResult
 	clusterCreationTimeout      = 30 * time.Minute
 	pollInterval                = 20 * time.Second
-	pollTimeout                 = 10 * time.Minute
+	pollTimeout                 = 20 * time.Minute
 	testImgPullSecretName       = "test-secret"
 	testNamespace               = "test-ns"
 	testRegistry                = "projects-stg.registry.vmware.com"


### PR DESCRIPTION
**What this PR does / why we need it:**
- This PR is to increase poll timeout for package plugin integration tests

**Describe testing done for PR:**
existing integration tests

**Does this PR introduce a user-facing change?:**
None

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
increases poll timeout for package plugin integration tests
```

**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
