### PR TITLE
Update references to old config directory

### DIFF
--- a/docs/cli/commands/tanzu_completion.md
+++ b/docs/cli/commands/tanzu_completion.md
@@ -27,8 +27,10 @@ tanzu completion [bash zsh]
   source <(tanzu completion bash)
 
   ## Load for all new sessions:
-  tanzu completion bash >  $HOME/.tanzu/completion.bash.inc
-  printf "\n# Tanzu shell completion\nsource '$HOME/.tanzu/completion.bash.inc'\n" >> $HOME/.bash_profile
+  tanzu completion bash >  $HOME/.config/tanzu/completion.bash.inc
+  printf "\n# Tanzu shell completion\nsource '$HOME/.config/tanzu/completion.bash.inc'\n" >> $HOME/.bash_profile
+
+  ## NOTE: the bash-completion package must be installed.
 
 # Zsh instructions:
 

--- a/pkg/v1/cli/command/core/completion.go
+++ b/pkg/v1/cli/command/core/completion.go
@@ -38,8 +38,10 @@ var (
 		  source <(tanzu completion bash)
 
 		  ## Load for all new sessions:
-		  tanzu completion bash >  $HOME/.tanzu/completion.bash.inc
-		  printf "\n# Tanzu shell completion\nsource '$HOME/.tanzu/completion.bash.inc'\n" >> $HOME/.bash_profile
+		  tanzu completion bash >  $HOME/.config/tanzu/completion.bash.inc
+		  printf "\n# Tanzu shell completion\nsource '$HOME/.config/tanzu/completion.bash.inc'\n" >> $HOME/.bash_profile
+
+		  ## NOTE: the bash-completion package must be installed.
 
 		# Zsh instructions:
 


### PR DESCRIPTION
### What this PR does / why we need it

Some of our completion docs still referenced the old `~/.tanzu`
directory path. This updates those references to refer to the current
`.config/tanzu` directory.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1214

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access
