### PR TITLE
Fixes error in custom resource group usecase

### DIFF
--- a/pkg/v1/tkg/web/src/app/views/landing/azure-wizard/provider-step/azure-provider-step.component.ts
+++ b/pkg/v1/tkg/web/src/app/views/landing/azure-wizard/provider-step/azure-provider-step.component.ts
@@ -194,7 +194,7 @@ export class AzureProviderStepComponent extends StepFormDirective implements OnI
 
                     // handle case where a new resource group was created, saved to local storage, and the browser was refreshed
                     if (this.getSavedValue('resourceGroupExisting', '') === ''
-                        && this.regions.indexOf(this.getSavedValue('resourceGroupCustom', '') >= 0)) {
+                        && this.resourceGroups.indexOf(this.getSavedValue('resourceGroupCustom', '') >= 0)) {
                         // select the newly created resource group in the existing resource group dropdown
                         this.formGroup.get('resourceGroupExisting').setValue(this.getSavedValue('resourceGroupCustom', ''))
                     }


### PR DESCRIPTION
### What this PR does / why we need it
Fixes error in custom resource group usecase (an edge case).
If a user specifies a custom resource group which is subsequently created, when we reload their data from local storage, we should select that resource from the existing-resources group. There was an error (essentially a typo) in finding the resource that would always cause it to fail. This PR fixes that.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
