### PR TITLE
Adding management cluster upgrade version compatibility validation

### DIFF
--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -1010,7 +1010,7 @@ func (c *client) PatchClusterObjectWithTKGVersion(clusterName, namespace, tkgVer
 }
 
 func (c *client) GetManagementClusterTKGVersion(mgmtClusterName, clusterNamespace string) (string, error) {
-	mcObject := &capi.Cluster{}
+	mcObject := &capiv1alpha3.Cluster{}
 	err := c.GetResource(mcObject, mgmtClusterName, clusterNamespace, nil, nil)
 	if err != nil {
 		return "", errors.Wrap(err, "unable to get the cluster object")


### PR DESCRIPTION
Signed-off-by: PremKumar Kalle <pkalle@vmware.com>

### What this PR does / why we need it
This PR checks the upgrade version compatibility before management cluster upgrade
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes # #1299 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

1. Created a management cluster with v1.3.0 and tried to upgrade to v1.5.0 and the checks shows detects the incompatibility(minor version skip upgrade) and warns the user with prompt.
```
$ tanzu management-cluster upgrade -v 9
compatibility file (/Users/pkalle/.config/tanzu/tkg/compatibility/tkg-compatibility.yaml) already exists, skipping download
BOM files inside /Users/pkalle/.config/tanzu/tkg/bom already exists, skipping download
Upgrading management cluster 'test-aws-upgradeversion-validation-mc' to TKG version 'v1.6.0-zshippable' with Kubernetes version 'v1.22.3+vmware.1'. Are you sure? [y/N]: y
Validating the compatibility before management cluster upgrade
Management cluster SemVersion is "1.3.1" and current TKG SemVersion(to be upgraded to) is "1.6.0-zshippable"
Upgrade skipping minor version is detected and is not recommended. It could leave cluster unmanageable
Do you want to continue with the upgrade? [y/N]: N
Error: upgrade version compatibility validation failed: aborted
```

2.  Created a management cluster with v1.5.0 and tried to upgrade to v1.6.0(tip of main) and the checks shows detects no  incompatibility(minor version skip upgrade) and upgrade went through without any user prompt
```
$ tanzu management-cluster upgrade -v 9
compatibility file (/Users/pkalle/.config/tanzu/tkg/compatibility/tkg-compatibility.yaml) already exists, skipping download
BOM files inside /Users/pkalle/.config/tanzu/tkg/bom already exists, skipping download
Upgrading management cluster 'test-aws-upgradeversion-validation-mc' to TKG version 'v1.6.0-zshippable' with Kubernetes version 'v1.22.3+vmware.1'. Are you sure? [y/N]: y
Validating the compatibility before management cluster upgrade
Management cluster SemVersion is "1.5.0-rc.1" and current TKG SemVersion(to be upgraded to) is "1.6.0-zshippable"
Upgrading management cluster providers.
```


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Adding management cluster upgrade version compatibility validation
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
