### PR TITLE
add nilness check for secret export

### DIFF
--- a/cmd/cli/plugin/secret/registry_secret_add.go
+++ b/cmd/cli/plugin/secret/registry_secret_add.go
@@ -200,7 +200,10 @@ func checkSecretExportExists(pkgClient tkgpackageclient.TKGPackageClient, kc kap
 	export := ""
 	secretExport, err := pkgClient.GetSecretExport(registrySecretOp)
 
-	if err != nil && !apierrors.IsNotFound(err) {
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it

this PR fixes the bug that cause segmentation fault on trying to access non existing SecretExport object (regression introduced after adding the case for kubectl-created secret-export)
Fixes # https://github.com/vmware-tanzu/tanzu-framework/issues/1284

### Describe testing done for PR
 manually tested in the local cluster

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
fixes the bug that cause segmentation fault on trying to access non existing SecretExport object
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
