### PR TITLE
adapt ako's fix for avi resource deletion in k8s 1.22

### DIFF
--- a/pkg/v1/tkg/clusterclient/resource.go
+++ b/pkg/v1/tkg/clusterclient/resource.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -305,10 +304,8 @@ func VerifyCRSAppliedSuccessfully(obj crtclient.ObjectList) error {
 func VerifyAVIResourceCleanupFinished(obj crtclient.Object) error {
 	switch statefulSet := obj.(type) {
 	case *appsv1.StatefulSet:
-		for _, condition := range statefulSet.Status.Conditions {
-			if condition.Type == constants.AkoCleanupCondition && condition.Status == corev1.ConditionFalse {
-				return nil
-			}
+		if statefulSet.Annotations != nil && statefulSet.Annotations[constants.AkoCleanUpAnnotationKey] == constants.AkoCleanUpFinishedStatus {
+			return nil
 		}
 		return errors.Errorf("AVI Resource clean up in progress")
 	default:

--- a/pkg/v1/tkg/constants/cluster_internal.go
+++ b/pkg/v1/tkg/constants/cluster_internal.go
@@ -49,10 +49,11 @@ const (
 	TkrControllerDeploymentName  = "tkr-controller-manager"
 	KappControllerPackageName    = "kapp-controller"
 
-	AkoStatefulSetName  = "ako"
-	AkoAddonName        = "load-balancer-and-ingress-service"
-	AkoNamespace        = "avi-system"
-	AkoCleanupCondition = "ako.vmware.com/ObjectDeletionInProgress"
+	AkoStatefulSetName       = "ako"
+	AkoAddonName             = "load-balancer-and-ingress-service"
+	AkoNamespace             = "avi-system"
+	AkoCleanUpAnnotationKey  = "AviObjectDeletionStatus"
+	AkoCleanUpFinishedStatus = "Done"
 
 	ServiceDNSSuffix             = ".svc"
 	ServiceDNSClusterLocalSuffix = ".svc.cluster.local"


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

### What this PR does / why we need it

Adapt AKO's fix to use annotations to show the resources deletion status in k8s 1.22.

See this: https://github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/pull/688 for details.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

- Launched a bolt MR to test full TKG on vsphere lifecycle with this change and it passed.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
This changes to wait for AKO statefulset annotations instead of status for AKO cleanup AVI resources because of AKO k8s 1.22 fixing.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->

/kind bug