### PR TITLE
Update node-pool API to handle vpshere ipv6

### DIFF
--- a/pkg/v1/tkg/client/machine_deployment_test.go
+++ b/pkg/v1/tkg/client/machine_deployment_test.go
@@ -1306,12 +1306,17 @@ var _ = Describe("Machine Deployment", func() {
 						StoragePolicyName: "policy1",
 						Folder:            "folder1",
 						Network:           "network1",
-						ResourcePool:      "rp1",
-						VCIP:              "0.0.0.2",
-						Template:          "template1",
-						MemoryMiB:         8192,
-						DiskGiB:           65536,
-						NumCPUs:           8,
+						Nameservers: []string{
+							"8.8.8.8",
+							"8.8.4.4",
+						},
+						TKGIPFamily:  "ipv4,ipv6",
+						ResourcePool: "rp1",
+						VCIP:         "0.0.0.2",
+						Template:     "template1",
+						MemoryMiB:    8192,
+						DiskGiB:      65536,
+						NumCPUs:      8,
 					}
 
 					callIndex := 0
@@ -1362,6 +1367,9 @@ var _ = Describe("Machine Deployment", func() {
 						Expect(mt.Spec.Template.Spec.Server).To(Equal(options.VSphere.VCIP))
 						Expect(mt.Spec.Template.Spec.Template).To(Equal(options.VSphere.Template))
 						Expect(mt.Spec.Template.Spec.Network.Devices[0].NetworkName).To(Equal(options.VSphere.Network))
+						Expect(mt.Spec.Template.Spec.Network.Devices[0].DHCP4).To(Equal(true))
+						Expect(mt.Spec.Template.Spec.Network.Devices[0].DHCP6).To(Equal(true))
+						Expect(mt.Spec.Template.Spec.Network.Devices[0].Nameservers).To(Equal(options.VSphere.Nameservers))
 
 						obj, _, _, _ = clusterClient.CreateResourceArgsForCall(2)
 						md := obj.(*capi.MachineDeployment)


### PR DESCRIPTION
This change updates the vsphere node pool definition to accept the tkg
ip family and nameservers. These properties will only be applied if the
network name is also given.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #1116 

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1116 

### Describe testing done for PR
Added unit tests to confirm properties are set correctly.
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Node pools on vSphere now properly set ip family and nameservers using properties tkgIPFamily and nameservers
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
