### PR TITLE
Fix the upgrade issue when the clusters are configured with non-defau…

### DIFF
--- a/pkg/v1/providers/infrastructure-azure/v1.0.0/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.0.0/ytt/overlay.yaml
@@ -165,6 +165,14 @@ spec:
         advertiseAddress: '0.0.0.0'
         bindPort: #@ data.values.CLUSTER_API_SERVER_PORT
       #@ end
+    joinConfiguration:
+      #@ if data.values.CLUSTER_API_SERVER_PORT:
+      #@overlay/match missing_ok=True
+      controlPlane:
+        localAPIEndpoint:
+          advertiseAddress: '0.0.0.0'
+          bindPort: #@ data.values.CLUSTER_API_SERVER_PORT
+      #@ end
     #@ if data.values.AZURE_ENABLE_PRIVATE_CLUSTER:
     #@overlay/match missing_ok=True
     preKubeadmCommands:

--- a/pkg/v1/providers/infrastructure-vsphere/v1.0.1/ytt/overlay-windows.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.0.1/ytt/overlay-windows.yaml
@@ -212,12 +212,24 @@ spec:
       #@ if (not data.values.AVI_CONTROL_PLANE_HA_PROVIDER) and data.values.CLUSTER_API_SERVER_PORT:
       #@overlay/match missing_ok=True
       localAPIEndpoint:
-        #@ if data.values.TKG_IP_FAMILY == "ipv6":
-        advertiseAddress: '::\0'
+        #@ if data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"]:
+        advertiseAddress: '::/0'
         #@ else:
         advertiseAddress: '0.0.0.0'
         #@ end
         bindPort: #@ data.values.CLUSTER_API_SERVER_PORT
+      #@ end
+    joinConfiguration:
+      #@ if (not data.values.AVI_CONTROL_PLANE_HA_PROVIDER) and data.values.CLUSTER_API_SERVER_PORT:
+      #@overlay/match missing_ok=True
+      controlPlane:
+        localAPIEndpoint:
+          #@ if data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"]:
+          advertiseAddress: '::/0'
+          #@ else:
+          advertiseAddress: '0.0.0.0'
+          #@ end
+          bindPort: #@ data.values.CLUSTER_API_SERVER_PORT
       #@ end
     clusterConfiguration:
       imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.imageRepository)

--- a/pkg/v1/providers/infrastructure-vsphere/v1.0.1/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.0.1/ytt/overlay.yaml
@@ -216,8 +216,8 @@ spec:
       #@ if (not data.values.AVI_CONTROL_PLANE_HA_PROVIDER) and data.values.CLUSTER_API_SERVER_PORT:
       #@overlay/match missing_ok=True
       localAPIEndpoint:
-        #@ if data.values.TKG_IP_FAMILY == "ipv6":
-        advertiseAddress: '::\0'
+        #@ if data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"]:
+        advertiseAddress: '::/0'
         #@ else:
         advertiseAddress: '0.0.0.0'
         #@ end
@@ -229,13 +229,24 @@ spec:
           #@overlay/match missing_ok=True
           node-ip: "::"
       #@ end
-    #@ if data.values.TKG_IP_FAMILY == "ipv6,ipv4":
     joinConfiguration:
+      #@ if (not data.values.AVI_CONTROL_PLANE_HA_PROVIDER) and data.values.CLUSTER_API_SERVER_PORT:
+      #@overlay/match missing_ok=True
+      controlPlane:
+        localAPIEndpoint:
+          #@ if data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"]:
+          advertiseAddress: '::/0'
+          #@ else:
+          advertiseAddress: '0.0.0.0'
+          #@ end
+          bindPort: #@ data.values.CLUSTER_API_SERVER_PORT
+      #@ end
+      #@ if data.values.TKG_IP_FAMILY == "ipv6,ipv4":
       nodeRegistration:
         kubeletExtraArgs:
           #@overlay/match missing_ok=True
           node-ip: "::"
-    #@ end
+      #@ end
     clusterConfiguration:
       imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.imageRepository)
       etcd:

