### PR TITLE
Revert "Antrea offload capability"

### DIFF
--- a/pkg/v1/providers/vendir.lock.yml
+++ b/pkg/v1/providers/vendir.lock.yml
@@ -11,10 +11,10 @@ directories:
   path: ytt/vendir/vsphere_cpi/_ytt_lib
 - contents:
   - git:
-      commitTitle: Adding antrea agent tweak configmap (#2683)
-      sha: a9353f7de25d8f2aa6baafacd295ce5c8d98d38b
+      commitTitle: Add update strategy for calico controllers (#2621)...
+      sha: c3fe6a25cf2d0aea3280e79ab142cf8d6e325ea7
       tags:
-      - v0.10.0-dev.4-23-ga9353f7d
+      - v0.10.0-dev.2-43-gc3fe6a25
     path: .
   path: ytt/vendir/cni/_ytt_lib
 - contents:

--- a/pkg/v1/providers/vendir.yml
+++ b/pkg/v1/providers/vendir.yml
@@ -14,7 +14,7 @@ directories:
   - path: .
     git:
       url: git@github.com:vmware-tanzu/tce.git
-      ref: a9353f7de25d8f2aa6baafacd295ce5c8d98d38b
+      ref: c3fe6a25cf2d0aea3280e79ab142cf8d6e325ea7
     includePaths:
     - addons/packages/antrea/1.2.3/bundle/config/**/*
     - addons/packages/calico/3.19.1/bundle/config/**/*

--- a/pkg/v1/providers/ytt/vendir/cni/_ytt_lib/addons/packages/antrea/1.2.3/bundle/config/overlay/antrea_overlay.yaml
+++ b/pkg/v1/providers/ytt/vendir/cni/_ytt_lib/addons/packages/antrea/1.2.3/bundle/config/overlay/antrea_overlay.yaml
@@ -86,8 +86,7 @@ noSNAT: #@ values.antrea.config.noSNAT
 #@ if/end values.antrea.config.defaultMTU:
 defaultMTU: #@ values.antrea.config.defaultMTU
 
-#! Whether or not to enable IPsec encryption of tunnel traffic. IPsec encryption is only supported
-#! for the GRE tunnel type.
+#! Whether or not to enable IPsec encryption of tunnel traffic.
 #!enableIPSecTunnel: false
 
 #! ClusterIP CIDR range for Services. It's required when AntreaProxy is not enabled, and should be
@@ -100,8 +99,7 @@ serviceCIDR: #@ values.antrea.config.serviceCIDR
 #! cluster or an IPv6 only cluster. The value should be the same as the configuration for kube-apiserver specified by
 #! --service-cluster-ip-range. When AntreaProxy is enabled, this parameter is not needed.
 #! No default value for this field.
-#@ if/end values.antrea.config.serviceCIDRv6:
-serviceCIDRv6: #@ values.antrea.config.serviceCIDRv6
+#!serviceCIDRv6:
 
 #! The port for the antrea-agent APIServer to serve on.
 #! Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -122,9 +120,10 @@ serviceCIDRv6: #@ values.antrea.config.serviceCIDRv6
 #! flow aggregator.
 #!flowCollectorAddr: "flow-aggregator.flow-aggregator.svc:4739:tls"
 
-#! Provide flow poll interval as a duration string. This determines how often the flow exporter dumps connections from the conntrack module.
-#! Flow poll interval should be greater than or equal to 1s (one second).
-#! Valid time units are "ns", "us" (or "Âµs"), "ms", "s", "m", "h".
+#! Provide flow poll interval as a duration string. This determines how often the
+#! flow exporter dumps connections from the conntrack module. Flow poll interval
+#! should be greater than or equal to 1s (one second).
+#! Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 #!flowPollInterval: "5s"
 
 #! Provide the active flow export timeout, which is the timeout after which a flow
@@ -143,7 +142,7 @@ serviceCIDRv6: #@ values.antrea.config.serviceCIDRv6
 #! Provide the port range used by NodePortLocal. When the NodePortLocal feature is enabled, a port from that range will be assigned
 #! whenever a Pod's container defines a specific port to be exposed (each container can define a list of ports as pod.spec.containers[].ports),
 #! and all Node traffic directed to that port will be forwarded to the Pod.
-#!nplPortRange: 40000-41000
+#!nplPortRange: 61000-62000
 
 #! Provide the address of Kubernetes apiserver, to override any value provided in kubeconfig or InClusterConfig.
 #! Defaults to "". It must be a host string, a host:port pair, or a URL to the base of the apiserver.
@@ -177,6 +176,9 @@ featureGates:
 
 #! Enable controlling SNAT IPs of Pod egress traffic.
   Egress: #@ values.antrea.config.featureGates.Egress
+
+#! Run Kubernetes NodeIPAMController with Antrea.
+#!  NodeIPAM: false
 
 #! The port for the antrea-controller APIServer to serve on.
 #! Note that if it's set to another value, the `containerPort` of the `api` port of the
@@ -216,7 +218,33 @@ tlsCipherSuites: #@ values.antrea.config.tlsCipherSuites
 #! longer be reflected in the new CRD, and all CRUD operations should be done through the new
 #! API groups. After adding the annotation, legacy CRDs can be deleted safely without impacting
 #! new CRDs.
-#! legacyCRDMirroring: true
+legacyCRDMirroring: true
+
+#! Enable usage reporting (telemetry) to VMware.
+#! enableUsageReporting: false
+#! nodeIPAM:
+
+#! Enable the integrated Node IPAM controller within the Antrea controller.
+#!  enableNodeIPAM: false
+
+#! CIDR Ranges for Pods in cluster. String array containing single CIDR range, or multiple ranges.
+#! The CIDRs could be either IPv4 or IPv6. Value ignored when enableNodeIPAM is false.
+#!  clusterCIDRs: []
+
+#! CIDR Ranges for Services in cluster. It is not necessary to specify it when there is no overlap with clusterCIDRs.
+#! Value ignored when enableNodeIPAM is false.
+#!  serviceCIDR:
+#!  serviceCIDRv6:
+
+#! Mask size for IPv4 Node CIDR in IPv4 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+#! or when IPv4 Pod CIDR is not configured. Valid range is 16 to 30.
+#!  nodeCIDRMaskSizeIPv4: 24
+
+#! Mask size for IPv6 Node CIDR in IPv6 or dual-stack cluster. Value ignored when enableNodeIPAM is false
+#! or when IPv6 Pod CIDR is not configured. Valid range is 64 to 126.
+#!  nodeCIDRMaskSizeIPv6: 64
+
+#! enterpriseAntrea: true
 #@ end
 
 #@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name": "antrea-config-822fk25299"}})
@@ -234,7 +262,6 @@ metadata:
   #@overlay/match missing_ok=True
   annotations:
     kapp.k14s.io/disable-default-label-scoping-rules: ""
-
 
 #@overlay/match by=overlay.subset({"kind":"DaemonSet","metadata":{"name": "antrea-agent"}})
 ---

--- a/pkg/v1/providers/ytt/vendir/cni/_ytt_lib/addons/packages/antrea/1.2.3/bundle/config/upstream/antrea.yaml
+++ b/pkg/v1/providers/ytt/vendir/cni/_ytt_lib/addons/packages/antrea/1.2.3/bundle/config/upstream/antrea.yaml
@@ -3779,19 +3779,6 @@ subjects:
 ---
 apiVersion: v1
 data:
-  antrea-agent-tweaker.conf: |-
-    # Enable disableUdpTunnelOffload will disable udp tunnel offloading feature on kubernetes node's default interface.
-    # By default, no actions will be taken.
-    disableUdpTunnelOffload: false
-kind: ConfigMap
-metadata:
-  labels:
-    app: antrea
-  name: antrea-agent-tweaker-g56hc6fh8t
-  namespace: kube-system
----
-apiVersion: v1
-data:
   antrea-agent.conf: |
     # FeatureGates is a map of feature names to bools that enable or disable experimental features.
     featureGates:
@@ -4455,29 +4442,6 @@ spec:
           readOnly: true
         - mountPath: /var/run/antrea
           name: host-var-run-antrea
-      - args:
-        - --config
-        - /etc/antrea/antrea-agent-tweaker.conf
-        command:
-        - antrea-agent-tweaker
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        image: antrea/antrea-ubuntu:v1.2.3
-        name: antrea-agent-tweaker
-        resources:
-          requests:
-            cpu: 100m
-        securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
-        volumeMounts:
-        - mountPath: /etc/antrea/antrea-agent-tweaker.conf
-          name: antrea-agent-tweaker-config
-          subPath: antrea-agent-tweaker.conf
       nodeSelector:
         kubernetes.io/os: linux
       priorityClassName: system-node-critical
@@ -4493,9 +4457,6 @@ spec:
       - configMap:
           name: antrea-config-822fk25299
         name: antrea-config
-      - configMap:
-          name: antrea-agent-tweaker-g56hc6fh8t
-        name: antrea-agent-tweaker-config
       - hostPath:
           path: /etc/cni/net.d
         name: host-cni-conf

--- a/pkg/v1/providers/ytt/vendir/cni/_ytt_lib/addons/packages/antrea/1.2.3/bundle/config/values.yaml
+++ b/pkg/v1/providers/ytt/vendir/cni/_ytt_lib/addons/packages/antrea/1.2.3/bundle/config/values.yaml
@@ -6,7 +6,6 @@ infraProvider: vsphere
 antrea:
   config:
     serviceCIDR: 10.96.0.0/12
-    serviceCIDRv6: null
     trafficEncapMode: encap
     noSNAT: false
     #! Setting defaultMTU to null since antrea-agent will discover the MTU of the Node's primary interface and

--- a/pkg/v1/providers/ytt/vendir/vsphere_cpi/_ytt_lib/NOTICE
+++ b/pkg/v1/providers/ytt/vendir/vsphere_cpi/_ytt_lib/NOTICE
@@ -179,4 +179,3 @@ warranty or additional liability.
 END OF TERMS AND CONDITIONS 
 
 
-


### PR DESCRIPTION
### What this PR does / why we need it
Reverting Antrea PR since we need more tests before doing this bump avoiding collisions in the TKR with different versions. 

### Describe testing done for PR
Test environment proves the difference between versions in the TKR and specification breaks due missing commands in the initContainer.

### Which issue(s) this PR fixes

https://github.com/vmware-tanzu/tanzu-framework/issues/1315

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access

