### PR TITLE
Fix clustergen tests

### DIFF
--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
@@ -136,12 +136,12 @@ BUILD_EDITION: "tkg", "tce"
 IDENTITY_MANAGEMENT_TYPE: "none", "oidc", "ldap"
 
 # pass --VSPHERE-CONTROLPLANE-ENDPOINT flag only for vSphere provider
-IF [_INFRA] = "\"vsphere:v0.7.8\"" THEN [--VSPHERE-CONTROLPLANE-ENDPOINT] = "\"10.10.10.10\"";
-IF [_INFRA] <> "\"vsphere:v0.7.8\"" THEN [--VSPHERE-CONTROLPLANE-ENDPOINT] = "\"NOTPROVIDED\"";
+IF [_INFRA] LIKE "\"vsphere:*" THEN [--VSPHERE-CONTROLPLANE-ENDPOINT] = "\"10.10.10.10\"";
+IF [_INFRA] NOT LIKE "\"vsphere:*" THEN [--VSPHERE-CONTROLPLANE-ENDPOINT] = "\"NOTPROVIDED\"";
 
-IF [_INFRA] <> "\"vsphere:v0.7.8\"" THEN [OS_NAME] <> "\"photon\"";
-IF [_INFRA] <> "\"vsphere:v0.7.8\"" THEN [CONTROL_PLANE_NODE_NAMESERVERS] = "\"NOTPROVIDED\"";
-IF [_INFRA] <> "\"vsphere:v0.7.8\"" THEN [WORKER_NODE_NAMESERVERS] = "\"NOTPROVIDED\"";
+IF [_INFRA] NOT LIKE "\"vsphere:*" THEN [OS_NAME] <> "\"photon\"";
+IF [_INFRA] NOT LIKE "\"vsphere:*" THEN [CONTROL_PLANE_NODE_NAMESERVERS] = "\"\"";
+IF [_INFRA] NOT LIKE "\"vsphere:*" THEN [WORKER_NODE_NAMESERVERS] = "\"\"";
 
 IF [TKG_HTTP_PROXY] = "\"http://10.0.200.100\"" THEN [TKG_HTTPS_PROXY] = "\"http://10.0.200.100\"";
 IF [TKG_HTTP_PROXY] LIKE "\"http://[fc00*" THEN [TKG_HTTPS_PROXY] <> "\"http://10.0.200.100\"";


### PR DESCRIPTION

### What this PR does / why we need it

We saw that optional cluster model values were not getting included in case files.

- generate cases correctly when value is NoneType
- Update constraint check so it matches the current vsphere version
- change "NOTPROVIDED" -> "" in constraints, "NOTPROVIDED" is only handled when
  variable keys start with "--"

### Describe testing done for PR

ran the clustergen steps and saw case get generated with the optional model data.

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
