### PR TITLE
Fix vsphere ssh key for multi AZ MDs

### DIFF
--- a/pkg/v1/providers/infrastructure-vsphere/ytt/vsphere-overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/ytt/vsphere-overlay.yaml
@@ -187,7 +187,7 @@ spec:
       users:
         - name: capv
           sshAuthorizedKeys:
-            - '${ VSPHERE_SSH_AUTHORIZED_KEY }'
+            - #@ data.values.VSPHERE_SSH_AUTHORIZED_KEY
           sudo: ALL=(ALL) NOPASSWD:ALL
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
@@ -216,6 +216,6 @@ spec:
       users:
         - name: capv
           sshAuthorizedKeys:
-            - '${ VSPHERE_SSH_AUTHORIZED_KEY }'
+            - #@ data.values.VSPHERE_SSH_AUTHORIZED_KEY
           sudo: ALL=(ALL) NOPASSWD:ALL
 #@ end


### PR DESCRIPTION
### What this PR does / why we need it
Fixes the authorized ssh keys for MachineDeployment 1 and MachineDeployment 2 when using the prod cluster plan in vSphere. These MDs were added in TKG 1.5
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Deployed vSphere management cluster. Accessed KubeadmConfigTemplate resources and confirmed that the ssh key is properly configured.
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixes an issue where the ssh key is not propagated to vsphere machine deployment 1 and 2 in prod plan clusters.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer
This does introduce provider changes. Clustergen output should be verified.
<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
