### PR TITLE
Don't override image version during docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -551,7 +551,7 @@ kbld-image-replace: $(COMPONENTS)
 
 .PHONY: $(COMPONENTS)
 $(COMPONENTS):
-	$(MAKE) -C $@ $(TARGET) IMG_VERSION_OVERRIDE=$(BUILD_VERSION)
+	$(MAKE) -C $@ $(TARGET)
 
 .PHONY: docker-all
 docker-all: docker-build docker-publish kbld-image-replace


### PR DESCRIPTION
### What this PR does / why we need it

This change removes overriding `IMG_VERSION_OVERRIDE` variable with
`BUILD_VERSION` when `docker-build` or `kbld-image-replace` targets are
called with `IMG_VERSION_OVERRIDE`.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1064

### Describe testing done for PR

Ran the following command and verified it overrides the image version correctly. 

```
$ make docker-build OCI_REGISTRY=localhost:5000 IMG_VERSION_OVERRIDE=v0.11.0-dev-9-g41cbcdee
make -C pkg/v1/sdk/features docker-build
make[1]: Entering directory '/Users/ragasthya/go/src/github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/features'
cd ../../../../ && docker build -t localhost:5000/featuregates-controller-manager:v0.11.0-dev-9-g41cbcdee -f pkg/v1/sdk/features/Dockerfile --build-arg LD_FLAGS="-s -w -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.Date=$(date -u +"%Y-%m-%d")' -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.SHA=$(git describe --match= --always --dirty)' -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.Version=v0.11.0-dev'"
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
