### PR TITLE
Remove nameservers and dualstack settings from clustergen models

### DIFF
--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
@@ -97,11 +97,7 @@ TKG_NO_PROXY: "NA", "10.0.200.1/24", "10.184.90.80"
 TKG_PROXY_CA_CERT: "NA", "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tClBST1hZIENBIENFUlQ="
 
 # ip family
-TKG_IP_FAMILY: "NA", "", "ipv4", "ipv6", "ipv4<comma>ipv6", "ipv6<comma>ipv4"
-
-# nameservers
-CONTROL_PLANE_NODE_NAMESERVERS: "NA", "", "8.8.8.8", "2001:4860:4860::8888"
-WORKER_NODE_NAMESERVERS: "NA", "", "8.8.8.8", "2001:4860:4860::8888"
+TKG_IP_FAMILY: "NA", "", "ipv4", "ipv6"
 
 # audit logging
 ENABLE_AUDIT_LOGGING: "true", "false"
@@ -140,13 +136,11 @@ IF [_INFRA] LIKE "\"vsphere:*" THEN [--VSPHERE-CONTROLPLANE-ENDPOINT] = "\"10.10
 IF [_INFRA] NOT LIKE "\"vsphere:*" THEN [--VSPHERE-CONTROLPLANE-ENDPOINT] = "\"NOTPROVIDED\"";
 
 IF [_INFRA] NOT LIKE "\"vsphere:*" THEN [OS_NAME] <> "\"photon\"";
-IF [_INFRA] NOT LIKE "\"vsphere:*" THEN [CONTROL_PLANE_NODE_NAMESERVERS] = "\"\"";
-IF [_INFRA] NOT LIKE "\"vsphere:*" THEN [WORKER_NODE_NAMESERVERS] = "\"\"";
 
 IF [TKG_HTTP_PROXY] = "\"http://10.0.200.100\"" THEN [TKG_HTTPS_PROXY] = "\"http://10.0.200.100\"";
 IF [TKG_HTTP_PROXY] LIKE "\"http://[fc00*" THEN [TKG_HTTPS_PROXY] <> "\"http://10.0.200.100\"";
 IF [TKG_IP_FAMILY] = "\"ipv6\"" THEN [SERVICE_CIDR] = "\"fd00:100:64::/108\"";
-IF [TKG_IP_FAMILY] IN { "NA", "", "ipv4" } THEN [SERVICE_CIDR] = "\"100.64.0.0/18\"";
-IF [TKG_IP_FAMILY] IN { "NA", "", "ipv4" } THEN [TKG_HTTPS_PROXY] <> "\"http://[fc00:f853:ccd:e793::1]:3128\"";
-IF [TKG_IP_FAMILY] IN { "NA", "", "ipv4" } THEN [TKG_HTTP_PROXY] = "\"http://10.0.200.100\"";
-IF [TKG_IP_FAMILY] IN { "NA", "", "ipv4" } THEN [CLUSTER_CIDR] <> "\"fd00:100:96::/48\"";
+IF [TKG_IP_FAMILY] IN { "\"NA\"", "\"\"", "\"ipv4\"" } THEN [SERVICE_CIDR] = "\"100.64.0.0/18\"";
+IF [TKG_IP_FAMILY] IN { "\"NA\"", "\"\"", "\"ipv4\"" } THEN [TKG_HTTPS_PROXY] <> "\"http://[fc00:f853:ccd:e793::1]:3128\"";
+IF [TKG_IP_FAMILY] IN { "\"NA\"", "\"\"", "\"ipv4\"" } THEN [TKG_HTTP_PROXY] = "\"http://10.0.200.100\"";
+IF [TKG_IP_FAMILY] IN { "\"NA\"", "\"\"", "\"ipv4\"" } THEN [CLUSTER_CIDR] <> "\"fd00:100:96::/48\"";


### PR DESCRIPTION

### What this PR does / why we need it
remove ipv4,ipv6 and ipv6,ipv4 from cluster_optional.model
remove custom nameservers from cluster_optional.model

These settings are feature-gated, which clustergen does not handle at
the moment. This is causing many negative test cases, which is
undesirable.

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
ran clustergen, noted the output does not contain related negative cases
### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access

