### PR TITLE
Add MachineDeployment specifier to node pool

### DIFF
--- a/cmd/cli/plugin/cluster/set_node_pool.go
+++ b/cmd/cli/plugin/cluster/set_node_pool.go
@@ -17,8 +17,9 @@ import (
 )
 
 type clusterSetNodePoolCmdOptions struct {
-	FilePath  string
-	Namespace string
+	FilePath              string
+	Namespace             string
+	BaseMachineDeployment string
 }
 
 var setNodePoolOptions clusterSetNodePoolCmdOptions
@@ -32,6 +33,7 @@ var clusterSetNodePoolCmd = &cobra.Command{
 func init() {
 	clusterSetNodePoolCmd.Flags().StringVarP(&setNodePoolOptions.FilePath, "file", "f", "", "The file describing the node pool (required)")
 	clusterSetNodePoolCmd.Flags().StringVar(&setNodePoolOptions.Namespace, "namespace", "default", "The namespace the cluster is found in.")
+	clusterSetNodePoolCmd.Flags().StringVar(&setNodePoolOptions.BaseMachineDeployment, "base-machine-deployment", "", "The machine deployment to use as a base for creating a new node pool (ignored for TKGs)")
 	_ = clusterSetNodePoolCmd.MarkFlagRequired("file")
 	clusterNodePoolCmd.AddCommand(clusterSetNodePoolCmd)
 }
@@ -64,6 +66,7 @@ func SetNodePool(server *v1alpha1.Server, clusterName string) error {
 	if err = yaml.Unmarshal(fileContent, &nodePool); err != nil {
 		return errors.Wrap(err, "Could not parse file contents")
 	}
+	nodePool.BaseMachineDeployment = setNodePoolOptions.BaseMachineDeployment
 
 	options := client.SetMachineDeploymentOptions{
 		ClusterName: clusterName,


### PR DESCRIPTION
Adds a command line flag to specify the MachineDeployment to use as a
base when creating a new node pool

### What this PR does / why we need it

### Which issue(s) this PR fixes
Fixes #1067 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Adds a new flag to cluster node-pool set `--machine-deployment-base` This flag allows a user to specify an explicit MachineDeployment as the base from which a new node pool will be created.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
