### PR TITLE
Configure cluster DNS in kapp controller package

### DIFF
--- a/pkg/v1/providers/config_default.yaml
+++ b/pkg/v1/providers/config_default.yaml
@@ -446,6 +446,10 @@ CLUSTER_CIDR:
 SERVICE_CIDR:
 NODE_STARTUP_TIMEOUT: 20m
 
+#! CORE_DNS_IP is the IP of core DNS service, supports both IPv4 and IPv6
+#! It is the 10th index of SERVICE_CIDR subnet
+CORE_DNS_IP:
+
 CONTROL_PLANE_MACHINE_COUNT:
 WORKER_MACHINE_COUNT:
 #! sets the number of worker nodes in the first AZ, AWS_NODE_AZ.

--- a/pkg/v1/providers/config_default.yaml
+++ b/pkg/v1/providers/config_default.yaml
@@ -446,10 +446,6 @@ CLUSTER_CIDR:
 SERVICE_CIDR:
 NODE_STARTUP_TIMEOUT: 20m
 
-#! CORE_DNS_IP is the IP of core DNS service, supports both IPv4 and IPv6
-#! It is the 10th index of SERVICE_CIDR subnet
-CORE_DNS_IP:
-
 CONTROL_PLANE_MACHINE_COUNT:
 WORKER_MACHINE_COUNT:
 #! sets the number of worker nodes in the first AZ, AWS_NODE_AZ.
@@ -622,6 +618,9 @@ AWS_AMI_ID:
 TKR_DISCOVER_FREQUENCY: 600
 #! vSphere version
 VSPHERE_VERSION:
+#! CORE_DNS_IP is the IP of core DNS service, supports both IPv4 and IPv6
+#! It is the 10th index of SERVICE_CIDR subnet
+CORE_DNS_IP:
 
 
 #! ---------------------------------------------------------------------

--- a/pkg/v1/providers/tests/unit/windows_test.go
+++ b/pkg/v1/providers/tests/unit/windows_test.go
@@ -49,6 +49,7 @@ var _ = Describe("Windows Ytt Templating", func() {
 			"VSPHERE_SSH_AUTHORIZED_KEY":  "ssh-rsa AAAA...+M7Q== vmware-tanzu.local",
 			"TKG_DEFAULT_BOM":             "tkg-bom-v1.4.0.yaml",
 			"KUBERNETES_RELEASE":          "v1.21.2---vmware.1-tkg.1",
+			"CORE_DNS_IP":                 "10.64.0.10",
 		})
 
 		// Printing these values helps for debugging the ytt command if needed

--- a/pkg/v1/providers/vendir.lock.yml
+++ b/pkg/v1/providers/vendir.lock.yml
@@ -19,10 +19,10 @@ directories:
 - contents:
   - git:
       commitTitle: Add kapp controller init container to configure core DNS for cluster
