### PR TITLE
Fixes potential issue where contents get unzipped outside current directory

### DIFF
--- a/pkg/v1/tkg/tkgconfigupdater/helper.go
+++ b/pkg/v1/tkg/tkgconfigupdater/helper.go
@@ -49,11 +49,18 @@ func unzip(srcfilepath, destdir string) error {
 	}
 	defer r.Close()
 
+	if strings.Contains(destdir, "..") {
+		return errors.Wrapf(err, "destination contains directory(parent) \"..\" which could lead to zip file being extracted outside the current directory")
+	}
+
 	for _, f := range r.File {
 		fpath := filepath.Join(destdir, f.Name) // #nosec
+		if strings.Contains(fpath, "..") {
+			return errors.Wrapf(err, "filepath contains directory(parent) \"..\" which could lead to zip file being extracted outside the current directory")
+		}
 		if f.FileInfo().IsDir() {
 			if err = os.MkdirAll(fpath, os.ModePerm); err != nil {
-				return errors.Wrap(err, "failed top make directory during unzip")
+				return errors.Wrap(err, "failed to make directory during unzip")
 			}
 			continue
 		}

--- a/pkg/v1/tkg/tkgconfigupdater/helper.go
+++ b/pkg/v1/tkg/tkgconfigupdater/helper.go
@@ -49,15 +49,11 @@ func unzip(srcfilepath, destdir string) error {
 	}
 	defer r.Close()
 
-	if strings.Contains(destdir, "..") {
-		return errors.Wrapf(err, "destination contains directory(parent) \"..\" which could lead to zip file being extracted outside the current directory")
-	}
-
 	for _, f := range r.File {
-		fpath := filepath.Join(destdir, f.Name) // #nosec
-		if strings.Contains(fpath, "..") {
-			return errors.Wrapf(err, "filepath contains directory(parent) \"..\" which could lead to zip file being extracted outside the current directory")
+		if strings.Contains(f.Name, "..") {
+			return errors.New("filepath contains directory(parent) \"..\" which could lead to zip file being extracted outside the current directory")
 		}
+		fpath := filepath.Join(destdir, f.Name) // #nosec
 		if f.FileInfo().IsDir() {
 			if err = os.MkdirAll(fpath, os.ModePerm); err != nil {
 				return errors.Wrap(err, "failed to make directory during unzip")

--- a/pkg/v1/tkg/tkgconfigupdater/helper_test.go
+++ b/pkg/v1/tkg/tkgconfigupdater/helper_test.go
@@ -1,0 +1,25 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgconfigupdater
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	sampleFilePath string
+	destDir        string
+)
+
+var _ = Describe("Tests while unzipping a file", func() {
+	Context("Validating destDir path", func() {
+		It("when file path is invalid", func() {
+			sampleFilePath = "baz"
+			destDir = "foo/../bar"
+			err := unzip(sampleFilePath, destDir)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/pkg/v1/tkg/tkgconfigupdater/helper_test.go
+++ b/pkg/v1/tkg/tkgconfigupdater/helper_test.go
@@ -4,22 +4,105 @@
 package tkgconfigupdater
 
 import (
+	"archive/zip"
+	"io"
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var (
-	sampleFilePath string
-	destDir        string
+	sampleFilePath    string
+	sampleFilePath2   string
+	destDir           string
+	baseDir           string
+	incorrectFileName string
 )
 
 var _ = Describe("Tests while unzipping a file", func() {
+	BeforeEach(func() {
+		sampleFilePath = "/tmp/baz.zip"
+		sampleFilePath2 = "/tmp/foobar.zip"
+		contentFileName := "foo.txt"
+		incorrectFileName = "../foobar.txt"
+		baseDir, err = os.MkdirTemp("/tmp", "test-zip")
+		if err != nil {
+			return
+		}
+
+		err = setupSampleZipFile(sampleFilePath, contentFileName)
+		if err != nil {
+			return
+		}
+	})
 	Context("Validating destDir path", func() {
-		It("when file path is invalid", func() {
-			sampleFilePath = "baz"
-			destDir = "foo/../bar"
+		AfterEach(func() {
+			os.RemoveAll(baseDir)
+			os.Remove(sampleFilePath)
+			os.Remove(sampleFilePath2)
+			os.Remove("/tmp/foobar.txt")
+		})
+		It("when content file path is valid", func() {
+			destDir = "/tmp/foo"
 			err := unzip(sampleFilePath, destDir)
-			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeNil())
+
+			os.RemoveAll(destDir)
+		})
+		It("when content file path is invalid", func() {
+			err := setupSampleZipFile(sampleFilePath2, incorrectFileName)
+			Expect(err).To(BeNil())
+			destDir = "/tmp/bar"
+			err = unzip(sampleFilePath2, destDir)
+			Expect(err).To(Not(BeNil()))
+			Expect(err.Error()).To(ContainSubstring("filepath contains directory(parent)"))
 		})
 	})
 })
+
+func setupSampleZipFile(zipFileName, contentFileName string) error {
+	nestedDir, err := os.Create(baseDir + "/" + contentFileName)
+	if err != nil {
+		return err
+	}
+
+	zipFile, err := os.Create(zipFileName)
+	if err != nil {
+		return err
+	}
+	defer zipFile.Close()
+
+	zipWriter := zip.NewWriter(zipFile)
+	defer zipWriter.Close()
+
+	fileToZip, err := os.Open(nestedDir.Name())
+	if err != nil {
+		return err
+	}
+
+	info, err := fileToZip.Stat()
+	if err != nil {
+		return err
+	}
+
+	header, err := zip.FileInfoHeader(info)
+	if err != nil {
+		return err
+	}
+
+	// Using FileInfoHeader() above only uses the basename of the file. If we want
+	// to preserve the folder structure we can overwrite this with the full path.
+	header.Name = fileToZip.Name()
+
+	// Change to deflate to gain better compression
+	// see http://golang.org/pkg/archive/zip/#pkg-constants
+	header.Method = zip.Deflate
+
+	writer, err := zipWriter.CreateHeader(header)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(writer, fileToZip)
+	return err
+}


### PR DESCRIPTION
Fixes potential issue where contents get unzipped outside current directory

Signed-off-by: Sudarshan <asudarshan@vmware.com>

### What this PR does / why we need it
There is no filepath validation when we extract the contents of a zip. This could potentially lead to files being extracted outside of the desired destination directory. This PR fixes that, and also adds some validations to satisfy the gosec linter that was previously commented out.
 
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
* Unit test added for filePath validation.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Validates filepaths to ensure that an archive cannot be unzipped outside the current directory
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
