### PR TITLE
Add network separation feature gate

### DIFF
--- a/pkg/v1/config/clientconfig.go
+++ b/pkg/v1/config/clientconfig.go
@@ -37,6 +37,11 @@ const (
 	// when creating a cluster.
 	FeatureFlagManagementClusterCustomNameservers = "features.management-cluster.custom-nameservers"
 	FeatureFlagClusterCustomNameservers           = "features.cluster.custom-nameservers"
+	// Network Separation feature flags determine whether it is permitted to
+	// provide the AVI_MANAGEMENT_CLUSTER_SERVICE_ENGINE_GROUP, AVI_CONTROL_PLANE_NETWORK, AVI_CONTROL_PLANE_NETWORK_CIDR,
+	// AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_NAME and AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_CIDR
+	// when creating a cluster.
+	FeatureFlagManagementClusterNetworkSeparation = "features.management-cluster.network-separation-beta"
 )
 
 // DefaultCliFeatureFlags is used to populate an initially empty config file with default values for feature flags.
@@ -63,6 +68,7 @@ var (
 		FeatureFlagClusterDualStackIPv6Primary:                false,
 		FeatureFlagManagementClusterCustomNameservers:         false,
 		FeatureFlagClusterCustomNameservers:                   false,
+		FeatureFlagManagementClusterNetworkSeparation:         false,
 	}
 )
 

--- a/pkg/v1/providers/config_default.yaml
+++ b/pkg/v1/providers/config_default.yaml
@@ -552,15 +552,30 @@ AVI_USERNAME: ""
 AVI_PASSWORD: ""
 AVI_CLOUD_NAME:
 AVI_SERVICE_ENGINE_GROUP:
+
+#! WARNING: service engine group separation support is not enabled (because it is under development).
+#! To use a different service engine group in the management cluster, set AVI_MANAGEMENT_CLUSTER_SERVICE_ENGINE_GROUP variable to the management cluster service engine group
 AVI_MANAGEMENT_CLUSTER_SERVICE_ENGINE_GROUP:
 AVI_DATA_NETWORK:
 AVI_DATA_NETWORK_CIDR:
+
+#! WARNING: workload cluster network separation support is not enabled (because it is under development).
+#! To use a different control plane network in the workload cluster:
+#! set AVI_CONTROL_PLANE_NETWORK variable to name of the control plane network in the workload cluster
+#! set AVI_CONTROL_PLANE_NETWORK_CIDR variable to cidr of the control plane network in the workload cluster
 AVI_CONTROL_PLANE_NETWORK:
 AVI_CONTROL_PLANE_NETWORK_CIDR:
+
 AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_NAME:
 AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_CIDR:
-AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_CIDR:
+
+#! WARNING: management cluster network separation support is not enabled (because it is under development).
+#! To use a different control plane network in the management cluster:
+#! set AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_NAME variable to name of the control plane network in the management cluster
+#! set AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_CIDR variable to cidr of the control plane network in the management cluster
 AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_NAME:
+AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_CIDR:
+
 AVI_CA_DATA_B64: ""
 AVI_LABELS: ""
 

--- a/pkg/v1/tkg/client/validate_test.go
+++ b/pkg/v1/tkg/client/validate_test.go
@@ -1089,6 +1089,52 @@ var _ = Describe("Validate", func() {
 				})
 			})
 		})
+
+		Context("Network Separation configuration and validation", func() {
+			It("should allow empty network separation configurations", func() {
+				validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+				Expect(validationError).NotTo(HaveOccurred())
+			})
+
+			Context("Avi Management Cluster Service Engine Group", func() {
+				BeforeEach(func() {
+					featureFlagClient.IsConfigFeatureActivatedReturns(false, nil)
+					tkgConfigReaderWriter.Set(constants.ConfigVariableAviManagementClusterServiceEngineGroup, "SEG-1")
+				})
+
+				It("should return an error", func() {
+					validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+					Expect(validationError).To(HaveOccurred())
+					Expect(validationError.Error()).To(ContainSubstring("option AVI_MANAGEMENT_CLUSTER_SERVICE_ENGINE_GROUP is set to \"SEG-1\", but network separation support is not enabled (because it is not fully functional). To enable network separation, run the command: tanzu config set features.management-cluster.network-separation-beta true"))
+				})
+			})
+			Context("Avi Data Plane Network", func() {
+				BeforeEach(func() {
+					featureFlagClient.IsConfigFeatureActivatedReturns(false, nil)
+					tkgConfigReaderWriter.Set(constants.ConfigVariableAviControlPlaneNetwork, "VM Network")
+					tkgConfigReaderWriter.Set(constants.ConfigVariableAviControlPlaneNetworkCidr, "8.8.8.8/20")
+				})
+
+				It("should return an error", func() {
+					validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+					Expect(validationError).To(HaveOccurred())
+					Expect(validationError.Error()).To(ContainSubstring("option AVI_CONTROL_PLANE_NETWORK is set to \"VM Network\", but network separation support is not enabled (because it is not fully functional). To enable network separation, run the command: tanzu config set features.management-cluster.network-separation-beta true"))
+				})
+			})
+			Context("Avi Control Plane Network", func() {
+				BeforeEach(func() {
+					featureFlagClient.IsConfigFeatureActivatedReturns(false, nil)
+					tkgConfigReaderWriter.Set(constants.ConfigVariableAviManagementClusterControlPlaneVipNetworkName, "VM Network")
+					tkgConfigReaderWriter.Set(constants.ConfigVariableAviManagementClusterControlPlaneVipNetworkCidr, "8.8.8.8/20")
+				})
+
+				It("should return an error", func() {
+					validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+					Expect(validationError).To(HaveOccurred())
+					Expect(validationError.Error()).To(ContainSubstring("option AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_NAME is set to \"VM Network\", but network separation support is not enabled (because it is not fully functional). To enable network separation, run the command: tanzu config set features.management-cluster.network-separation-beta true"))
+				})
+			})
+		})
 	})
 
 	Context("ConfigureAndValidateWorkloadClusterConfiguration", func() {

--- a/pkg/v1/tkg/constants/config_variables.go
+++ b/pkg/v1/tkg/constants/config_variables.go
@@ -182,4 +182,11 @@ const (
 
 	// Windows specific variables
 	ConfigVariableIsWindowsWorkloadCluster = "IS_WINDOWS_WORKLOAD_CLUSTER"
+
+	// AVI specific variables
+	ConfigVariableAviManagementClusterServiceEngineGroup         = "AVI_MANAGEMENT_CLUSTER_SERVICE_ENGINE_GROUP"
+	ConfigVariableAviControlPlaneNetwork                         = "AVI_CONTROL_PLANE_NETWORK"
+	ConfigVariableAviControlPlaneNetworkCidr                     = "AVI_CONTROL_PLANE_NETWORK_CIDR"
+	ConfigVariableAviManagementClusterControlPlaneVipNetworkName = "AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_NAME"
+	ConfigVariableAviManagementClusterControlPlaneVipNetworkCidr = "AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_CIDR"
 )


### PR DESCRIPTION
### What this PR does / why we need it

We have added five new variables for avi vip separation feature:
"AVI_MANAGEMENT_CLUSTER_SERVICE_ENGINE_GROUP"
"AVI_CONTROL_PLANE_NETWORK"
"AVI_CONTROL_PLANE_NETWORK_CIDR"
"AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_NAME"
"AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_CIDR"

These variables default to "" and warmings are added for users
to fill in this variables and enable avi vip separation functionality while it is still under development.

Signed-off-by: Xinqi Li <lxinqi@vmware.com>


### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
