### PR TITLE
UI Fixes AWS link in tooltip inaccessible

### DIFF
--- a/pkg/v1/tkg/web/src/app/views/landing/aws-wizard/provider-step/aws-provider-step.component.html
+++ b/pkg/v1/tkg/web/src/app/views/landing/aws-wizard/provider-step/aws-provider-step.component.html
@@ -122,6 +122,7 @@
             in the UI.
             <br/><br/>
             Credential profiles can be <a href="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-profiles" target="_blank">configured using the AWS CLI</a>.
+            These profiles are loaded automatically following the <a target="_blank" href="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-precedence">AWS CLI precendence rules</a>.
         </p>
         <div class="clr-row">
             <div class="clr-col-4">
@@ -132,7 +133,7 @@
                             <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                             <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
                                 <span>
-                                    AWS Credential Profiles <a target="_blank" href="https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-precedence">are loaded automatically following the AWS CLI precedence rules.</a>.
+                                    Select an existing AWS credential profile. These profiles contain your AWS access key information.
                                 </span>
                             </clr-tooltip-content>
                         </clr-tooltip>


### PR DESCRIPTION
Corrects error of putting a hyperlink in AWS credential profile tooltip, which is inaccessible to users

### Which issue(s) this PR fixes
Fixes #1174

### Describe testing done for PR

Verified on local dev environment that tooltip is corrected. Link has been moved to description on step.


### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
