### PR TITLE
Replace deprecated linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -34,8 +34,6 @@ linters-settings:
     min-complexity: 15
   goimports:
     local-prefixes: github.com/vmware-tanzu
-  golint:
-    min-confidence: 0.3
   govet:
     check-shadowing: true
     settings:
@@ -70,17 +68,16 @@ linters:
     - gocyclo
     - goheader
     - goimports
-    - golint
     - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - maligned
     - misspell
     - nakedret
     - noctx
     - nolintlint
+    - revive
     - rowserrcheck
     - staticcheck
     - structcheck
@@ -106,7 +103,6 @@ linters:
   # - nestif
   # - prealloc
   # - testpackage
-  # - revive
   # - scopelint
   # - wsl
 
@@ -138,8 +134,16 @@ issues:
         - nolintlint
       text: "is unused for linter staticcheck"
 
+    - linters:
+        - revive
+      text: "that stutters"
+
+    - path: zz_.*\.go
+      linters:
+        - revive
+      text: "it will be inferred from"
+
   include:
-    - EXC0002 # disable excluding of issues about missing comments on exported symbols from golint
     - EXC0011 # disable excluding of issues about missing package comments from stylecheck
 
   # Show all errors for all linters. Setting these to 0 disables limiting error reporting.

--- a/Makefile
+++ b/Makefile
@@ -488,7 +488,11 @@ fmt: tools ## Run goimports
 vet: ## Run go vet
 	$(GO) vet ./...
 
-lint: tools doc-lint ## Run linting checks
+lint: tools go-lint doc-lint ## Run linting checks
+	# Check licenses in shell scripts and Makefile
+	hack/check-license.sh
+
+go-lint: tools ## Run linting of go source
 	# Linter runs per module, add each one here and make sure they match
 	# in .github/workflows/main.yaml for CI coverage
 
@@ -499,9 +503,6 @@ lint: tools doc-lint ## Run linting checks
 
 	# Linting for the YTT generation test code...
 	cd $(YTT_TESTS_DIR); $(GOLANGCI_LINT) run -v
-
-	# Check licenses in shell scripts and Makefile
-	hack/check-license.sh
 
 doc-lint: tools ## Run linting checks for docs
 	$(VALE) --config=.vale/config.ini --glob='*.md' ./

