### PR TITLE
Fix windows plugin invocation when context-aware discovery is enabled

### DIFF
--- a/pkg/v1/cli/runner.go
+++ b/pkg/v1/cli/runner.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/aunum/log"
 
@@ -72,7 +73,7 @@ func (r *Runner) RunOutput(ctx context.Context) (string, string, error) {
 // execution is emitted to os.Stdout and os.Stderr respectively. Otherwise any command output
 // is captured in the bytes.Buffer.
 func (r *Runner) run(ctx context.Context, pluginPath string, stdout, stderr *bytes.Buffer) error {
-	if BuildArch().IsWindows() {
+	if BuildArch().IsWindows() && !strings.HasSuffix(pluginPath, ".exe") {
 		pluginPath += ".exe"
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it

- Fixes the issue related to multiple '.exe' getting added to the
  windows binary invocation
- As `catalog.yaml` file which saves the `pluginPath` already includes
  '.exe' suffix, when invoking the binary as part of runner we do not
  need to add '.exe' suffix

Signed-off-by: Anuj Chaudhari <anujc@vmware.com>

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1204

### Describe testing done for PR

- Tested the plugin installation and invocation on windows environment 

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix windows plugin invocation issue on windows environments
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
