### PR TITLE
Support set/unset environment variables through tanzu config file

### DIFF
--- a/apis/config/v1alpha1/clientconfig.go
+++ b/apis/config/v1alpha1/clientconfig.go
@@ -88,12 +88,11 @@ func (c *ClientConfig) IsConfigFeatureActivated(featurePath string) (bool, error
 
 // GetEnvConfigurations returns a map of environment variables to values
 // it returns nil if configuration is not yet defined
-func (c *ClientConfig) GetEnvConfigurations(plugin string) EnvMap {
-	if c.ClientOptions == nil || c.ClientOptions.Env == nil ||
-		c.ClientOptions.Env[plugin] == nil {
+func (c *ClientConfig) GetEnvConfigurations() map[string]string {
+	if c.ClientOptions == nil || c.ClientOptions.Env == nil {
 		return nil
 	}
-	return c.ClientOptions.Env[plugin]
+	return c.ClientOptions.Env
 }
 
 // SplitFeaturePath splits a features path into the pluginName and the featureName

--- a/apis/config/v1alpha1/clientconfig_types.go
+++ b/apis/config/v1alpha1/clientconfig_types.go
@@ -93,7 +93,7 @@ type ClientOptions struct {
 	// CLI options specific to the CLI.
 	CLI      *CLIOptions           `json:"cli,omitempty" yaml:"cli"`
 	Features map[string]FeatureMap `json:"features,omitempty" yaml:"features"`
-	Env      map[string]EnvMap     `json:"env,omitempty" yaml:"env"`
+	Env      map[string]string     `json:"env,omitempty" yaml:"env"`
 }
 
 // FeatureMap is simply a hash table, but needs an explicit type to be an object in another hash map (cf ClientOptions.Features)

--- a/pkg/v1/cli/command/core/config_test.go
+++ b/pkg/v1/cli/command/core/config_test.go
@@ -90,35 +90,22 @@ func Test_config_Feature(t *testing.T) {
 	}
 }
 
-// Test_config_GlobalEnv validates functionality when env feature path argument is provided.
-func Test_config_GlobalEnv(t *testing.T) {
+// Test_config_SetUnsetEnv validates set and unset functionality when env config path argument is provided.
+func Test_config_SetUnsetEnv(t *testing.T) {
+	assert := assert.New(t)
+
 	cfg := &configv1alpha1.ClientConfig{}
 	value := "baar"
-	err := setConfiguration(cfg, "env.global.foo", value)
-	if err != nil {
-		t.Errorf("Unexpected error returned for global env path argument: %s", err.Error())
-	}
+	err := setConfiguration(cfg, "env.foo", value)
+	assert.Nil(err)
+	assert.Equal(value, cfg.ClientOptions.Env["foo"])
 
-	if cfg.ClientOptions.Env["global"]["foo"] != value {
-		t.Error("cfg.ClientOptions.Env[\"global\"][\"foo\"] was not assigned the value \"" + value + "\"")
-	}
+	err = unsetConfiguration(cfg, "env.foo")
+	assert.Nil(err)
+	assert.Equal(cfg.ClientOptions.Env["foo"], "")
 }
 
-// Test_config_Env validates functionality when normal env path argument is provided.
-func Test_config_Env(t *testing.T) {
-	cfg := &configv1alpha1.ClientConfig{}
-	value := "baarr"
-	err := setConfiguration(cfg, "env.any-plugin.foo", value)
-	if err != nil {
-		t.Errorf("Unexpected error returned for any-plugin env path argument: %s", err.Error())
-	}
-
-	if cfg.ClientOptions.Env["any-plugin"]["foo"] != value {
-		t.Error("cfg.ClientOptions.Features[\"any-plugin\"][\"foo\"] was not assigned the value \"" + value + "\"")
-	}
-}
-
-// Test_config_Env validates functionality when normal env path argument is provided.
+// Test_config_IncorrectConfigLiteral validates incorrect config literal
 func Test_config_IncorrectConfigLiteral(t *testing.T) {
 	assert := assert.New(t)
 
@@ -126,5 +113,5 @@ func Test_config_IncorrectConfigLiteral(t *testing.T) {
 	value := "b"
 	err := setConfiguration(cfg, "fake.any-plugin.foo", value)
 	assert.NotNil(err)
-	assert.Contains(err.Error(), "unsupported config path parameter [fake] (was expecting 'features.<plugin>.<feature>' or 'env.<plugin>.<env_variable>')")
+	assert.Contains(err.Error(), "unsupported config path parameter [fake] (was expecting 'features.<plugin>.<feature>' or 'env.<env_variable>')")
 }

--- a/pkg/v1/cli/command/core/root.go
+++ b/pkg/v1/cli/command/core/root.go
@@ -44,6 +44,9 @@ func NewRootCmd() (*cobra.Command, error) {
 		color = false
 	}
 
+	// configure defined environment variables under tanzu config file
+	config.ConfigureEnvVariables()
+
 	au := aurora.NewAurora(color)
 	RootCmd.Short = au.Bold(`Tanzu CLI`).String()
 
@@ -77,11 +80,6 @@ func NewRootCmd() (*cobra.Command, error) {
 			return nil, err
 		}
 	}
-
-	// configure defined global environment variables
-	// under tanzu config file
-	// global environment variables can be defined as `env.global.FOO`
-	config.ConfigureEnvVariables("global")
 
 	for _, plugin := range plugins {
 		RootCmd.AddCommand(cli.GetCmd(plugin))

--- a/pkg/v1/cli/runner.go
+++ b/pkg/v1/cli/runner.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 
 	"github.com/aunum/log"
-
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 )
 
 // Runner is a plugin runner.
@@ -41,9 +39,6 @@ func NewRunner(name, pluginAbsPath string, args []string, options ...Option) *Ru
 
 // Run runs a plugin.
 func (r *Runner) Run(ctx context.Context) error {
-	// configures plugin specific environment variables
-	// defined under tanzu config file
-	config.ConfigureEnvVariables(r.name)
 	return r.runStdOutput(ctx, r.pluginPath())
 }
 

--- a/pkg/v1/config/clientconfig.go
+++ b/pkg/v1/config/clientconfig.go
@@ -556,19 +556,18 @@ func GetDiscoverySources(serverName string) []configv1alpha1.PluginDiscovery {
 // GetEnvConfigurations returns a map of configured environment variables
 // to values as part of tanzu configuration file
 // it returns nil if configuration is not yet defined
-func GetEnvConfigurations(plugin string) configv1alpha1.EnvMap {
+func GetEnvConfigurations() map[string]string {
 	cfg, err := GetClientConfig()
 	if err != nil {
 		return nil
 	}
-	return cfg.GetEnvConfigurations(plugin)
+	return cfg.GetEnvConfigurations()
 }
 
 // ConfigureEnvVariables reads and configures provided environment variables
-// as part of tanzu configuration file based on the provided plugin name
-// plugin can be a name of the plugin or 'global' if it generic variable
-func ConfigureEnvVariables(plugin string) {
-	envMap := GetEnvConfigurations(plugin)
+// as part of tanzu configuration file
+func ConfigureEnvVariables() {
+	envMap := GetEnvConfigurations()
 	if envMap == nil {
 		return
 	}


### PR DESCRIPTION
### What this PR does / why we need it

- The change allows users to configure env variables as part of tanzu
  config file
- Env configuration can be set using `tanzu config set env.<variable> <value>`
  command
- User can unset the already configured settings with the new `tanzu config
  unset env.<variable>` command
- In the case of conflicts, meaning the user has set environment variable
  outside tanzu config file with `export FOO=bar` and as part of tanzu
  config file, higher precedence is given to the user-configured environment
  variable to allow the user to override config for one-off command runs

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1035

### Describe testing done for PR

- tanzu config set env.FOO bar
- tanzu config set env.FOO1 baz
- tanzu config unset env.FOO
- tanzu config unset env.FOO1

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix `tanzu config set env` command to not be namespace-based
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
