### PR TITLE
Fix upgrade exits prematurely when upgrade does not involve a change in Kubernetes version

### DIFF
--- a/pkg/v1/tkg/clusterclient/clusterclient_test.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient_test.go
@@ -135,6 +135,9 @@ var _ = Describe("Cluster Client", func() {
 		tkcConditions      []capiv1alpha3.Condition
 	)
 
+	// Mock the sleep implementation for unit tests
+	Sleep = func(d time.Duration) {}
+
 	BeforeSuite(createTempDirectory)
 	AfterSuite(deleteTempDirectory)
 


### PR DESCRIPTION
### What this PR does / why we need it
Wait for 60 seconds before we start the polling to check the upgrade status
This is done to account for the CP/MD upgrade to start rolling out
because it was noticed that CP/MD upgrade rollout take few seconds
to update the conditions which we rely on to check the upgrade status
ClusterReady is already present and wait logic to come out of the poll
loop assuming the upgrade is complete whereas the upgrade has not been
started yet

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1282

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixed upgrade exits prematurely when upgrade does not involve a change in Kubernetes version
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
