### PR TITLE
Fix plugin download from OCI registry if bundle includes test directory

### DIFF
--- a/pkg/v1/cli/artifact/oci.go
+++ b/pkg/v1/cli/artifact/oci.go
@@ -4,7 +4,7 @@
 package artifact
 
 import (
-	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -36,7 +36,7 @@ func (g *OCIArtifact) Fetch() ([]byte, error) {
 
 	for path, fileData := range filesMap {
 		// Skip any testing related directory paths if bundled
-		if utils.ContainsString(filepath.SplitList(path), "test") {
+		if utils.ContainsString(strings.Split(path, "/"), "test") {
 			continue
 		}
 


### PR DESCRIPTION
### What this PR does / why we need it
- Fixes the issue if the OCI bundle includes the test directory.
- filepath.SplitList(path) was used incorrectly as it splits list of
  path based on ':' separator. Updated it to use string.Split

Signed-off-by: Anuj Chaudhari <anujc@vmware.com>
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1123

### Describe testing done for PR
- `tanzu plugin sync` with management context set and was able to download plugins successfully

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
