### PR TITLE
Registry CA cert will be used when copying images

### DIFF
--- a/hack/gen-publish-images-fromtar.sh
+++ b/hack/gen-publish-images-fromtar.sh
@@ -2,7 +2,7 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set -euo pipefail
+set -eo pipefail
 
 TANZU_BOM_DIR=${HOME}/.config/tanzu/tkg/bom
 INSTALL_INSTRUCTIONS='See https://github.com/mikefarah/yq#install for installation instructions'
@@ -43,7 +43,20 @@ function imgpkg_copy() {
     echo "imgpkg copy --tar $src.tar --to-repo $dst"
 }
 
-echo "set -euo pipefail"
+if [ -n "$TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE" ]; then
+  function imgpkg_copy() {
+      src=$1
+      dst=$2
+      echo ""
+      echo "imgpkg copy --tar $src.tar --to-repo $dst --registry-ca-cert-path /tmp/cacrtbase64d.crt"
+  }
+fi
+
+echo "set -eo pipefail"
+echo 'if [ -n "$TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE" ]; then
+  echo $TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE > /tmp/cacrtbase64
+  base64 -d /tmp/cacrtbase64 > /tmp/cacrtbase64d.crt
+fi'
 echodual "Note that yq must be version above or equal to version 4.9.2 and below version 5."
 
 actualImageRepository="$TKG_IMAGE_REPO"


### PR DESCRIPTION
### What this PR does / why we need it
TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE is not used while copying the images to image registry in airgap environment. This PR will add that capability.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1201

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Tested the script to see if the resultant publish-images-fromtar.sh script uses the variable.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixes the issue where gen-publish-images-fromtar.sh script fails to use the certificate set in environment variable while copying the images to private registry.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