--- a/pkg/v1/providers/tests/unit/ip_family_test.go
+++ b/pkg/v1/providers/tests/unit/ip_family_test.go
@@ -314,11 +314,12 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 			When("data values are set to single stack IPv4 settings", func() {
 				BeforeEach(func() {
 					values = createDataValues(map[string]string{
-						"CLUSTER_NAME":     "foo",
-						"TKG_CLUSTER_ROLE": "workload",
-						"TKG_IP_FAMILY":    "ipv4",
-						"CLUSTER_CIDR":     "100.96.0.0/11",
-						"SERVICE_CIDR":     "100.64.0.0/18",
+						"CLUSTER_NAME":            "foo",
+						"TKG_CLUSTER_ROLE":        "workload",
+						"TKG_IP_FAMILY":           "ipv4",
+						"CLUSTER_CIDR":            "100.96.0.0/11",
+						"SERVICE_CIDR":            "100.64.0.0/18",
+						"CLUSTER_API_SERVER_PORT": "443",
 					})
 				})
 				It("renders control plane and worker templates each with an ipv4 single stack network device", func() {
@@ -338,17 +339,33 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 						Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[1]"))
 					}
 				})
+				It("renders control plane template to bind the local apiServer endpoint to '0.0.0.0' as the node IP and port to custom api server port configured", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					kubeadmControlPlaneDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "KubeadmControlPlane",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(kubeadmControlPlaneDocs).To(HaveLen(1))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.initConfiguration.localAPIEndpoint.advertiseAddress", "0.0.0.0"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.initConfiguration.localAPIEndpoint.bindPort", "443"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.advertiseAddress", "0.0.0.0"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.bindPort", "443"))
+				})
 
 			})
 
 			When("data values are set to single stack IPv6 settings", func() {
 				BeforeEach(func() {
 					values = createDataValues(map[string]string{
-						"CLUSTER_NAME":     "foo",
-						"TKG_CLUSTER_ROLE": "workload",
-						"TKG_IP_FAMILY":    "ipv6",
-						"CLUSTER_CIDR":     "fd00:100:96::/48",
-						"SERVICE_CIDR":     "fd00:100:64::/108",
+						"CLUSTER_NAME":            "foo",
+						"TKG_CLUSTER_ROLE":        "workload",
+						"TKG_IP_FAMILY":           "ipv6",
+						"CLUSTER_CIDR":            "fd00:100:96::/48",
+						"SERVICE_CIDR":            "fd00:100:64::/108",
+						"CLUSTER_API_SERVER_PORT": "443",
 					})
 				})
 				It("renders control plane and worker templates each with an ipv6 single stack network device", func() {
@@ -368,16 +385,32 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 						Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[1]"))
 					}
 				})
+				It("renders control plane template to bind the local apiServer endpoint to '::/0' as the node IP and port to custom api server port configured", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					kubeadmControlPlaneDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "KubeadmControlPlane",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(kubeadmControlPlaneDocs).To(HaveLen(1))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.initConfiguration.localAPIEndpoint.advertiseAddress", "::/0"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.initConfiguration.localAPIEndpoint.bindPort", "443"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.advertiseAddress", "::/0"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.bindPort", "443"))
+				})
 			})
 
 			When("data values are set to ipv4,ipv6 dual stack settings", func() {
 				BeforeEach(func() {
 					values = createDataValues(map[string]string{
-						"CLUSTER_NAME":     "foo",
-						"TKG_CLUSTER_ROLE": "workload",
-						"TKG_IP_FAMILY":    "ipv4,ipv6",
-						"CLUSTER_CIDR":     "100.96.0.0/11,fd00:100:96::/48",
-						"SERVICE_CIDR":     "100.64.0.0/18,fd00:100:64::/108",
+						"CLUSTER_NAME":            "foo",
+						"TKG_CLUSTER_ROLE":        "workload",
+						"TKG_IP_FAMILY":           "ipv4,ipv6",
+						"CLUSTER_CIDR":            "100.96.0.0/11,fd00:100:96::/48",
+						"SERVICE_CIDR":            "100.64.0.0/18,fd00:100:64::/108",
+						"CLUSTER_API_SERVER_PORT": "443",
 					})
 				})
 				It("renders control plane and worker templates each with a dual stack network device", func() {
@@ -396,6 +429,21 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 						Expect(machineDoc).To(HaveYAMLPathWithValue("$.spec.template.spec.network.devices[0].networkName", "VM Network"))
 						Expect(machineDoc).NotTo(HaveYAMLPath("$.spec.template.spec.network.devices[1]"))
 					}
+				})
+				It("renders control plane template to bind the local apiServer endpoint to '0.0.0.0' as the node IP and port to custom api server port configured", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					kubeadmControlPlaneDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "KubeadmControlPlane",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(kubeadmControlPlaneDocs).To(HaveLen(1))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.initConfiguration.localAPIEndpoint.advertiseAddress", "0.0.0.0"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.initConfiguration.localAPIEndpoint.bindPort", "443"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.advertiseAddress", "0.0.0.0"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.bindPort", "443"))
 				})
 				It("does not render bind-address field", func() {
 					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
@@ -455,6 +503,7 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 						"CLUSTER_CIDR":                   "fd00:100:96::/48,100.96.0.0/11",
 						"SERVICE_CIDR":                   "fd00:100:64::/108,100.64.0.0/18",
 						"VSPHERE_CONTROL_PLANE_ENDPOINT": "2001:db8::2",
+						"CLUSTER_API_SERVER_PORT":        "443",
 					})
 				})
 				It("renders a control plane and worker template each with a dual stack network device", func() {
@@ -487,6 +536,21 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.bind-address", "::"))
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.clusterConfiguration.controllerManager.extraArgs.bind-address", "::"))
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.clusterConfiguration.scheduler.extraArgs.bind-address", "::"))
+				})
+				It("renders control plane template to bind the local apiServer endpoint to '::/0' as the node IP and port to custom api server port configured", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					kubeadmControlPlaneDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "KubeadmControlPlane",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(kubeadmControlPlaneDocs).To(HaveLen(1))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.initConfiguration.localAPIEndpoint.advertiseAddress", "::/0"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.initConfiguration.localAPIEndpoint.bindPort", "443"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.advertiseAddress", "::/0"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.bindPort", "443"))
 				})
 				It("renders control plane template to advertise control plane endpoint on the apiServer", func() {
 					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
@@ -524,6 +588,50 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 			})
 		})
 
