### PR TITLE
Add log-file flag to package plugin commands

### DIFF
--- a/cmd/cli/plugin/package/display_utils.go
+++ b/cmd/cli/plugin/package/display_utils.go
@@ -37,16 +37,18 @@ func DisplayProgress(initialMsg string, pp *tkgpackagedatamodel.PackageProgress)
 		if s, err = newSpinner(); err != nil {
 			return err
 		}
-		log.Infof("\n")
+		writeToStdout("\n")
 		s.Suffix = fmt.Sprintf(" %s", msg)
 		s.Start()
 		return nil
 	}
 
+	writeToLogFile(initialMsg)
 	s.Suffix = fmt.Sprintf(" %s", initialMsg)
 	s.Start()
 
 	defer func() {
+		log.QuietMode(false)
 		s.Stop()
 	}()
 	for {
@@ -59,6 +61,7 @@ func DisplayProgress(initialMsg string, pp *tkgpackagedatamodel.PackageProgress)
 				if err := writeProgress(s, msg); err != nil {
 					return err
 				}
+				writeToLogFile(msg)
 				currMsg = msg
 			}
 		case <-pp.Done:
@@ -73,5 +76,21 @@ func DisplayProgress(initialMsg string, pp *tkgpackagedatamodel.PackageProgress)
 			}
 			return nil
 		}
+	}
+}
+
+func writeToLogFile(msg string) {
+	log.QuietMode(true)
+	log.SetFile(logFile)
+	if msg != "" {
+		log.Infof(msg)
+	}
+}
+
+func writeToStdout(msg string) {
+	log.QuietMode(false)
+	log.SetFile("")
+	if msg != "" {
+		log.Infof(msg)
 	}
 }

--- a/cmd/cli/plugin/package/main.go
+++ b/cmd/cli/plugin/package/main.go
@@ -21,6 +21,7 @@ var descriptor = cliv1alpha1.PluginDescriptor{
 }
 
 var logLevel int32
+var logFile string
 var outputFormat string
 
 func main() {
@@ -30,6 +31,7 @@ func main() {
 	}
 
 	p.Cmd.PersistentFlags().Int32VarP(&logLevel, "verbose", "", 0, "Number for the log level verbosity(0-9)")
+	p.Cmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Log file path")
 
 	p.AddCommands(
 		repositoryCmd,

--- a/cmd/cli/plugin/package/package_available_get.go
+++ b/cmd/cli/plugin/package/package_available_get.go
@@ -57,6 +57,8 @@ func validatePackage(cmd *cobra.Command, args []string) error {
 }
 
 func packageAvailableGet(cmd *cobra.Command, args []string) error {
+	log.SetFile(logFile)
+
 	kc, kcErr := kappclient.NewKappClient(packageAvailableOp.KubeConfig)
 	if kcErr != nil {
 		return kcErr

--- a/cmd/cli/plugin/package/package_available_list.go
+++ b/cmd/cli/plugin/package/package_available_list.go
@@ -36,6 +36,8 @@ func init() {
 }
 
 func packageAvailableList(cmd *cobra.Command, args []string) error {
+	log.SetFile(logFile)
+
 	kc, err := kappclient.NewKappClient(packageAvailableOp.KubeConfig)
 	if err != nil {
 		return err

--- a/cmd/cli/plugin/package/package_install.go
+++ b/cmd/cli/plugin/package/package_install.go
@@ -68,7 +68,6 @@ func packageInstall(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Infof("\n %s", fmt.Sprintf("Added installed package '%s'",
-		packageInstallOp.PkgInstallName))
+	log.Infof(fmt.Sprintf("Added installed package '%s'", packageInstallOp.PkgInstallName))
 	return nil
 }

--- a/cmd/cli/plugin/package/package_installed_delete.go
+++ b/cmd/cli/plugin/package/package_installed_delete.go
@@ -65,6 +65,6 @@ func packageUninstall(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Infof("%s", fmt.Sprintf("Uninstalled package '%s' from namespace '%s'", packageInstalledOp.PkgInstallName, packageInstalledOp.Namespace))
+	log.Infof(fmt.Sprintf("Uninstalled package '%s' from namespace '%s'", packageInstalledOp.PkgInstallName, packageInstalledOp.Namespace))
 	return nil
 }

--- a/cmd/cli/plugin/package/package_installed_get.go
+++ b/cmd/cli/plugin/package/package_installed_get.go
@@ -36,6 +36,8 @@ func init() {
 }
 
 func packageInstalledGet(cmd *cobra.Command, args []string) error {
+	log.SetFile(logFile)
+
 	kc, err := kappclient.NewKappClient(packageInstalledOp.KubeConfig)
 	if err != nil {
 		return err

--- a/cmd/cli/plugin/package/package_installed_update.go
+++ b/cmd/cli/plugin/package/package_installed_update.go
@@ -74,6 +74,6 @@ func packageUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Infof("%s", fmt.Sprintf("Updated installed package '%s' in namespace '%s'", packageInstalledOp.PkgInstallName, packageInstalledOp.Namespace))
+	log.Infof(fmt.Sprintf("Updated installed package '%s' in namespace '%s'", packageInstalledOp.PkgInstallName, packageInstalledOp.Namespace))
 	return nil
 }

--- a/pkg/v1/tkg/fakes/kappclient.go
+++ b/pkg/v1/tkg/fakes/kappclient.go
@@ -4,14 +4,15 @@ package fakes
 import (
 	"sync"
 
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	v1alpha1a "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	v1alpha1b "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
 	v1alpha1c "github.com/vmware-tanzu/carvel-secretgen-controller/pkg/apis/secretgen2/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/kappclient"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
-	v1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type KappClient struct {

--- a/pkg/v1/tkg/tkgpackageclient/repository_get.go
+++ b/pkg/v1/tkg/tkgpackageclient/repository_get.go
@@ -7,21 +7,15 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	kappipkg "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
 )
 
 func (p *pkgClient) GetRepository(o *tkgpackagedatamodel.RepositoryOptions) (*kappipkg.PackageRepository, error) {
 	packageRepository, err := p.kappClient.GetPackageRepository(o.RepositoryName, o.Namespace)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Warningf("package repository '%s' does not exist in namespace '%s'", o.RepositoryName, o.Namespace)
-			return nil, nil
-		}
 		return nil, errors.Wrap(err, fmt.Sprintf("failed to find package repository '%s' in namespace '%s'", o.RepositoryName, o.Namespace))
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it:**
- This PR is to add log-file flag to package plugin commands
- Addressed https://github.com/vmware-tanzu/tanzu-framework/issues/338

**Describe testing done for PR:**
existing integration tests

**Does this PR introduce a user-facing change?:**
None

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
adds log-file flag to package plugin commands
```

**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
