### PR TITLE
Send both IP families to vsphere-cpi

### DIFF
--- a/pkg/v1/providers/tests/unit/ip_family_test.go
+++ b/pkg/v1/providers/tests/unit/ip_family_test.go
@@ -686,7 +686,7 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 				})
 			})
 			When("TKG_IP_FAMILY is ipv4,ipv6", func() {
-				It("configure the CPI for ipv4 only", func() {
+				It("configure the CPI for ipv4 and ipv6", func() {
 					values := createDataValues(map[string]string{
 						"PROVIDER_TYPE": "vsphere",
 						"TKG_IP_FAMILY": "ipv4,ipv6",
@@ -694,9 +694,19 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
 					Expect(err).NotTo(HaveOccurred())
 
-					// TODO: change this to ipv4,ipv6 once this issue is resolved:
-					// https://github.com/kubernetes/cloud-provider-vsphere/issues/302
-					Expect(output).To(HaveYAMLPathWithValue(ipFamilyPath, "ipv4"))
+					Expect(output).To(HaveYAMLPathWithValue(ipFamilyPath, "ipv4,ipv6"))
+				})
+			})
+			When("TKG_IP_FAMILY is ipv6,ipv4", func() {
+				It("configure the CPI for ipv6 and ipv4", func() {
+					values := createDataValues(map[string]string{
+						"PROVIDER_TYPE": "vsphere",
+						"TKG_IP_FAMILY": "ipv6,ipv4",
+					})
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(output).To(HaveYAMLPathWithValue(ipFamilyPath, "ipv6,ipv4"))
 				})
 			})
 		})

--- a/pkg/v1/providers/vendir.lock.yml
+++ b/pkg/v1/providers/vendir.lock.yml
@@ -2,10 +2,10 @@ apiVersion: vendir.k14s.io/v1alpha1
 directories:
 - contents:
   - git:
-      commitTitle: Add prefix to data hash, so it cannot be parsed as integer. (#2694)
-      sha: 3b497a299c4d67377ca30036bd38e934794ca0f8
+      commitTitle: update vsphere-cpi validations to allow dualstack (#2734)...
+      sha: 165340fbaf9d7729c84434471d5a190f6096c492
       tags:
-      - v0.10.0-dev.4-29-g3b497a29
+      - v0.10.0-dev.4-43-g165340fb
     path: .
   path: ytt/vendir/vsphere_cpi/_ytt_lib
 - contents:

--- a/pkg/v1/providers/vendir.yml
+++ b/pkg/v1/providers/vendir.yml
@@ -5,8 +5,8 @@ directories:
   contents:
   - path: .
     git:
-      url: git@github.com:vmware-tanzu/tce.git
-      ref: 3b497a299c4d67377ca30036bd38e934794ca0f8
+      url: git@github.com:vmware-tanzu/community-edition.git
+      ref: 165340fbaf9d7729c84434471d5a190f6096c492
     includePaths:
     - addons/packages/vsphere-cpi/1.22.4/bundle/config/**/*
 - path: ytt/vendir/cni/_ytt_lib

--- a/pkg/v1/providers/ytt/02_addons/cpi/cpi_addon_data.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/cpi/cpi_addon_data.lib.yaml
@@ -16,10 +16,7 @@ vsphereCPI:
   zone: #@ data.values.VSPHERE_ZONE
   insecureFlag: #@ data.values.VSPHERE_INSECURE
 #@ if data.values.TKG_IP_FAMILY:
-  #! For now, use the first ipFamily when TKG_IP_FAMILY is a dual stack value (ipv4,ipv6 or ipv6,ipv4)
-  #! TODO: stop doing this when this issue is resolved:
-  #! https://github.com/kubernetes/cloud-provider-vsphere/issues/302
-  ipFamily: #@ data.values.TKG_IP_FAMILY.split(",")[0]
+  ipFamily: #@ data.values.TKG_IP_FAMILY
 #@ end
 #@ if data.values.TKG_CLUSTER_ROLE == "workload": #! For backwards compatibility. i.e. C.1 mgmt cluster creates a C.0 wlc with older addon templates.
   image:

--- a/pkg/v1/providers/ytt/vendir/vsphere_cpi/_ytt_lib/addons/packages/vsphere-cpi/1.22.4/bundle/config/values.star
+++ b/pkg/v1/providers/ytt/vendir/vsphere_cpi/_ytt_lib/addons/packages/vsphere-cpi/1.22.4/bundle/config/values.star
@@ -9,8 +9,8 @@ def validate_vsphereCPI():
    if not data.values.vsphereCPI.insecureFlag:
      data.values.vsphereCPI.tlsThumbprint or assert.fail("vsphereCPI tlsThumbprint should be provided when insecureFlag is False")
    end
-   if data.values.vsphereCPI.ipFamily and (data.values.vsphereCPI.ipFamily not in ["ipv4", "ipv6"]):
-     assert.fail("vsphereCPI ipFamily should be either ipv4 or ipv6 if provided")
+   if data.values.vsphereCPI.ipFamily and (data.values.vsphereCPI.ipFamily not in ["ipv4", "ipv6", "ipv4,ipv6", "ipv6,ipv4"]):
+     assert.fail("vsphereCPI ipFamily should be one of \"ipv4\", \"ipv6\", \"ipv4,ipv6\", or \"ipv6,ipv4\" if provided")
    end
 end
 


### PR DESCRIPTION
### What this PR does / why we need it

for dual-stack support

The CPI had previously not been able to accommodate receiving both IP families, causing undesired behavior.
Now that the CPI has been fixed and bumped, send both IP families.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

#616

### Describe testing done for PR

deployed updated package to test cluster, verified dualstack TKG_IP_FAMILY can be deployed

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Nodes include secondary IP family when dual stack clusters are deployed on vSphere
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
