### PR TITLE
Fix panic on node-pool set with no cluster name

### DIFF
--- a/cmd/cli/plugin/cluster/set_node_pool.go
+++ b/cmd/cli/plugin/cluster/set_node_pool.go
@@ -27,6 +27,7 @@ var setNodePoolOptions clusterSetNodePoolCmdOptions
 var clusterSetNodePoolCmd = &cobra.Command{
 	Use:   "set CLUSTER_NAME",
 	Short: "Set node pool for cluster",
+	Args:  cobra.ExactArgs(1),
 	RunE:  runSetNodePool,
 }
 


### PR DESCRIPTION
updates cluster node-pool set command to enforce the cluster name arg to
avoid a panic.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #644  

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #644 

### Describe testing done for PR

Tested cluster node-pool set command without giving a cluster name. Confirmed that the appropriate cobra command help is displayed.
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
