### PR TITLE
introduce feature flags for custom nameservers

### DIFF
--- a/pkg/v1/config/clientconfig.go
+++ b/pkg/v1/config/clientconfig.go
@@ -32,6 +32,11 @@ const (
 	FeatureFlagManagementClusterDualStackIPv6Primary = "features.management-cluster.dual-stack-ipv6-primary"
 	FeatureFlagClusterDualStackIPv4Primary           = "features.cluster.dual-stack-ipv4-primary"
 	FeatureFlagClusterDualStackIPv6Primary           = "features.cluster.dual-stack-ipv6-primary"
+	// Custom Nameserver feature flags determine whether it is permitted to
+	// provide the CONTROL_PLANE_NODE_NAMESERVERS and WORKER_NODE_NAMESERVERS
+	// when creating a cluster.
+	FeatureFlagManagementClusterCustomNameservers = "features.management-cluster.custom-nameservers"
+	FeatureFlagClusterCustomNameservers           = "features.cluster.custom-nameservers"
 )
 
 // DefaultCliFeatureFlags is used to populate an initially empty config file with default values for feature flags.
@@ -50,6 +55,8 @@ var (
 		FeatureFlagManagementClusterDualStackIPv6Primary:      false,
 		FeatureFlagClusterDualStackIPv4Primary:                false,
 		FeatureFlagClusterDualStackIPv6Primary:                false,
+		FeatureFlagManagementClusterCustomNameservers:         false,
+		FeatureFlagClusterCustomNameservers:                   false,
 	}
 )
 

--- a/pkg/v1/tkg/client/cluster.go
+++ b/pkg/v1/tkg/client/cluster.go
@@ -554,6 +554,10 @@ func (c *TkgClient) ConfigureAndValidateWorkloadClusterConfiguration(options *Cr
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
+	if err = c.ConfigureAndValidateNameserverConfiguration(TkgLabelClusterRoleWorkload); err != nil {
+		return NewValidationError(ValidationErrorCode, err.Error())
+	}
+
 	switch name {
 	case AWSProviderName:
 		if err := c.ConfigureAndValidateAWSConfig(options.TKRVersion, options.NodeSizeOptions, skipValidation,

--- a/pkg/v1/tkg/client/validate_test.go
+++ b/pkg/v1/tkg/client/validate_test.go
@@ -915,6 +915,19 @@ var _ = Describe("Validate", func() {
 			})
 
 			Context("Control Plane Node Nameservers", func() {
+				Context("Custom Nameserver feature gate is false", func() {
+					BeforeEach(func() {
+						featureFlagClient.IsConfigFeatureActivatedReturns(false, nil)
+						tkgConfigReaderWriter.Set(constants.ConfigVariableControlPlaneNodeNameservers, "8.8.8.8")
+					})
+
+					It("should return an error", func() {
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("option CONTROL_PLANE_NODE_NAMESERVERS is set to \"8.8.8.8\", but custom nameserver support is not enabled (because it is not fully functional). To enable custom nameservers, run the command: tanzu config set features.management-cluster.custom-nameservers true"))
+					})
+				})
+
 				Context("when CONTROL_PLANE_NODE_NAMESERVERS is a valid set of IPv4 address", func() {
 					It("should pass validation", func() {
 						tkgConfigReaderWriter.Set(constants.ConfigVariableControlPlaneNodeNameservers, "8.8.8.8,8.8.4.4")
@@ -989,6 +1002,19 @@ var _ = Describe("Validate", func() {
 				})
 			})
 			Context("Worker Node Nameservers", func() {
+				Context("Custom Nameserver feature gate is false", func() {
+					BeforeEach(func() {
+						featureFlagClient.IsConfigFeatureActivatedReturns(false, nil)
+						tkgConfigReaderWriter.Set(constants.ConfigVariableWorkerNodeNameservers, "8.8.8.8")
+					})
+
+					It("should return an error", func() {
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).To(HaveOccurred())
+						Expect(validationError.Error()).To(ContainSubstring("option WORKER_NODE_NAMESERVERS is set to \"8.8.8.8\", but custom nameserver support is not enabled (because it is not fully functional). To enable custom nameservers, run the command: tanzu config set features.management-cluster.custom-nameservers true"))
+					})
+				})
+
 				Context("when WORKER_NODE_NAMESERVERS is a valid set of IPv4 address", func() {
 					It("should pass validation", func() {
 						tkgConfigReaderWriter.Set(constants.ConfigVariableWorkerNodeNameservers, "8.8.8.8,8.8.4.4")


### PR DESCRIPTION
### What this PR does / why we need it
Custom nameservers support is not fully functional and may not work in all environments.

Two new feature flags are added with this commit, one for each plugin:
`features.management-cluster.custom-nameservers`
`features.cluster.custom-nameservers`

This is related to #1103, once that issue is resolved, we believe we can remove these flags.

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
We tested cluster creation with the CONTROL_PLANE_NODE_NAMESERVERS and WORKER_NODE_NAMESERVERS with the new flags set to true and set to false. We verified that the message is displayed to users correctly when the feature is disabled and that the cluster is able to deploy when it is enabled.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
