### PR TITLE
Add retry with polling when patching Cluster resource after successfu…

### DIFF
--- a/pkg/v1/tkg/client/upgrade_cluster.go
+++ b/pkg/v1/tkg/client/upgrade_cluster.go
@@ -328,7 +328,8 @@ func (c *TkgClient) addKubernetesReleaseLabel(regionalClusterClient clusterclien
 		}
 	}`
 	patchLabel := fmt.Sprintf(patchFormat, utils.GetTkrNameFromTkrVersion(options.TkrVersion))
-	err := regionalClusterClient.PatchClusterObject(options.ClusterName, options.Namespace, patchLabel)
+	pollOptions := clusterclient.PollOptions{Interval: upgradePatchInterval, Timeout: upgradePatchTimeout}
+	err := regionalClusterClient.PatchClusterObjectWithPollOptions(options.ClusterName, options.Namespace, patchLabel, &pollOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to patch the cluster object with TanzuKubernetesRelease label")
 	}

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -260,6 +260,8 @@ type Client interface {
 	PatchClusterObjectWithOptionalMetadata(clusterName, clusterNamespace, metadataKey string, metadata map[string]string) (string, error)
 	// PatchClusterObject patches cluster object with specified json patch
 	PatchClusterObject(clusterName, clusterNamespace string, patchJSONString string) error
+	// PatchClusterObject patches cluster object with specified json patch with poll options
+	PatchClusterObjectWithPollOptions(clusterName, clusterNamespace, patchJSONString string, pollOptions *PollOptions) error
 	// DeleteExistingKappController deletes the kapp-controller that already exists in the cluster.
 	DeleteExistingKappController() error
 	// UpdateAWSCNIIngressRules updates the cniIngressRules field for the AWSCluster resource.
@@ -878,12 +880,16 @@ func (c *client) waitK8sVersionUpdateGeneric(clusterName, namespace, newK8sVersi
 	return c.poller.PollImmediateInfiniteWithGetter(interval, getterFunc)
 }
 
-func (c *client) PatchClusterObject(clusterName, clusterNamespace, patchJSONString string) error {
-	err := c.PatchResource(&capi.Cluster{}, clusterName, clusterNamespace, patchJSONString, types.MergePatchType, nil)
+func (c *client) PatchClusterObjectWithPollOptions(clusterName, clusterNamespace, patchJSONString string, pollOptions *PollOptions) error {
+	err := c.PatchResource(&capi.Cluster{}, clusterName, clusterNamespace, patchJSONString, types.MergePatchType, pollOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to patch the cluster object")
 	}
 	return nil
+}
+
+func (c *client) PatchClusterObject(clusterName, clusterNamespace, patchJSONString string) error {
+	return c.PatchClusterObjectWithPollOptions(clusterName, clusterNamespace, patchJSONString, nil)
 }
 
 func (c *client) GetClusterStatusInfo(clusterName, namespace string, workloadClusterClient Client) ClusterStatusInfo {

--- a/pkg/v1/tkg/fakes/clusterclient.go
+++ b/pkg/v1/tkg/fakes/clusterclient.go
@@ -725,6 +725,20 @@ type ClusterClient struct {
 		result1 string
 		result2 error
 	}
+	PatchClusterObjectWithPollOptionsStub        func(string, string, string, *clusterclient.PollOptions) error
+	patchClusterObjectWithPollOptionsMutex       sync.RWMutex
+	patchClusterObjectWithPollOptionsArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 *clusterclient.PollOptions
+	}
+	patchClusterObjectWithPollOptionsReturns struct {
+		result1 error
+	}
+	patchClusterObjectWithPollOptionsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	PatchClusterObjectWithTKGVersionStub        func(string, string, string) error
 	patchClusterObjectWithTKGVersionMutex       sync.RWMutex
 	patchClusterObjectWithTKGVersionArgsForCall []struct {
@@ -1109,15 +1123,16 @@ func (fake *ClusterClient) ActivateTanzuKubernetesReleases(arg1 string) error {
 	fake.activateTanzuKubernetesReleasesArgsForCall = append(fake.activateTanzuKubernetesReleasesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ActivateTanzuKubernetesReleasesStub
+	fakeReturns := fake.activateTanzuKubernetesReleasesReturns
 	fake.recordInvocation("ActivateTanzuKubernetesReleases", []interface{}{arg1})
 	fake.activateTanzuKubernetesReleasesMutex.Unlock()
-	if fake.ActivateTanzuKubernetesReleasesStub != nil {
-		return fake.ActivateTanzuKubernetesReleasesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.activateTanzuKubernetesReleasesReturns
 	return fakeReturns.result1
 }
 
@@ -1176,15 +1191,16 @@ func (fake *ClusterClient) AddCEIPTelemetryJob(arg1 string, arg2 string, arg3 *t
 		arg7 string
 		arg8 string
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
+	stub := fake.AddCEIPTelemetryJobStub
+	fakeReturns := fake.addCEIPTelemetryJobReturns
 	fake.recordInvocation("AddCEIPTelemetryJob", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
 	fake.addCEIPTelemetryJobMutex.Unlock()
-	if fake.AddCEIPTelemetryJobStub != nil {
-		return fake.AddCEIPTelemetryJobStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addCEIPTelemetryJobReturns
 	return fakeReturns.result1
 }
 
@@ -1236,15 +1252,16 @@ func (fake *ClusterClient) Apply(arg1 string) error {
 	fake.applyArgsForCall = append(fake.applyArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ApplyStub
+	fakeReturns := fake.applyReturns
 	fake.recordInvocation("Apply", []interface{}{arg1})
 	fake.applyMutex.Unlock()
-	if fake.ApplyStub != nil {
-		return fake.ApplyStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.applyReturns
 	return fakeReturns.result1
 }
 
@@ -1296,15 +1313,16 @@ func (fake *ClusterClient) ApplyFile(arg1 string) error {
 	fake.applyFileArgsForCall = append(fake.applyFileArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ApplyFileStub
+	fakeReturns := fake.applyFileReturns
 	fake.recordInvocation("ApplyFile", []interface{}{arg1})
 	fake.applyFileMutex.Unlock()
-	if fake.ApplyFileStub != nil {
-		return fake.ApplyFileStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.applyFileReturns
 	return fakeReturns.result1
 }
 
@@ -1356,15 +1374,16 @@ func (fake *ClusterClient) CloneWithTimeout(arg1 time.Duration) clusterclient.Cl
 	fake.cloneWithTimeoutArgsForCall = append(fake.cloneWithTimeoutArgsForCall, struct {
 		arg1 time.Duration
 	}{arg1})
+	stub := fake.CloneWithTimeoutStub
+	fakeReturns := fake.cloneWithTimeoutReturns
 	fake.recordInvocation("CloneWithTimeout", []interface{}{arg1})
 	fake.cloneWithTimeoutMutex.Unlock()
-	if fake.CloneWithTimeoutStub != nil {
-		return fake.CloneWithTimeoutStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cloneWithTimeoutReturns
 	return fakeReturns.result1
 }
 
@@ -1416,15 +1435,16 @@ func (fake *ClusterClient) CreateNamespace(arg1 string) error {
 	fake.createNamespaceArgsForCall = append(fake.createNamespaceArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.CreateNamespaceStub
+	fakeReturns := fake.createNamespaceReturns
 	fake.recordInvocation("CreateNamespace", []interface{}{arg1})
 	fake.createNamespaceMutex.Unlock()
-	if fake.CreateNamespaceStub != nil {
-		return fake.CreateNamespaceStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createNamespaceReturns
 	return fakeReturns.result1
 }
 
@@ -1479,15 +1499,16 @@ func (fake *ClusterClient) CreateResource(arg1 interface{}, arg2 string, arg3 st
 		arg3 string
 		arg4 []client.CreateOption
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.CreateResourceStub
+	fakeReturns := fake.createResourceReturns
 	fake.recordInvocation("CreateResource", []interface{}{arg1, arg2, arg3, arg4})
 	fake.createResourceMutex.Unlock()
-	if fake.CreateResourceStub != nil {
-		return fake.CreateResourceStub(arg1, arg2, arg3, arg4...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createResourceReturns
 	return fakeReturns.result1
 }
 
@@ -1539,15 +1560,16 @@ func (fake *ClusterClient) DeactivateTanzuKubernetesReleases(arg1 string) error 
 	fake.deactivateTanzuKubernetesReleasesArgsForCall = append(fake.deactivateTanzuKubernetesReleasesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DeactivateTanzuKubernetesReleasesStub
+	fakeReturns := fake.deactivateTanzuKubernetesReleasesReturns
 	fake.recordInvocation("DeactivateTanzuKubernetesReleases", []interface{}{arg1})
 	fake.deactivateTanzuKubernetesReleasesMutex.Unlock()
-	if fake.DeactivateTanzuKubernetesReleasesStub != nil {
-		return fake.DeactivateTanzuKubernetesReleasesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deactivateTanzuKubernetesReleasesReturns
 	return fakeReturns.result1
 }
 
@@ -1600,15 +1622,16 @@ func (fake *ClusterClient) DeleteCluster(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.DeleteClusterStub
+	fakeReturns := fake.deleteClusterReturns
 	fake.recordInvocation("DeleteCluster", []interface{}{arg1, arg2})
 	fake.deleteClusterMutex.Unlock()
-	if fake.DeleteClusterStub != nil {
-		return fake.DeleteClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteClusterReturns
 	return fakeReturns.result1
 }
 
@@ -1659,15 +1682,16 @@ func (fake *ClusterClient) DeleteExistingKappController() error {
 	ret, specificReturn := fake.deleteExistingKappControllerReturnsOnCall[len(fake.deleteExistingKappControllerArgsForCall)]
 	fake.deleteExistingKappControllerArgsForCall = append(fake.deleteExistingKappControllerArgsForCall, struct {
 	}{})
+	stub := fake.DeleteExistingKappControllerStub
+	fakeReturns := fake.deleteExistingKappControllerReturns
 	fake.recordInvocation("DeleteExistingKappController", []interface{}{})
 	fake.deleteExistingKappControllerMutex.Unlock()
-	if fake.DeleteExistingKappControllerStub != nil {
-		return fake.DeleteExistingKappControllerStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteExistingKappControllerReturns
 	return fakeReturns.result1
 }
 
@@ -1712,15 +1736,16 @@ func (fake *ClusterClient) DeleteResource(arg1 interface{}) error {
 	fake.deleteResourceArgsForCall = append(fake.deleteResourceArgsForCall, struct {
 		arg1 interface{}
 	}{arg1})
+	stub := fake.DeleteResourceStub
+	fakeReturns := fake.deleteResourceReturns
 	fake.recordInvocation("DeleteResource", []interface{}{arg1})
 	fake.deleteResourceMutex.Unlock()
-	if fake.DeleteResourceStub != nil {
-		return fake.DeleteResourceStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteResourceReturns
 	return fakeReturns.result1
 }
 
@@ -1771,15 +1796,16 @@ func (fake *ClusterClient) ExportCurrentKubeconfigToFile() (string, error) {
 	ret, specificReturn := fake.exportCurrentKubeconfigToFileReturnsOnCall[len(fake.exportCurrentKubeconfigToFileArgsForCall)]
 	fake.exportCurrentKubeconfigToFileArgsForCall = append(fake.exportCurrentKubeconfigToFileArgsForCall, struct {
 	}{})
+	stub := fake.ExportCurrentKubeconfigToFileStub
+	fakeReturns := fake.exportCurrentKubeconfigToFileReturns
 	fake.recordInvocation("ExportCurrentKubeconfigToFile", []interface{}{})
 	fake.exportCurrentKubeconfigToFileMutex.Unlock()
-	if fake.ExportCurrentKubeconfigToFileStub != nil {
-		return fake.ExportCurrentKubeconfigToFileStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.exportCurrentKubeconfigToFileReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1826,15 +1852,16 @@ func (fake *ClusterClient) GetAWSCredentialsFromSecret() (string, error) {
 	ret, specificReturn := fake.getAWSCredentialsFromSecretReturnsOnCall[len(fake.getAWSCredentialsFromSecretArgsForCall)]
 	fake.getAWSCredentialsFromSecretArgsForCall = append(fake.getAWSCredentialsFromSecretArgsForCall, struct {
 	}{})
+	stub := fake.GetAWSCredentialsFromSecretStub
+	fakeReturns := fake.getAWSCredentialsFromSecretReturns
 	fake.recordInvocation("GetAWSCredentialsFromSecret", []interface{}{})
 	fake.getAWSCredentialsFromSecretMutex.Unlock()
-	if fake.GetAWSCredentialsFromSecretStub != nil {
-		return fake.GetAWSCredentialsFromSecretStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getAWSCredentialsFromSecretReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1881,15 +1908,16 @@ func (fake *ClusterClient) GetAzureCredentialsFromSecret() (azure.Credentials, e
 	ret, specificReturn := fake.getAzureCredentialsFromSecretReturnsOnCall[len(fake.getAzureCredentialsFromSecretArgsForCall)]
 	fake.getAzureCredentialsFromSecretArgsForCall = append(fake.getAzureCredentialsFromSecretArgsForCall, struct {
 	}{})
+	stub := fake.GetAzureCredentialsFromSecretStub
+	fakeReturns := fake.getAzureCredentialsFromSecretReturns
 	fake.recordInvocation("GetAzureCredentialsFromSecret", []interface{}{})
 	fake.getAzureCredentialsFromSecretMutex.Unlock()
-	if fake.GetAzureCredentialsFromSecretStub != nil {
-		return fake.GetAzureCredentialsFromSecretStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getAzureCredentialsFromSecretReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1937,15 +1965,16 @@ func (fake *ClusterClient) GetBomConfigMap(arg1 string) (v1.ConfigMap, error) {
 	fake.getBomConfigMapArgsForCall = append(fake.getBomConfigMapArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetBomConfigMapStub
+	fakeReturns := fake.getBomConfigMapReturns
 	fake.recordInvocation("GetBomConfigMap", []interface{}{arg1})
 	fake.getBomConfigMapMutex.Unlock()
-	if fake.GetBomConfigMapStub != nil {
-		return fake.GetBomConfigMapStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getBomConfigMapReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1999,15 +2028,16 @@ func (fake *ClusterClient) GetClientSet() clusterclient.CrtClient {
 	ret, specificReturn := fake.getClientSetReturnsOnCall[len(fake.getClientSetArgsForCall)]
 	fake.getClientSetArgsForCall = append(fake.getClientSetArgsForCall, struct {
 	}{})
+	stub := fake.GetClientSetStub
+	fakeReturns := fake.getClientSetReturns
 	fake.recordInvocation("GetClientSet", []interface{}{})
 	fake.getClientSetMutex.Unlock()
-	if fake.GetClientSetStub != nil {
-		return fake.GetClientSetStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getClientSetReturns
 	return fakeReturns.result1
 }
 
@@ -2051,15 +2081,16 @@ func (fake *ClusterClient) GetClusterInfrastructure() (string, error) {
 	ret, specificReturn := fake.getClusterInfrastructureReturnsOnCall[len(fake.getClusterInfrastructureArgsForCall)]
 	fake.getClusterInfrastructureArgsForCall = append(fake.getClusterInfrastructureArgsForCall, struct {
 	}{})
+	stub := fake.GetClusterInfrastructureStub
+	fakeReturns := fake.getClusterInfrastructureReturns
 	fake.recordInvocation("GetClusterInfrastructure", []interface{}{})
 	fake.getClusterInfrastructureMutex.Unlock()
-	if fake.GetClusterInfrastructureStub != nil {
-		return fake.GetClusterInfrastructureStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getClusterInfrastructureReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2107,15 +2138,16 @@ func (fake *ClusterClient) GetCurrentClusterName(arg1 string) (string, error) {
 	fake.getCurrentClusterNameArgsForCall = append(fake.getCurrentClusterNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetCurrentClusterNameStub
+	fakeReturns := fake.getCurrentClusterNameReturns
 	fake.recordInvocation("GetCurrentClusterName", []interface{}{arg1})
 	fake.getCurrentClusterNameMutex.Unlock()
-	if fake.GetCurrentClusterNameStub != nil {
-		return fake.GetCurrentClusterNameStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getCurrentClusterNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2169,15 +2201,16 @@ func (fake *ClusterClient) GetCurrentKubeContext() (string, error) {
 	ret, specificReturn := fake.getCurrentKubeContextReturnsOnCall[len(fake.getCurrentKubeContextArgsForCall)]
 	fake.getCurrentKubeContextArgsForCall = append(fake.getCurrentKubeContextArgsForCall, struct {
 	}{})
+	stub := fake.GetCurrentKubeContextStub
+	fakeReturns := fake.getCurrentKubeContextReturns
 	fake.recordInvocation("GetCurrentKubeContext", []interface{}{})
 	fake.getCurrentKubeContextMutex.Unlock()
-	if fake.GetCurrentKubeContextStub != nil {
-		return fake.GetCurrentKubeContextStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getCurrentKubeContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2224,15 +2257,16 @@ func (fake *ClusterClient) GetCurrentKubeconfigFile() string {
 	ret, specificReturn := fake.getCurrentKubeconfigFileReturnsOnCall[len(fake.getCurrentKubeconfigFileArgsForCall)]
 	fake.getCurrentKubeconfigFileArgsForCall = append(fake.getCurrentKubeconfigFileArgsForCall, struct {
 	}{})
+	stub := fake.GetCurrentKubeconfigFileStub
+	fakeReturns := fake.getCurrentKubeconfigFileReturns
 	fake.recordInvocation("GetCurrentKubeconfigFile", []interface{}{})
 	fake.getCurrentKubeconfigFileMutex.Unlock()
-	if fake.GetCurrentKubeconfigFileStub != nil {
-		return fake.GetCurrentKubeconfigFileStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getCurrentKubeconfigFileReturns
 	return fakeReturns.result1
 }
 
@@ -2276,15 +2310,16 @@ func (fake *ClusterClient) GetCurrentNamespace() (string, error) {
 	ret, specificReturn := fake.getCurrentNamespaceReturnsOnCall[len(fake.getCurrentNamespaceArgsForCall)]
 	fake.getCurrentNamespaceArgsForCall = append(fake.getCurrentNamespaceArgsForCall, struct {
 	}{})
+	stub := fake.GetCurrentNamespaceStub
+	fakeReturns := fake.getCurrentNamespaceReturns
 	fake.recordInvocation("GetCurrentNamespace", []interface{}{})
 	fake.getCurrentNamespaceMutex.Unlock()
-	if fake.GetCurrentNamespaceStub != nil {
-		return fake.GetCurrentNamespaceStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getCurrentNamespaceReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2333,15 +2368,16 @@ func (fake *ClusterClient) GetKCPObjectForCluster(arg1 string, arg2 string) (*v1
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetKCPObjectForClusterStub
+	fakeReturns := fake.getKCPObjectForClusterReturns
 	fake.recordInvocation("GetKCPObjectForCluster", []interface{}{arg1, arg2})
 	fake.getKCPObjectForClusterMutex.Unlock()
-	if fake.GetKCPObjectForClusterStub != nil {
-		return fake.GetKCPObjectForClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getKCPObjectForClusterReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2398,15 +2434,16 @@ func (fake *ClusterClient) GetKubeConfigForCluster(arg1 string, arg2 string, arg
 		arg2 string
 		arg3 *clusterclient.PollOptions
 	}{arg1, arg2, arg3})
+	stub := fake.GetKubeConfigForClusterStub
+	fakeReturns := fake.getKubeConfigForClusterReturns
 	fake.recordInvocation("GetKubeConfigForCluster", []interface{}{arg1, arg2, arg3})
 	fake.getKubeConfigForClusterMutex.Unlock()
-	if fake.GetKubeConfigForClusterStub != nil {
-		return fake.GetKubeConfigForClusterStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getKubeConfigForClusterReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2460,15 +2497,16 @@ func (fake *ClusterClient) GetKubernetesVersion() (string, error) {
 	ret, specificReturn := fake.getKubernetesVersionReturnsOnCall[len(fake.getKubernetesVersionArgsForCall)]
 	fake.getKubernetesVersionArgsForCall = append(fake.getKubernetesVersionArgsForCall, struct {
 	}{})
+	stub := fake.GetKubernetesVersionStub
+	fakeReturns := fake.getKubernetesVersionReturns
 	fake.recordInvocation("GetKubernetesVersion", []interface{}{})
 	fake.getKubernetesVersionMutex.Unlock()
-	if fake.GetKubernetesVersionStub != nil {
-		return fake.GetKubernetesVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getKubernetesVersionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2517,15 +2555,16 @@ func (fake *ClusterClient) GetMDObjectForCluster(arg1 string, arg2 string) ([]v1
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetMDObjectForClusterStub
+	fakeReturns := fake.getMDObjectForClusterReturns
 	fake.recordInvocation("GetMDObjectForCluster", []interface{}{arg1, arg2})
 	fake.getMDObjectForClusterMutex.Unlock()
-	if fake.GetMDObjectForClusterStub != nil {
-		return fake.GetMDObjectForClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getMDObjectForClusterReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2581,15 +2620,16 @@ func (fake *ClusterClient) GetMachineObjectsForCluster(arg1 string, arg2 string)
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetMachineObjectsForClusterStub
+	fakeReturns := fake.getMachineObjectsForClusterReturns
 	fake.recordInvocation("GetMachineObjectsForCluster", []interface{}{arg1, arg2})
 	fake.getMachineObjectsForClusterMutex.Unlock()
-	if fake.GetMachineObjectsForClusterStub != nil {
-		return fake.GetMachineObjectsForClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getMachineObjectsForClusterReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2648,15 +2688,16 @@ func (fake *ClusterClient) GetManagementClusterTKGVersion(arg1 string, arg2 stri
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetManagementClusterTKGVersionStub
+	fakeReturns := fake.getManagementClusterTKGVersionReturns
 	fake.recordInvocation("GetManagementClusterTKGVersion", []interface{}{arg1, arg2})
 	fake.getManagementClusterTKGVersionMutex.Unlock()
-	if fake.GetManagementClusterTKGVersionStub != nil {
-		return fake.GetManagementClusterTKGVersionStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getManagementClusterTKGVersionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2712,15 +2753,16 @@ func (fake *ClusterClient) GetPacificClusterObject(arg1 string, arg2 string) (*v
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetPacificClusterObjectStub
+	fakeReturns := fake.getPacificClusterObjectReturns
 	fake.recordInvocation("GetPacificClusterObject", []interface{}{arg1, arg2})
 	fake.getPacificClusterObjectMutex.Unlock()
-	if fake.GetPacificClusterObjectStub != nil {
-		return fake.GetPacificClusterObjectStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getPacificClusterObjectReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2774,15 +2816,16 @@ func (fake *ClusterClient) GetPacificTKCAPIVersion() (string, error) {
 	ret, specificReturn := fake.getPacificTKCAPIVersionReturnsOnCall[len(fake.getPacificTKCAPIVersionArgsForCall)]
 	fake.getPacificTKCAPIVersionArgsForCall = append(fake.getPacificTKCAPIVersionArgsForCall, struct {
 	}{})
+	stub := fake.GetPacificTKCAPIVersionStub
+	fakeReturns := fake.getPacificTKCAPIVersionReturns
 	fake.recordInvocation("GetPacificTKCAPIVersion", []interface{}{})
 	fake.getPacificTKCAPIVersionMutex.Unlock()
-	if fake.GetPacificTKCAPIVersionStub != nil {
-		return fake.GetPacificTKCAPIVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getPacificTKCAPIVersionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2829,15 +2872,16 @@ func (fake *ClusterClient) GetPacificTanzuKubernetesReleases() ([]string, error)
 	ret, specificReturn := fake.getPacificTanzuKubernetesReleasesReturnsOnCall[len(fake.getPacificTanzuKubernetesReleasesArgsForCall)]
 	fake.getPacificTanzuKubernetesReleasesArgsForCall = append(fake.getPacificTanzuKubernetesReleasesArgsForCall, struct {
 	}{})
+	stub := fake.GetPacificTanzuKubernetesReleasesStub
+	fakeReturns := fake.getPacificTanzuKubernetesReleasesReturns
 	fake.recordInvocation("GetPacificTanzuKubernetesReleases", []interface{}{})
 	fake.getPacificTanzuKubernetesReleasesMutex.Unlock()
-	if fake.GetPacificTanzuKubernetesReleasesStub != nil {
-		return fake.GetPacificTanzuKubernetesReleasesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getPacificTanzuKubernetesReleasesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2884,15 +2928,16 @@ func (fake *ClusterClient) GetPinnipedIssuerURLAndCA() (string, string, error) {
 	ret, specificReturn := fake.getPinnipedIssuerURLAndCAReturnsOnCall[len(fake.getPinnipedIssuerURLAndCAArgsForCall)]
 	fake.getPinnipedIssuerURLAndCAArgsForCall = append(fake.getPinnipedIssuerURLAndCAArgsForCall, struct {
 	}{})
+	stub := fake.GetPinnipedIssuerURLAndCAStub
+	fakeReturns := fake.getPinnipedIssuerURLAndCAReturns
 	fake.recordInvocation("GetPinnipedIssuerURLAndCA", []interface{}{})
 	fake.getPinnipedIssuerURLAndCAMutex.Unlock()
-	if fake.GetPinnipedIssuerURLAndCAStub != nil {
-		return fake.GetPinnipedIssuerURLAndCAStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getPinnipedIssuerURLAndCAReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2943,15 +2988,16 @@ func (fake *ClusterClient) GetRegionalClusterDefaultProviderName(arg1 v1alpha3.P
 	fake.getRegionalClusterDefaultProviderNameArgsForCall = append(fake.getRegionalClusterDefaultProviderNameArgsForCall, struct {
 		arg1 v1alpha3.ProviderType
 	}{arg1})
+	stub := fake.GetRegionalClusterDefaultProviderNameStub
+	fakeReturns := fake.getRegionalClusterDefaultProviderNameReturns
 	fake.recordInvocation("GetRegionalClusterDefaultProviderName", []interface{}{arg1})
 	fake.getRegionalClusterDefaultProviderNameMutex.Unlock()
-	if fake.GetRegionalClusterDefaultProviderNameStub != nil {
-		return fake.GetRegionalClusterDefaultProviderNameStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getRegionalClusterDefaultProviderNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3010,15 +3056,16 @@ func (fake *ClusterClient) GetResource(arg1 interface{}, arg2 string, arg3 strin
 		arg4 clusterclient.PostVerifyrFunc
 		arg5 *clusterclient.PollOptions
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.GetResourceStub
+	fakeReturns := fake.getResourceReturns
 	fake.recordInvocation("GetResource", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.getResourceMutex.Unlock()
-	if fake.GetResourceStub != nil {
-		return fake.GetResourceStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getResourceReturns
 	return fakeReturns.result1
 }
 
@@ -3074,15 +3121,16 @@ func (fake *ClusterClient) GetResourceList(arg1 interface{}, arg2 string, arg3 s
 		arg4 clusterclient.PostVerifyListrFunc
 		arg5 *clusterclient.PollOptions
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.GetResourceListStub
+	fakeReturns := fake.getResourceListReturns
 	fake.recordInvocation("GetResourceList", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.getResourceListMutex.Unlock()
-	if fake.GetResourceListStub != nil {
-		return fake.GetResourceListStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getResourceListReturns
 	return fakeReturns.result1
 }
 
@@ -3137,15 +3185,16 @@ func (fake *ClusterClient) GetSecretValue(arg1 string, arg2 string, arg3 string,
 		arg3 string
 		arg4 *clusterclient.PollOptions
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.GetSecretValueStub
+	fakeReturns := fake.getSecretValueReturns
 	fake.recordInvocation("GetSecretValue", []interface{}{arg1, arg2, arg3, arg4})
 	fake.getSecretValueMutex.Unlock()
-	if fake.GetSecretValueStub != nil {
-		return fake.GetSecretValueStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSecretValueReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3200,15 +3249,16 @@ func (fake *ClusterClient) GetTanzuKubernetesReleases(arg1 string) ([]v1alpha1.T
 	fake.getTanzuKubernetesReleasesArgsForCall = append(fake.getTanzuKubernetesReleasesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetTanzuKubernetesReleasesStub
+	fakeReturns := fake.getTanzuKubernetesReleasesReturns
 	fake.recordInvocation("GetTanzuKubernetesReleases", []interface{}{arg1})
 	fake.getTanzuKubernetesReleasesMutex.Unlock()
-	if fake.GetTanzuKubernetesReleasesStub != nil {
-		return fake.GetTanzuKubernetesReleasesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getTanzuKubernetesReleasesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3265,15 +3315,16 @@ func (fake *ClusterClient) GetVCClientAndDataCenter(arg1 string, arg2 string, ar
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.GetVCClientAndDataCenterStub
+	fakeReturns := fake.getVCClientAndDataCenterReturns
 	fake.recordInvocation("GetVCClientAndDataCenter", []interface{}{arg1, arg2, arg3})
 	fake.getVCClientAndDataCenterMutex.Unlock()
-	if fake.GetVCClientAndDataCenterStub != nil {
-		return fake.GetVCClientAndDataCenterStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getVCClientAndDataCenterReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -3331,15 +3382,16 @@ func (fake *ClusterClient) GetVCCredentialsFromSecret(arg1 string) (string, stri
 	fake.getVCCredentialsFromSecretArgsForCall = append(fake.getVCCredentialsFromSecretArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetVCCredentialsFromSecretStub
+	fakeReturns := fake.getVCCredentialsFromSecretReturns
 	fake.recordInvocation("GetVCCredentialsFromSecret", []interface{}{arg1})
 	fake.getVCCredentialsFromSecretMutex.Unlock()
-	if fake.GetVCCredentialsFromSecretStub != nil {
-		return fake.GetVCCredentialsFromSecretStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getVCCredentialsFromSecretReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -3396,15 +3448,16 @@ func (fake *ClusterClient) GetVCServer() (string, error) {
 	ret, specificReturn := fake.getVCServerReturnsOnCall[len(fake.getVCServerArgsForCall)]
 	fake.getVCServerArgsForCall = append(fake.getVCServerArgsForCall, struct {
 	}{})
+	stub := fake.GetVCServerStub
+	fakeReturns := fake.getVCServerReturns
 	fake.recordInvocation("GetVCServer", []interface{}{})
 	fake.getVCServerMutex.Unlock()
-	if fake.GetVCServerStub != nil {
-		return fake.GetVCServerStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getVCServerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3452,15 +3505,16 @@ func (fake *ClusterClient) HasCEIPTelemetryJob(arg1 string) (bool, error) {
 	fake.hasCEIPTelemetryJobArgsForCall = append(fake.hasCEIPTelemetryJobArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.HasCEIPTelemetryJobStub
+	fakeReturns := fake.hasCEIPTelemetryJobReturns
 	fake.recordInvocation("HasCEIPTelemetryJob", []interface{}{arg1})
 	fake.hasCEIPTelemetryJobMutex.Unlock()
-	if fake.HasCEIPTelemetryJobStub != nil {
-		return fake.HasCEIPTelemetryJobStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.hasCEIPTelemetryJobReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3514,15 +3568,16 @@ func (fake *ClusterClient) IsClusterRegisteredToTMC() (bool, error) {
 	ret, specificReturn := fake.isClusterRegisteredToTMCReturnsOnCall[len(fake.isClusterRegisteredToTMCArgsForCall)]
 	fake.isClusterRegisteredToTMCArgsForCall = append(fake.isClusterRegisteredToTMCArgsForCall, struct {
 	}{})
+	stub := fake.IsClusterRegisteredToTMCStub
+	fakeReturns := fake.isClusterRegisteredToTMCReturns
 	fake.recordInvocation("IsClusterRegisteredToTMC", []interface{}{})
 	fake.isClusterRegisteredToTMCMutex.Unlock()
-	if fake.IsClusterRegisteredToTMCStub != nil {
-		return fake.IsClusterRegisteredToTMCStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.isClusterRegisteredToTMCReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3569,15 +3624,16 @@ func (fake *ClusterClient) IsPacificRegionalCluster() (bool, error) {
 	ret, specificReturn := fake.isPacificRegionalClusterReturnsOnCall[len(fake.isPacificRegionalClusterArgsForCall)]
 	fake.isPacificRegionalClusterArgsForCall = append(fake.isPacificRegionalClusterArgsForCall, struct {
 	}{})
+	stub := fake.IsPacificRegionalClusterStub
+	fakeReturns := fake.isPacificRegionalClusterReturns
 	fake.recordInvocation("IsPacificRegionalCluster", []interface{}{})
 	fake.isPacificRegionalClusterMutex.Unlock()
-	if fake.IsPacificRegionalClusterStub != nil {
-		return fake.IsPacificRegionalClusterStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.isPacificRegionalClusterReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3624,15 +3680,16 @@ func (fake *ClusterClient) IsRegionalCluster() error {
 	ret, specificReturn := fake.isRegionalClusterReturnsOnCall[len(fake.isRegionalClusterArgsForCall)]
 	fake.isRegionalClusterArgsForCall = append(fake.isRegionalClusterArgsForCall, struct {
 	}{})
+	stub := fake.IsRegionalClusterStub
+	fakeReturns := fake.isRegionalClusterReturns
 	fake.recordInvocation("IsRegionalCluster", []interface{}{})
 	fake.isRegionalClusterMutex.Unlock()
-	if fake.IsRegionalClusterStub != nil {
-		return fake.IsRegionalClusterStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isRegionalClusterReturns
 	return fakeReturns.result1
 }
 
@@ -3676,15 +3733,16 @@ func (fake *ClusterClient) ListCLIPluginResources() ([]v1alpha1a.CLIPlugin, erro
 	ret, specificReturn := fake.listCLIPluginResourcesReturnsOnCall[len(fake.listCLIPluginResourcesArgsForCall)]
 	fake.listCLIPluginResourcesArgsForCall = append(fake.listCLIPluginResourcesArgsForCall, struct {
 	}{})
+	stub := fake.ListCLIPluginResourcesStub
+	fakeReturns := fake.listCLIPluginResourcesReturns
 	fake.recordInvocation("ListCLIPluginResources", []interface{}{})
 	fake.listCLIPluginResourcesMutex.Unlock()
-	if fake.ListCLIPluginResourcesStub != nil {
-		return fake.ListCLIPluginResourcesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listCLIPluginResourcesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3732,15 +3790,16 @@ func (fake *ClusterClient) ListClusters(arg1 string) ([]v1beta1a.Cluster, error)
 	fake.listClustersArgsForCall = append(fake.listClustersArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListClustersStub
+	fakeReturns := fake.listClustersReturns
 	fake.recordInvocation("ListClusters", []interface{}{arg1})
 	fake.listClustersMutex.Unlock()
-	if fake.ListClustersStub != nil {
-		return fake.ListClustersStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listClustersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3796,15 +3855,16 @@ func (fake *ClusterClient) ListPacificClusterObjects(arg1 string, arg2 *client.L
 		arg1 string
 		arg2 *client.ListOptions
 	}{arg1, arg2})
+	stub := fake.ListPacificClusterObjectsStub
+	fakeReturns := fake.listPacificClusterObjectsReturns
 	fake.recordInvocation("ListPacificClusterObjects", []interface{}{arg1, arg2})
 	fake.listPacificClusterObjectsMutex.Unlock()
-	if fake.ListPacificClusterObjectsStub != nil {
-		return fake.ListPacificClusterObjectsStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listPacificClusterObjectsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3860,15 +3920,16 @@ func (fake *ClusterClient) ListResources(arg1 interface{}, arg2 ...client.ListOp
 		arg1 interface{}
 		arg2 []client.ListOption
 	}{arg1, arg2})
+	stub := fake.ListResourcesStub
+	fakeReturns := fake.listResourcesReturns
 	fake.recordInvocation("ListResources", []interface{}{arg1, arg2})
 	fake.listResourcesMutex.Unlock()
-	if fake.ListResourcesStub != nil {
-		return fake.ListResourcesStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.listResourcesReturns
 	return fakeReturns.result1
 }
 
@@ -3919,15 +3980,16 @@ func (fake *ClusterClient) LoadCurrentKubeconfigBytes() ([]byte, error) {
 	ret, specificReturn := fake.loadCurrentKubeconfigBytesReturnsOnCall[len(fake.loadCurrentKubeconfigBytesArgsForCall)]
 	fake.loadCurrentKubeconfigBytesArgsForCall = append(fake.loadCurrentKubeconfigBytesArgsForCall, struct {
 	}{})
+	stub := fake.LoadCurrentKubeconfigBytesStub
+	fakeReturns := fake.loadCurrentKubeconfigBytesReturns
 	fake.recordInvocation("LoadCurrentKubeconfigBytes", []interface{}{})
 	fake.loadCurrentKubeconfigBytesMutex.Unlock()
-	if fake.LoadCurrentKubeconfigBytesStub != nil {
-		return fake.LoadCurrentKubeconfigBytesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.loadCurrentKubeconfigBytesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3981,15 +4043,16 @@ func (fake *ClusterClient) MergeAndUseConfigForCluster(arg1 []byte, arg2 string)
 		arg1 []byte
 		arg2 string
 	}{arg1Copy, arg2})
+	stub := fake.MergeAndUseConfigForClusterStub
+	fakeReturns := fake.mergeAndUseConfigForClusterReturns
 	fake.recordInvocation("MergeAndUseConfigForCluster", []interface{}{arg1Copy, arg2})
 	fake.mergeAndUseConfigForClusterMutex.Unlock()
-	if fake.MergeAndUseConfigForClusterStub != nil {
-		return fake.MergeAndUseConfigForClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.mergeAndUseConfigForClusterReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -4053,15 +4116,16 @@ func (fake *ClusterClient) MergeConfigForCluster(arg1 []byte, arg2 string) error
 		arg1 []byte
 		arg2 string
 	}{arg1Copy, arg2})
+	stub := fake.MergeConfigForClusterStub
+	fakeReturns := fake.mergeConfigForClusterReturns
 	fake.recordInvocation("MergeConfigForCluster", []interface{}{arg1Copy, arg2})
 	fake.mergeConfigForClusterMutex.Unlock()
-	if fake.MergeConfigForClusterStub != nil {
-		return fake.MergeConfigForClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.mergeConfigForClusterReturns
 	return fakeReturns.result1
 }
 
@@ -4114,15 +4178,16 @@ func (fake *ClusterClient) PatchCalicoKubeControllerDeploymentWithNewNodeSelecto
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.PatchCalicoKubeControllerDeploymentWithNewNodeSelectorStub
+	fakeReturns := fake.patchCalicoKubeControllerDeploymentWithNewNodeSelectorReturns
 	fake.recordInvocation("PatchCalicoKubeControllerDeploymentWithNewNodeSelector", []interface{}{arg1, arg2})
 	fake.patchCalicoKubeControllerDeploymentWithNewNodeSelectorMutex.Unlock()
-	if fake.PatchCalicoKubeControllerDeploymentWithNewNodeSelectorStub != nil {
-		return fake.PatchCalicoKubeControllerDeploymentWithNewNodeSelectorStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchCalicoKubeControllerDeploymentWithNewNodeSelectorReturns
 	return fakeReturns.result1
 }
 
@@ -4175,15 +4240,16 @@ func (fake *ClusterClient) PatchCalicoNodeDaemonSetWithNewNodeSelector(arg1 stri
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.PatchCalicoNodeDaemonSetWithNewNodeSelectorStub
+	fakeReturns := fake.patchCalicoNodeDaemonSetWithNewNodeSelectorReturns
 	fake.recordInvocation("PatchCalicoNodeDaemonSetWithNewNodeSelector", []interface{}{arg1, arg2})
 	fake.patchCalicoNodeDaemonSetWithNewNodeSelectorMutex.Unlock()
-	if fake.PatchCalicoNodeDaemonSetWithNewNodeSelectorStub != nil {
-		return fake.PatchCalicoNodeDaemonSetWithNewNodeSelectorStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchCalicoNodeDaemonSetWithNewNodeSelectorReturns
 	return fakeReturns.result1
 }
 
@@ -4234,15 +4300,16 @@ func (fake *ClusterClient) PatchClusterAPIAWSControllersToUseEC2Credentials() er
 	ret, specificReturn := fake.patchClusterAPIAWSControllersToUseEC2CredentialsReturnsOnCall[len(fake.patchClusterAPIAWSControllersToUseEC2CredentialsArgsForCall)]
 	fake.patchClusterAPIAWSControllersToUseEC2CredentialsArgsForCall = append(fake.patchClusterAPIAWSControllersToUseEC2CredentialsArgsForCall, struct {
 	}{})
+	stub := fake.PatchClusterAPIAWSControllersToUseEC2CredentialsStub
+	fakeReturns := fake.patchClusterAPIAWSControllersToUseEC2CredentialsReturns
 	fake.recordInvocation("PatchClusterAPIAWSControllersToUseEC2Credentials", []interface{}{})
 	fake.patchClusterAPIAWSControllersToUseEC2CredentialsMutex.Unlock()
-	if fake.PatchClusterAPIAWSControllersToUseEC2CredentialsStub != nil {
-		return fake.PatchClusterAPIAWSControllersToUseEC2CredentialsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchClusterAPIAWSControllersToUseEC2CredentialsReturns
 	return fakeReturns.result1
 }
 
@@ -4289,15 +4356,16 @@ func (fake *ClusterClient) PatchClusterObject(arg1 string, arg2 string, arg3 str
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.PatchClusterObjectStub
+	fakeReturns := fake.patchClusterObjectReturns
 	fake.recordInvocation("PatchClusterObject", []interface{}{arg1, arg2, arg3})
 	fake.patchClusterObjectMutex.Unlock()
-	if fake.PatchClusterObjectStub != nil {
-		return fake.PatchClusterObjectStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchClusterObjectReturns
 	return fakeReturns.result1
 }
 
@@ -4352,15 +4420,16 @@ func (fake *ClusterClient) PatchClusterObjectWithOptionalMetadata(arg1 string, a
 		arg3 string
 		arg4 map[string]string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.PatchClusterObjectWithOptionalMetadataStub
+	fakeReturns := fake.patchClusterObjectWithOptionalMetadataReturns
 	fake.recordInvocation("PatchClusterObjectWithOptionalMetadata", []interface{}{arg1, arg2, arg3, arg4})
 	fake.patchClusterObjectWithOptionalMetadataMutex.Unlock()
-	if fake.PatchClusterObjectWithOptionalMetadataStub != nil {
-		return fake.PatchClusterObjectWithOptionalMetadataStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.patchClusterObjectWithOptionalMetadataReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -4409,6 +4478,70 @@ func (fake *ClusterClient) PatchClusterObjectWithOptionalMetadataReturnsOnCall(i
 	}{result1, result2}
 }
 
+func (fake *ClusterClient) PatchClusterObjectWithPollOptions(arg1 string, arg2 string, arg3 string, arg4 *clusterclient.PollOptions) error {
+	fake.patchClusterObjectWithPollOptionsMutex.Lock()
+	ret, specificReturn := fake.patchClusterObjectWithPollOptionsReturnsOnCall[len(fake.patchClusterObjectWithPollOptionsArgsForCall)]
+	fake.patchClusterObjectWithPollOptionsArgsForCall = append(fake.patchClusterObjectWithPollOptionsArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 *clusterclient.PollOptions
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.PatchClusterObjectWithPollOptionsStub
+	fakeReturns := fake.patchClusterObjectWithPollOptionsReturns
+	fake.recordInvocation("PatchClusterObjectWithPollOptions", []interface{}{arg1, arg2, arg3, arg4})
+	fake.patchClusterObjectWithPollOptionsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *ClusterClient) PatchClusterObjectWithPollOptionsCallCount() int {
+	fake.patchClusterObjectWithPollOptionsMutex.RLock()
+	defer fake.patchClusterObjectWithPollOptionsMutex.RUnlock()
+	return len(fake.patchClusterObjectWithPollOptionsArgsForCall)
+}
+
+func (fake *ClusterClient) PatchClusterObjectWithPollOptionsCalls(stub func(string, string, string, *clusterclient.PollOptions) error) {
+	fake.patchClusterObjectWithPollOptionsMutex.Lock()
+	defer fake.patchClusterObjectWithPollOptionsMutex.Unlock()
+	fake.PatchClusterObjectWithPollOptionsStub = stub
+}
+
+func (fake *ClusterClient) PatchClusterObjectWithPollOptionsArgsForCall(i int) (string, string, string, *clusterclient.PollOptions) {
+	fake.patchClusterObjectWithPollOptionsMutex.RLock()
+	defer fake.patchClusterObjectWithPollOptionsMutex.RUnlock()
+	argsForCall := fake.patchClusterObjectWithPollOptionsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *ClusterClient) PatchClusterObjectWithPollOptionsReturns(result1 error) {
+	fake.patchClusterObjectWithPollOptionsMutex.Lock()
+	defer fake.patchClusterObjectWithPollOptionsMutex.Unlock()
+	fake.PatchClusterObjectWithPollOptionsStub = nil
+	fake.patchClusterObjectWithPollOptionsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ClusterClient) PatchClusterObjectWithPollOptionsReturnsOnCall(i int, result1 error) {
+	fake.patchClusterObjectWithPollOptionsMutex.Lock()
+	defer fake.patchClusterObjectWithPollOptionsMutex.Unlock()
+	fake.PatchClusterObjectWithPollOptionsStub = nil
+	if fake.patchClusterObjectWithPollOptionsReturnsOnCall == nil {
+		fake.patchClusterObjectWithPollOptionsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.patchClusterObjectWithPollOptionsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *ClusterClient) PatchClusterObjectWithTKGVersion(arg1 string, arg2 string, arg3 string) error {
 	fake.patchClusterObjectWithTKGVersionMutex.Lock()
 	ret, specificReturn := fake.patchClusterObjectWithTKGVersionReturnsOnCall[len(fake.patchClusterObjectWithTKGVersionArgsForCall)]
@@ -4417,15 +4550,16 @@ func (fake *ClusterClient) PatchClusterObjectWithTKGVersion(arg1 string, arg2 st
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.PatchClusterObjectWithTKGVersionStub
+	fakeReturns := fake.patchClusterObjectWithTKGVersionReturns
 	fake.recordInvocation("PatchClusterObjectWithTKGVersion", []interface{}{arg1, arg2, arg3})
 	fake.patchClusterObjectWithTKGVersionMutex.Unlock()
-	if fake.PatchClusterObjectWithTKGVersionStub != nil {
-		return fake.PatchClusterObjectWithTKGVersionStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchClusterObjectWithTKGVersionReturns
 	return fakeReturns.result1
 }
 
@@ -4480,15 +4614,16 @@ func (fake *ClusterClient) PatchClusterWithOperationStartedStatus(arg1 string, a
 		arg3 string
 		arg4 time.Duration
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.PatchClusterWithOperationStartedStatusStub
+	fakeReturns := fake.patchClusterWithOperationStartedStatusReturns
 	fake.recordInvocation("PatchClusterWithOperationStartedStatus", []interface{}{arg1, arg2, arg3, arg4})
 	fake.patchClusterWithOperationStartedStatusMutex.Unlock()
-	if fake.PatchClusterWithOperationStartedStatusStub != nil {
-		return fake.PatchClusterWithOperationStartedStatusStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchClusterWithOperationStartedStatusReturns
 	return fakeReturns.result1
 }
 
@@ -4540,15 +4675,16 @@ func (fake *ClusterClient) PatchCoreDNSImageRepositoryInKubeadmConfigMap(arg1 st
 	fake.patchCoreDNSImageRepositoryInKubeadmConfigMapArgsForCall = append(fake.patchCoreDNSImageRepositoryInKubeadmConfigMapArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.PatchCoreDNSImageRepositoryInKubeadmConfigMapStub
+	fakeReturns := fake.patchCoreDNSImageRepositoryInKubeadmConfigMapReturns
 	fake.recordInvocation("PatchCoreDNSImageRepositoryInKubeadmConfigMap", []interface{}{arg1})
 	fake.patchCoreDNSImageRepositoryInKubeadmConfigMapMutex.Unlock()
-	if fake.PatchCoreDNSImageRepositoryInKubeadmConfigMapStub != nil {
-		return fake.PatchCoreDNSImageRepositoryInKubeadmConfigMapStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchCoreDNSImageRepositoryInKubeadmConfigMapReturns
 	return fakeReturns.result1
 }
 
@@ -4600,15 +4736,16 @@ func (fake *ClusterClient) PatchImageRepositoryInKubeProxyDaemonSet(arg1 string)
 	fake.patchImageRepositoryInKubeProxyDaemonSetArgsForCall = append(fake.patchImageRepositoryInKubeProxyDaemonSetArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.PatchImageRepositoryInKubeProxyDaemonSetStub
+	fakeReturns := fake.patchImageRepositoryInKubeProxyDaemonSetReturns
 	fake.recordInvocation("PatchImageRepositoryInKubeProxyDaemonSet", []interface{}{arg1})
 	fake.patchImageRepositoryInKubeProxyDaemonSetMutex.Unlock()
-	if fake.PatchImageRepositoryInKubeProxyDaemonSetStub != nil {
-		return fake.PatchImageRepositoryInKubeProxyDaemonSetStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchImageRepositoryInKubeProxyDaemonSetReturns
 	return fakeReturns.result1
 }
 
@@ -4662,15 +4799,16 @@ func (fake *ClusterClient) PatchK8SVersionToPacificCluster(arg1 string, arg2 str
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.PatchK8SVersionToPacificClusterStub
+	fakeReturns := fake.patchK8SVersionToPacificClusterReturns
 	fake.recordInvocation("PatchK8SVersionToPacificCluster", []interface{}{arg1, arg2, arg3})
 	fake.patchK8SVersionToPacificClusterMutex.Unlock()
-	if fake.PatchK8SVersionToPacificClusterStub != nil {
-		return fake.PatchK8SVersionToPacificClusterStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchK8SVersionToPacificClusterReturns
 	return fakeReturns.result1
 }
 
@@ -4727,15 +4865,16 @@ func (fake *ClusterClient) PatchResource(arg1 interface{}, arg2 string, arg3 str
 		arg5 types.PatchType
 		arg6 *clusterclient.PollOptions
 	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	stub := fake.PatchResourceStub
+	fakeReturns := fake.patchResourceReturns
 	fake.recordInvocation("PatchResource", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.patchResourceMutex.Unlock()
-	if fake.PatchResourceStub != nil {
-		return fake.PatchResourceStub(arg1, arg2, arg3, arg4, arg5, arg6)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchResourceReturns
 	return fakeReturns.result1
 }
 
@@ -4787,15 +4926,16 @@ func (fake *ClusterClient) RemoveCEIPTelemetryJob(arg1 string) error {
 	fake.removeCEIPTelemetryJobArgsForCall = append(fake.removeCEIPTelemetryJobArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RemoveCEIPTelemetryJobStub
+	fakeReturns := fake.removeCEIPTelemetryJobReturns
 	fake.recordInvocation("RemoveCEIPTelemetryJob", []interface{}{arg1})
 	fake.removeCEIPTelemetryJobMutex.Unlock()
-	if fake.RemoveCEIPTelemetryJobStub != nil {
-		return fake.RemoveCEIPTelemetryJobStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeCEIPTelemetryJobReturns
 	return fakeReturns.result1
 }
 
@@ -4849,15 +4989,16 @@ func (fake *ClusterClient) ScalePacificClusterControlPlane(arg1 string, arg2 str
 		arg2 string
 		arg3 int32
 	}{arg1, arg2, arg3})
+	stub := fake.ScalePacificClusterControlPlaneStub
+	fakeReturns := fake.scalePacificClusterControlPlaneReturns
 	fake.recordInvocation("ScalePacificClusterControlPlane", []interface{}{arg1, arg2, arg3})
 	fake.scalePacificClusterControlPlaneMutex.Unlock()
-	if fake.ScalePacificClusterControlPlaneStub != nil {
-		return fake.ScalePacificClusterControlPlaneStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.scalePacificClusterControlPlaneReturns
 	return fakeReturns.result1
 }
 
@@ -4911,15 +5052,16 @@ func (fake *ClusterClient) ScalePacificClusterWorkerNodes(arg1 string, arg2 stri
 		arg2 string
 		arg3 int32
 	}{arg1, arg2, arg3})
+	stub := fake.ScalePacificClusterWorkerNodesStub
+	fakeReturns := fake.scalePacificClusterWorkerNodesReturns
 	fake.recordInvocation("ScalePacificClusterWorkerNodes", []interface{}{arg1, arg2, arg3})
 	fake.scalePacificClusterWorkerNodesMutex.Unlock()
-	if fake.ScalePacificClusterWorkerNodesStub != nil {
-		return fake.ScalePacificClusterWorkerNodesStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.scalePacificClusterWorkerNodesReturns
 	return fakeReturns.result1
 }
 
@@ -4972,15 +5114,16 @@ func (fake *ClusterClient) UpdateAWSCNIIngressRules(arg1 string, arg2 string) er
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.UpdateAWSCNIIngressRulesStub
+	fakeReturns := fake.updateAWSCNIIngressRulesReturns
 	fake.recordInvocation("UpdateAWSCNIIngressRules", []interface{}{arg1, arg2})
 	fake.updateAWSCNIIngressRulesMutex.Unlock()
-	if fake.UpdateAWSCNIIngressRulesStub != nil {
-		return fake.UpdateAWSCNIIngressRulesStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateAWSCNIIngressRulesReturns
 	return fakeReturns.result1
 }
 
@@ -5033,15 +5176,16 @@ func (fake *ClusterClient) UpdateCapvManagerBootstrapCredentialsSecret(arg1 stri
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.UpdateCapvManagerBootstrapCredentialsSecretStub
+	fakeReturns := fake.updateCapvManagerBootstrapCredentialsSecretReturns
 	fake.recordInvocation("UpdateCapvManagerBootstrapCredentialsSecret", []interface{}{arg1, arg2})
 	fake.updateCapvManagerBootstrapCredentialsSecretMutex.Unlock()
-	if fake.UpdateCapvManagerBootstrapCredentialsSecretStub != nil {
-		return fake.UpdateCapvManagerBootstrapCredentialsSecretStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateCapvManagerBootstrapCredentialsSecretReturns
 	return fakeReturns.result1
 }
 
@@ -5096,15 +5240,16 @@ func (fake *ClusterClient) UpdateReplicas(arg1 interface{}, arg2 string, arg3 st
 		arg3 string
 		arg4 int32
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.UpdateReplicasStub
+	fakeReturns := fake.updateReplicasReturns
 	fake.recordInvocation("UpdateReplicas", []interface{}{arg1, arg2, arg3, arg4})
 	fake.updateReplicasMutex.Unlock()
-	if fake.UpdateReplicasStub != nil {
-		return fake.UpdateReplicasStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateReplicasReturns
 	return fakeReturns.result1
 }
 
@@ -5159,15 +5304,16 @@ func (fake *ClusterClient) UpdateResource(arg1 interface{}, arg2 string, arg3 st
 		arg3 string
 		arg4 []client.UpdateOption
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.UpdateResourceStub
+	fakeReturns := fake.updateResourceReturns
 	fake.recordInvocation("UpdateResource", []interface{}{arg1, arg2, arg3, arg4})
 	fake.updateResourceMutex.Unlock()
-	if fake.UpdateResourceStub != nil {
-		return fake.UpdateResourceStub(arg1, arg2, arg3, arg4...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateResourceReturns
 	return fakeReturns.result1
 }
 
@@ -5223,15 +5369,16 @@ func (fake *ClusterClient) UpdateResourceWithPolling(arg1 interface{}, arg2 stri
 		arg4 *clusterclient.PollOptions
 		arg5 []client.UpdateOption
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.UpdateResourceWithPollingStub
+	fakeReturns := fake.updateResourceWithPollingReturns
 	fake.recordInvocation("UpdateResourceWithPolling", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.updateResourceWithPollingMutex.Unlock()
-	if fake.UpdateResourceWithPollingStub != nil {
-		return fake.UpdateResourceWithPollingStub(arg1, arg2, arg3, arg4, arg5...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateResourceWithPollingReturns
 	return fakeReturns.result1
 }
 
@@ -5286,15 +5433,16 @@ func (fake *ClusterClient) UpdateVsphereCloudProviderCredentialsSecret(arg1 stri
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.UpdateVsphereCloudProviderCredentialsSecretStub
+	fakeReturns := fake.updateVsphereCloudProviderCredentialsSecretReturns
 	fake.recordInvocation("UpdateVsphereCloudProviderCredentialsSecret", []interface{}{arg1, arg2, arg3, arg4})
 	fake.updateVsphereCloudProviderCredentialsSecretMutex.Unlock()
-	if fake.UpdateVsphereCloudProviderCredentialsSecretStub != nil {
-		return fake.UpdateVsphereCloudProviderCredentialsSecretStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateVsphereCloudProviderCredentialsSecretReturns
 	return fakeReturns.result1
 }
 
@@ -5349,15 +5497,16 @@ func (fake *ClusterClient) UpdateVsphereCsiConfigSecret(arg1 string, arg2 string
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.UpdateVsphereCsiConfigSecretStub
+	fakeReturns := fake.updateVsphereCsiConfigSecretReturns
 	fake.recordInvocation("UpdateVsphereCsiConfigSecret", []interface{}{arg1, arg2, arg3, arg4})
 	fake.updateVsphereCsiConfigSecretMutex.Unlock()
-	if fake.UpdateVsphereCsiConfigSecretStub != nil {
-		return fake.UpdateVsphereCsiConfigSecretStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateVsphereCsiConfigSecretReturns
 	return fakeReturns.result1
 }
 
@@ -5412,15 +5561,16 @@ func (fake *ClusterClient) UpdateVsphereIdentityRefSecret(arg1 string, arg2 stri
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.UpdateVsphereIdentityRefSecretStub
+	fakeReturns := fake.updateVsphereIdentityRefSecretReturns
 	fake.recordInvocation("UpdateVsphereIdentityRefSecret", []interface{}{arg1, arg2, arg3, arg4})
 	fake.updateVsphereIdentityRefSecretMutex.Unlock()
-	if fake.UpdateVsphereIdentityRefSecretStub != nil {
-		return fake.UpdateVsphereIdentityRefSecretStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateVsphereIdentityRefSecretReturns
 	return fakeReturns.result1
 }
 
@@ -5472,15 +5622,16 @@ func (fake *ClusterClient) UseContext(arg1 string) error {
 	fake.useContextArgsForCall = append(fake.useContextArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.UseContextStub
+	fakeReturns := fake.useContextReturns
 	fake.recordInvocation("UseContext", []interface{}{arg1})
 	fake.useContextMutex.Unlock()
-	if fake.UseContextStub != nil {
-		return fake.UseContextStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.useContextReturns
 	return fakeReturns.result1
 }
 
@@ -5533,15 +5684,16 @@ func (fake *ClusterClient) WaitForAVIResourceCleanUp(arg1 string, arg2 string) e
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.WaitForAVIResourceCleanUpStub
+	fakeReturns := fake.waitForAVIResourceCleanUpReturns
 	fake.recordInvocation("WaitForAVIResourceCleanUp", []interface{}{arg1, arg2})
 	fake.waitForAVIResourceCleanUpMutex.Unlock()
-	if fake.WaitForAVIResourceCleanUpStub != nil {
-		return fake.WaitForAVIResourceCleanUpStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForAVIResourceCleanUpReturns
 	return fakeReturns.result1
 }
 
@@ -5594,15 +5746,16 @@ func (fake *ClusterClient) WaitForAutoscalerDeployment(arg1 string, arg2 string)
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.WaitForAutoscalerDeploymentStub
+	fakeReturns := fake.waitForAutoscalerDeploymentReturns
 	fake.recordInvocation("WaitForAutoscalerDeployment", []interface{}{arg1, arg2})
 	fake.waitForAutoscalerDeploymentMutex.Unlock()
-	if fake.WaitForAutoscalerDeploymentStub != nil {
-		return fake.WaitForAutoscalerDeploymentStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForAutoscalerDeploymentReturns
 	return fakeReturns.result1
 }
 
@@ -5655,15 +5808,16 @@ func (fake *ClusterClient) WaitForClusterDeletion(arg1 string, arg2 string) erro
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.WaitForClusterDeletionStub
+	fakeReturns := fake.waitForClusterDeletionReturns
 	fake.recordInvocation("WaitForClusterDeletion", []interface{}{arg1, arg2})
 	fake.waitForClusterDeletionMutex.Unlock()
-	if fake.WaitForClusterDeletionStub != nil {
-		return fake.WaitForClusterDeletionStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForClusterDeletionReturns
 	return fakeReturns.result1
 }
 
@@ -5716,15 +5870,16 @@ func (fake *ClusterClient) WaitForClusterInitialized(arg1 string, arg2 string) e
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.WaitForClusterInitializedStub
+	fakeReturns := fake.waitForClusterInitializedReturns
 	fake.recordInvocation("WaitForClusterInitialized", []interface{}{arg1, arg2})
 	fake.waitForClusterInitializedMutex.Unlock()
-	if fake.WaitForClusterInitializedStub != nil {
-		return fake.WaitForClusterInitializedStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForClusterInitializedReturns
 	return fakeReturns.result1
 }
 
@@ -5778,15 +5933,16 @@ func (fake *ClusterClient) WaitForClusterReady(arg1 string, arg2 string, arg3 bo
 		arg2 string
 		arg3 bool
 	}{arg1, arg2, arg3})
+	stub := fake.WaitForClusterReadyStub
+	fakeReturns := fake.waitForClusterReadyReturns
 	fake.recordInvocation("WaitForClusterReady", []interface{}{arg1, arg2, arg3})
 	fake.waitForClusterReadyMutex.Unlock()
-	if fake.WaitForClusterReadyStub != nil {
-		return fake.WaitForClusterReadyStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForClusterReadyReturns
 	return fakeReturns.result1
 }
 
@@ -5839,15 +5995,16 @@ func (fake *ClusterClient) WaitForDeployment(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.WaitForDeploymentStub
+	fakeReturns := fake.waitForDeploymentReturns
 	fake.recordInvocation("WaitForDeployment", []interface{}{arg1, arg2})
 	fake.waitForDeploymentMutex.Unlock()
-	if fake.WaitForDeploymentStub != nil {
-		return fake.WaitForDeploymentStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForDeploymentReturns
 	return fakeReturns.result1
 }
 
@@ -5900,15 +6057,16 @@ func (fake *ClusterClient) WaitForPacificCluster(arg1 string, arg2 string) error
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.WaitForPacificClusterStub
+	fakeReturns := fake.waitForPacificClusterReturns
 	fake.recordInvocation("WaitForPacificCluster", []interface{}{arg1, arg2})
 	fake.waitForPacificClusterMutex.Unlock()
-	if fake.WaitForPacificClusterStub != nil {
-		return fake.WaitForPacificClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForPacificClusterReturns
 	return fakeReturns.result1
 }
 
@@ -5962,15 +6120,16 @@ func (fake *ClusterClient) WaitForPacificClusterK8sVersionUpdate(arg1 string, ar
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.WaitForPacificClusterK8sVersionUpdateStub
+	fakeReturns := fake.waitForPacificClusterK8sVersionUpdateReturns
 	fake.recordInvocation("WaitForPacificClusterK8sVersionUpdate", []interface{}{arg1, arg2, arg3})
 	fake.waitForPacificClusterK8sVersionUpdateMutex.Unlock()
-	if fake.WaitForPacificClusterK8sVersionUpdateStub != nil {
-		return fake.WaitForPacificClusterK8sVersionUpdateStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForPacificClusterK8sVersionUpdateReturns
 	return fakeReturns.result1
 }
 
@@ -6024,15 +6183,16 @@ func (fake *ClusterClient) WaitForPackageInstall(arg1 string, arg2 string, arg3 
 		arg2 string
 		arg3 time.Duration
 	}{arg1, arg2, arg3})
+	stub := fake.WaitForPackageInstallStub
+	fakeReturns := fake.waitForPackageInstallReturns
 	fake.recordInvocation("WaitForPackageInstall", []interface{}{arg1, arg2, arg3})
 	fake.waitForPackageInstallMutex.Unlock()
-	if fake.WaitForPackageInstallStub != nil {
-		return fake.WaitForPackageInstallStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForPackageInstallReturns
 	return fakeReturns.result1
 }
 
@@ -6087,15 +6247,16 @@ func (fake *ClusterClient) WaitK8sVersionUpdateForCPNodes(arg1 string, arg2 stri
 		arg3 string
 		arg4 clusterclient.Client
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.WaitK8sVersionUpdateForCPNodesStub
+	fakeReturns := fake.waitK8sVersionUpdateForCPNodesReturns
 	fake.recordInvocation("WaitK8sVersionUpdateForCPNodes", []interface{}{arg1, arg2, arg3, arg4})
 	fake.waitK8sVersionUpdateForCPNodesMutex.Unlock()
-	if fake.WaitK8sVersionUpdateForCPNodesStub != nil {
-		return fake.WaitK8sVersionUpdateForCPNodesStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitK8sVersionUpdateForCPNodesReturns
 	return fakeReturns.result1
 }
 
@@ -6150,15 +6311,16 @@ func (fake *ClusterClient) WaitK8sVersionUpdateForWorkerNodes(arg1 string, arg2 
 		arg3 string
 		arg4 clusterclient.Client
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.WaitK8sVersionUpdateForWorkerNodesStub
+	fakeReturns := fake.waitK8sVersionUpdateForWorkerNodesReturns
 	fake.recordInvocation("WaitK8sVersionUpdateForWorkerNodes", []interface{}{arg1, arg2, arg3, arg4})
 	fake.waitK8sVersionUpdateForWorkerNodesMutex.Unlock()
-	if fake.WaitK8sVersionUpdateForWorkerNodesStub != nil {
-		return fake.WaitK8sVersionUpdateForWorkerNodesStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitK8sVersionUpdateForWorkerNodesReturns
 	return fakeReturns.result1
 }
 
@@ -6317,6 +6479,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.patchClusterObjectMutex.RUnlock()
 	fake.patchClusterObjectWithOptionalMetadataMutex.RLock()
 	defer fake.patchClusterObjectWithOptionalMetadataMutex.RUnlock()
+	fake.patchClusterObjectWithPollOptionsMutex.RLock()
+	defer fake.patchClusterObjectWithPollOptionsMutex.RUnlock()
 	fake.patchClusterObjectWithTKGVersionMutex.RLock()
 	defer fake.patchClusterObjectWithTKGVersionMutex.RUnlock()
 	fake.patchClusterWithOperationStartedStatusMutex.RLock()


### PR DESCRIPTION
…l upgrade

### What this PR does / why we need it

- In some of the test pipelines, we are observing that patching the `Cluster` object just after a successful upgrade is causing the issue and throws an error `Internal error occurred: failed calling webhook "default.cluster.cluster.x-k8s.io": Post "https://capi-webhook-service.capi-webhook-system.svc:443/mutate-cluster-x-k8s-io-v1alpha3-cluster?timeout=30s": dial tcp 100.64.234.120:443: connect: connection refused`
- This is possible because the pods like the webhook controller are not ready yet and CLI only tries to patch the resource only once. This change uses polling to patch the resource multiple times before throwing error.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1311

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix cluster patch failing after successful k8s nodes upgrade for management-cluster
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
