### PR TITLE
Fixes Kickstart UI's control plane subnet CIDR issue

### DIFF
--- a/pkg/v1/tkg/web/src/app/views/landing/azure-wizard/azure-wizard.component.ts
+++ b/pkg/v1/tkg/web/src/app/views/landing/azure-wizard/azure-wizard.component.ts
@@ -162,6 +162,7 @@ export class AzureWizardComponent extends WizardBaseDirective implements OnInit 
                 ["vnetName", "vnetForm", "vnetNameExisting"],
                 ["vnetCidr", "vnetForm", "vnetCidrBlock"],
                 ["controlPlaneSubnet", "vnetForm", "controlPlaneSubnet"],
+                ["controlPlaneSubnetCidr", "vnetForm", "controlPlaneSubnetCidr"],
                 ["workerNodeSubnet", "vnetForm", "workerNodeSubnet"],
             ];
         }

--- a/pkg/v1/tkg/web/src/app/views/landing/azure-wizard/vnet-step/vnet-step.component.html
+++ b/pkg/v1/tkg/web/src/app/views/landing/azure-wizard/vnet-step/vnet-step.component.html
@@ -266,6 +266,9 @@
                     <option *ngFor="let cps of controlPlaneSubnets" [value]="cps.name">{{ cps.name }}
                     </option>
                 </select>
+                <!-- Add a hidden control to hold the associated subnet CIDR -->
+                <input class="hidden" name="controlPlaneSubnetCidr" formControlName="controlPlaneSubnetCidr" />
+
                 <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
                 <clr-control-helper></clr-control-helper>
                 <clr-control-error i18n="azure resource group required msg" *clrIfError="validatorEnum.REQUIRED">

--- a/pkg/v1/tkg/web/src/app/views/landing/azure-wizard/vnet-step/vnet-step.component.ts
+++ b/pkg/v1/tkg/web/src/app/views/landing/azure-wizard/vnet-step/vnet-step.component.ts
@@ -80,6 +80,11 @@ export class VnetStepComponent extends StepFormDirective implements OnInit {
                 this.validationService.isValidIpNetworkSegment()
             ])
         ));
+        // special hidden field used to capture existing subnet cidr when user selects existing subnet
+        this.formGroup.addControl(
+            'controlPlaneSubnetCidr',
+            new FormControl('', [])
+        );
 
         this.formGroup.get('vnetOption').setValue(this.showOption);
 
@@ -218,7 +223,17 @@ export class VnetStepComponent extends StepFormDirective implements OnInit {
     }
 
     onControlPlaneSubnetChange(name: string) {
-        this.cidrHolder[EXISTING] = this.controlPlaneSubnets.find(subnet => subnet.name === name)?.cidr;
+        // when the user selects an existing subnet, we look up the associated CIDR and set a hidden field with the CIDR value,
+        // which is later used in creating the AzureRegionalClusterParams payload object
+        const subnetEntry = this.controlPlaneSubnets.find(subnet => subnet.name === name);
+        const cidrOfSelectedControlPlaneSubnet = (subnetEntry) ? subnetEntry.cidr : '';
+
+        const control = this.formGroup.controls['controlPlaneSubnetCidr'];
+        if (control) {
+            control.setValue(cidrOfSelectedControlPlaneSubnet);
+        }
+        // Leaving cidrHolder assignment in place, but unable to see how it is useful
+        this.cidrHolder[EXISTING] = cidrOfSelectedControlPlaneSubnet;
     }
 
     onControlPlaneSubnetCidrNewChange(value: string) {


### PR DESCRIPTION
### What this PR does / why we need it
Fixes issue: when Azure user selects an existing control plane subnet, the corresponding subnet CIDR is *not* currently submitted from the Kickstart UI

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