--- a/apis/run/v1alpha2/tanzukubernetescluster_types.go
+++ b/apis/run/v1alpha2/tanzukubernetescluster_types.go
@@ -266,13 +266,13 @@ type ProxyConfiguration struct {
 	// Example: http://<user>:<pwd>@<ip>:<port>
 	//
 	// +optional
-	HttpProxy *string `json:"httpProxy,omitempty"` //nolint:golint,stylecheck
+	HttpProxy *string `json:"httpProxy,omitempty"` //nolint:revive,stylecheck
 
 	// HttpsProxy specifies a proxy URL to use for creating HTTPS connections outside the cluster.
 	// Example: http://<user>:<pwd>@<ip>:<port>
 	//
 	// +optional
-	HttpsProxy *string `json:"httpsProxy,omitempty"` //nolint:golint,stylecheck
+	HttpsProxy *string `json:"httpsProxy,omitempty"` //nolint:revive,stylecheck
 
 	// NoProxy specifies a list of destination domain names, domains, IP addresses or other network CIDRs to exclude proxying.
 	// Example: [localhost, 127.0.0.1, 10.10.10.0/24]

--- a/cmd/cli/plugin/cluster/set_node_pool.go
+++ b/cmd/cli/plugin/cluster/set_node_pool.go
@@ -61,7 +61,7 @@ func SetNodePool(server *v1alpha1.Server, clusterName string) error {
 	var nodePool client.NodePool
 	var fileContent []byte
 	if fileContent, err = os.ReadFile(setNodePoolOptions.FilePath); err != nil {
-		return errors.New(fmt.Sprintf("Unable to read file %s", setNodePoolOptions.FilePath))
+		return fmt.Errorf("unable to read file %s", setNodePoolOptions.FilePath)
 	}
 
 	if err = yaml.Unmarshal(fileContent, &nodePool); err != nil {

--- a/cmd/cli/plugin/package/package_available.go
+++ b/cmd/cli/plugin/package/package_available.go
@@ -34,7 +34,7 @@ func packagingAvailabilityCheck(_ *cobra.Command, _ []string) error {
 		return errors.Wrap(err, fmt.Sprintf("failed to check for the availability of '%s' API", tkgpackagedatamodel.PackagingAPIName))
 	}
 	if !found {
-		return errors.New(fmt.Sprintf(tkgpackagedatamodel.PackagingAPINotAvailable, tkgpackagedatamodel.PackagingAPIName, tkgpackagedatamodel.PackagingAPIVersion))
+		return fmt.Errorf(tkgpackagedatamodel.PackagingAPINotAvailable, tkgpackagedatamodel.PackagingAPIName, tkgpackagedatamodel.PackagingAPIVersion)
 	}
 
 	return nil

--- a/cmd/cli/plugin/secret/registry.go
+++ b/cmd/cli/plugin/secret/registry.go
@@ -34,7 +34,7 @@ func secretGenAvailabilityCheck(_ *cobra.Command, _ []string) error {
 		return errors.Wrap(err, fmt.Sprintf("failed to check for the availability of '%s' API", tkgpackagedatamodel.SecretGenAPIName))
 	}
 	if !found {
-		return errors.New(fmt.Sprintf(tkgpackagedatamodel.SecretGenAPINotAvailable, tkgpackagedatamodel.SecretGenAPIName, tkgpackagedatamodel.SecretGenAPIVersion))
+		return fmt.Errorf(tkgpackagedatamodel.SecretGenAPINotAvailable, tkgpackagedatamodel.SecretGenAPIName, tkgpackagedatamodel.SecretGenAPIVersion)
 	}
 
 	return nil

--- a/pkg/v1/builder/command/publish/publisher.go
+++ b/pkg/v1/builder/command/publish/publisher.go
@@ -36,7 +36,7 @@ type Metadata struct {
 // This function is responsible for auto-detecting the available plugin versions
 // as well as os-arch and publishing artifacts to correct discovery and distribution
 // based on the publisher type
-func PublishPlugins(pm *Metadata) error { //nolint:golint // ignore stutters warning for 'publish.PublishPlugins'
+func PublishPlugins(pm *Metadata) error {
 	_ = ensureResourceDir(pm.LocalDiscoveryPath, true)
 
 	availablePluginInfo, err := detectAvailablePluginInfo(pm.InputArtifactDir, pm.Plugins, pm.OSArch, pm.RecommendedVersion)

--- a/pkg/v1/builder/template/plugintemplates/dotgolangci.txt.tmpl
+++ b/pkg/v1/builder/template/plugintemplates/dotgolangci.txt.tmpl
@@ -17,8 +17,6 @@ linters-settings:
       - wrapperFunc
   gocyclo:
     min-complexity: 15
-  golint:
-    min-confidence: 0
   gomnd:
     settings:
       mnd:
@@ -52,7 +50,6 @@ linters:
     - gocritic
     - gocyclo
     - goheader
-    - golint
     - gomnd
     - goprintffuncname
     - gosec
@@ -88,7 +85,6 @@ linters:
   # - nestif
   # - prealloc
   # - testpackage
-  # - revive
   # - scopelint
   # - wsl
 

--- a/pkg/v1/cli/command/core/config.go
+++ b/pkg/v1/cli/command/core/config.go
@@ -283,7 +283,7 @@ var deleteServersCmd = &cobra.Command{
 					return err
 				}
 			} else {
-				return errors.New(fmt.Sprintf("Server %s not found in list of known servers", args[0]))
+				return fmt.Errorf("server %s not found in list of known servers", args[0])
 			}
 		}
 

--- a/pkg/v1/tkg/client/delete_region.go
+++ b/pkg/v1/tkg/client/delete_region.go
@@ -266,10 +266,7 @@ func (c *TkgClient) deleteCluster(kubeconfig, clusterName, clusterNamespace stri
 	clusterObject.Name = clusterName
 	clusterObject.Namespace = clusterNamespace
 
-	if err := clusterClient.DeleteResource(clusterObject); err != nil {
-		return err
-	}
-	return nil
+	return clusterClient.DeleteResource(clusterObject)
 }
 
 func (c *TkgClient) waitForClusterDeletion(kubeconfig, clusterName, clusterNamespace string) error {

--- a/pkg/v1/tkg/client/get_cluster_helper.go
+++ b/pkg/v1/tkg/client/get_cluster_helper.go
@@ -117,7 +117,7 @@ func getClusterObjectsMapForPacific(clusterClient clusterclient.Client, listOpti
 }
 
 func getClusterWorkerCountForPacific(clusterInfo *clusterObjectsForPacific) string {
-	var desiredReplicasCount int32 = 0
+	var desiredReplicasCount int32
 	nodePools := clusterInfo.cluster.Spec.Topology.NodePools
 	for idx := range nodePools {
 		if nodePools[idx].Replicas != nil {
@@ -125,7 +125,7 @@ func getClusterWorkerCountForPacific(clusterInfo *clusterObjectsForPacific) stri
 		}
 	}
 
-	var readyReplicasCount int32 = 0
+	var readyReplicasCount int32
 	for idx := range clusterInfo.mds {
 		readyReplicasCount += clusterInfo.mds[idx].Status.ReadyReplicas
 	}
@@ -247,10 +247,10 @@ func getClusterWorkerCount(clusterInfo *clusterObjects) string {
 }
 
 func getClusterReplicas(mds []capi.MachineDeployment) (int32, int32, int32, int32) {
-	var readyReplicas int32 = 0
-	var specReplicas int32 = 0
-	var replicas int32 = 0
-	var updatedReplicas int32 = 0
+	var readyReplicas int32
+	var specReplicas int32
+	var replicas int32
+	var updatedReplicas int32
 	for i := range mds {
 		readyReplicas += mds[i].Status.ReadyReplicas
 		replicas += mds[i].Status.Replicas

--- a/pkg/v1/tkg/client/init.go
+++ b/pkg/v1/tkg/client/init.go
@@ -58,7 +58,7 @@ const (
 )
 
 // InitRegionSteps management cluster init step sequence
-var InitRegionSteps []string = []string{
+var InitRegionSteps = []string{
 	StepConfigPrerequisite,
 	StepValidateConfiguration,
 	StepGenerateClusterConfiguration,

--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -128,10 +128,7 @@ func (c *TkgClient) DownloadBomFile(tkrName string) error {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(bomDir, "tkr-bom-"+tkrName+".yaml"), bomData, 0o600); err != nil {
-		return err
-	}
-	return nil
+	return os.WriteFile(filepath.Join(bomDir, "tkr-bom-"+tkrName+".yaml"), bomData, 0o600)
 }
 
 // ConfigureAndValidateTkrVersion takes tkrVersion, if empty fetches default tkr & k8s version from config

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -2550,14 +2550,14 @@ func (c *crtClientFactory) NewClient(config *rest.Config, options crtclient.Opti
 //go:generate counterfeiter -o ../fakes/clusterclientfactory.go --fake-name ClusterClientFactory . ClusterClientFactory
 
 // ClusterClientFactory a factory for creating cluster clients
-type ClusterClientFactory interface { // nolint
-	NewClient(kubeConfigPath string, context string, options Options) (Client, error)
+type ClusterClientFactory interface {
+	NewClient(kubeConfigPath, context string, options Options) (Client, error)
 }
 
 type clusterClientFactory struct{}
 
 // NewClient creates new clusterclient
-func (c *clusterClientFactory) NewClient(kubeConfigPath string, context string, options Options) (Client, error) { // nolint:gocritic
+func (c *clusterClientFactory) NewClient(kubeConfigPath, context string, options Options) (Client, error) { //nolint:gocritic
 	return NewClient(kubeConfigPath, context, options)
 }
 

--- a/pkg/v1/tkg/kind/client.go
+++ b/pkg/v1/tkg/kind/client.go
@@ -79,14 +79,14 @@ type Client interface {
 //go:generate counterfeiter -o ../fakes/kindprovider.go --fake-name KindProvider . KindClusterProvider
 
 // KindClusterProvider is interface for creating/deleting kind cluster
-type KindClusterProvider interface { //nolint:golint
+type KindClusterProvider interface {
 	Create(name string, options ...cluster.CreateOption) error
 	Delete(name, explicitKubeconfigPath string) error
 	KubeConfig(name string, internal bool) (string, error)
 }
 
 // KindClusterOptions carries options to configure kind cluster
-type KindClusterOptions struct { //nolint:golint
+type KindClusterOptions struct {
 	Provider         KindClusterProvider
 	ClusterName      string
 	NodeImage        string
@@ -97,7 +97,7 @@ type KindClusterOptions struct { //nolint:golint
 }
 
 // KindClusterProxy return the Proxy used for operating kubernetes-in-docker clusters
-type KindClusterProxy struct { //nolint:golint
+type KindClusterProxy struct {
 	options    *KindClusterOptions
 	caCertPath string
 }

--- a/pkg/v1/tkg/region/interface.go
+++ b/pkg/v1/tkg/region/interface.go
@@ -13,7 +13,7 @@ const (
 )
 
 // RegionContext holds the region context
-type RegionContext struct { //nolint:golint
+type RegionContext struct {
 	ClusterName      string           `yaml:"name" json:"name"`
 	ContextName      string           `yaml:"context" json:"context"`
 	SourceFilePath   string           `yaml:"file" json:"file"`

--- a/pkg/v1/tkg/test/framework/cluster_proxy.go
+++ b/pkg/v1/tkg/test/framework/cluster_proxy.go
@@ -7,7 +7,7 @@ package framework
 import (
 	"context"
 
-	. "github.com/onsi/gomega" // nolint:golint,stylecheck
+	. "github.com/onsi/gomega" // nolint:stylecheck
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/v1/tkg/test/framework/e2e_config.go
+++ b/pkg/v1/tkg/test/framework/e2e_config.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
-	. "github.com/onsi/gomega" // nolint:golint,stylecheck
+	. "github.com/onsi/gomega" // nolint:stylecheck
 	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 

--- a/pkg/v1/tkg/test/framework/exec/kubectl.go
+++ b/pkg/v1/tkg/test/framework/exec/kubectl.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 
-	. "github.com/onsi/ginkgo" // nolint:stylecheck,golint
+	. "github.com/onsi/ginkgo" // nolint:stylecheck
 )
 
 // KubectlApplyWithArgs applies config with args

--- a/pkg/v1/tkg/test/framework/utils.go
+++ b/pkg/v1/tkg/test/framework/utils.go
@@ -14,7 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"sigs.k8s.io/cluster-api/util"
 
-	. "github.com/onsi/ginkgo" // nolint:golint,stylecheck
+	. "github.com/onsi/ginkgo" // nolint:stylecheck
 )
 
 // CreateClusterOptions represent options to create a TKG cluster

--- a/pkg/v1/tkg/test/tkgctl/shared/addons.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/addons.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint:typecheck,goconst,gocritic,golint,stylecheck,nolintlint
+// nolint:typecheck,goconst,gocritic,stylecheck,nolintlint
 package shared
 
 import (

--- a/pkg/v1/tkg/test/tkgctl/shared/autoscaler.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/autoscaler.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint:typecheck,goconst,gocritic,golint,stylecheck,nolintlint
+// nolint:typecheck,goconst,gocritic,stylecheck,nolintlint
 package shared
 
 import (

--- a/pkg/v1/tkg/test/tkgctl/shared/ceip.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/ceip.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint:typecheck,goconst,gocritic,golint,stylecheck,nolintlint
+// nolint:typecheck,goconst,gocritic,stylecheck,nolintlint
 package shared
 
 import (

--- a/pkg/v1/tkg/test/tkgctl/shared/e2e_common.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/e2e_common.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint:typecheck,goconst,gocritic,golint,stylecheck,nolintlint
+// nolint:typecheck,goconst,gocritic,stylecheck,nolintlint
 package shared
 
 import (

--- a/pkg/v1/tkg/test/tkgctl/shared/mhc.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/mhc.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint:typecheck,goconst,gocritic,golint,stylecheck,nolintlint
+// nolint:typecheck,goconst,gocritic,stylecheck,nolintlint
 package shared
 
 import (

--- a/pkg/v1/tkg/test/tkgctl/shared/scale.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/scale.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint:typecheck,goconst,gocritic,golint,stylecheck,nolintlint
+// nolint:typecheck,goconst,gocritic,stylecheck,nolintlint
 package shared
 
 import (

--- a/pkg/v1/tkg/test/tkgctl/shared/upgrade.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/upgrade.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint:typecheck,goconst,gocritic,golint,stylecheck,nolintlint
+// nolint:typecheck,goconst,gocritic,stylecheck,nolintlint
 package shared
 
 import (

--- a/pkg/v1/tkg/tkgconfigbom/bom.go
+++ b/pkg/v1/tkg/tkgconfigbom/bom.go
@@ -250,7 +250,7 @@ func (c *client) GetAutoscalerImageForK8sVersion(k8sVersion string) (string, err
 	}
 
 	if autoscalerImage == nil {
-		return "", errors.New(fmt.Sprintf("autoscaler image not available for kubernetes minor version %s", k8sVersionPrefix))
+		return "", fmt.Errorf("autoscaler image not available for kubernetes minor version %s", k8sVersionPrefix)
 	}
 
 	if imageCount > 1 {
@@ -372,7 +372,7 @@ func GetTKRBOMImageTagNameFromTKRVersion(tkrVersion string) string {
 	return strings.ReplaceAll(tkrVersion, "+", "_")
 }
 
-var errorDownloadingDefaultBOMFiles string = `failed to download the BOM file from image name '%s':%v
+var errorDownloadingDefaultBOMFiles = `failed to download the BOM file from image name '%s':%v
 If this is an internet-restricted environment please refer to the documentation to set TKG_CUSTOM_IMAGE_REPOSITORY and related configuration variables in %s 
 `
 
@@ -447,7 +447,7 @@ func (c *client) DownloadDefaultBOMFilesFromRegistry(bomRegistry registry.Regist
 	return nil
 }
 
-var errorDownloadingTKGCompatibilityFile string = `failed to download the TKG Compatibility file from image name '%s':%v
+var errorDownloadingTKGCompatibilityFile = `failed to download the TKG Compatibility file from image name '%s':%v
 If this is an internet-restricted environment please refer to the documentation to set TKG_CUSTOM_IMAGE_REPOSITORY and related configuration variables in %s 
 `
 

--- a/pkg/v1/tkg/tkgconfighelper/validate.go
+++ b/pkg/v1/tkg/tkgconfighelper/validate.go
@@ -14,7 +14,7 @@ import (
 
 // ManagementClusterVersionToK8sVersionSupportMatrix defines the support matrix of which k8s version
 // are supported based on management cluster version
-var ManagementClusterVersionToK8sVersionSupportMatrix map[string][]string = map[string][]string{
+var ManagementClusterVersionToK8sVersionSupportMatrix = map[string][]string{
 	"v1.0": {"v1.17"},
 	"v1.1": {"v1.17", "v1.18"},
 	"v1.2": {"v1.17", "v1.18", "v1.19"},

--- a/pkg/v1/tkg/tkgctl/constants.go
+++ b/pkg/v1/tkg/tkgctl/constants.go
@@ -4,7 +4,7 @@
 package tkgctl
 
 // Warningvsphere7WithoutPacific indicates that a vSphere7 environment has been detected without vSphere with Tanzu
-var Warningvsphere7WithoutPacific string = `
+var Warningvsphere7WithoutPacific = `
 vSphere 7.0 Environment Detected.
 
 You have connected to a vSphere 7.0 environment which does not have vSphere with Tanzu enabled. vSphere with Tanzu includes
@@ -15,7 +15,7 @@ Tanzu Kubernetes Grid Service is the preferred way to consume Tanzu Kubernetes G
 deploy a non-integrated Tanzu Kubernetes Grid instance on vSphere 7.0.`
 
 // Warningvsphere7WithPacific indicates that a vSphere7 environment has been detected with vSphere with Tanzu
-var Warningvsphere7WithPacific string = `
+var Warningvsphere7WithPacific = `
 vSphere 7.0 with Tanzu Detected.
 
 You have connected to a vSphere 7.0 with Tanzu environment that includes an integrated Tanzu Kubernetes Grid Service which

--- a/pkg/v1/tkg/tkgpackageclient/package_install.go
+++ b/pkg/v1/tkg/tkgpackageclient/package_install.go
@@ -130,7 +130,7 @@ func (p *pkgClient) createRelatedResources(o *tkgpackagedatamodel.PackageOptions
 		}
 		if svcAccountAnnotation, ok := svcAccount.GetAnnotations()[tkgpackagedatamodel.TanzuPkgPluginAnnotation]; ok {
 			if svcAccountAnnotation != fmt.Sprintf(tkgpackagedatamodel.TanzuPkgPluginResource, o.PkgInstallName, o.Namespace) {
-				err = errors.New(fmt.Sprintf("provided service account '%s' is already used by another package in namespace '%s'", o.ServiceAccountName, o.Namespace))
+				err = fmt.Errorf("provided service account '%s' is already used by another package in namespace '%s'", o.ServiceAccountName, o.Namespace)
 				return &pkgPluginResourceCreationStatus, err
 			}
 		}
@@ -375,7 +375,7 @@ func (p *pkgClient) waitForResourceInstallation(name, namespace string, pollInte
 	}
 
 	if !reconcileSucceeded {
-		return errors.New(fmt.Sprintf("'%s' resource reconciliation failed", rscType.String()))
+		return fmt.Errorf("'%s' resource reconciliation failed", rscType.String())
 	}
 
 	return nil

--- a/pkg/v1/tkg/tkgpackageclient/package_update.go
+++ b/pkg/v1/tkg/tkgpackageclient/package_update.go
@@ -96,7 +96,7 @@ func (p *pkgClient) preparePackageInstallForUpdate(o *tkgpackagedatamodel.Packag
 	pkgInstallToUpdate := pkgInstall.DeepCopy()
 
 	if pkgInstallToUpdate.Spec.PackageRef == nil || pkgInstallToUpdate.Spec.PackageRef.VersionSelection == nil {
-		err := errors.New(fmt.Sprintf("failed to update package '%s' as no existing package reference/version was found in the package install", o.PkgInstallName))
+		err := fmt.Errorf("failed to update package '%s' as no existing package reference/version was found in the package install", o.PkgInstallName)
 		return nil, false, err
 	}
 
@@ -104,7 +104,7 @@ func (p *pkgClient) preparePackageInstallForUpdate(o *tkgpackagedatamodel.Packag
 	// This will prevent the users from accidentally overwriting an installed package with another package content due to choosing a pre-existing name for the package isntall.
 	// Otherwise if o.PackageName is not provided, fill it from the installed package spec, as the validation logic in GetPackage() needs this field to be set.
 	if o.PackageName != "" && pkgInstallToUpdate.Spec.PackageRef.RefName != o.PackageName {
-		err := errors.New(fmt.Sprintf("installed package '%s' is already associated with package '%s'", o.PkgInstallName, pkgInstallToUpdate.Spec.PackageRef.RefName))
+		err := fmt.Errorf("installed package '%s' is already associated with package '%s'", o.PkgInstallName, pkgInstallToUpdate.Spec.PackageRef.RefName)
 		return nil, false, err
 	}
 	o.PackageName = pkgInstallToUpdate.Spec.PackageRef.RefName

--- a/pkg/v1/tkg/tkgpackageclient/registry_secret_update.go
+++ b/pkg/v1/tkg/tkgpackageclient/registry_secret_update.go
@@ -34,7 +34,7 @@ func (p *pkgClient) UpdateRegistrySecret(o *tkgpackagedatamodel.RegistrySecretOp
 
 	if err := p.kappClient.GetClient().Get(context.Background(), crtclient.ObjectKey{Name: o.SecretName, Namespace: o.Namespace}, secret); err != nil {
 		if apierrors.IsNotFound(err) {
-			return errors.New(fmt.Sprintf("secret '%s' does not exist in namespace '%s'", o.SecretName, o.Namespace))
+			return fmt.Errorf("secret '%s' does not exist in namespace '%s'", o.SecretName, o.Namespace)
 		}
 		return err
 	}
@@ -46,12 +46,12 @@ func (p *pkgClient) UpdateRegistrySecret(o *tkgpackagedatamodel.RegistrySecretOp
 
 	auths, ok := dataMap["auths"]
 	if !ok {
-		return errors.New(fmt.Sprintf("no 'auths' entry exists in secret '%s'", o.SecretName))
+		return fmt.Errorf("no 'auths' entry exists in secret '%s'", o.SecretName)
 	}
 
 	entries := auths.(map[string]interface{})
 	if len(entries) != 1 {
-		return errors.New(fmt.Sprintf("updating secret '%s' is not allowed as multiple registry entries exists", o.SecretName))
+		return fmt.Errorf("updating secret '%s' is not allowed as multiple registry entries exists", o.SecretName)
 	}
 
 	for reg, v := range entries {
@@ -59,12 +59,12 @@ func (p *pkgClient) UpdateRegistrySecret(o *tkgpackagedatamodel.RegistrySecretOp
 		credentials := v.(map[string]interface{})
 		currentUsername, ok := credentials["username"]
 		if !ok {
-			return errors.New(fmt.Sprintf("no 'username' entry exists in secret '%s'", o.SecretName))
+			return fmt.Errorf("no 'username' entry exists in secret '%s'", o.SecretName)
 		}
 		username = currentUsername.(string)
 		currentPassword, ok := credentials["password"]
 		if !ok {
-			return errors.New(fmt.Sprintf("no 'password' entry exists in secret '%s'", o.SecretName))
+			return fmt.Errorf("no 'password' entry exists in secret '%s'", o.SecretName)
 		}
 		password = currentPassword.(string)
 	}

--- a/pkg/v1/tkg/tkgpackageclient/repository_add.go
+++ b/pkg/v1/tkg/tkgpackageclient/repository_add.go
@@ -120,12 +120,12 @@ func (p *pkgClient) validateRepositoryAdd(repositoryName, repositoryImg, namespa
 
 	for _, repository := range repositoryList.Items { //nolint:gocritic
 		if repository.Name == repositoryName {
-			return errors.New(fmt.Sprintf("package repository name '%s' already exists in namespace '%s'", repositoryName, namespace))
+			return fmt.Errorf("package repository name '%s' already exists in namespace '%s'", repositoryName, namespace)
 		}
 
 		if repository.Spec.Fetch != nil && repository.Spec.Fetch.ImgpkgBundle != nil &&
 			repository.Spec.Fetch.ImgpkgBundle.Image == repositoryImg {
-			return errors.New(fmt.Sprintf("package repository URL '%s' already exists in namespace '%s'", repositoryImg, namespace))
+			return fmt.Errorf("package repository URL '%s' already exists in namespace '%s'", repositoryImg, namespace)
 		}
 	}
 

--- a/pkg/v1/tkg/tkgpackagedatamodel/constants.go
+++ b/pkg/v1/tkg/tkgpackagedatamodel/constants.go
@@ -27,7 +27,7 @@ const (
 	KindSecret                          = "Secret"
 	KindSecretExport                    = "SecretExport"
 	KindServiceAccount                  = "ServiceAccount"
-	PackagingAPINotAvailable            = "Package plugin can not be used as '%s/%s' API is not available in the cluster"
+	PackagingAPINotAvailable            = "package plugin can not be used as '%s/%s' API is not available in the cluster"
 	PackagingAPIName                    = "packaging.carvel.dev"
 	PackagingAPIVersion                 = "v1alpha1"
 	SecretGenAPINotAvailable            = "secret plugin can not be used as '%s/%s' API is not available in the cluster"

--- a/pkg/v1/tkg/tkgpackagedatamodel/types.go
+++ b/pkg/v1/tkg/tkgpackagedatamodel/types.go
@@ -6,8 +6,6 @@ package tkgpackagedatamodel
 
 import (
 	"fmt"
-
-	"github.com/pkg/errors"
 )
 
 // PackagePluginNonCriticalError is used for non critical package plugin errors which should be treated more like warnings
@@ -65,7 +63,7 @@ func (v *TypeBoolPtr) Set(val string) error {
 	} else if val == "false" || val == "False" {
 		v.ExportToAllNamespaces = &f
 	} else if val != "" {
-		return errors.New(fmt.Sprintf("invalid argument '%s'", val))
+		return fmt.Errorf("invalid argument '%s'", val)
 	}
 
 	return nil

--- a/pkg/v1/tkg/utils/common.go
+++ b/pkg/v1/tkg/utils/common.go
@@ -28,7 +28,7 @@ import (
 )
 
 // nolint:gosec
-var seededRand *rand.Rand = rand.New(
+var seededRand = rand.New(
 	rand.NewSource(time.Now().UnixNano()))
 
 var (


### PR DESCRIPTION
### What this PR does / why we need it

We have a couple of deprecated linters to be run by golangci-lint,
resulting in these errors when running lint checks:

```
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.
WARN [runner] The linter 'maligned' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner.  Replaced by govet 'fieldalignment'.
```

Following the suggested replacements, this removes the 'golint' linter
and adds the 'revive' one. We were already using 'govet', so this just
removes the 'maligned' linter.

Also addresses new issues `revive` uncovered as well as adds a `go-lint` make target to be able to run the go
source file linting directly without the other checks included in the default `lint` target.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #525

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Ran and built locally.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access