### PR TITLE
Convert vSphere resource names to full paths

### DIFF
--- a/pkg/v1/tkg/client/client_suite_test.go
+++ b/pkg/v1/tkg/client/client_suite_test.go
@@ -243,6 +243,78 @@ var _ = Describe("ValidateVSphereVersion", func() {
 	})
 })
 
+var _ = Describe("ValidateVsphereResources", func() {
+	var (
+		vcClient  = &fakes.VCClient{}
+		tkgClient *TkgClient
+		err       error
+
+		dc               = "dc0"
+		dcPath           = "/dc0"
+		network          = "VM Network"
+		networkPath      = "/dc0/network/VM Network"
+		resourcePool     = "cluster0/Resources"
+		resourcePoolPath = "/dc0/host/cluster0/Resources"
+		datastore        = "sharedVmfs-1"
+		datastorePath    = "/dc0/datastore/sharedVmfs-1"
+		folder           = "vm"
+		folderPath       = "/dc0/vm"
+	)
+
+	Context("When vSphere resource names are passed in instead of resource paths", func() {
+		BeforeEach(func() {
+			tkgClient, err = CreateTKGClient(configFile, testingDir, defaultTKGBoMFileForTesting, 2*time.Second)
+
+			vcClient.FindDataCenterReturns(dc, nil)
+			vcClient.GetPathReturnsOnCall(0, dcPath, nil, nil)
+
+			vcClient.FindNetworkReturns(network, nil)
+			vcClient.GetPathReturnsOnCall(1, networkPath, nil, nil)
+
+			vcClient.FindResourcePoolReturns(resourcePool, nil)
+			vcClient.GetPathReturnsOnCall(2, resourcePoolPath, nil, nil)
+
+			vcClient.FindDatastoreReturns(datastore, nil)
+			vcClient.GetPathReturnsOnCall(3, datastorePath, nil, nil)
+
+			vcClient.FindFolderReturns(folder, nil)
+			vcClient.GetPathReturnsOnCall(4, folderPath, nil, nil)
+
+			os.Setenv(constants.ConfigVariableVsphereDatacenter, dc)
+			os.Setenv(constants.ConfigVariableVsphereNetwork, network)
+			os.Setenv(constants.ConfigVariableVsphereResourcePool, resourcePool)
+			os.Setenv(constants.ConfigVariableVsphereDatastore, datastore)
+			os.Setenv(constants.ConfigVariableVsphereFolder, folder)
+
+			err = tkgClient.ValidateVsphereResources(vcClient, dc)
+		})
+
+		It("should not return an error ", func() {
+			Expect(err).ToNot(HaveOccurred())
+
+			actualDcPath, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableVsphereDatacenter)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dcPath).To(Equal(actualDcPath))
+
+			actualDcNetworkPath, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableVsphereNetwork)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(networkPath).To(Equal(actualDcNetworkPath))
+
+			actualResourcePoolPath, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableVsphereResourcePool)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resourcePoolPath).To(Equal(actualResourcePoolPath))
+
+			actualDataStorePath, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableVsphereDatastore)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(datastorePath).To(Equal(actualDataStorePath))
+
+			actualFolderPath, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableVsphereFolder)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(folderPath).To(Equal(actualFolderPath))
+		})
+	})
+})
+
 var _ = Describe("ValidateVSphereControlPlaneEndpointIP", func() {
 	var (
 		tkgClient     *TkgClient

--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -64,7 +64,7 @@ var (
 var trueString = "true"
 
 // VsphereResourceType vsphere resource types
-var VsphereResourceType = []string{constants.ConfigVariableVsphereResourcePool, constants.ConfigVariableVsphereDatastore, constants.ConfigVariableVsphereFolder}
+var VsphereResourceType = []string{constants.ConfigVariableVsphereDatacenter, constants.ConfigVariableVsphereNetwork, constants.ConfigVariableVsphereResourcePool, constants.ConfigVariableVsphereDatastore, constants.ConfigVariableVsphereFolder}
 
 // CNITypes supported CNI types
 var CNITypes = map[string]bool{"calico": true, "antrea": true, "none": true}
@@ -813,27 +813,40 @@ func (c *TkgClient) ValidateVsphereVipWorkloadCluster(clusterClient clusterclien
 
 // ValidateVsphereResources validates vsphere resource path specified in tkgconfig
 func (c *TkgClient) ValidateVsphereResources(vcClient vc.Client, dcPath string) error {
+	var path, resourceMoid string
+	var err error
+
 	for _, resourceType := range VsphereResourceType {
-		path, err := c.TKGConfigReaderWriter().Get(resourceType)
+		path, err = c.TKGConfigReaderWriter().Get(resourceType)
 		if err != nil {
 			continue
 		}
 
 		switch resourceType {
+		case constants.ConfigVariableVsphereDatacenter:
+			resourceMoid, err = vcClient.FindDataCenter(context.Background(), dcPath)
+			if err != nil {
+				return errors.Wrapf(err, "invalid %s", resourceType)
+			}
+		case constants.ConfigVariableVsphereNetwork:
+			resourceMoid, err = vcClient.FindNetwork(context.Background(), path, dcPath)
+			if err != nil {
+				return errors.Wrapf(err, "invalid %s", resourceType)
+			}
 		case constants.ConfigVariableVsphereResourcePool:
-			_, err := vcClient.FindResourcePool(context.Background(), path, dcPath)
+			resourceMoid, err = vcClient.FindResourcePool(context.Background(), path, dcPath)
 			if err != nil {
 				return errors.Wrapf(err, "invalid %s", resourceType)
 			}
 		case constants.ConfigVariableVsphereDatastore:
 			if path != "" {
-				_, err := vcClient.FindDatastore(context.Background(), path, dcPath)
+				resourceMoid, err = vcClient.FindDatastore(context.Background(), path, dcPath)
 				if err != nil {
 					return errors.Wrapf(err, "invalid %s", resourceType)
 				}
 			}
 		case constants.ConfigVariableVsphereFolder:
-			_, err := vcClient.FindFolder(context.Background(), path, dcPath)
+			resourceMoid, err = vcClient.FindFolder(context.Background(), path, dcPath)
 			if err != nil {
 				return errors.Wrapf(err, "invalid %s", resourceType)
 			}
@@ -841,9 +854,30 @@ func (c *TkgClient) ValidateVsphereResources(vcClient vc.Client, dcPath string) 
 		default:
 			return errors.Errorf("unknown vsphere resource type %s", resourceType)
 		}
+
+		err = c.setFullPath(vcClient, resourceType, path, resourceMoid)
+		if err != nil {
+			return err
+		}
 	}
 
 	return c.verifyDatastoreOrStoragePolicySet()
+}
+
+func (c *TkgClient) setFullPath(vcClient vc.Client, resourceType, path, resourceMoid string) error {
+	if path != "" {
+		resourcePath, _, err := vcClient.GetPath(context.Background(), resourceMoid)
+		if err != nil {
+			return err
+		}
+
+		if resourcePath != path {
+			log.Infof("Setting config variable %q to value %q", resourceType, resourcePath)
+			c.TKGConfigReaderWriter().Set(resourceType, resourcePath)
+		}
+	}
+
+	return nil
 }
 
 func (c *TkgClient) verifyDatastoreOrStoragePolicySet() error {

--- a/pkg/v1/tkg/fakes/clusterclient.go
+++ b/pkg/v1/tkg/fakes/clusterclient.go
@@ -1109,15 +1109,16 @@ func (fake *ClusterClient) ActivateTanzuKubernetesReleases(arg1 string) error {
 	fake.activateTanzuKubernetesReleasesArgsForCall = append(fake.activateTanzuKubernetesReleasesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ActivateTanzuKubernetesReleasesStub
+	fakeReturns := fake.activateTanzuKubernetesReleasesReturns
 	fake.recordInvocation("ActivateTanzuKubernetesReleases", []interface{}{arg1})
 	fake.activateTanzuKubernetesReleasesMutex.Unlock()
-	if fake.ActivateTanzuKubernetesReleasesStub != nil {
-		return fake.ActivateTanzuKubernetesReleasesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.activateTanzuKubernetesReleasesReturns
 	return fakeReturns.result1
 }
 
@@ -1176,15 +1177,16 @@ func (fake *ClusterClient) AddCEIPTelemetryJob(arg1 string, arg2 string, arg3 *t
 		arg7 string
 		arg8 string
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
+	stub := fake.AddCEIPTelemetryJobStub
+	fakeReturns := fake.addCEIPTelemetryJobReturns
 	fake.recordInvocation("AddCEIPTelemetryJob", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
 	fake.addCEIPTelemetryJobMutex.Unlock()
-	if fake.AddCEIPTelemetryJobStub != nil {
-		return fake.AddCEIPTelemetryJobStub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.addCEIPTelemetryJobReturns
 	return fakeReturns.result1
 }
 
@@ -1236,15 +1238,16 @@ func (fake *ClusterClient) Apply(arg1 string) error {
 	fake.applyArgsForCall = append(fake.applyArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ApplyStub
+	fakeReturns := fake.applyReturns
 	fake.recordInvocation("Apply", []interface{}{arg1})
 	fake.applyMutex.Unlock()
-	if fake.ApplyStub != nil {
-		return fake.ApplyStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.applyReturns
 	return fakeReturns.result1
 }
 
@@ -1296,15 +1299,16 @@ func (fake *ClusterClient) ApplyFile(arg1 string) error {
 	fake.applyFileArgsForCall = append(fake.applyFileArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ApplyFileStub
+	fakeReturns := fake.applyFileReturns
 	fake.recordInvocation("ApplyFile", []interface{}{arg1})
 	fake.applyFileMutex.Unlock()
-	if fake.ApplyFileStub != nil {
-		return fake.ApplyFileStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.applyFileReturns
 	return fakeReturns.result1
 }
 
@@ -1356,15 +1360,16 @@ func (fake *ClusterClient) CloneWithTimeout(arg1 time.Duration) clusterclient.Cl
 	fake.cloneWithTimeoutArgsForCall = append(fake.cloneWithTimeoutArgsForCall, struct {
 		arg1 time.Duration
 	}{arg1})
+	stub := fake.CloneWithTimeoutStub
+	fakeReturns := fake.cloneWithTimeoutReturns
 	fake.recordInvocation("CloneWithTimeout", []interface{}{arg1})
 	fake.cloneWithTimeoutMutex.Unlock()
-	if fake.CloneWithTimeoutStub != nil {
-		return fake.CloneWithTimeoutStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.cloneWithTimeoutReturns
 	return fakeReturns.result1
 }
 
@@ -1416,15 +1421,16 @@ func (fake *ClusterClient) CreateNamespace(arg1 string) error {
 	fake.createNamespaceArgsForCall = append(fake.createNamespaceArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.CreateNamespaceStub
+	fakeReturns := fake.createNamespaceReturns
 	fake.recordInvocation("CreateNamespace", []interface{}{arg1})
 	fake.createNamespaceMutex.Unlock()
-	if fake.CreateNamespaceStub != nil {
-		return fake.CreateNamespaceStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createNamespaceReturns
 	return fakeReturns.result1
 }
 
@@ -1479,15 +1485,16 @@ func (fake *ClusterClient) CreateResource(arg1 interface{}, arg2 string, arg3 st
 		arg3 string
 		arg4 []client.CreateOption
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.CreateResourceStub
+	fakeReturns := fake.createResourceReturns
 	fake.recordInvocation("CreateResource", []interface{}{arg1, arg2, arg3, arg4})
 	fake.createResourceMutex.Unlock()
-	if fake.CreateResourceStub != nil {
-		return fake.CreateResourceStub(arg1, arg2, arg3, arg4...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createResourceReturns
 	return fakeReturns.result1
 }
 
@@ -1539,15 +1546,16 @@ func (fake *ClusterClient) DeactivateTanzuKubernetesReleases(arg1 string) error 
 	fake.deactivateTanzuKubernetesReleasesArgsForCall = append(fake.deactivateTanzuKubernetesReleasesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.DeactivateTanzuKubernetesReleasesStub
+	fakeReturns := fake.deactivateTanzuKubernetesReleasesReturns
 	fake.recordInvocation("DeactivateTanzuKubernetesReleases", []interface{}{arg1})
 	fake.deactivateTanzuKubernetesReleasesMutex.Unlock()
-	if fake.DeactivateTanzuKubernetesReleasesStub != nil {
-		return fake.DeactivateTanzuKubernetesReleasesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deactivateTanzuKubernetesReleasesReturns
 	return fakeReturns.result1
 }
 
@@ -1600,15 +1608,16 @@ func (fake *ClusterClient) DeleteCluster(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.DeleteClusterStub
+	fakeReturns := fake.deleteClusterReturns
 	fake.recordInvocation("DeleteCluster", []interface{}{arg1, arg2})
 	fake.deleteClusterMutex.Unlock()
-	if fake.DeleteClusterStub != nil {
-		return fake.DeleteClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteClusterReturns
 	return fakeReturns.result1
 }
 
@@ -1659,15 +1668,16 @@ func (fake *ClusterClient) DeleteExistingKappController() error {
 	ret, specificReturn := fake.deleteExistingKappControllerReturnsOnCall[len(fake.deleteExistingKappControllerArgsForCall)]
 	fake.deleteExistingKappControllerArgsForCall = append(fake.deleteExistingKappControllerArgsForCall, struct {
 	}{})
+	stub := fake.DeleteExistingKappControllerStub
+	fakeReturns := fake.deleteExistingKappControllerReturns
 	fake.recordInvocation("DeleteExistingKappController", []interface{}{})
 	fake.deleteExistingKappControllerMutex.Unlock()
-	if fake.DeleteExistingKappControllerStub != nil {
-		return fake.DeleteExistingKappControllerStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteExistingKappControllerReturns
 	return fakeReturns.result1
 }
 
@@ -1712,15 +1722,16 @@ func (fake *ClusterClient) DeleteResource(arg1 interface{}) error {
 	fake.deleteResourceArgsForCall = append(fake.deleteResourceArgsForCall, struct {
 		arg1 interface{}
 	}{arg1})
+	stub := fake.DeleteResourceStub
+	fakeReturns := fake.deleteResourceReturns
 	fake.recordInvocation("DeleteResource", []interface{}{arg1})
 	fake.deleteResourceMutex.Unlock()
-	if fake.DeleteResourceStub != nil {
-		return fake.DeleteResourceStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteResourceReturns
 	return fakeReturns.result1
 }
 
@@ -1771,15 +1782,16 @@ func (fake *ClusterClient) ExportCurrentKubeconfigToFile() (string, error) {
 	ret, specificReturn := fake.exportCurrentKubeconfigToFileReturnsOnCall[len(fake.exportCurrentKubeconfigToFileArgsForCall)]
 	fake.exportCurrentKubeconfigToFileArgsForCall = append(fake.exportCurrentKubeconfigToFileArgsForCall, struct {
 	}{})
+	stub := fake.ExportCurrentKubeconfigToFileStub
+	fakeReturns := fake.exportCurrentKubeconfigToFileReturns
 	fake.recordInvocation("ExportCurrentKubeconfigToFile", []interface{}{})
 	fake.exportCurrentKubeconfigToFileMutex.Unlock()
-	if fake.ExportCurrentKubeconfigToFileStub != nil {
-		return fake.ExportCurrentKubeconfigToFileStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.exportCurrentKubeconfigToFileReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1826,15 +1838,16 @@ func (fake *ClusterClient) GetAWSCredentialsFromSecret() (string, error) {
 	ret, specificReturn := fake.getAWSCredentialsFromSecretReturnsOnCall[len(fake.getAWSCredentialsFromSecretArgsForCall)]
 	fake.getAWSCredentialsFromSecretArgsForCall = append(fake.getAWSCredentialsFromSecretArgsForCall, struct {
 	}{})
+	stub := fake.GetAWSCredentialsFromSecretStub
+	fakeReturns := fake.getAWSCredentialsFromSecretReturns
 	fake.recordInvocation("GetAWSCredentialsFromSecret", []interface{}{})
 	fake.getAWSCredentialsFromSecretMutex.Unlock()
-	if fake.GetAWSCredentialsFromSecretStub != nil {
-		return fake.GetAWSCredentialsFromSecretStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getAWSCredentialsFromSecretReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1881,15 +1894,16 @@ func (fake *ClusterClient) GetAzureCredentialsFromSecret() (azure.Credentials, e
 	ret, specificReturn := fake.getAzureCredentialsFromSecretReturnsOnCall[len(fake.getAzureCredentialsFromSecretArgsForCall)]
 	fake.getAzureCredentialsFromSecretArgsForCall = append(fake.getAzureCredentialsFromSecretArgsForCall, struct {
 	}{})
+	stub := fake.GetAzureCredentialsFromSecretStub
+	fakeReturns := fake.getAzureCredentialsFromSecretReturns
 	fake.recordInvocation("GetAzureCredentialsFromSecret", []interface{}{})
 	fake.getAzureCredentialsFromSecretMutex.Unlock()
-	if fake.GetAzureCredentialsFromSecretStub != nil {
-		return fake.GetAzureCredentialsFromSecretStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getAzureCredentialsFromSecretReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1937,15 +1951,16 @@ func (fake *ClusterClient) GetBomConfigMap(arg1 string) (v1.ConfigMap, error) {
 	fake.getBomConfigMapArgsForCall = append(fake.getBomConfigMapArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetBomConfigMapStub
+	fakeReturns := fake.getBomConfigMapReturns
 	fake.recordInvocation("GetBomConfigMap", []interface{}{arg1})
 	fake.getBomConfigMapMutex.Unlock()
-	if fake.GetBomConfigMapStub != nil {
-		return fake.GetBomConfigMapStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getBomConfigMapReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1999,15 +2014,16 @@ func (fake *ClusterClient) GetClientSet() clusterclient.CrtClient {
 	ret, specificReturn := fake.getClientSetReturnsOnCall[len(fake.getClientSetArgsForCall)]
 	fake.getClientSetArgsForCall = append(fake.getClientSetArgsForCall, struct {
 	}{})
+	stub := fake.GetClientSetStub
+	fakeReturns := fake.getClientSetReturns
 	fake.recordInvocation("GetClientSet", []interface{}{})
 	fake.getClientSetMutex.Unlock()
-	if fake.GetClientSetStub != nil {
-		return fake.GetClientSetStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getClientSetReturns
 	return fakeReturns.result1
 }
 
@@ -2051,15 +2067,16 @@ func (fake *ClusterClient) GetClusterInfrastructure() (string, error) {
 	ret, specificReturn := fake.getClusterInfrastructureReturnsOnCall[len(fake.getClusterInfrastructureArgsForCall)]
 	fake.getClusterInfrastructureArgsForCall = append(fake.getClusterInfrastructureArgsForCall, struct {
 	}{})
+	stub := fake.GetClusterInfrastructureStub
+	fakeReturns := fake.getClusterInfrastructureReturns
 	fake.recordInvocation("GetClusterInfrastructure", []interface{}{})
 	fake.getClusterInfrastructureMutex.Unlock()
-	if fake.GetClusterInfrastructureStub != nil {
-		return fake.GetClusterInfrastructureStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getClusterInfrastructureReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2107,15 +2124,16 @@ func (fake *ClusterClient) GetCurrentClusterName(arg1 string) (string, error) {
 	fake.getCurrentClusterNameArgsForCall = append(fake.getCurrentClusterNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetCurrentClusterNameStub
+	fakeReturns := fake.getCurrentClusterNameReturns
 	fake.recordInvocation("GetCurrentClusterName", []interface{}{arg1})
 	fake.getCurrentClusterNameMutex.Unlock()
-	if fake.GetCurrentClusterNameStub != nil {
-		return fake.GetCurrentClusterNameStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getCurrentClusterNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2169,15 +2187,16 @@ func (fake *ClusterClient) GetCurrentKubeContext() (string, error) {
 	ret, specificReturn := fake.getCurrentKubeContextReturnsOnCall[len(fake.getCurrentKubeContextArgsForCall)]
 	fake.getCurrentKubeContextArgsForCall = append(fake.getCurrentKubeContextArgsForCall, struct {
 	}{})
+	stub := fake.GetCurrentKubeContextStub
+	fakeReturns := fake.getCurrentKubeContextReturns
 	fake.recordInvocation("GetCurrentKubeContext", []interface{}{})
 	fake.getCurrentKubeContextMutex.Unlock()
-	if fake.GetCurrentKubeContextStub != nil {
-		return fake.GetCurrentKubeContextStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getCurrentKubeContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2224,15 +2243,16 @@ func (fake *ClusterClient) GetCurrentKubeconfigFile() string {
 	ret, specificReturn := fake.getCurrentKubeconfigFileReturnsOnCall[len(fake.getCurrentKubeconfigFileArgsForCall)]
 	fake.getCurrentKubeconfigFileArgsForCall = append(fake.getCurrentKubeconfigFileArgsForCall, struct {
 	}{})
+	stub := fake.GetCurrentKubeconfigFileStub
+	fakeReturns := fake.getCurrentKubeconfigFileReturns
 	fake.recordInvocation("GetCurrentKubeconfigFile", []interface{}{})
 	fake.getCurrentKubeconfigFileMutex.Unlock()
-	if fake.GetCurrentKubeconfigFileStub != nil {
-		return fake.GetCurrentKubeconfigFileStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getCurrentKubeconfigFileReturns
 	return fakeReturns.result1
 }
 
@@ -2276,15 +2296,16 @@ func (fake *ClusterClient) GetCurrentNamespace() (string, error) {
 	ret, specificReturn := fake.getCurrentNamespaceReturnsOnCall[len(fake.getCurrentNamespaceArgsForCall)]
 	fake.getCurrentNamespaceArgsForCall = append(fake.getCurrentNamespaceArgsForCall, struct {
 	}{})
+	stub := fake.GetCurrentNamespaceStub
+	fakeReturns := fake.getCurrentNamespaceReturns
 	fake.recordInvocation("GetCurrentNamespace", []interface{}{})
 	fake.getCurrentNamespaceMutex.Unlock()
-	if fake.GetCurrentNamespaceStub != nil {
-		return fake.GetCurrentNamespaceStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getCurrentNamespaceReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2333,15 +2354,16 @@ func (fake *ClusterClient) GetKCPObjectForCluster(arg1 string, arg2 string) (*v1
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetKCPObjectForClusterStub
+	fakeReturns := fake.getKCPObjectForClusterReturns
 	fake.recordInvocation("GetKCPObjectForCluster", []interface{}{arg1, arg2})
 	fake.getKCPObjectForClusterMutex.Unlock()
-	if fake.GetKCPObjectForClusterStub != nil {
-		return fake.GetKCPObjectForClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getKCPObjectForClusterReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2398,15 +2420,16 @@ func (fake *ClusterClient) GetKubeConfigForCluster(arg1 string, arg2 string, arg
 		arg2 string
 		arg3 *clusterclient.PollOptions
 	}{arg1, arg2, arg3})
+	stub := fake.GetKubeConfigForClusterStub
+	fakeReturns := fake.getKubeConfigForClusterReturns
 	fake.recordInvocation("GetKubeConfigForCluster", []interface{}{arg1, arg2, arg3})
 	fake.getKubeConfigForClusterMutex.Unlock()
-	if fake.GetKubeConfigForClusterStub != nil {
-		return fake.GetKubeConfigForClusterStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getKubeConfigForClusterReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2460,15 +2483,16 @@ func (fake *ClusterClient) GetKubernetesVersion() (string, error) {
 	ret, specificReturn := fake.getKubernetesVersionReturnsOnCall[len(fake.getKubernetesVersionArgsForCall)]
 	fake.getKubernetesVersionArgsForCall = append(fake.getKubernetesVersionArgsForCall, struct {
 	}{})
+	stub := fake.GetKubernetesVersionStub
+	fakeReturns := fake.getKubernetesVersionReturns
 	fake.recordInvocation("GetKubernetesVersion", []interface{}{})
 	fake.getKubernetesVersionMutex.Unlock()
-	if fake.GetKubernetesVersionStub != nil {
-		return fake.GetKubernetesVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getKubernetesVersionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2517,15 +2541,16 @@ func (fake *ClusterClient) GetMDObjectForCluster(arg1 string, arg2 string) ([]v1
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetMDObjectForClusterStub
+	fakeReturns := fake.getMDObjectForClusterReturns
 	fake.recordInvocation("GetMDObjectForCluster", []interface{}{arg1, arg2})
 	fake.getMDObjectForClusterMutex.Unlock()
-	if fake.GetMDObjectForClusterStub != nil {
-		return fake.GetMDObjectForClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getMDObjectForClusterReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2581,15 +2606,16 @@ func (fake *ClusterClient) GetMachineObjectsForCluster(arg1 string, arg2 string)
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetMachineObjectsForClusterStub
+	fakeReturns := fake.getMachineObjectsForClusterReturns
 	fake.recordInvocation("GetMachineObjectsForCluster", []interface{}{arg1, arg2})
 	fake.getMachineObjectsForClusterMutex.Unlock()
-	if fake.GetMachineObjectsForClusterStub != nil {
-		return fake.GetMachineObjectsForClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getMachineObjectsForClusterReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2648,15 +2674,16 @@ func (fake *ClusterClient) GetManagementClusterTKGVersion(arg1 string, arg2 stri
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetManagementClusterTKGVersionStub
+	fakeReturns := fake.getManagementClusterTKGVersionReturns
 	fake.recordInvocation("GetManagementClusterTKGVersion", []interface{}{arg1, arg2})
 	fake.getManagementClusterTKGVersionMutex.Unlock()
-	if fake.GetManagementClusterTKGVersionStub != nil {
-		return fake.GetManagementClusterTKGVersionStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getManagementClusterTKGVersionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2712,15 +2739,16 @@ func (fake *ClusterClient) GetPacificClusterObject(arg1 string, arg2 string) (*v
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetPacificClusterObjectStub
+	fakeReturns := fake.getPacificClusterObjectReturns
 	fake.recordInvocation("GetPacificClusterObject", []interface{}{arg1, arg2})
 	fake.getPacificClusterObjectMutex.Unlock()
-	if fake.GetPacificClusterObjectStub != nil {
-		return fake.GetPacificClusterObjectStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getPacificClusterObjectReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2774,15 +2802,16 @@ func (fake *ClusterClient) GetPacificTKCAPIVersion() (string, error) {
 	ret, specificReturn := fake.getPacificTKCAPIVersionReturnsOnCall[len(fake.getPacificTKCAPIVersionArgsForCall)]
 	fake.getPacificTKCAPIVersionArgsForCall = append(fake.getPacificTKCAPIVersionArgsForCall, struct {
 	}{})
+	stub := fake.GetPacificTKCAPIVersionStub
+	fakeReturns := fake.getPacificTKCAPIVersionReturns
 	fake.recordInvocation("GetPacificTKCAPIVersion", []interface{}{})
 	fake.getPacificTKCAPIVersionMutex.Unlock()
-	if fake.GetPacificTKCAPIVersionStub != nil {
-		return fake.GetPacificTKCAPIVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getPacificTKCAPIVersionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2829,15 +2858,16 @@ func (fake *ClusterClient) GetPacificTanzuKubernetesReleases() ([]string, error)
 	ret, specificReturn := fake.getPacificTanzuKubernetesReleasesReturnsOnCall[len(fake.getPacificTanzuKubernetesReleasesArgsForCall)]
 	fake.getPacificTanzuKubernetesReleasesArgsForCall = append(fake.getPacificTanzuKubernetesReleasesArgsForCall, struct {
 	}{})
+	stub := fake.GetPacificTanzuKubernetesReleasesStub
+	fakeReturns := fake.getPacificTanzuKubernetesReleasesReturns
 	fake.recordInvocation("GetPacificTanzuKubernetesReleases", []interface{}{})
 	fake.getPacificTanzuKubernetesReleasesMutex.Unlock()
-	if fake.GetPacificTanzuKubernetesReleasesStub != nil {
-		return fake.GetPacificTanzuKubernetesReleasesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getPacificTanzuKubernetesReleasesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -2884,15 +2914,16 @@ func (fake *ClusterClient) GetPinnipedIssuerURLAndCA() (string, string, error) {
 	ret, specificReturn := fake.getPinnipedIssuerURLAndCAReturnsOnCall[len(fake.getPinnipedIssuerURLAndCAArgsForCall)]
 	fake.getPinnipedIssuerURLAndCAArgsForCall = append(fake.getPinnipedIssuerURLAndCAArgsForCall, struct {
 	}{})
+	stub := fake.GetPinnipedIssuerURLAndCAStub
+	fakeReturns := fake.getPinnipedIssuerURLAndCAReturns
 	fake.recordInvocation("GetPinnipedIssuerURLAndCA", []interface{}{})
 	fake.getPinnipedIssuerURLAndCAMutex.Unlock()
-	if fake.GetPinnipedIssuerURLAndCAStub != nil {
-		return fake.GetPinnipedIssuerURLAndCAStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getPinnipedIssuerURLAndCAReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -2943,15 +2974,16 @@ func (fake *ClusterClient) GetRegionalClusterDefaultProviderName(arg1 v1alpha3.P
 	fake.getRegionalClusterDefaultProviderNameArgsForCall = append(fake.getRegionalClusterDefaultProviderNameArgsForCall, struct {
 		arg1 v1alpha3.ProviderType
 	}{arg1})
+	stub := fake.GetRegionalClusterDefaultProviderNameStub
+	fakeReturns := fake.getRegionalClusterDefaultProviderNameReturns
 	fake.recordInvocation("GetRegionalClusterDefaultProviderName", []interface{}{arg1})
 	fake.getRegionalClusterDefaultProviderNameMutex.Unlock()
-	if fake.GetRegionalClusterDefaultProviderNameStub != nil {
-		return fake.GetRegionalClusterDefaultProviderNameStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getRegionalClusterDefaultProviderNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3010,15 +3042,16 @@ func (fake *ClusterClient) GetResource(arg1 interface{}, arg2 string, arg3 strin
 		arg4 clusterclient.PostVerifyrFunc
 		arg5 *clusterclient.PollOptions
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.GetResourceStub
+	fakeReturns := fake.getResourceReturns
 	fake.recordInvocation("GetResource", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.getResourceMutex.Unlock()
-	if fake.GetResourceStub != nil {
-		return fake.GetResourceStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getResourceReturns
 	return fakeReturns.result1
 }
 
@@ -3074,15 +3107,16 @@ func (fake *ClusterClient) GetResourceList(arg1 interface{}, arg2 string, arg3 s
 		arg4 clusterclient.PostVerifyListrFunc
 		arg5 *clusterclient.PollOptions
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.GetResourceListStub
+	fakeReturns := fake.getResourceListReturns
 	fake.recordInvocation("GetResourceList", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.getResourceListMutex.Unlock()
-	if fake.GetResourceListStub != nil {
-		return fake.GetResourceListStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getResourceListReturns
 	return fakeReturns.result1
 }
 
@@ -3137,15 +3171,16 @@ func (fake *ClusterClient) GetSecretValue(arg1 string, arg2 string, arg3 string,
 		arg3 string
 		arg4 *clusterclient.PollOptions
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.GetSecretValueStub
+	fakeReturns := fake.getSecretValueReturns
 	fake.recordInvocation("GetSecretValue", []interface{}{arg1, arg2, arg3, arg4})
 	fake.getSecretValueMutex.Unlock()
-	if fake.GetSecretValueStub != nil {
-		return fake.GetSecretValueStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSecretValueReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3200,15 +3235,16 @@ func (fake *ClusterClient) GetTanzuKubernetesReleases(arg1 string) ([]v1alpha1.T
 	fake.getTanzuKubernetesReleasesArgsForCall = append(fake.getTanzuKubernetesReleasesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetTanzuKubernetesReleasesStub
+	fakeReturns := fake.getTanzuKubernetesReleasesReturns
 	fake.recordInvocation("GetTanzuKubernetesReleases", []interface{}{arg1})
 	fake.getTanzuKubernetesReleasesMutex.Unlock()
-	if fake.GetTanzuKubernetesReleasesStub != nil {
-		return fake.GetTanzuKubernetesReleasesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getTanzuKubernetesReleasesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3265,15 +3301,16 @@ func (fake *ClusterClient) GetVCClientAndDataCenter(arg1 string, arg2 string, ar
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.GetVCClientAndDataCenterStub
+	fakeReturns := fake.getVCClientAndDataCenterReturns
 	fake.recordInvocation("GetVCClientAndDataCenter", []interface{}{arg1, arg2, arg3})
 	fake.getVCClientAndDataCenterMutex.Unlock()
-	if fake.GetVCClientAndDataCenterStub != nil {
-		return fake.GetVCClientAndDataCenterStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getVCClientAndDataCenterReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -3331,15 +3368,16 @@ func (fake *ClusterClient) GetVCCredentialsFromSecret(arg1 string) (string, stri
 	fake.getVCCredentialsFromSecretArgsForCall = append(fake.getVCCredentialsFromSecretArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GetVCCredentialsFromSecretStub
+	fakeReturns := fake.getVCCredentialsFromSecretReturns
 	fake.recordInvocation("GetVCCredentialsFromSecret", []interface{}{arg1})
 	fake.getVCCredentialsFromSecretMutex.Unlock()
-	if fake.GetVCCredentialsFromSecretStub != nil {
-		return fake.GetVCCredentialsFromSecretStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.getVCCredentialsFromSecretReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -3396,15 +3434,16 @@ func (fake *ClusterClient) GetVCServer() (string, error) {
 	ret, specificReturn := fake.getVCServerReturnsOnCall[len(fake.getVCServerArgsForCall)]
 	fake.getVCServerArgsForCall = append(fake.getVCServerArgsForCall, struct {
 	}{})
+	stub := fake.GetVCServerStub
+	fakeReturns := fake.getVCServerReturns
 	fake.recordInvocation("GetVCServer", []interface{}{})
 	fake.getVCServerMutex.Unlock()
-	if fake.GetVCServerStub != nil {
-		return fake.GetVCServerStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getVCServerReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3452,15 +3491,16 @@ func (fake *ClusterClient) HasCEIPTelemetryJob(arg1 string) (bool, error) {
 	fake.hasCEIPTelemetryJobArgsForCall = append(fake.hasCEIPTelemetryJobArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.HasCEIPTelemetryJobStub
+	fakeReturns := fake.hasCEIPTelemetryJobReturns
 	fake.recordInvocation("HasCEIPTelemetryJob", []interface{}{arg1})
 	fake.hasCEIPTelemetryJobMutex.Unlock()
-	if fake.HasCEIPTelemetryJobStub != nil {
-		return fake.HasCEIPTelemetryJobStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.hasCEIPTelemetryJobReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3514,15 +3554,16 @@ func (fake *ClusterClient) IsClusterRegisteredToTMC() (bool, error) {
 	ret, specificReturn := fake.isClusterRegisteredToTMCReturnsOnCall[len(fake.isClusterRegisteredToTMCArgsForCall)]
 	fake.isClusterRegisteredToTMCArgsForCall = append(fake.isClusterRegisteredToTMCArgsForCall, struct {
 	}{})
+	stub := fake.IsClusterRegisteredToTMCStub
+	fakeReturns := fake.isClusterRegisteredToTMCReturns
 	fake.recordInvocation("IsClusterRegisteredToTMC", []interface{}{})
 	fake.isClusterRegisteredToTMCMutex.Unlock()
-	if fake.IsClusterRegisteredToTMCStub != nil {
-		return fake.IsClusterRegisteredToTMCStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.isClusterRegisteredToTMCReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3569,15 +3610,16 @@ func (fake *ClusterClient) IsPacificRegionalCluster() (bool, error) {
 	ret, specificReturn := fake.isPacificRegionalClusterReturnsOnCall[len(fake.isPacificRegionalClusterArgsForCall)]
 	fake.isPacificRegionalClusterArgsForCall = append(fake.isPacificRegionalClusterArgsForCall, struct {
 	}{})
+	stub := fake.IsPacificRegionalClusterStub
+	fakeReturns := fake.isPacificRegionalClusterReturns
 	fake.recordInvocation("IsPacificRegionalCluster", []interface{}{})
 	fake.isPacificRegionalClusterMutex.Unlock()
-	if fake.IsPacificRegionalClusterStub != nil {
-		return fake.IsPacificRegionalClusterStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.isPacificRegionalClusterReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3624,15 +3666,16 @@ func (fake *ClusterClient) IsRegionalCluster() error {
 	ret, specificReturn := fake.isRegionalClusterReturnsOnCall[len(fake.isRegionalClusterArgsForCall)]
 	fake.isRegionalClusterArgsForCall = append(fake.isRegionalClusterArgsForCall, struct {
 	}{})
+	stub := fake.IsRegionalClusterStub
+	fakeReturns := fake.isRegionalClusterReturns
 	fake.recordInvocation("IsRegionalCluster", []interface{}{})
 	fake.isRegionalClusterMutex.Unlock()
-	if fake.IsRegionalClusterStub != nil {
-		return fake.IsRegionalClusterStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.isRegionalClusterReturns
 	return fakeReturns.result1
 }
 
@@ -3676,15 +3719,16 @@ func (fake *ClusterClient) ListCLIPluginResources() ([]v1alpha1a.CLIPlugin, erro
 	ret, specificReturn := fake.listCLIPluginResourcesReturnsOnCall[len(fake.listCLIPluginResourcesArgsForCall)]
 	fake.listCLIPluginResourcesArgsForCall = append(fake.listCLIPluginResourcesArgsForCall, struct {
 	}{})
+	stub := fake.ListCLIPluginResourcesStub
+	fakeReturns := fake.listCLIPluginResourcesReturns
 	fake.recordInvocation("ListCLIPluginResources", []interface{}{})
 	fake.listCLIPluginResourcesMutex.Unlock()
-	if fake.ListCLIPluginResourcesStub != nil {
-		return fake.ListCLIPluginResourcesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listCLIPluginResourcesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3732,15 +3776,16 @@ func (fake *ClusterClient) ListClusters(arg1 string) ([]v1beta1a.Cluster, error)
 	fake.listClustersArgsForCall = append(fake.listClustersArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListClustersStub
+	fakeReturns := fake.listClustersReturns
 	fake.recordInvocation("ListClusters", []interface{}{arg1})
 	fake.listClustersMutex.Unlock()
-	if fake.ListClustersStub != nil {
-		return fake.ListClustersStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listClustersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3796,15 +3841,16 @@ func (fake *ClusterClient) ListPacificClusterObjects(arg1 string, arg2 *client.L
 		arg1 string
 		arg2 *client.ListOptions
 	}{arg1, arg2})
+	stub := fake.ListPacificClusterObjectsStub
+	fakeReturns := fake.listPacificClusterObjectsReturns
 	fake.recordInvocation("ListPacificClusterObjects", []interface{}{arg1, arg2})
 	fake.listPacificClusterObjectsMutex.Unlock()
-	if fake.ListPacificClusterObjectsStub != nil {
-		return fake.ListPacificClusterObjectsStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listPacificClusterObjectsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3860,15 +3906,16 @@ func (fake *ClusterClient) ListResources(arg1 interface{}, arg2 ...client.ListOp
 		arg1 interface{}
 		arg2 []client.ListOption
 	}{arg1, arg2})
+	stub := fake.ListResourcesStub
+	fakeReturns := fake.listResourcesReturns
 	fake.recordInvocation("ListResources", []interface{}{arg1, arg2})
 	fake.listResourcesMutex.Unlock()
-	if fake.ListResourcesStub != nil {
-		return fake.ListResourcesStub(arg1, arg2...)
+	if stub != nil {
+		return stub(arg1, arg2...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.listResourcesReturns
 	return fakeReturns.result1
 }
 
@@ -3919,15 +3966,16 @@ func (fake *ClusterClient) LoadCurrentKubeconfigBytes() ([]byte, error) {
 	ret, specificReturn := fake.loadCurrentKubeconfigBytesReturnsOnCall[len(fake.loadCurrentKubeconfigBytesArgsForCall)]
 	fake.loadCurrentKubeconfigBytesArgsForCall = append(fake.loadCurrentKubeconfigBytesArgsForCall, struct {
 	}{})
+	stub := fake.LoadCurrentKubeconfigBytesStub
+	fakeReturns := fake.loadCurrentKubeconfigBytesReturns
 	fake.recordInvocation("LoadCurrentKubeconfigBytes", []interface{}{})
 	fake.loadCurrentKubeconfigBytesMutex.Unlock()
-	if fake.LoadCurrentKubeconfigBytesStub != nil {
-		return fake.LoadCurrentKubeconfigBytesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.loadCurrentKubeconfigBytesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -3981,15 +4029,16 @@ func (fake *ClusterClient) MergeAndUseConfigForCluster(arg1 []byte, arg2 string)
 		arg1 []byte
 		arg2 string
 	}{arg1Copy, arg2})
+	stub := fake.MergeAndUseConfigForClusterStub
+	fakeReturns := fake.mergeAndUseConfigForClusterReturns
 	fake.recordInvocation("MergeAndUseConfigForCluster", []interface{}{arg1Copy, arg2})
 	fake.mergeAndUseConfigForClusterMutex.Unlock()
-	if fake.MergeAndUseConfigForClusterStub != nil {
-		return fake.MergeAndUseConfigForClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.mergeAndUseConfigForClusterReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -4053,15 +4102,16 @@ func (fake *ClusterClient) MergeConfigForCluster(arg1 []byte, arg2 string) error
 		arg1 []byte
 		arg2 string
 	}{arg1Copy, arg2})
+	stub := fake.MergeConfigForClusterStub
+	fakeReturns := fake.mergeConfigForClusterReturns
 	fake.recordInvocation("MergeConfigForCluster", []interface{}{arg1Copy, arg2})
 	fake.mergeConfigForClusterMutex.Unlock()
-	if fake.MergeConfigForClusterStub != nil {
-		return fake.MergeConfigForClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.mergeConfigForClusterReturns
 	return fakeReturns.result1
 }
 
@@ -4114,15 +4164,16 @@ func (fake *ClusterClient) PatchCalicoKubeControllerDeploymentWithNewNodeSelecto
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.PatchCalicoKubeControllerDeploymentWithNewNodeSelectorStub
+	fakeReturns := fake.patchCalicoKubeControllerDeploymentWithNewNodeSelectorReturns
 	fake.recordInvocation("PatchCalicoKubeControllerDeploymentWithNewNodeSelector", []interface{}{arg1, arg2})
 	fake.patchCalicoKubeControllerDeploymentWithNewNodeSelectorMutex.Unlock()
-	if fake.PatchCalicoKubeControllerDeploymentWithNewNodeSelectorStub != nil {
-		return fake.PatchCalicoKubeControllerDeploymentWithNewNodeSelectorStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchCalicoKubeControllerDeploymentWithNewNodeSelectorReturns
 	return fakeReturns.result1
 }
 
@@ -4175,15 +4226,16 @@ func (fake *ClusterClient) PatchCalicoNodeDaemonSetWithNewNodeSelector(arg1 stri
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.PatchCalicoNodeDaemonSetWithNewNodeSelectorStub
+	fakeReturns := fake.patchCalicoNodeDaemonSetWithNewNodeSelectorReturns
 	fake.recordInvocation("PatchCalicoNodeDaemonSetWithNewNodeSelector", []interface{}{arg1, arg2})
 	fake.patchCalicoNodeDaemonSetWithNewNodeSelectorMutex.Unlock()
-	if fake.PatchCalicoNodeDaemonSetWithNewNodeSelectorStub != nil {
-		return fake.PatchCalicoNodeDaemonSetWithNewNodeSelectorStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchCalicoNodeDaemonSetWithNewNodeSelectorReturns
 	return fakeReturns.result1
 }
 
@@ -4234,15 +4286,16 @@ func (fake *ClusterClient) PatchClusterAPIAWSControllersToUseEC2Credentials() er
 	ret, specificReturn := fake.patchClusterAPIAWSControllersToUseEC2CredentialsReturnsOnCall[len(fake.patchClusterAPIAWSControllersToUseEC2CredentialsArgsForCall)]
 	fake.patchClusterAPIAWSControllersToUseEC2CredentialsArgsForCall = append(fake.patchClusterAPIAWSControllersToUseEC2CredentialsArgsForCall, struct {
 	}{})
+	stub := fake.PatchClusterAPIAWSControllersToUseEC2CredentialsStub
+	fakeReturns := fake.patchClusterAPIAWSControllersToUseEC2CredentialsReturns
 	fake.recordInvocation("PatchClusterAPIAWSControllersToUseEC2Credentials", []interface{}{})
 	fake.patchClusterAPIAWSControllersToUseEC2CredentialsMutex.Unlock()
-	if fake.PatchClusterAPIAWSControllersToUseEC2CredentialsStub != nil {
-		return fake.PatchClusterAPIAWSControllersToUseEC2CredentialsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchClusterAPIAWSControllersToUseEC2CredentialsReturns
 	return fakeReturns.result1
 }
 
@@ -4289,15 +4342,16 @@ func (fake *ClusterClient) PatchClusterObject(arg1 string, arg2 string, arg3 str
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.PatchClusterObjectStub
+	fakeReturns := fake.patchClusterObjectReturns
 	fake.recordInvocation("PatchClusterObject", []interface{}{arg1, arg2, arg3})
 	fake.patchClusterObjectMutex.Unlock()
-	if fake.PatchClusterObjectStub != nil {
-		return fake.PatchClusterObjectStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchClusterObjectReturns
 	return fakeReturns.result1
 }
 
@@ -4352,15 +4406,16 @@ func (fake *ClusterClient) PatchClusterObjectWithOptionalMetadata(arg1 string, a
 		arg3 string
 		arg4 map[string]string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.PatchClusterObjectWithOptionalMetadataStub
+	fakeReturns := fake.patchClusterObjectWithOptionalMetadataReturns
 	fake.recordInvocation("PatchClusterObjectWithOptionalMetadata", []interface{}{arg1, arg2, arg3, arg4})
 	fake.patchClusterObjectWithOptionalMetadataMutex.Unlock()
-	if fake.PatchClusterObjectWithOptionalMetadataStub != nil {
-		return fake.PatchClusterObjectWithOptionalMetadataStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.patchClusterObjectWithOptionalMetadataReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -4417,15 +4472,16 @@ func (fake *ClusterClient) PatchClusterObjectWithTKGVersion(arg1 string, arg2 st
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.PatchClusterObjectWithTKGVersionStub
+	fakeReturns := fake.patchClusterObjectWithTKGVersionReturns
 	fake.recordInvocation("PatchClusterObjectWithTKGVersion", []interface{}{arg1, arg2, arg3})
 	fake.patchClusterObjectWithTKGVersionMutex.Unlock()
-	if fake.PatchClusterObjectWithTKGVersionStub != nil {
-		return fake.PatchClusterObjectWithTKGVersionStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchClusterObjectWithTKGVersionReturns
 	return fakeReturns.result1
 }
 
@@ -4480,15 +4536,16 @@ func (fake *ClusterClient) PatchClusterWithOperationStartedStatus(arg1 string, a
 		arg3 string
 		arg4 time.Duration
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.PatchClusterWithOperationStartedStatusStub
+	fakeReturns := fake.patchClusterWithOperationStartedStatusReturns
 	fake.recordInvocation("PatchClusterWithOperationStartedStatus", []interface{}{arg1, arg2, arg3, arg4})
 	fake.patchClusterWithOperationStartedStatusMutex.Unlock()
-	if fake.PatchClusterWithOperationStartedStatusStub != nil {
-		return fake.PatchClusterWithOperationStartedStatusStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchClusterWithOperationStartedStatusReturns
 	return fakeReturns.result1
 }
 
@@ -4540,15 +4597,16 @@ func (fake *ClusterClient) PatchCoreDNSImageRepositoryInKubeadmConfigMap(arg1 st
 	fake.patchCoreDNSImageRepositoryInKubeadmConfigMapArgsForCall = append(fake.patchCoreDNSImageRepositoryInKubeadmConfigMapArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.PatchCoreDNSImageRepositoryInKubeadmConfigMapStub
+	fakeReturns := fake.patchCoreDNSImageRepositoryInKubeadmConfigMapReturns
 	fake.recordInvocation("PatchCoreDNSImageRepositoryInKubeadmConfigMap", []interface{}{arg1})
 	fake.patchCoreDNSImageRepositoryInKubeadmConfigMapMutex.Unlock()
-	if fake.PatchCoreDNSImageRepositoryInKubeadmConfigMapStub != nil {
-		return fake.PatchCoreDNSImageRepositoryInKubeadmConfigMapStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchCoreDNSImageRepositoryInKubeadmConfigMapReturns
 	return fakeReturns.result1
 }
 
@@ -4600,15 +4658,16 @@ func (fake *ClusterClient) PatchImageRepositoryInKubeProxyDaemonSet(arg1 string)
 	fake.patchImageRepositoryInKubeProxyDaemonSetArgsForCall = append(fake.patchImageRepositoryInKubeProxyDaemonSetArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.PatchImageRepositoryInKubeProxyDaemonSetStub
+	fakeReturns := fake.patchImageRepositoryInKubeProxyDaemonSetReturns
 	fake.recordInvocation("PatchImageRepositoryInKubeProxyDaemonSet", []interface{}{arg1})
 	fake.patchImageRepositoryInKubeProxyDaemonSetMutex.Unlock()
-	if fake.PatchImageRepositoryInKubeProxyDaemonSetStub != nil {
-		return fake.PatchImageRepositoryInKubeProxyDaemonSetStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchImageRepositoryInKubeProxyDaemonSetReturns
 	return fakeReturns.result1
 }
 
@@ -4662,15 +4721,16 @@ func (fake *ClusterClient) PatchK8SVersionToPacificCluster(arg1 string, arg2 str
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.PatchK8SVersionToPacificClusterStub
+	fakeReturns := fake.patchK8SVersionToPacificClusterReturns
 	fake.recordInvocation("PatchK8SVersionToPacificCluster", []interface{}{arg1, arg2, arg3})
 	fake.patchK8SVersionToPacificClusterMutex.Unlock()
-	if fake.PatchK8SVersionToPacificClusterStub != nil {
-		return fake.PatchK8SVersionToPacificClusterStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchK8SVersionToPacificClusterReturns
 	return fakeReturns.result1
 }
 
@@ -4727,15 +4787,16 @@ func (fake *ClusterClient) PatchResource(arg1 interface{}, arg2 string, arg3 str
 		arg5 types.PatchType
 		arg6 *clusterclient.PollOptions
 	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	stub := fake.PatchResourceStub
+	fakeReturns := fake.patchResourceReturns
 	fake.recordInvocation("PatchResource", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.patchResourceMutex.Unlock()
-	if fake.PatchResourceStub != nil {
-		return fake.PatchResourceStub(arg1, arg2, arg3, arg4, arg5, arg6)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchResourceReturns
 	return fakeReturns.result1
 }
 
@@ -4787,15 +4848,16 @@ func (fake *ClusterClient) RemoveCEIPTelemetryJob(arg1 string) error {
 	fake.removeCEIPTelemetryJobArgsForCall = append(fake.removeCEIPTelemetryJobArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.RemoveCEIPTelemetryJobStub
+	fakeReturns := fake.removeCEIPTelemetryJobReturns
 	fake.recordInvocation("RemoveCEIPTelemetryJob", []interface{}{arg1})
 	fake.removeCEIPTelemetryJobMutex.Unlock()
-	if fake.RemoveCEIPTelemetryJobStub != nil {
-		return fake.RemoveCEIPTelemetryJobStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.removeCEIPTelemetryJobReturns
 	return fakeReturns.result1
 }
 
@@ -4849,15 +4911,16 @@ func (fake *ClusterClient) ScalePacificClusterControlPlane(arg1 string, arg2 str
 		arg2 string
 		arg3 int32
 	}{arg1, arg2, arg3})
+	stub := fake.ScalePacificClusterControlPlaneStub
+	fakeReturns := fake.scalePacificClusterControlPlaneReturns
 	fake.recordInvocation("ScalePacificClusterControlPlane", []interface{}{arg1, arg2, arg3})
 	fake.scalePacificClusterControlPlaneMutex.Unlock()
-	if fake.ScalePacificClusterControlPlaneStub != nil {
-		return fake.ScalePacificClusterControlPlaneStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.scalePacificClusterControlPlaneReturns
 	return fakeReturns.result1
 }
 
@@ -4911,15 +4974,16 @@ func (fake *ClusterClient) ScalePacificClusterWorkerNodes(arg1 string, arg2 stri
 		arg2 string
 		arg3 int32
 	}{arg1, arg2, arg3})
+	stub := fake.ScalePacificClusterWorkerNodesStub
+	fakeReturns := fake.scalePacificClusterWorkerNodesReturns
 	fake.recordInvocation("ScalePacificClusterWorkerNodes", []interface{}{arg1, arg2, arg3})
 	fake.scalePacificClusterWorkerNodesMutex.Unlock()
-	if fake.ScalePacificClusterWorkerNodesStub != nil {
-		return fake.ScalePacificClusterWorkerNodesStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.scalePacificClusterWorkerNodesReturns
 	return fakeReturns.result1
 }
 
@@ -4972,15 +5036,16 @@ func (fake *ClusterClient) UpdateAWSCNIIngressRules(arg1 string, arg2 string) er
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.UpdateAWSCNIIngressRulesStub
+	fakeReturns := fake.updateAWSCNIIngressRulesReturns
 	fake.recordInvocation("UpdateAWSCNIIngressRules", []interface{}{arg1, arg2})
 	fake.updateAWSCNIIngressRulesMutex.Unlock()
-	if fake.UpdateAWSCNIIngressRulesStub != nil {
-		return fake.UpdateAWSCNIIngressRulesStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateAWSCNIIngressRulesReturns
 	return fakeReturns.result1
 }
 
@@ -5033,15 +5098,16 @@ func (fake *ClusterClient) UpdateCapvManagerBootstrapCredentialsSecret(arg1 stri
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.UpdateCapvManagerBootstrapCredentialsSecretStub
+	fakeReturns := fake.updateCapvManagerBootstrapCredentialsSecretReturns
 	fake.recordInvocation("UpdateCapvManagerBootstrapCredentialsSecret", []interface{}{arg1, arg2})
 	fake.updateCapvManagerBootstrapCredentialsSecretMutex.Unlock()
-	if fake.UpdateCapvManagerBootstrapCredentialsSecretStub != nil {
-		return fake.UpdateCapvManagerBootstrapCredentialsSecretStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateCapvManagerBootstrapCredentialsSecretReturns
 	return fakeReturns.result1
 }
 
@@ -5096,15 +5162,16 @@ func (fake *ClusterClient) UpdateReplicas(arg1 interface{}, arg2 string, arg3 st
 		arg3 string
 		arg4 int32
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.UpdateReplicasStub
+	fakeReturns := fake.updateReplicasReturns
 	fake.recordInvocation("UpdateReplicas", []interface{}{arg1, arg2, arg3, arg4})
 	fake.updateReplicasMutex.Unlock()
-	if fake.UpdateReplicasStub != nil {
-		return fake.UpdateReplicasStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateReplicasReturns
 	return fakeReturns.result1
 }
 
@@ -5159,15 +5226,16 @@ func (fake *ClusterClient) UpdateResource(arg1 interface{}, arg2 string, arg3 st
 		arg3 string
 		arg4 []client.UpdateOption
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.UpdateResourceStub
+	fakeReturns := fake.updateResourceReturns
 	fake.recordInvocation("UpdateResource", []interface{}{arg1, arg2, arg3, arg4})
 	fake.updateResourceMutex.Unlock()
-	if fake.UpdateResourceStub != nil {
-		return fake.UpdateResourceStub(arg1, arg2, arg3, arg4...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateResourceReturns
 	return fakeReturns.result1
 }
 
@@ -5223,15 +5291,16 @@ func (fake *ClusterClient) UpdateResourceWithPolling(arg1 interface{}, arg2 stri
 		arg4 *clusterclient.PollOptions
 		arg5 []client.UpdateOption
 	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.UpdateResourceWithPollingStub
+	fakeReturns := fake.updateResourceWithPollingReturns
 	fake.recordInvocation("UpdateResourceWithPolling", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.updateResourceWithPollingMutex.Unlock()
-	if fake.UpdateResourceWithPollingStub != nil {
-		return fake.UpdateResourceWithPollingStub(arg1, arg2, arg3, arg4, arg5...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateResourceWithPollingReturns
 	return fakeReturns.result1
 }
 
@@ -5286,15 +5355,16 @@ func (fake *ClusterClient) UpdateVsphereCloudProviderCredentialsSecret(arg1 stri
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.UpdateVsphereCloudProviderCredentialsSecretStub
+	fakeReturns := fake.updateVsphereCloudProviderCredentialsSecretReturns
 	fake.recordInvocation("UpdateVsphereCloudProviderCredentialsSecret", []interface{}{arg1, arg2, arg3, arg4})
 	fake.updateVsphereCloudProviderCredentialsSecretMutex.Unlock()
-	if fake.UpdateVsphereCloudProviderCredentialsSecretStub != nil {
-		return fake.UpdateVsphereCloudProviderCredentialsSecretStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateVsphereCloudProviderCredentialsSecretReturns
 	return fakeReturns.result1
 }
 
@@ -5349,15 +5419,16 @@ func (fake *ClusterClient) UpdateVsphereCsiConfigSecret(arg1 string, arg2 string
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.UpdateVsphereCsiConfigSecretStub
+	fakeReturns := fake.updateVsphereCsiConfigSecretReturns
 	fake.recordInvocation("UpdateVsphereCsiConfigSecret", []interface{}{arg1, arg2, arg3, arg4})
 	fake.updateVsphereCsiConfigSecretMutex.Unlock()
-	if fake.UpdateVsphereCsiConfigSecretStub != nil {
-		return fake.UpdateVsphereCsiConfigSecretStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateVsphereCsiConfigSecretReturns
 	return fakeReturns.result1
 }
 
@@ -5412,15 +5483,16 @@ func (fake *ClusterClient) UpdateVsphereIdentityRefSecret(arg1 string, arg2 stri
 		arg3 string
 		arg4 string
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.UpdateVsphereIdentityRefSecretStub
+	fakeReturns := fake.updateVsphereIdentityRefSecretReturns
 	fake.recordInvocation("UpdateVsphereIdentityRefSecret", []interface{}{arg1, arg2, arg3, arg4})
 	fake.updateVsphereIdentityRefSecretMutex.Unlock()
-	if fake.UpdateVsphereIdentityRefSecretStub != nil {
-		return fake.UpdateVsphereIdentityRefSecretStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateVsphereIdentityRefSecretReturns
 	return fakeReturns.result1
 }
 
@@ -5472,15 +5544,16 @@ func (fake *ClusterClient) UseContext(arg1 string) error {
 	fake.useContextArgsForCall = append(fake.useContextArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.UseContextStub
+	fakeReturns := fake.useContextReturns
 	fake.recordInvocation("UseContext", []interface{}{arg1})
 	fake.useContextMutex.Unlock()
-	if fake.UseContextStub != nil {
-		return fake.UseContextStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.useContextReturns
 	return fakeReturns.result1
 }
 
@@ -5533,15 +5606,16 @@ func (fake *ClusterClient) WaitForAVIResourceCleanUp(arg1 string, arg2 string) e
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.WaitForAVIResourceCleanUpStub
+	fakeReturns := fake.waitForAVIResourceCleanUpReturns
 	fake.recordInvocation("WaitForAVIResourceCleanUp", []interface{}{arg1, arg2})
 	fake.waitForAVIResourceCleanUpMutex.Unlock()
-	if fake.WaitForAVIResourceCleanUpStub != nil {
-		return fake.WaitForAVIResourceCleanUpStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForAVIResourceCleanUpReturns
 	return fakeReturns.result1
 }
 
@@ -5594,15 +5668,16 @@ func (fake *ClusterClient) WaitForAutoscalerDeployment(arg1 string, arg2 string)
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.WaitForAutoscalerDeploymentStub
+	fakeReturns := fake.waitForAutoscalerDeploymentReturns
 	fake.recordInvocation("WaitForAutoscalerDeployment", []interface{}{arg1, arg2})
 	fake.waitForAutoscalerDeploymentMutex.Unlock()
-	if fake.WaitForAutoscalerDeploymentStub != nil {
-		return fake.WaitForAutoscalerDeploymentStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForAutoscalerDeploymentReturns
 	return fakeReturns.result1
 }
 
@@ -5655,15 +5730,16 @@ func (fake *ClusterClient) WaitForClusterDeletion(arg1 string, arg2 string) erro
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.WaitForClusterDeletionStub
+	fakeReturns := fake.waitForClusterDeletionReturns
 	fake.recordInvocation("WaitForClusterDeletion", []interface{}{arg1, arg2})
 	fake.waitForClusterDeletionMutex.Unlock()
-	if fake.WaitForClusterDeletionStub != nil {
-		return fake.WaitForClusterDeletionStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForClusterDeletionReturns
 	return fakeReturns.result1
 }
 
@@ -5716,15 +5792,16 @@ func (fake *ClusterClient) WaitForClusterInitialized(arg1 string, arg2 string) e
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.WaitForClusterInitializedStub
+	fakeReturns := fake.waitForClusterInitializedReturns
 	fake.recordInvocation("WaitForClusterInitialized", []interface{}{arg1, arg2})
 	fake.waitForClusterInitializedMutex.Unlock()
-	if fake.WaitForClusterInitializedStub != nil {
-		return fake.WaitForClusterInitializedStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForClusterInitializedReturns
 	return fakeReturns.result1
 }
 
@@ -5778,15 +5855,16 @@ func (fake *ClusterClient) WaitForClusterReady(arg1 string, arg2 string, arg3 bo
 		arg2 string
 		arg3 bool
 	}{arg1, arg2, arg3})
+	stub := fake.WaitForClusterReadyStub
+	fakeReturns := fake.waitForClusterReadyReturns
 	fake.recordInvocation("WaitForClusterReady", []interface{}{arg1, arg2, arg3})
 	fake.waitForClusterReadyMutex.Unlock()
-	if fake.WaitForClusterReadyStub != nil {
-		return fake.WaitForClusterReadyStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForClusterReadyReturns
 	return fakeReturns.result1
 }
 
@@ -5839,15 +5917,16 @@ func (fake *ClusterClient) WaitForDeployment(arg1 string, arg2 string) error {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.WaitForDeploymentStub
+	fakeReturns := fake.waitForDeploymentReturns
 	fake.recordInvocation("WaitForDeployment", []interface{}{arg1, arg2})
 	fake.waitForDeploymentMutex.Unlock()
-	if fake.WaitForDeploymentStub != nil {
-		return fake.WaitForDeploymentStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForDeploymentReturns
 	return fakeReturns.result1
 }
 
@@ -5900,15 +5979,16 @@ func (fake *ClusterClient) WaitForPacificCluster(arg1 string, arg2 string) error
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.WaitForPacificClusterStub
+	fakeReturns := fake.waitForPacificClusterReturns
 	fake.recordInvocation("WaitForPacificCluster", []interface{}{arg1, arg2})
 	fake.waitForPacificClusterMutex.Unlock()
-	if fake.WaitForPacificClusterStub != nil {
-		return fake.WaitForPacificClusterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForPacificClusterReturns
 	return fakeReturns.result1
 }
 
@@ -5962,15 +6042,16 @@ func (fake *ClusterClient) WaitForPacificClusterK8sVersionUpdate(arg1 string, ar
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.WaitForPacificClusterK8sVersionUpdateStub
+	fakeReturns := fake.waitForPacificClusterK8sVersionUpdateReturns
 	fake.recordInvocation("WaitForPacificClusterK8sVersionUpdate", []interface{}{arg1, arg2, arg3})
 	fake.waitForPacificClusterK8sVersionUpdateMutex.Unlock()
-	if fake.WaitForPacificClusterK8sVersionUpdateStub != nil {
-		return fake.WaitForPacificClusterK8sVersionUpdateStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForPacificClusterK8sVersionUpdateReturns
 	return fakeReturns.result1
 }
 
@@ -6024,15 +6105,16 @@ func (fake *ClusterClient) WaitForPackageInstall(arg1 string, arg2 string, arg3 
 		arg2 string
 		arg3 time.Duration
 	}{arg1, arg2, arg3})
+	stub := fake.WaitForPackageInstallStub
+	fakeReturns := fake.waitForPackageInstallReturns
 	fake.recordInvocation("WaitForPackageInstall", []interface{}{arg1, arg2, arg3})
 	fake.waitForPackageInstallMutex.Unlock()
-	if fake.WaitForPackageInstallStub != nil {
-		return fake.WaitForPackageInstallStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitForPackageInstallReturns
 	return fakeReturns.result1
 }
 
@@ -6087,15 +6169,16 @@ func (fake *ClusterClient) WaitK8sVersionUpdateForCPNodes(arg1 string, arg2 stri
 		arg3 string
 		arg4 clusterclient.Client
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.WaitK8sVersionUpdateForCPNodesStub
+	fakeReturns := fake.waitK8sVersionUpdateForCPNodesReturns
 	fake.recordInvocation("WaitK8sVersionUpdateForCPNodes", []interface{}{arg1, arg2, arg3, arg4})
 	fake.waitK8sVersionUpdateForCPNodesMutex.Unlock()
-	if fake.WaitK8sVersionUpdateForCPNodesStub != nil {
-		return fake.WaitK8sVersionUpdateForCPNodesStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitK8sVersionUpdateForCPNodesReturns
 	return fakeReturns.result1
 }
 
@@ -6150,15 +6233,16 @@ func (fake *ClusterClient) WaitK8sVersionUpdateForWorkerNodes(arg1 string, arg2 
 		arg3 string
 		arg4 clusterclient.Client
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.WaitK8sVersionUpdateForWorkerNodesStub
+	fakeReturns := fake.waitK8sVersionUpdateForWorkerNodesReturns
 	fake.recordInvocation("WaitK8sVersionUpdateForWorkerNodes", []interface{}{arg1, arg2, arg3, arg4})
 	fake.waitK8sVersionUpdateForWorkerNodesMutex.Unlock()
-	if fake.WaitK8sVersionUpdateForWorkerNodesStub != nil {
-		return fake.WaitK8sVersionUpdateForWorkerNodesStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.waitK8sVersionUpdateForWorkerNodesReturns
 	return fakeReturns.result1
 }
 

--- a/pkg/v1/tkg/fakes/clusterclientfactory.go
+++ b/pkg/v1/tkg/fakes/clusterclientfactory.go
@@ -35,15 +35,16 @@ func (fake *ClusterClientFactory) NewClient(arg1 string, arg2 string, arg3 clust
 		arg2 string
 		arg3 clusterclient.Options
 	}{arg1, arg2, arg3})
+	stub := fake.NewClientStub
+	fakeReturns := fake.newClientReturns
 	fake.recordInvocation("NewClient", []interface{}{arg1, arg2, arg3})
 	fake.newClientMutex.Unlock()
-	if fake.NewClientStub != nil {
-		return fake.NewClientStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.newClientReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/pkg/v1/tkg/fakes/crtclientfactory.go
+++ b/pkg/v1/tkg/fakes/crtclientfactory.go
@@ -36,15 +36,16 @@ func (fake *CrtClientFactory) NewClient(arg1 *rest.Config, arg2 client.Options) 
 		arg1 *rest.Config
 		arg2 client.Options
 	}{arg1, arg2})
+	stub := fake.NewClientStub
+	fakeReturns := fake.newClientReturns
 	fake.recordInvocation("NewClient", []interface{}{arg1, arg2})
 	fake.newClientMutex.Unlock()
-	if fake.NewClientStub != nil {
-		return fake.NewClientStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.newClientReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/pkg/v1/tkg/fakes/crtclusterclient.go
+++ b/pkg/v1/tkg/fakes/crtclusterclient.go
@@ -148,15 +148,16 @@ func (fake *CRTClusterClient) Create(arg1 context.Context, arg2 client.Object, a
 		arg2 client.Object
 		arg3 []client.CreateOption
 	}{arg1, arg2, arg3})
+	stub := fake.CreateStub
+	fakeReturns := fake.createReturns
 	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3})
 	fake.createMutex.Unlock()
-	if fake.CreateStub != nil {
-		return fake.CreateStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createReturns
 	return fakeReturns.result1
 }
 
@@ -210,15 +211,16 @@ func (fake *CRTClusterClient) Delete(arg1 context.Context, arg2 client.Object, a
 		arg2 client.Object
 		arg3 []client.DeleteOption
 	}{arg1, arg2, arg3})
+	stub := fake.DeleteStub
+	fakeReturns := fake.deleteReturns
 	fake.recordInvocation("Delete", []interface{}{arg1, arg2, arg3})
 	fake.deleteMutex.Unlock()
-	if fake.DeleteStub != nil {
-		return fake.DeleteStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteReturns
 	return fakeReturns.result1
 }
 
@@ -272,15 +274,16 @@ func (fake *CRTClusterClient) DeleteAllOf(arg1 context.Context, arg2 client.Obje
 		arg2 client.Object
 		arg3 []client.DeleteAllOfOption
 	}{arg1, arg2, arg3})
+	stub := fake.DeleteAllOfStub
+	fakeReturns := fake.deleteAllOfReturns
 	fake.recordInvocation("DeleteAllOf", []interface{}{arg1, arg2, arg3})
 	fake.deleteAllOfMutex.Unlock()
-	if fake.DeleteAllOfStub != nil {
-		return fake.DeleteAllOfStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteAllOfReturns
 	return fakeReturns.result1
 }
 
@@ -334,15 +337,16 @@ func (fake *CRTClusterClient) Get(arg1 context.Context, arg2 types.NamespacedNam
 		arg2 types.NamespacedName
 		arg3 client.Object
 	}{arg1, arg2, arg3})
+	stub := fake.GetStub
+	fakeReturns := fake.getReturns
 	fake.recordInvocation("Get", []interface{}{arg1, arg2, arg3})
 	fake.getMutex.Unlock()
-	if fake.GetStub != nil {
-		return fake.GetStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getReturns
 	return fakeReturns.result1
 }
 
@@ -396,15 +400,16 @@ func (fake *CRTClusterClient) List(arg1 context.Context, arg2 client.ObjectList,
 		arg2 client.ObjectList
 		arg3 []client.ListOption
 	}{arg1, arg2, arg3})
+	stub := fake.ListStub
+	fakeReturns := fake.listReturns
 	fake.recordInvocation("List", []interface{}{arg1, arg2, arg3})
 	fake.listMutex.Unlock()
-	if fake.ListStub != nil {
-		return fake.ListStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.listReturns
 	return fakeReturns.result1
 }
 
@@ -459,15 +464,16 @@ func (fake *CRTClusterClient) Patch(arg1 context.Context, arg2 client.Object, ar
 		arg3 client.Patch
 		arg4 []client.PatchOption
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.PatchStub
+	fakeReturns := fake.patchReturns
 	fake.recordInvocation("Patch", []interface{}{arg1, arg2, arg3, arg4})
 	fake.patchMutex.Unlock()
-	if fake.PatchStub != nil {
-		return fake.PatchStub(arg1, arg2, arg3, arg4...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.patchReturns
 	return fakeReturns.result1
 }
 
@@ -518,15 +524,16 @@ func (fake *CRTClusterClient) RESTMapper() meta.RESTMapper {
 	ret, specificReturn := fake.rESTMapperReturnsOnCall[len(fake.rESTMapperArgsForCall)]
 	fake.rESTMapperArgsForCall = append(fake.rESTMapperArgsForCall, struct {
 	}{})
+	stub := fake.RESTMapperStub
+	fakeReturns := fake.rESTMapperReturns
 	fake.recordInvocation("RESTMapper", []interface{}{})
 	fake.rESTMapperMutex.Unlock()
-	if fake.RESTMapperStub != nil {
-		return fake.RESTMapperStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.rESTMapperReturns
 	return fakeReturns.result1
 }
 
@@ -570,15 +577,16 @@ func (fake *CRTClusterClient) Scheme() *runtime.Scheme {
 	ret, specificReturn := fake.schemeReturnsOnCall[len(fake.schemeArgsForCall)]
 	fake.schemeArgsForCall = append(fake.schemeArgsForCall, struct {
 	}{})
+	stub := fake.SchemeStub
+	fakeReturns := fake.schemeReturns
 	fake.recordInvocation("Scheme", []interface{}{})
 	fake.schemeMutex.Unlock()
-	if fake.SchemeStub != nil {
-		return fake.SchemeStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.schemeReturns
 	return fakeReturns.result1
 }
 
@@ -622,15 +630,16 @@ func (fake *CRTClusterClient) Status() client.StatusWriter {
 	ret, specificReturn := fake.statusReturnsOnCall[len(fake.statusArgsForCall)]
 	fake.statusArgsForCall = append(fake.statusArgsForCall, struct {
 	}{})
+	stub := fake.StatusStub
+	fakeReturns := fake.statusReturns
 	fake.recordInvocation("Status", []interface{}{})
 	fake.statusMutex.Unlock()
-	if fake.StatusStub != nil {
-		return fake.StatusStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.statusReturns
 	return fakeReturns.result1
 }
 
@@ -677,15 +686,16 @@ func (fake *CRTClusterClient) Update(arg1 context.Context, arg2 client.Object, a
 		arg2 client.Object
 		arg3 []client.UpdateOption
 	}{arg1, arg2, arg3})
+	stub := fake.UpdateStub
+	fakeReturns := fake.updateReturns
 	fake.recordInvocation("Update", []interface{}{arg1, arg2, arg3})
 	fake.updateMutex.Unlock()
-	if fake.UpdateStub != nil {
-		return fake.UpdateStub(arg1, arg2, arg3...)
+	if stub != nil {
+		return stub(arg1, arg2, arg3...)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updateReturns
 	return fakeReturns.result1
 }
 

--- a/pkg/v1/tkg/fakes/discoveryclientfactory.go
+++ b/pkg/v1/tkg/fakes/discoveryclientfactory.go
@@ -34,15 +34,16 @@ func (fake *DiscoveryClientFactory) NewDiscoveryClientForConfig(arg1 *rest.Confi
 	fake.newDiscoveryClientForConfigArgsForCall = append(fake.newDiscoveryClientForConfigArgsForCall, struct {
 		arg1 *rest.Config
 	}{arg1})
+	stub := fake.NewDiscoveryClientForConfigStub
+	fakeReturns := fake.newDiscoveryClientForConfigReturns
 	fake.recordInvocation("NewDiscoveryClientForConfig", []interface{}{arg1})
 	fake.newDiscoveryClientForConfigMutex.Unlock()
-	if fake.NewDiscoveryClientForConfigStub != nil {
-		return fake.NewDiscoveryClientForConfigStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.newDiscoveryClientForConfigReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/pkg/v1/tkg/fakes/discoveryclusterclient.go
+++ b/pkg/v1/tkg/fakes/discoveryclusterclient.go
@@ -131,15 +131,16 @@ func (fake *DiscoveryClient) OpenAPISchema() (*openapi_v2.Document, error) {
 	ret, specificReturn := fake.openAPISchemaReturnsOnCall[len(fake.openAPISchemaArgsForCall)]
 	fake.openAPISchemaArgsForCall = append(fake.openAPISchemaArgsForCall, struct {
 	}{})
+	stub := fake.OpenAPISchemaStub
+	fakeReturns := fake.openAPISchemaReturns
 	fake.recordInvocation("OpenAPISchema", []interface{}{})
 	fake.openAPISchemaMutex.Unlock()
-	if fake.OpenAPISchemaStub != nil {
-		return fake.OpenAPISchemaStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.openAPISchemaReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -186,15 +187,16 @@ func (fake *DiscoveryClient) RESTClient() rest.Interface {
 	ret, specificReturn := fake.rESTClientReturnsOnCall[len(fake.rESTClientArgsForCall)]
 	fake.rESTClientArgsForCall = append(fake.rESTClientArgsForCall, struct {
 	}{})
+	stub := fake.RESTClientStub
+	fakeReturns := fake.rESTClientReturns
 	fake.recordInvocation("RESTClient", []interface{}{})
 	fake.rESTClientMutex.Unlock()
-	if fake.RESTClientStub != nil {
-		return fake.RESTClientStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.rESTClientReturns
 	return fakeReturns.result1
 }
 
@@ -238,15 +240,16 @@ func (fake *DiscoveryClient) ServerGroups() (*v1.APIGroupList, error) {
 	ret, specificReturn := fake.serverGroupsReturnsOnCall[len(fake.serverGroupsArgsForCall)]
 	fake.serverGroupsArgsForCall = append(fake.serverGroupsArgsForCall, struct {
 	}{})
+	stub := fake.ServerGroupsStub
+	fakeReturns := fake.serverGroupsReturns
 	fake.recordInvocation("ServerGroups", []interface{}{})
 	fake.serverGroupsMutex.Unlock()
-	if fake.ServerGroupsStub != nil {
-		return fake.ServerGroupsStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.serverGroupsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -293,15 +296,16 @@ func (fake *DiscoveryClient) ServerGroupsAndResources() ([]*v1.APIGroup, []*v1.A
 	ret, specificReturn := fake.serverGroupsAndResourcesReturnsOnCall[len(fake.serverGroupsAndResourcesArgsForCall)]
 	fake.serverGroupsAndResourcesArgsForCall = append(fake.serverGroupsAndResourcesArgsForCall, struct {
 	}{})
+	stub := fake.ServerGroupsAndResourcesStub
+	fakeReturns := fake.serverGroupsAndResourcesReturns
 	fake.recordInvocation("ServerGroupsAndResources", []interface{}{})
 	fake.serverGroupsAndResourcesMutex.Unlock()
-	if fake.ServerGroupsAndResourcesStub != nil {
-		return fake.ServerGroupsAndResourcesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.serverGroupsAndResourcesReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -351,15 +355,16 @@ func (fake *DiscoveryClient) ServerPreferredNamespacedResources() ([]*v1.APIReso
 	ret, specificReturn := fake.serverPreferredNamespacedResourcesReturnsOnCall[len(fake.serverPreferredNamespacedResourcesArgsForCall)]
 	fake.serverPreferredNamespacedResourcesArgsForCall = append(fake.serverPreferredNamespacedResourcesArgsForCall, struct {
 	}{})
+	stub := fake.ServerPreferredNamespacedResourcesStub
+	fakeReturns := fake.serverPreferredNamespacedResourcesReturns
 	fake.recordInvocation("ServerPreferredNamespacedResources", []interface{}{})
 	fake.serverPreferredNamespacedResourcesMutex.Unlock()
-	if fake.ServerPreferredNamespacedResourcesStub != nil {
-		return fake.ServerPreferredNamespacedResourcesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.serverPreferredNamespacedResourcesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -406,15 +411,16 @@ func (fake *DiscoveryClient) ServerPreferredResources() ([]*v1.APIResourceList, 
 	ret, specificReturn := fake.serverPreferredResourcesReturnsOnCall[len(fake.serverPreferredResourcesArgsForCall)]
 	fake.serverPreferredResourcesArgsForCall = append(fake.serverPreferredResourcesArgsForCall, struct {
 	}{})
+	stub := fake.ServerPreferredResourcesStub
+	fakeReturns := fake.serverPreferredResourcesReturns
 	fake.recordInvocation("ServerPreferredResources", []interface{}{})
 	fake.serverPreferredResourcesMutex.Unlock()
-	if fake.ServerPreferredResourcesStub != nil {
-		return fake.ServerPreferredResourcesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.serverPreferredResourcesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -461,15 +467,16 @@ func (fake *DiscoveryClient) ServerResources() ([]*v1.APIResourceList, error) {
 	ret, specificReturn := fake.serverResourcesReturnsOnCall[len(fake.serverResourcesArgsForCall)]
 	fake.serverResourcesArgsForCall = append(fake.serverResourcesArgsForCall, struct {
 	}{})
+	stub := fake.ServerResourcesStub
+	fakeReturns := fake.serverResourcesReturns
 	fake.recordInvocation("ServerResources", []interface{}{})
 	fake.serverResourcesMutex.Unlock()
-	if fake.ServerResourcesStub != nil {
-		return fake.ServerResourcesStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.serverResourcesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -517,15 +524,16 @@ func (fake *DiscoveryClient) ServerResourcesForGroupVersion(arg1 string) (*v1.AP
 	fake.serverResourcesForGroupVersionArgsForCall = append(fake.serverResourcesForGroupVersionArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ServerResourcesForGroupVersionStub
+	fakeReturns := fake.serverResourcesForGroupVersionReturns
 	fake.recordInvocation("ServerResourcesForGroupVersion", []interface{}{arg1})
 	fake.serverResourcesForGroupVersionMutex.Unlock()
-	if fake.ServerResourcesForGroupVersionStub != nil {
-		return fake.ServerResourcesForGroupVersionStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.serverResourcesForGroupVersionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -579,15 +587,16 @@ func (fake *DiscoveryClient) ServerVersion() (*version.Info, error) {
 	ret, specificReturn := fake.serverVersionReturnsOnCall[len(fake.serverVersionArgsForCall)]
 	fake.serverVersionArgsForCall = append(fake.serverVersionArgsForCall, struct {
 	}{})
+	stub := fake.ServerVersionStub
+	fakeReturns := fake.serverVersionReturns
 	fake.recordInvocation("ServerVersion", []interface{}{})
 	fake.serverVersionMutex.Unlock()
-	if fake.ServerVersionStub != nil {
-		return fake.ServerVersionStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.serverVersionReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/pkg/v1/tkg/fakes/kappclient.go
+++ b/pkg/v1/tkg/fakes/kappclient.go
@@ -271,15 +271,16 @@ func (fake *KappClient) CreatePackageInstall(arg1 *v1alpha1.PackageInstall, arg2
 		arg1 *v1alpha1.PackageInstall
 		arg2 *tkgpackagedatamodel.PkgPluginResourceCreationStatus
 	}{arg1, arg2})
+	stub := fake.CreatePackageInstallStub
+	fakeReturns := fake.createPackageInstallReturns
 	fake.recordInvocation("CreatePackageInstall", []interface{}{arg1, arg2})
 	fake.createPackageInstallMutex.Unlock()
-	if fake.CreatePackageInstallStub != nil {
-		return fake.CreatePackageInstallStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createPackageInstallReturns
 	return fakeReturns.result1
 }
 
@@ -331,15 +332,16 @@ func (fake *KappClient) CreatePackageRepository(arg1 *v1alpha1.PackageRepository
 	fake.createPackageRepositoryArgsForCall = append(fake.createPackageRepositoryArgsForCall, struct {
 		arg1 *v1alpha1.PackageRepository
 	}{arg1})
+	stub := fake.CreatePackageRepositoryStub
+	fakeReturns := fake.createPackageRepositoryReturns
 	fake.recordInvocation("CreatePackageRepository", []interface{}{arg1})
 	fake.createPackageRepositoryMutex.Unlock()
-	if fake.CreatePackageRepositoryStub != nil {
-		return fake.CreatePackageRepositoryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.createPackageRepositoryReturns
 	return fakeReturns.result1
 }
 
@@ -391,15 +393,16 @@ func (fake *KappClient) DeletePackageRepository(arg1 *v1alpha1.PackageRepository
 	fake.deletePackageRepositoryArgsForCall = append(fake.deletePackageRepositoryArgsForCall, struct {
 		arg1 *v1alpha1.PackageRepository
 	}{arg1})
+	stub := fake.DeletePackageRepositoryStub
+	fakeReturns := fake.deletePackageRepositoryReturns
 	fake.recordInvocation("DeletePackageRepository", []interface{}{arg1})
 	fake.deletePackageRepositoryMutex.Unlock()
-	if fake.DeletePackageRepositoryStub != nil {
-		return fake.DeletePackageRepositoryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deletePackageRepositoryReturns
 	return fakeReturns.result1
 }
 
@@ -452,15 +455,16 @@ func (fake *KappClient) GetAppCR(arg1 string, arg2 string) (*v1alpha1a.App, erro
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetAppCRStub
+	fakeReturns := fake.getAppCRReturns
 	fake.recordInvocation("GetAppCR", []interface{}{arg1, arg2})
 	fake.getAppCRMutex.Unlock()
-	if fake.GetAppCRStub != nil {
-		return fake.GetAppCRStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getAppCRReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -514,15 +518,16 @@ func (fake *KappClient) GetClient() client.Client {
 	ret, specificReturn := fake.getClientReturnsOnCall[len(fake.getClientArgsForCall)]
 	fake.getClientArgsForCall = append(fake.getClientArgsForCall, struct {
 	}{})
+	stub := fake.GetClientStub
+	fakeReturns := fake.getClientReturns
 	fake.recordInvocation("GetClient", []interface{}{})
 	fake.getClientMutex.Unlock()
-	if fake.GetClientStub != nil {
-		return fake.GetClientStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.getClientReturns
 	return fakeReturns.result1
 }
 
@@ -568,15 +573,16 @@ func (fake *KappClient) GetPackage(arg1 string, arg2 string) (*v1alpha1b.Package
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetPackageStub
+	fakeReturns := fake.getPackageReturns
 	fake.recordInvocation("GetPackage", []interface{}{arg1, arg2})
 	fake.getPackageMutex.Unlock()
-	if fake.GetPackageStub != nil {
-		return fake.GetPackageStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getPackageReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -632,15 +638,16 @@ func (fake *KappClient) GetPackageInstall(arg1 string, arg2 string) (*v1alpha1.P
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetPackageInstallStub
+	fakeReturns := fake.getPackageInstallReturns
 	fake.recordInvocation("GetPackageInstall", []interface{}{arg1, arg2})
 	fake.getPackageInstallMutex.Unlock()
-	if fake.GetPackageInstallStub != nil {
-		return fake.GetPackageInstallStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getPackageInstallReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -696,15 +703,16 @@ func (fake *KappClient) GetPackageMetadataByName(arg1 string, arg2 string) (*v1a
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetPackageMetadataByNameStub
+	fakeReturns := fake.getPackageMetadataByNameReturns
 	fake.recordInvocation("GetPackageMetadataByName", []interface{}{arg1, arg2})
 	fake.getPackageMetadataByNameMutex.Unlock()
-	if fake.GetPackageMetadataByNameStub != nil {
-		return fake.GetPackageMetadataByNameStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getPackageMetadataByNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -760,15 +768,16 @@ func (fake *KappClient) GetPackageRepository(arg1 string, arg2 string) (*v1alpha
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetPackageRepositoryStub
+	fakeReturns := fake.getPackageRepositoryReturns
 	fake.recordInvocation("GetPackageRepository", []interface{}{arg1, arg2})
 	fake.getPackageRepositoryMutex.Unlock()
-	if fake.GetPackageRepositoryStub != nil {
-		return fake.GetPackageRepositoryStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getPackageRepositoryReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -824,15 +833,16 @@ func (fake *KappClient) GetSecretExport(arg1 string, arg2 string) (*v1alpha1c.Se
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetSecretExportStub
+	fakeReturns := fake.getSecretExportReturns
 	fake.recordInvocation("GetSecretExport", []interface{}{arg1, arg2})
 	fake.getSecretExportMutex.Unlock()
-	if fake.GetSecretExportStub != nil {
-		return fake.GetSecretExportStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSecretExportReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -888,15 +898,16 @@ func (fake *KappClient) GetSecretValue(arg1 string, arg2 string) ([]byte, error)
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.GetSecretValueStub
+	fakeReturns := fake.getSecretValueReturns
 	fake.recordInvocation("GetSecretValue", []interface{}{arg1, arg2})
 	fake.getSecretValueMutex.Unlock()
-	if fake.GetSecretValueStub != nil {
-		return fake.GetSecretValueStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getSecretValueReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -951,15 +962,16 @@ func (fake *KappClient) ListPackageInstalls(arg1 string) (*v1alpha1.PackageInsta
 	fake.listPackageInstallsArgsForCall = append(fake.listPackageInstallsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListPackageInstallsStub
+	fakeReturns := fake.listPackageInstallsReturns
 	fake.recordInvocation("ListPackageInstalls", []interface{}{arg1})
 	fake.listPackageInstallsMutex.Unlock()
-	if fake.ListPackageInstallsStub != nil {
-		return fake.ListPackageInstallsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listPackageInstallsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1014,15 +1026,16 @@ func (fake *KappClient) ListPackageMetadata(arg1 string) (*v1alpha1b.PackageMeta
 	fake.listPackageMetadataArgsForCall = append(fake.listPackageMetadataArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListPackageMetadataStub
+	fakeReturns := fake.listPackageMetadataReturns
 	fake.recordInvocation("ListPackageMetadata", []interface{}{arg1})
 	fake.listPackageMetadataMutex.Unlock()
-	if fake.ListPackageMetadataStub != nil {
-		return fake.ListPackageMetadataStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listPackageMetadataReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1077,15 +1090,16 @@ func (fake *KappClient) ListPackageRepositories(arg1 string) (*v1alpha1.PackageR
 	fake.listPackageRepositoriesArgsForCall = append(fake.listPackageRepositoriesArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListPackageRepositoriesStub
+	fakeReturns := fake.listPackageRepositoriesReturns
 	fake.recordInvocation("ListPackageRepositories", []interface{}{arg1})
 	fake.listPackageRepositoriesMutex.Unlock()
-	if fake.ListPackageRepositoriesStub != nil {
-		return fake.ListPackageRepositoriesStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listPackageRepositoriesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1141,15 +1155,16 @@ func (fake *KappClient) ListPackages(arg1 string, arg2 string) (*v1alpha1b.Packa
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
+	stub := fake.ListPackagesStub
+	fakeReturns := fake.listPackagesReturns
 	fake.recordInvocation("ListPackages", []interface{}{arg1, arg2})
 	fake.listPackagesMutex.Unlock()
-	if fake.ListPackagesStub != nil {
-		return fake.ListPackagesStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listPackagesReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1204,15 +1219,16 @@ func (fake *KappClient) ListRegistrySecrets(arg1 string) (*v1.SecretList, error)
 	fake.listRegistrySecretsArgsForCall = append(fake.listRegistrySecretsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListRegistrySecretsStub
+	fakeReturns := fake.listRegistrySecretsReturns
 	fake.recordInvocation("ListRegistrySecrets", []interface{}{arg1})
 	fake.listRegistrySecretsMutex.Unlock()
-	if fake.ListRegistrySecretsStub != nil {
-		return fake.ListRegistrySecretsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listRegistrySecretsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1267,15 +1283,16 @@ func (fake *KappClient) ListSecretExports(arg1 string) (*v1alpha1c.SecretExportL
 	fake.listSecretExportsArgsForCall = append(fake.listSecretExportsArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.ListSecretExportsStub
+	fakeReturns := fake.listSecretExportsReturns
 	fake.recordInvocation("ListSecretExports", []interface{}{arg1})
 	fake.listSecretExportsMutex.Unlock()
-	if fake.ListSecretExportsStub != nil {
-		return fake.ListSecretExportsStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listSecretExportsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1331,15 +1348,16 @@ func (fake *KappClient) UpdatePackageInstall(arg1 *v1alpha1.PackageInstall, arg2
 		arg1 *v1alpha1.PackageInstall
 		arg2 *tkgpackagedatamodel.PkgPluginResourceCreationStatus
 	}{arg1, arg2})
+	stub := fake.UpdatePackageInstallStub
+	fakeReturns := fake.updatePackageInstallReturns
 	fake.recordInvocation("UpdatePackageInstall", []interface{}{arg1, arg2})
 	fake.updatePackageInstallMutex.Unlock()
-	if fake.UpdatePackageInstallStub != nil {
-		return fake.UpdatePackageInstallStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updatePackageInstallReturns
 	return fakeReturns.result1
 }
 
@@ -1391,15 +1409,16 @@ func (fake *KappClient) UpdatePackageRepository(arg1 *v1alpha1.PackageRepository
 	fake.updatePackageRepositoryArgsForCall = append(fake.updatePackageRepositoryArgsForCall, struct {
 		arg1 *v1alpha1.PackageRepository
 	}{arg1})
+	stub := fake.UpdatePackageRepositoryStub
+	fakeReturns := fake.updatePackageRepositoryReturns
 	fake.recordInvocation("UpdatePackageRepository", []interface{}{arg1})
 	fake.updatePackageRepositoryMutex.Unlock()
-	if fake.UpdatePackageRepositoryStub != nil {
-		return fake.UpdatePackageRepositoryStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.updatePackageRepositoryReturns
 	return fakeReturns.result1
 }
 

--- a/pkg/v1/tkg/fakes/poller.go
+++ b/pkg/v1/tkg/fakes/poller.go
@@ -75,15 +75,16 @@ func (fake *Poller) PollImmediate(arg1 time.Duration, arg2 time.Duration, arg3 w
 		arg2 time.Duration
 		arg3 wait.ConditionFunc
 	}{arg1, arg2, arg3})
+	stub := fake.PollImmediateStub
+	fakeReturns := fake.pollImmediateReturns
 	fake.recordInvocation("PollImmediate", []interface{}{arg1, arg2, arg3})
 	fake.pollImmediateMutex.Unlock()
-	if fake.PollImmediateStub != nil {
-		return fake.PollImmediateStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pollImmediateReturns
 	return fakeReturns.result1
 }
 
@@ -136,15 +137,16 @@ func (fake *Poller) PollImmediateInfinite(arg1 time.Duration, arg2 wait.Conditio
 		arg1 time.Duration
 		arg2 wait.ConditionFunc
 	}{arg1, arg2})
+	stub := fake.PollImmediateInfiniteStub
+	fakeReturns := fake.pollImmediateInfiniteReturns
 	fake.recordInvocation("PollImmediateInfinite", []interface{}{arg1, arg2})
 	fake.pollImmediateInfiniteMutex.Unlock()
-	if fake.PollImmediateInfiniteStub != nil {
-		return fake.PollImmediateInfiniteStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pollImmediateInfiniteReturns
 	return fakeReturns.result1
 }
 
@@ -197,15 +199,16 @@ func (fake *Poller) PollImmediateInfiniteWithGetter(arg1 time.Duration, arg2 clu
 		arg1 time.Duration
 		arg2 clusterclient.GetterFunc
 	}{arg1, arg2})
+	stub := fake.PollImmediateInfiniteWithGetterStub
+	fakeReturns := fake.pollImmediateInfiniteWithGetterReturns
 	fake.recordInvocation("PollImmediateInfiniteWithGetter", []interface{}{arg1, arg2})
 	fake.pollImmediateInfiniteWithGetterMutex.Unlock()
-	if fake.PollImmediateInfiniteWithGetterStub != nil {
-		return fake.PollImmediateInfiniteWithGetterStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.pollImmediateInfiniteWithGetterReturns
 	return fakeReturns.result1
 }
 
@@ -259,15 +262,16 @@ func (fake *Poller) PollImmediateWithGetter(arg1 time.Duration, arg2 time.Durati
 		arg2 time.Duration
 		arg3 clusterclient.GetterFunc
 	}{arg1, arg2, arg3})
+	stub := fake.PollImmediateWithGetterStub
+	fakeReturns := fake.pollImmediateWithGetterReturns
 	fake.recordInvocation("PollImmediateWithGetter", []interface{}{arg1, arg2, arg3})
 	fake.pollImmediateWithGetterMutex.Unlock()
-	if fake.PollImmediateWithGetterStub != nil {
-		return fake.PollImmediateWithGetterStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.pollImmediateWithGetterReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/pkg/v1/tkg/fakes/vcclient.go
+++ b/pkg/v1/tkg/fakes/vcclient.go
@@ -93,6 +93,21 @@ type VCClient struct {
 		result1 string
 		result2 error
 	}
+	FindNetworkStub        func(context.Context, string, string) (string, error)
+	findNetworkMutex       sync.RWMutex
+	findNetworkArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+	}
+	findNetworkReturns struct {
+		result1 string
+		result2 error
+	}
+	findNetworkReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	FindResourcePoolStub        func(context.Context, string, string) (string, error)
 	findResourcePoolMutex       sync.RWMutex
 	findResourcePoolArgsForCall []struct {
@@ -222,6 +237,22 @@ type VCClient struct {
 	getNetworksReturnsOnCall map[int]struct {
 		result1 []*models.VSphereNetwork
 		result2 error
+	}
+	GetPathStub        func(context.Context, string) (string, []*models.VSphereManagementObject, error)
+	getPathMutex       sync.RWMutex
+	getPathArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+	}
+	getPathReturns struct {
+		result1 string
+		result2 []*models.VSphereManagementObject
+		result3 error
+	}
+	getPathReturnsOnCall map[int]struct {
+		result1 string
+		result2 []*models.VSphereManagementObject
+		result3 error
 	}
 	GetResourcePoolsStub        func(context.Context, string) ([]*models.VSphereResourcePool, error)
 	getResourcePoolsMutex       sync.RWMutex
@@ -666,6 +697,72 @@ func (fake *VCClient) FindFolderReturnsOnCall(i int, result1 string, result2 err
 		})
 	}
 	fake.findFolderReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *VCClient) FindNetwork(arg1 context.Context, arg2 string, arg3 string) (string, error) {
+	fake.findNetworkMutex.Lock()
+	ret, specificReturn := fake.findNetworkReturnsOnCall[len(fake.findNetworkArgsForCall)]
+	fake.findNetworkArgsForCall = append(fake.findNetworkArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.FindNetworkStub
+	fakeReturns := fake.findNetworkReturns
+	fake.recordInvocation("FindNetwork", []interface{}{arg1, arg2, arg3})
+	fake.findNetworkMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *VCClient) FindNetworkCallCount() int {
+	fake.findNetworkMutex.RLock()
+	defer fake.findNetworkMutex.RUnlock()
+	return len(fake.findNetworkArgsForCall)
+}
+
+func (fake *VCClient) FindNetworkCalls(stub func(context.Context, string, string) (string, error)) {
+	fake.findNetworkMutex.Lock()
+	defer fake.findNetworkMutex.Unlock()
+	fake.FindNetworkStub = stub
+}
+
+func (fake *VCClient) FindNetworkArgsForCall(i int) (context.Context, string, string) {
+	fake.findNetworkMutex.RLock()
+	defer fake.findNetworkMutex.RUnlock()
+	argsForCall := fake.findNetworkArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *VCClient) FindNetworkReturns(result1 string, result2 error) {
+	fake.findNetworkMutex.Lock()
+	defer fake.findNetworkMutex.Unlock()
+	fake.FindNetworkStub = nil
+	fake.findNetworkReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *VCClient) FindNetworkReturnsOnCall(i int, result1 string, result2 error) {
+	fake.findNetworkMutex.Lock()
+	defer fake.findNetworkMutex.Unlock()
+	fake.FindNetworkStub = nil
+	if fake.findNetworkReturnsOnCall == nil {
+		fake.findNetworkReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.findNetworkReturnsOnCall[i] = struct {
 		result1 string
 		result2 error
 	}{result1, result2}
@@ -1265,6 +1362,74 @@ func (fake *VCClient) GetNetworksReturnsOnCall(i int, result1 []*models.VSphereN
 	}{result1, result2}
 }
 
+func (fake *VCClient) GetPath(arg1 context.Context, arg2 string) (string, []*models.VSphereManagementObject, error) {
+	fake.getPathMutex.Lock()
+	ret, specificReturn := fake.getPathReturnsOnCall[len(fake.getPathArgsForCall)]
+	fake.getPathArgsForCall = append(fake.getPathArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.GetPathStub
+	fakeReturns := fake.getPathReturns
+	fake.recordInvocation("GetPath", []interface{}{arg1, arg2})
+	fake.getPathMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *VCClient) GetPathCallCount() int {
+	fake.getPathMutex.RLock()
+	defer fake.getPathMutex.RUnlock()
+	return len(fake.getPathArgsForCall)
+}
+
+func (fake *VCClient) GetPathCalls(stub func(context.Context, string) (string, []*models.VSphereManagementObject, error)) {
+	fake.getPathMutex.Lock()
+	defer fake.getPathMutex.Unlock()
+	fake.GetPathStub = stub
+}
+
+func (fake *VCClient) GetPathArgsForCall(i int) (context.Context, string) {
+	fake.getPathMutex.RLock()
+	defer fake.getPathMutex.RUnlock()
+	argsForCall := fake.getPathArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *VCClient) GetPathReturns(result1 string, result2 []*models.VSphereManagementObject, result3 error) {
+	fake.getPathMutex.Lock()
+	defer fake.getPathMutex.Unlock()
+	fake.GetPathStub = nil
+	fake.getPathReturns = struct {
+		result1 string
+		result2 []*models.VSphereManagementObject
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *VCClient) GetPathReturnsOnCall(i int, result1 string, result2 []*models.VSphereManagementObject, result3 error) {
+	fake.getPathMutex.Lock()
+	defer fake.getPathMutex.Unlock()
+	fake.GetPathStub = nil
+	if fake.getPathReturnsOnCall == nil {
+		fake.getPathReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 []*models.VSphereManagementObject
+			result3 error
+		})
+	}
+	fake.getPathReturnsOnCall[i] = struct {
+		result1 string
+		result2 []*models.VSphereManagementObject
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *VCClient) GetResourcePools(arg1 context.Context, arg2 string) ([]*models.VSphereResourcePool, error) {
 	fake.getResourcePoolsMutex.Lock()
 	ret, specificReturn := fake.getResourcePoolsReturnsOnCall[len(fake.getResourcePoolsArgsForCall)]
@@ -1600,6 +1765,8 @@ func (fake *VCClient) Invocations() map[string][][]interface{} {
 	defer fake.findDatastoreMutex.RUnlock()
 	fake.findFolderMutex.RLock()
 	defer fake.findFolderMutex.RUnlock()
+	fake.findNetworkMutex.RLock()
+	defer fake.findNetworkMutex.RUnlock()
 	fake.findResourcePoolMutex.RLock()
 	defer fake.findResourcePoolMutex.RUnlock()
 	fake.findVirtualMachineMutex.RLock()
@@ -1618,6 +1785,8 @@ func (fake *VCClient) Invocations() map[string][][]interface{} {
 	defer fake.getFoldersMutex.RUnlock()
 	fake.getNetworksMutex.RLock()
 	defer fake.getNetworksMutex.RUnlock()
+	fake.getPathMutex.RLock()
+	defer fake.getPathMutex.RUnlock()
 	fake.getResourcePoolsMutex.RLock()
 	defer fake.getResourcePoolsMutex.RUnlock()
 	fake.getVSphereVersionMutex.RLock()

--- a/pkg/v1/tkg/vc/client.go
+++ b/pkg/v1/tkg/vc/client.go
@@ -955,11 +955,10 @@ func (c *DefaultClient) FindDataCenter(ctx context.Context, path string) (string
 
 // FindNetwork finds the vSphere network from path, return moid
 func (c *DefaultClient) FindNetwork(ctx context.Context, path, dcPath string) (string, error) {
-	if c.vmomiClient == nil {
-		return "", fmt.Errorf("uninitialized vmomi client")
+	finder, err := c.newFinder(ctx, dcPath)
+	if err != nil {
+		return "", err
 	}
-
-	finder := find.NewFinder(c.vmomiClient.Client)
 	obj, err := finder.Network(ctx, path)
 	if err != nil {
 		return "", err

--- a/pkg/v1/tkg/vc/client.go
+++ b/pkg/v1/tkg/vc/client.go
@@ -191,7 +191,7 @@ func (c *DefaultClient) GetDatacenters(ctx context.Context) ([]*models.VSphereDa
 	datacenters := make([]*models.VSphereDatacenter, 0, len(dcs))
 
 	for i := range dcs {
-		path, _, err := c.getPath(ctx, dcs[i].Reference().Value)
+		path, _, err := c.GetPath(ctx, dcs[i].Reference().Value)
 		if err != nil {
 			continue
 		}
@@ -263,7 +263,7 @@ func (c *DefaultClient) GetDatastores(ctx context.Context, datacenterMOID string
 
 	for i := range dss {
 		managedObject := models.VSphereDatastore{Moid: dss[i].Self.Value}
-		path, _, err := c.getPath(ctx, dss[i].Reference().Value)
+		path, _, err := c.GetPath(ctx, dss[i].Reference().Value)
 
 		if err != nil {
 			managedObject.Name = dss[i].Name
@@ -275,11 +275,12 @@ func (c *DefaultClient) GetDatastores(ctx context.Context, datacenterMOID string
 	return results, err
 }
 
-func (c *DefaultClient) getPath(ctx context.Context, moid string) (string, []*models.VSphereManagementObject, error) {
+// GetPath takes in the MOID of a vsphere resource and returns a fully qualified path
+func (c *DefaultClient) GetPath(ctx context.Context, moid string) (string, []*models.VSphereManagementObject, error) {
 	client := c.vmomiClient
 	var objects []*models.VSphereManagementObject
 	if moid == "" {
-		return "", objects, errors.New("a non-empty moid should be passed to getPath")
+		return "", objects, errors.New("a non-empty moid should be passed to GetPath")
 	}
 	if client == nil {
 		return "", []*models.VSphereManagementObject{}, fmt.Errorf("uninitialized vmomi client")
@@ -444,7 +445,7 @@ func (c *DefaultClient) GetNetworks(ctx context.Context, datacenterMOID string) 
 
 	for i := range networks {
 		managedObject := models.VSphereNetwork{Moid: networks[i].Reference().Type + ":" + networks[i].Reference().Value}
-		path, _, err := c.getPath(ctx, networks[i].Reference().Value)
+		path, _, err := c.GetPath(ctx, networks[i].Reference().Value)
 		if err != nil {
 			managedObject.Name = networks[i].Name
 		} else {
@@ -492,7 +493,7 @@ func (c *DefaultClient) GetResourcePools(ctx context.Context, datacenterMOID str
 	}
 
 	for i := range rps {
-		path, _, err := c.getPath(ctx, rps[i].Self.Value)
+		path, _, err := c.GetPath(ctx, rps[i].Self.Value)
 		if err != nil {
 			continue
 		}
@@ -537,7 +538,7 @@ func (c *DefaultClient) GetVirtualMachines(ctx context.Context, datacenterMOID s
 	}
 
 	for i := range vms {
-		path, _, err := c.getPath(ctx, vms[i].Self.Value)
+		path, _, err := c.GetPath(ctx, vms[i].Self.Value)
 		if err != nil {
 			continue
 		}
@@ -622,7 +623,7 @@ func (c *DefaultClient) GetVirtualMachineImages(ctx context.Context, datacenterM
 
 	for i := range vms {
 		if ovaVersion, distroName, distroVersion, distroArch := c.getVMMetadata(&vms[i]); ovaVersion != "" {
-			path, _, err := c.getPath(ctx, vms[i].Self.Value)
+			path, _, err := c.GetPath(ctx, vms[i].Self.Value)
 			if err != nil {
 				continue
 			}
@@ -773,7 +774,7 @@ func (c *DefaultClient) GetFolders(ctx context.Context, datacenterMOID string) (
 			continue
 		}
 
-		path, _, err := c.getPath(ctx, folders[i].Reference().Value)
+		path, _, err := c.GetPath(ctx, folders[i].Reference().Value)
 		if err != nil {
 			continue
 		}
@@ -809,7 +810,7 @@ func (c *DefaultClient) GetComputeResources(ctx context.Context, datacenterMOID 
 	}
 
 	for i := range rps {
-		path, objects, err := c.getPath(ctx, rps[i].Self.Value)
+		path, objects, err := c.GetPath(ctx, rps[i].Self.Value)
 		if err != nil {
 			continue
 		}
@@ -945,6 +946,21 @@ func (c *DefaultClient) FindDataCenter(ctx context.Context, path string) (string
 	}
 	finder := find.NewFinder(c.vmomiClient.Client)
 	obj, err := finder.Datacenter(ctx, path)
+	if err != nil {
+		return "", err
+	}
+
+	return obj.Reference().Value, nil
+}
+
+// FindNetwork finds the vSphere network from path, return moid
+func (c *DefaultClient) FindNetwork(ctx context.Context, path, dcPath string) (string, error) {
+	if c.vmomiClient == nil {
+		return "", fmt.Errorf("uninitialized vmomi client")
+	}
+
+	finder := find.NewFinder(c.vmomiClient.Client)
+	obj, err := finder.Network(ctx, path)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/v1/tkg/vc/interface.go
+++ b/pkg/v1/tkg/vc/interface.go
@@ -85,6 +85,10 @@ type Client interface {
 	FindDataCenter(ctx context.Context, path string) (string, error)
 	// FindDatastore find the vSphere datastore from path, return moid
 	FindDatastore(ctx context.Context, path, dcPath string) (string, error)
+	// FindNetwork finds the vSphere network from path, return moid
+	FindNetwork(ctx context.Context, path, dcPath string) (string, error)
 	// GetAndValidateVirtualMachineTemplateForK8sVersion validates and returns valid virtual machine template
 	GetAndValidateVirtualMachineTemplate(ovaVersions []string, tkrName string, templateName, dc string, tkgConfigReaderWriter tkgconfigreaderwriter.TKGConfigReaderWriter) (*tkgtypes.VSphereVirtualMachine, error)
+	// GetPath returns the full path of a valid vSphere resource
+	GetPath(ctx context.Context, moid string) (string, []*models.VSphereManagementObject, error)
 }


### PR DESCRIPTION
### What this PR does / why we need it
Right now the user can pass just the vSphere resource names (eg. VSPHERE_FORLDER: "vm0") when creating TKG clusters on vSphere. This is causing problems for users with complex(huge) vSphere setups. This change will convert those names to fully qualified paths.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/1356

### Describe testing done for PR
Used the below config to create a workload cluster on vSphere.
```
VSPHERE_DATACENTER: dc0
VSPHERE_DATASTORE: sharedVmfs-1
VSPHERE_FOLDER: "vm"
VSPHERE_NETWORK: "VM Network"
VSPHERE_RESOURCE_POOL: cluster0/Resources
```

The above resources are converted to full paths when generating the templates.
```
Setting config variable "VSPHERE_DATACENTER" to value "/dc0"
Setting config variable "VSPHERE_NETWORK" to value "/dc0/network/VM Network"
Setting config variable "VSPHERE_RESOURCE_POOL" to value "/dc0/host/cluster0/Resources"
Setting config variable "VSPHERE_DATASTORE" to value "/dc0/datastore/sharedVmfs-1"
Setting config variable "VSPHERE_FOLDER" to value "/dc0/vm"
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Convert resource names to full paths when creating clusters on vSphere
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