+	})
+	Describe("infrastructure-vsphere windows overlay.yaml", func() {
+		var paths []string
+		BeforeEach(func() {
+			paths = []string{
+				filepath.Join("fixtures", "yttmocks"),
+				filepath.Join("..", "..", "infrastructure-vsphere", "v1.0.1", "ytt", "overlay-windows.yaml"),
+				filepath.Join("..", "..", "infrastructure-vsphere", "v1.0.1", "ytt", "base-template.yaml"),
+				filepath.Join("..", "..", "config_default.yaml"),
+			}
+		})
+
+		Describe("cluster api server port configuration", func() {
+			var values string
+			When("ip family is configured to ipv4", func() {
+				BeforeEach(func() {
+					values = createDataValues(map[string]string{
+						"CLUSTER_NAME":                "foo",
+						"TKG_CLUSTER_ROLE":            "workload",
+						"TKG_IP_FAMILY":               "ipv4",
+						"CLUSTER_CIDR":                "10.0.0.0/16",
+						"SERVICE_CIDR":                "10.0.0.0/18",
+						"CLUSTER_API_SERVER_PORT":     "443",
+						"IS_WINDOWS_WORKLOAD_CLUSTER": "true",
+					})
+				})
+
+				It("renders control plane template to bind the local apiServer endpoint to '0.0.0.0' as the node IP and port to custom api server port configured", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					kubeadmControlPlaneDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "KubeadmControlPlane",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(kubeadmControlPlaneDocs).To(HaveLen(1))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.initConfiguration.localAPIEndpoint.advertiseAddress", "0.0.0.0"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.initConfiguration.localAPIEndpoint.bindPort", "443"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.advertiseAddress", "0.0.0.0"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.bindPort", "443"))
+				})
+			})
+		})
 	})
 
 	Describe("vsphere cpi", func() {


### PR DESCRIPTION
…lt api server port

Signed-off-by: PremKumar Kalle <pkalle@vmware.com>

### What this PR does / why we need it
This PR would fix
1)  the issue where vSphere cluster and Azure clusters created with non-default API server port, was failing to upgrade. 
2) fixed the default ipv6 address when non-default API server port is configured

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes # #1371 

### Describe testing done for PR

Tests done:

vSphere:

1. created a vpshere cluster with dev plan (with  TKR  v1.20.12---vmware.1-tkg.2-zshippable) , upgraded cluster (to v1.21.6---vmware.1-tkg.2-zshippable), scaledup (both controlplane and workers), scaled down and deleted the cluster successfully
2. created a vpshere cluster with prod plan(with  TKR  v1.20.12---vmware.1-tkg.2-zshippable), upgraded cluster(to v1.21.6---vmware.1-tkg.2-zshippable), scaledup (both controlplane and workers), scaled down and deleted the cluster successfully

Azure:

1. created a azure cluster with dev plan(with  TKR  v1.20.12---vmware.1-tkg.2-zshippable), upgraded cluster(to v1.21.6---vmware.1-tkg.2-zshippable), scaledup (both controlplane and workers), scaled down and deleted the cluster successfully
2. created a vpshere cluster with prod plan(with  TKR  v1.20.12---vmware.1-tkg.2-zshippable), upgraded cluster(to v1.21.6---vmware.1-tkg.2-zshippable), scaledup (both controlplane and workers), scaled down and deleted the cluster successfully

Aws: Confimed that the fix is NOT necessary for AWS by creating cluster, upgrade and scaleup and scaledown and delete operation on both `dev` and `prod` plans

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix the upgrade issue when the clusters are configured with non-default api server port
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
