### PR TITLE
create namespace prior to metadata check

### DIFF
--- a/pkg/v1/tkg/fakes/kappclient.go
+++ b/pkg/v1/tkg/fakes/kappclient.go
@@ -4,14 +4,15 @@ package fakes
 import (
 	"sync"
 
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	v1alpha1a "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/kappctrl/v1alpha1"
 	"github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	v1alpha1b "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
 	v1alpha1c "github.com/vmware-tanzu/carvel-secretgen-controller/pkg/apis/secretgen2/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/kappclient"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgpackagedatamodel"
-	v1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type KappClient struct {

--- a/pkg/v1/tkg/test/tkgpackageclient/package_plugin_integration_test.go
+++ b/pkg/v1/tkg/test/tkgpackageclient/package_plugin_integration_test.go
@@ -386,59 +386,59 @@ func cleanup() {
 
 func testHelper() {
 	/*
-	TODO: Fix tests for secret registry plugin
-	By("trying to update package repository with a private URL")
-	repoOptions.RepositoryURL = config.RepositoryURLPrivate
-	repoOptions.CreateRepository = true
-	repoOptions.PollTimeout = 20 * time.Second
-	result = packagePlugin.UpdateRepository(&repoOptions)
-	Expect(result.Error).To(HaveOccurred())
+		TODO: Fix tests for secret registry plugin
+		By("trying to update package repository with a private URL")
+		repoOptions.RepositoryURL = config.RepositoryURLPrivate
+		repoOptions.CreateRepository = true
+		repoOptions.PollTimeout = 20 * time.Second
+		result = packagePlugin.UpdateRepository(&repoOptions)
+		Expect(result.Error).To(HaveOccurred())
 
-	By("add registry secret")
-	imgPullSecretOptions.Username = testRegistryUsername
-	imgPullSecretOptions.PasswordInput = testRegistryPassword
-	imgPullSecretOptions.Server = testRegistry
-	resultImgPullSecret = secretPlugin.AddRegistrySecret(&imgPullSecretOptions)
-	Expect(resultImgPullSecret.Error).ToNot(HaveOccurred())
+		By("add registry secret")
+		imgPullSecretOptions.Username = testRegistryUsername
+		imgPullSecretOptions.PasswordInput = testRegistryPassword
+		imgPullSecretOptions.Server = testRegistry
+		resultImgPullSecret = secretPlugin.AddRegistrySecret(&imgPullSecretOptions)
+		Expect(resultImgPullSecret.Error).ToNot(HaveOccurred())
 
-	By("update registry secret to export the secret from default namespace to all namespaces")
-	t := true
-	imgPullSecretOptions.Export = tkgpackagedatamodel.TypeBoolPtr{ExportToAllNamespaces: &t}
-	resultImgPullSecret = secretPlugin.UpdateRegistrySecret(&imgPullSecretOptions)
-	Expect(resultImgPullSecret.Error).ToNot(HaveOccurred())
+		By("update registry secret to export the secret from default namespace to all namespaces")
+		t := true
+		imgPullSecretOptions.Export = tkgpackagedatamodel.TypeBoolPtr{ExportToAllNamespaces: &t}
+		resultImgPullSecret = secretPlugin.UpdateRegistrySecret(&imgPullSecretOptions)
+		Expect(resultImgPullSecret.Error).ToNot(HaveOccurred())
 
-	By("list registry secret")
-	resultImgPullSecret = secretPlugin.ListRegistrySecret(&imgPullSecretOptions)
-	Expect(resultImgPullSecret.Error).ToNot(HaveOccurred())
-	err = json.Unmarshal(resultImgPullSecret.Stdout.Bytes(), &imgPullSecretOutput)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(len(imgPullSecretOutput)).To(BeNumerically(">=", 1))
+		By("list registry secret")
+		resultImgPullSecret = secretPlugin.ListRegistrySecret(&imgPullSecretOptions)
+		Expect(resultImgPullSecret.Error).ToNot(HaveOccurred())
+		err = json.Unmarshal(resultImgPullSecret.Stdout.Bytes(), &imgPullSecretOutput)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(imgPullSecretOutput)).To(BeNumerically(">=", 1))
 
-	By("wait for the private package repository reconciliation")
-	repoOptions.RepositoryURL = config.RepositoryURLPrivate
-	repoOptions.CreateRepository = true
-	repoOptions.PollInterval = pollInterval
-	repoOptions.PollTimeout = pollTimeout
-	result = packagePlugin.CheckRepositoryAvailable(&repoOptions)
-	Expect(result.Error).ToNot(HaveOccurred())
+		By("wait for the private package repository reconciliation")
+		repoOptions.RepositoryURL = config.RepositoryURLPrivate
+		repoOptions.CreateRepository = true
+		repoOptions.PollInterval = pollInterval
+		repoOptions.PollTimeout = pollTimeout
+		result = packagePlugin.CheckRepositoryAvailable(&repoOptions)
+		Expect(result.Error).ToNot(HaveOccurred())
 
-	By("list package repository")
-	repoOptions.AllNamespaces = true
-	result = packagePlugin.ListRepository(&repoOptions)
-	Expect(result.Error).ToNot(HaveOccurred())
-	err = json.Unmarshal(result.Stdout.Bytes(), &repoOutput)
-	Expect(err).ToNot(HaveOccurred())
+		By("list package repository")
+		repoOptions.AllNamespaces = true
+		result = packagePlugin.ListRepository(&repoOptions)
+		Expect(result.Error).ToNot(HaveOccurred())
+		err = json.Unmarshal(result.Stdout.Bytes(), &repoOutput)
+		Expect(err).ToNot(HaveOccurred())
 
-	By("get package repository")
-	repoOutput = []repositoryOutput{{Namespace: testNamespace}}
-	result = packagePlugin.GetRepository(&repoOptions)
-	Expect(result.Error).ToNot(HaveOccurred())
-	err = json.Unmarshal(result.Stdout.Bytes(), &repoOutput)
-	Expect(err).ToNot(HaveOccurred())
-	Expect(len(repoOutput)).To(BeNumerically("==", 1))
-	Expect(repoOutput[0]).To(Equal(expectedRepoOutputPrivate))
+		By("get package repository")
+		repoOutput = []repositoryOutput{{Namespace: testNamespace}}
+		result = packagePlugin.GetRepository(&repoOptions)
+		Expect(result.Error).ToNot(HaveOccurred())
+		err = json.Unmarshal(result.Stdout.Bytes(), &repoOutput)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(repoOutput)).To(BeNumerically("==", 1))
+		Expect(repoOutput[0]).To(Equal(expectedRepoOutputPrivate))
 	*/
-	
+
 	By("update package repository with a new URL without tag")
 	repoOptions.RepositoryURL = config.RepositoryURLNoTag
 	repoOptions.CreateRepository = true

--- a/pkg/v1/tkg/tkgpackageclient/package_install.go
+++ b/pkg/v1/tkg/tkgpackageclient/package_install.go
@@ -66,17 +66,17 @@ func (p *pkgClient) InstallPackage(o *tkgpackagedatamodel.PackageOptions, progre
 		return
 	}
 
-	progress.ProgressMsg <- fmt.Sprintf("Getting package metadata for '%s'", o.PackageName)
-	if _, _, err = p.GetPackage(o); err != nil {
-		return
-	}
-
 	if o.CreateNamespace {
 		progress.ProgressMsg <- fmt.Sprintf("Creating namespace '%s'", o.Namespace)
 		if err = p.createNamespace(o.Namespace); err != nil {
 			return
 		}
 	} else if err = p.kappClient.GetClient().Get(context.Background(), crtclient.ObjectKey{Name: o.Namespace}, &corev1.Namespace{}); err != nil {
+		return
+	}
+
+	progress.ProgressMsg <- fmt.Sprintf("Getting package metadata for '%s'", o.PackageName)
+	if _, _, err = p.GetPackage(o); err != nil {
 		return
 	}
 

--- a/pkg/v1/tkg/tkgpackageclient/package_update_test.go
+++ b/pkg/v1/tkg/tkgpackageclient/package_update_test.go
@@ -81,6 +81,8 @@ var _ = Describe("Update Package", func() {
 		BeforeEach(func() {
 			options.Install = true
 			kappCtl = &fakes.KappClient{}
+			crtCtl = &fakes.CRTClusterClient{}
+			kappCtl.GetClientReturns(crtCtl)
 			kappCtl.GetPackageInstallReturnsOnCall(0, nil, nil)
 			kappCtl.ListPackagesReturns(nil, errors.New("failure in ListPackages"))
 		})


### PR DESCRIPTION
**What this PR does / why we need it:**
- This PR is to create namespace prior to metadata check. This causes the package metadata check not fail as a result of non-existing namespace, specifically for packages made available as part of adding the package repository to a global namespace.
- Addresses https://github.com/vmware-tanzu/tanzu-framework/issues/1258

**Describe testing done for PR:**
existing unit & integration tests and manually tested in the local cluster

**Does this PR introduce a user-facing change?:**
None

**Release note**:
<!--
See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
for more details.

Please add a short text in the release-note block below (or "NONE" if not applicable)
if there is anything in this PR that is worthy of mention in the next release.
-->
```release-note
creates namespace prior to package metadata check. This causes the package metadata check not fail as a result of non-existing namespace, specifically for packages made available as part of adding the package repository to a global namespace.
```

**New PR Checklist**

- [X] Ensure PR contains only public links or terms
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Squash the commits in this branch before merge to preserve our git history
- [ ] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [X] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
