### PR TITLE
clustergen: update provider and image versions

### DIFF
--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_aws.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_aws.model
@@ -1,7 +1,7 @@
 --CONTROLPLANE-MACHINE-COUNT: "NOTPROVIDED", "1","3","5"
 --WORKER-MACHINE-COUNT:       "NOTPROVIDED", "3"
 --CONTROLPLANE-SIZE:          "NOTPROVIDED", "i3.xlarge"
---TKR:                        "NOTPROVIDED", "v1.21.2+vmware.1-tkg.1-zshippable"
+--TKR:                        "NOTPROVIDED", "v1.21.5+vmware.1-tkg.1-zshippable"
 --NAMESPACE:                  "NOTPROVIDED", "default", "test"
 --SIZE:                       "NOTPROVIDED", "t3.medium"
 --WORKER-SIZE:                "NOTPROVIDED", "m5.xlarge"
@@ -14,7 +14,7 @@ NODE_MACHINE_TYPE: "NA","m5.large"
 
 _CNAME: "testcluster", "c1"
 _PLAN: "dev", "prod"
-_INFRA: "aws:v0.6.6"
+_INFRA: "aws:v1.0.0"
 
 BASTION_HOST_ENABLED: "true"
 NODE_STARTUP_TIMEOUT: "20m"

--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_azure.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_azure.model
@@ -1,7 +1,7 @@
 --CONTROLPLANE-MACHINE-COUNT: "NOTPROVIDED", "1","3","5"
 --WORKER-MACHINE-COUNT:       "NOTPROVIDED", "3"
 --CONTROLPLANE-SIZE:          "NOTPROVIDED", "i3.xlarge"
---TKR:                        "NOTPROVIDED", "v1.21.2+vmware.1-tkg.1-zshippable", "v0.0.0+no-azure-image", "v0.0.0+marketplace-image", "v0.0.0+marketplace-image-no-thirdpartyimage", "v0.0.0+shared-gallery-image"
+--TKR:                        "NOTPROVIDED", "v1.21.5+vmware.1-tkg.1-zshippable", "v0.0.0+no-azure-image", "v0.0.0+marketplace-image", "v0.0.0+marketplace-image-no-thirdpartyimage", "v0.0.0+shared-gallery-image"
 --NAMESPACE:                  "NOTPROVIDED", "default", "test"
 --SIZE:                       "NOTPROVIDED", "t3.medium"
 --WORKER-SIZE:                "NOTPROVIDED", "m5.xlarge"
@@ -12,7 +12,7 @@ WORKER_MACHINE_COUNT: "NA","1","3","5"
 
 _CNAME: "testcluster"
 _PLAN: "dev", "prod"
-_INFRA: "azure:v0.4.15"
+_INFRA: "azure:v1.0.0"
 
 NODE_STARTUP_TIMEOUT: "20m"
 

--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
@@ -1,7 +1,7 @@
 --CONTROLPLANE-MACHINE-COUNT: "NOTPROVIDED"
 --WORKER-MACHINE-COUNT:       "NOTPROVIDED"
 --CONTROLPLANE-SIZE:          "NOTPROVIDED"
---TKR:                        "NOTPROVIDED", "v1.21.2+vmware.1-tkg.1-zshippable"
+--TKR:                        "NOTPROVIDED", "v1.21.5+vmware.1-tkg.1-zshippable"
 --NAMESPACE:                  "NOTPROVIDED"
 --SIZE:                       "NOTPROVIDED"
 --WORKER-SIZE:                "NOTPROVIDED"
@@ -17,7 +17,7 @@ NODE_MACHINE_TYPE: "NA"
 _TKG_CLUSTER_FORCE_ROLE: "NA", "management"
 
 _CNAME: "testcluster"
-_INFRA: "vsphere:v0.7.10", "aws:v0.6.6"
+_INFRA: "vsphere:v1.0.1", "aws:v1.0.0"
 _PLAN: "dev", "prod"
 CNI: "", "calico", "antrea", "none"
 

--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_vsphere.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_vsphere.model
@@ -16,7 +16,7 @@ NODE_MACHINE_TYPE: "NA","m5.large"
 _TKG_CLUSTER_FORCE_ROLE: "NA", "management"
 _CNAME: "testcluster", "c1", "really-long-cluster-name-with-hyphen"
 _PLAN: "dev", "prod"
-_INFRA: "vsphere:v0.7.10"
+_INFRA: "vsphere:v1.0.1"
 
 BASTION_HOST_ENABLED: "true"
 NODE_STARTUP_TIMEOUT: "20m"


### PR DESCRIPTION
### What this PR does / why we need it

This fixes all the generated output turning into error cases when the provider versions were bumped.

### Describe testing done for PR

Ran clustergen locally, monitor template tests
Use draft PR https://github.com/vmware-tanzu/tanzu-framework/pull/1085 to verify the expected diffs are being generated again.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
