### PR TITLE
Fix generated package repo bundle version to include prefix `v`

### DIFF
--- a/packages/package-values.yaml
+++ b/packages/package-values.yaml
@@ -28,8 +28,8 @@ managementPackageRepository:
       version: latest
       #! Gets replaced with imgpkg sha256 at build, this should be name:version
       sha256: "featuregates:latest"
-    - name: cliplugins
-      displayName: cliplugins
+    - name: core-management-cliplugins
+      displayName: core-management-cliplugins
       #! Relative path to package bundle
       path: packages/management/core-management-cliplugins
       domain: tanzu.vmware.com


### PR DESCRIPTION
### What this PR does / why we need it
This PR fixes the generated package repo bundle using `make package-repo-bundle` to have the same version as tanzu-framework version, which contains `v` prefix.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1075 

### Describe testing done for PR

```
$ make package-repo-bundle OCI_REGISTRY=projects.registry.vmware.com/tanzu_framework PACKAGE_REPOSITORY=management
```

Tree structure of the generated `build` directory

```
$ tree build
build
├── package-bundles
│   └── management
│       ├── core-management-cliplugins-v0.10.0-dev.tar.gz
│       └── featuregates-v0.10.0-dev.tar.gz
└── package-repo-bundles
    └── management
        ├── packages
        │   ├── core-management-cliplugins.tanzu.vmware.com
        │   │   ├── 0.10.0-dev.yml
        │   │   └── metadata.yml
        │   └── featuregates.tanzu.vmware.com
        │       ├── 0.10.0-dev.yml
        │       └── metadata.yml
        ├── tanzu-framework-management-repo-v0.10.0-dev.tar.gz
        └── tanzu-framework-management-repo-v0.10.0-dev.yaml
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
