### PR TITLE
Remove erroneous -f flag from delete command, use --force instead

### DIFF
--- a/pkg/v1/tkg/client/delete_region.go
+++ b/pkg/v1/tkg/client/delete_region.go
@@ -38,7 +38,7 @@ const (
 
 You need to delete these clusters first before deleting the management cluster.
 
-Alternatively, you can use the -f/--force flag to force the deletion of the management cluster but doing so will orphan the above-mentioned clusters and leave them unmanaged.`
+Alternatively, you can use the --force flag to force the deletion of the management cluster but doing so will orphan the above-mentioned clusters and leave them unmanaged.`
 )
 
 // DeleteRegion delete management cluster


### PR DESCRIPTION
Signed-off-by: Stuart Preston <spreston@vmware.com>

### What this PR does / why we need it

Fixes the help text to remove an erroneous -f flag. --force should be used when you want to delete a management-cluster whilst orphaning objects instead.

### Describe testing done for PR

None. Minor typo fix.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