-        IP access...
-      sha: 213f0ec0e23f7a61e00720d0f7d9f5b52d66d29d
+        IP access (#2727)...
+      sha: 1ce18be43347405d3dfbde4ba2cbb0d1e2fa0b41
       tags:
-      - v0.10.0-dev.1-321-g213f0ec0
+      - v0.10.0-dev.4-39-g1ce18be4
     path: .
   path: ytt/vendir/kapp-controller/_ytt_lib
 kind: LockConfig

--- a/pkg/v1/providers/vendir.lock.yml
+++ b/pkg/v1/providers/vendir.lock.yml
@@ -18,10 +18,11 @@ directories:
   path: ytt/vendir/cni/_ytt_lib
 - contents:
   - git:
-      commitTitle: add kapp-controller 0.30.0 package (#2558)...
-      sha: 87e39a645a0d5c7ee4ae1839b3be6d5208ddd23b
+      commitTitle: Add kapp controller init container to configure core DNS for cluster
+        IP access...
+      sha: 213f0ec0e23f7a61e00720d0f7d9f5b52d66d29d
       tags:
-      - v0.10.0-dev.2-7-g87e39a64
+      - v0.10.0-dev.1-321-g213f0ec0
     path: .
   path: ytt/vendir/kapp-controller/_ytt_lib
 kind: LockConfig

--- a/pkg/v1/providers/vendir.yml
+++ b/pkg/v1/providers/vendir.yml
@@ -22,7 +22,7 @@ directories:
   contents:
   - path: .
     git:
-      url: git@github.com:blc1996/community-edition.git
-      ref: 213f0ec0e23f7a61e00720d0f7d9f5b52d66d29d
+      url: git@github.com:vmware-tanzu/community-edition.git
+      ref: 1ce18be43347405d3dfbde4ba2cbb0d1e2fa0b41
     includePaths:
     - addons/packages/kapp-controller/0.30.0/bundle/config/**/*

--- a/pkg/v1/providers/vendir.yml
+++ b/pkg/v1/providers/vendir.yml
@@ -22,7 +22,7 @@ directories:
   contents:
   - path: .
     git:
-      url: git@github.com:vmware-tanzu/community-edition.git
-      ref: 87e39a645a0d5c7ee4ae1839b3be6d5208ddd23b
+      url: git@github.com:blc1996/community-edition.git
+      ref: 213f0ec0e23f7a61e00720d0f7d9f5b52d66d29d
     includePaths:
     - addons/packages/kapp-controller/0.30.0/bundle/config/**/*

--- a/pkg/v1/providers/ytt/02_addons/kapp-controller/kapp-controller_addon_data.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/kapp-controller/kapp-controller_addon_data.lib.yaml
@@ -21,6 +21,7 @@ kappController:
 #@ end
   deployment:
     concurrency: 4
+    coreDNSIP: #@ data.values.CORE_DNS_IP
     hostNetwork: true
     priorityClassName: system-cluster-critical
     apiPort: 10100

--- a/pkg/v1/providers/ytt/02_addons/kapp-controller/kapp-controller_overlay.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/kapp-controller/kapp-controller_overlay.lib.yaml
@@ -23,6 +23,10 @@ spec:
       #@overlay/match by=overlay.subset({"name":"kapp-controller"})
       - image: #@ "{}/{}:{}".format(get_image_repo_for_component(bomData.components["kapp-controller"][0].images.kappControllerImage), bomData.components["kapp-controller"][0].images.kappControllerImage.imagePath, bomData.components["kapp-controller"][0].images.kappControllerImage.tag)
       #@overlay/match missing_ok=True
+      initContainers:
+      #@overlay/match by=overlay.subset({"name":"init-kapp-controller"}), missing_ok=True
+      - image: #@ "{}/{}:{}".format(get_image_repo_for_component(bomData.components["kapp-controller"][0].images.kappControllerImage), bomData.components["kapp-controller"][0].images.kappControllerImage.imagePath, bomData.components["kapp-controller"][0].images.kappControllerImage.tag)
+      #@overlay/match missing_ok=True
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists

--- a/pkg/v1/providers/ytt/vendir/kapp-controller/_ytt_lib/addons/packages/kapp-controller/0.30.0/bundle/config/overlays/update-deployment.yaml
+++ b/pkg/v1/providers/ytt/vendir/kapp-controller/_ytt_lib/addons/packages/kapp-controller/0.30.0/bundle/config/overlays/update-deployment.yaml
@@ -1,5 +1,5 @@
 #@ load("@ytt:overlay", "overlay")
-#@ load("/values.star", "values")
+#@ load("/values.star", "values", "generateBashCmdForDNS")
 #@ load("@ytt:yaml", "yaml")
 
 #@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name": "kapp-controller"}})
@@ -29,10 +29,42 @@ spec:
           #@overlay/match by="name"
           - name: KAPPCTRL_API_PORT
             value: #@ str(values.kappController.deployment.apiPort)
+        #@ if values.kappController.deployment.hostNetwork:
+        volumeMounts:
+          - mountPath: /etc
+            name: etc
+        #@ end
+      #@ if values.kappController.deployment.hostNetwork:
+      #! Using init container bypasses the restriction of not having root access in main container
+      #! It modifies /etc/resolv.conf which is shared to main container
+      initContainers:
+      - args:
+        - -c
+        - #@ generateBashCmdForDNS(values.kappController.deployment.coreDNSIP)
+        command:
+        - /bin/sh
+        #! Beware, update this image with each version bump!!!!!!!
+        #! This image needs to be the same as the image used in basefile
+        image: ghcr.io/vmware-tanzu/carvel-kapp-controller@sha256:46f9c4e78d80a322ae3159cb97069350b445b974664f4aead0ab4ad593d79f45
+        name: init-kapp-controller
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /kapp-etc
+          name: etc
+      #@ end
       #@ if/end values.kappController.deployment.hostNetwork:
       hostNetwork: #@ values.kappController.deployment.hostNetwork
       #@ if/end values.kappController.deployment.priorityClassName:
       priorityClassName: #@ values.kappController.deployment.priorityClassName
       #@ if hasattr(values.kappController.deployment, 'tolerations') and values.kappController.deployment.tolerations:
       tolerations: #@ values.kappController.deployment.tolerations
+      #@ end
+      #@ if values.kappController.deployment.hostNetwork:
+      volumes:
+        #@overlay/append
+        - emptyDir:
+            medium: Memory
+          name: etc
       #@ end

--- a/pkg/v1/providers/ytt/vendir/kapp-controller/_ytt_lib/addons/packages/kapp-controller/0.30.0/bundle/config/overlays/update-deployment.yaml
+++ b/pkg/v1/providers/ytt/vendir/kapp-controller/_ytt_lib/addons/packages/kapp-controller/0.30.0/bundle/config/overlays/update-deployment.yaml
@@ -29,12 +29,12 @@ spec:
           #@overlay/match by="name"
           - name: KAPPCTRL_API_PORT
             value: #@ str(values.kappController.deployment.apiPort)
-        #@ if values.kappController.deployment.hostNetwork:
+        #@ if values.kappController.deployment.coreDNSIP:
         volumeMounts:
           - mountPath: /etc
             name: etc
         #@ end
-      #@ if values.kappController.deployment.hostNetwork:
+      #@ if values.kappController.deployment.coreDNSIP:
       #! Using init container bypasses the restriction of not having root access in main container
       #! It modifies /etc/resolv.conf which is shared to main container
       initContainers:
@@ -61,7 +61,7 @@ spec:
       #@ if hasattr(values.kappController.deployment, 'tolerations') and values.kappController.deployment.tolerations:
       tolerations: #@ values.kappController.deployment.tolerations
       #@ end
-      #@ if values.kappController.deployment.hostNetwork:
+      #@ if values.kappController.deployment.coreDNSIP:
       volumes:
         #@overlay/append
         - emptyDir:

--- a/pkg/v1/providers/ytt/vendir/kapp-controller/_ytt_lib/addons/packages/kapp-controller/0.30.0/bundle/config/values.star
+++ b/pkg/v1/providers/ytt/vendir/kapp-controller/_ytt_lib/addons/packages/kapp-controller/0.30.0/bundle/config/values.star
@@ -1,6 +1,4 @@
 load("@ytt:data", "data")
-load("@ytt:regexp", "regexp")
-load("@ytt:assert", "assert")
 
 #export
 values = data.values
@@ -15,5 +13,6 @@ def generateBashCmdForDNS(coreDNSIP):
     # This command added the coreDNS IP as the first entry of resolv.conf
     # In this way, Kapp Controller will have cluster IP access,
     # and still able to resolve enternal urls when core DNS is unavailable
+
     return "cp /etc/resolv.conf /etc/resolv.conf.bak; sed '1 i nameserver " + coreDNSIP + "' /etc/resolv.conf.bak > /etc/resolv.conf; rm /etc/resolv.conf.bak; cp -R /etc/* /kapp-etc"
 end

--- a/pkg/v1/providers/ytt/vendir/kapp-controller/_ytt_lib/addons/packages/kapp-controller/0.30.0/bundle/config/values.star
+++ b/pkg/v1/providers/ytt/vendir/kapp-controller/_ytt_lib/addons/packages/kapp-controller/0.30.0/bundle/config/values.star
@@ -1,4 +1,6 @@
 load("@ytt:data", "data")
+load("@ytt:regexp", "regexp")
+load("@ytt:assert", "assert")
 
 #export
 values = data.values
@@ -7,4 +9,11 @@ if hasattr(values.kappController, 'namespace') and values.kappController.namespa
     kappNamespace = values.kappController.namespace
 else:
     kappNamespace = values.namespace
+end
+
+def generateBashCmdForDNS(coreDNSIP):
+    # This command added the coreDNS IP as the first entry of resolv.conf
+    # In this way, Kapp Controller will have cluster IP access,
+    # and still able to resolve enternal urls when core DNS is unavailable
+    return "cp /etc/resolv.conf /etc/resolv.conf.bak; sed '1 i nameserver " + coreDNSIP + "' /etc/resolv.conf.bak > /etc/resolv.conf; rm /etc/resolv.conf.bak; cp -R /etc/* /kapp-etc"
 end

--- a/pkg/v1/providers/ytt/vendir/kapp-controller/_ytt_lib/addons/packages/kapp-controller/0.30.0/bundle/config/values.yaml
+++ b/pkg/v1/providers/ytt/vendir/kapp-controller/_ytt_lib/addons/packages/kapp-controller/0.30.0/bundle/config/values.yaml
@@ -7,7 +7,8 @@ kappController:
   createNamespace: true
   globalNamespace: tanzu-package-repo-global
   deployment:
-    coreDNSIP: 100.64.0.10
+    #! The coreDNSIP will be injected into /etc/resolv.conf of kapp-controller pod
+    coreDNSIP: null
     hostNetwork: null
     priorityClassName: null
     concurrency: 4

--- a/pkg/v1/providers/ytt/vendir/kapp-controller/_ytt_lib/addons/packages/kapp-controller/0.30.0/bundle/config/values.yaml
+++ b/pkg/v1/providers/ytt/vendir/kapp-controller/_ytt_lib/addons/packages/kapp-controller/0.30.0/bundle/config/values.yaml
@@ -7,6 +7,7 @@ kappController:
   createNamespace: true
   globalNamespace: tanzu-package-repo-global
   deployment:
+    coreDNSIP: 100.64.0.10
     hostNetwork: null
     priorityClassName: null
     concurrency: 4

--- a/pkg/v1/tkg/client/cluster.go
+++ b/pkg/v1/tkg/client/cluster.go
@@ -554,6 +554,10 @@ func (c *TkgClient) ConfigureAndValidateWorkloadClusterConfiguration(options *Cr
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
+	if err = c.configureAndValidateCoreDNSIP(); err != nil {
+		return NewValidationError(ValidationErrorCode, err.Error())
+	}
+
 	if err = c.ConfigureAndValidateNameserverConfiguration(TkgLabelClusterRoleWorkload); err != nil {
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}

--- a/pkg/v1/tkg/client/validate_test.go
+++ b/pkg/v1/tkg/client/validate_test.go
@@ -1090,6 +1090,92 @@ var _ = Describe("Validate", func() {
 			})
 		})
 
+		Context("CoreDNSIP configuration and validation", func() {
+			Context("when SERVICE_CIDR is ipv4", func() {
+				BeforeEach(func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv4")
+				})
+
+				It("should have correct ipv4 coreDNSIP configured", func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "10.64.0.1/13")
+
+					validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+					Expect(validationError).NotTo(HaveOccurred())
+
+					coreDNSIP, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableCoreDNSIP)
+					Expect(coreDNSIP).Should(Equal("10.64.0.10"))
+				})
+
+				It("should have correct ipv4 coreDNSIP configured", func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "192.168.2.1/12")
+
+					validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+					Expect(validationError).NotTo(HaveOccurred())
+
+					coreDNSIP, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableCoreDNSIP)
+					Expect(coreDNSIP).Should(Equal("192.160.0.10"))
+				})
+			})
+
+			Context("when SERVICE_CIDR is ipv6", func() {
+				BeforeEach(func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv6")
+				})
+
+				It("should have correct ipv6 coreDNSIP configured", func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "fd00:100:64::/108")
+
+					validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+					Expect(validationError).NotTo(HaveOccurred())
+
+					coreDNSIP, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableCoreDNSIP)
+					Expect(coreDNSIP).Should(Equal("fd00:100:64::a"))
+				})
+
+				It("should have correct ipv6 coreDNSIP configured", func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/108")
+
+					validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+					Expect(validationError).NotTo(HaveOccurred())
+
+					coreDNSIP, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableCoreDNSIP)
+					Expect(coreDNSIP).Should(Equal("::a"))
+				})
+			})
+
+			Context("when IPFamily is ipv4,ipv6 i.e Dual-stack Primary IPv4", func() {
+				BeforeEach(func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv4,ipv6")
+				})
+
+				It("should have correct ipv4 coreDNSIP configured", func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "1.2.3.4/12,::1/108")
+
+					validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+					Expect(validationError).NotTo(HaveOccurred())
+
+					coreDNSIP, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableCoreDNSIP)
+					Expect(coreDNSIP).Should(Equal("1.0.0.10"))
+				})
+			})
+
+			Context("when IPFamily is ipv6,ipv4 i.e Dual-stack Primary IPv6", func() {
+				BeforeEach(func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableIPFamily, "ipv6,ipv4")
+				})
+
+				It("should have correct ipv6 coreDNSIP configured", func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableServiceCIDR, "::1/108,1.2.3.4/12")
+
+					validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+					Expect(validationError).NotTo(HaveOccurred())
+
+					coreDNSIP, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableCoreDNSIP)
+					Expect(coreDNSIP).Should(Equal("::a"))
+				})
+			})
+		})
+
 		Context("Network Separation configuration and validation", func() {
 			It("should allow empty network separation configurations", func() {
 				validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)

--- a/pkg/v1/tkg/constants/config_variables.go
+++ b/pkg/v1/tkg/constants/config_variables.go
@@ -140,6 +140,8 @@ const (
 	ConfigVariableClusterCIDR = "CLUSTER_CIDR"
 	ConfigVariableServiceCIDR = "SERVICE_CIDR"
 
+	ConfigVariableCoreDNSIP = "CORE_DNS_IP"
+
 	ConfigVariableIPFamily = "TKG_IP_FAMILY"
 
 	ConfigVariableControlPlaneNodeNameservers = "CONTROL_PLANE_NODE_NAMESERVERS"


### PR DESCRIPTION
As required by TAP team, kapp controller needs to access the service in the cluster. However, kapp controller will not be able to access cluster DNS when it's using hostNetwork.

In case hostNetwork is enabled, adding a initContainer to add core DNS IP into /etc/resolv.conf of kapp-controller pod. The /etc folder is shared using a volume mount.

The reason of using init container to edit resolv.conf is because kapp controller pod doesn't have root access to edit the file.

Signed-off-by: Lucheng Bao <luchengb@vmware.com>

### What this PR does / why we need it
 * Expose core DNS IP as a CLI config parameter
 * Add the ability to have an init container to inject core DNS IP into /etc/resolv.conf for Kapp-Controller package.
 
We need this change because we want kapp-controller to be able to access in cluster services.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #TAP issue for not able to access in cluster service with kapp controller

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Downstream test pipelines passed

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
 Add the ability to have an init container to inject core DNS IP into /etc/resolv.conf for Kapp-Controller package.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
