### PR TITLE
Implement automation to create dev tag retrieval PR as part release automation

### DIFF
--- a/.github/workflows/dev_tag_retrieval_pr.yaml
+++ b/.github/workflows/dev_tag_retrieval_pr.yaml
@@ -1,0 +1,84 @@
+name: Release - Dev Tag Retrieval PR Generator
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.0"
+      - "!*-*"
+jobs:
+  gen_dev_tag_retrieval_pr:
+    name: Generate Dev Tag Retrieval PR
+    # Only run this job if we're in the main repo, not a fork.
+    if: github.repository == 'vmware-tanzu/tanzu-framework'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v1
+
+      - name: Fetch current version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: Increment Version to dev
+        id: next_version
+        run: |
+          IFS='.' read -ra ver <<< "${{ steps.get_version.outputs.VERSION }}"
+          patch=${ver[2]}
+          minor=${ver[1]}
+          major=${ver[0]}
+          patch=0
+          minor=$((minor+1))
+          echo ::set-output name=NEXT_VERSION::$major.$minor.$patch-dev
+
+      - name: Update version in file
+        run: sed -i -e "/TKGManagementClusterPluginVersion/ s/= .*/= \"${{ steps.next_version.outputs.NEXT_VERSION }}\"/" pkg/v1/tkg/tkgconfigpaths/zz_bundled_default_bom_files_configdata.go
+
+      - name: Set variables
+        id: vars
+        run: |
+          body=$(cat  << EOF
+          ### What this PR does / why we need it
+          Updating version tag used for BOM retrieval to ${{ steps.next_version.outputs.NEXT_VERSION }}\
+
+          ### Which issue(s) this PR fixes
+
+          Fixes #
+
+          ### Describe testing done for PR
+
+          ### Release note
+          ```release-note
+
+          ```
+
+          ### PR Checklist
+
+          - [x] Squash the commits into one or a small number of logical commits
+          - [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
+          - [x] Ensure PR contains terms all contributors can understand and links all contributors can access
+
+
+          ### Additional information
+
+          #### Special notes for your reviewer
+          EOF
+          )
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo ::set-output name=pr_title::"Update the BOM retrieval version to ${{ steps.next_version.outputs.NEXT_VERSION }}"
+          echo ::set-output name=commit_message::"Update the BOM retrieval version to ${{ steps.next_version.outputs.NEXT_VERSION }}"
+          echo ::set-output name=pr_body::$body
+          echo ::set-output name=pr_branch::"topic/releng/rel${{ steps.next_version.outputs.NEXT_VERSION }}"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          branch: ${{ steps.vars.outputs.pr_branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
+          title: ${{ steps.vars.outputs.pr_title }}
+          commit-message: ${{ steps.vars.outputs.commit_message }}
+          body: ${{ steps.vars.outputs.pr_body }}
+          delete-branch: true
+          labels: |
+            area/release


### PR DESCRIPTION
### What this PR does / why we need it
Automate workflow to create PR for dev tag retrieval when a new release tag is created

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #
As part of the release process, we need to create PR for dev tag to be pointing to next version(vX.Y.Z to vX.[Y+1].Z-dev) - dev tag retrieval PR. This workflow is part of the same to automate the whole process of the PR creation.

- This workflow gets triggered when a new release tag is generated(matching pattern  v[0-9]+.[0-9]+.0)

The below is the snapshot of the PR that gets generated:
![image](https://user-images.githubusercontent.com/89133855/142240308-f192f490-8228-4951-a7d9-3c4c4b82e2ea.png)

![image](https://user-images.githubusercontent.com/89133855/142240611-82a2e8f3-a9ac-421a-ba0a-7ae1fd2be5fd.png)

![image](https://user-images.githubusercontent.com/89133855/142240681-1d3c5c66-d5fe-4cea-a095-3ffb4a199040.png)


### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
