### PR TITLE
Antrea disable UDP workload setting

### DIFF
--- a/pkg/v1/providers/config_default.yaml
+++ b/pkg/v1/providers/config_default.yaml
@@ -582,7 +582,7 @@ ANTREA_ENDPOINTSLICE: false
 ANTREA_POLICY: true
 ANTREA_NODEPORTLOCAL: false
 ANTREA_TRACEFLOW: true
-
+ANTREA_DISABLE_UDP_TUNNEL_OFFLOAD: false
 
 
 #! ---------------------------------------------------------------------

--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
@@ -125,6 +125,8 @@ ANTREA_ENDPOINTSLICE: "false", "true"
 ANTREA_POLICY: "false", "true"
 ANTREA_NODEPORTLOCAL: "false", "true"
 ANTREA_TRACEFLOW: "false", "true"
+ANTREA_DISABLE_UDP_TUNNEL_OFFLOAD: "false", "true"
+
 
 BUILD_EDITION: "tkg", "tce"
 

--- a/pkg/v1/providers/vendir.lock.yml
+++ b/pkg/v1/providers/vendir.lock.yml
@@ -10,10 +10,10 @@ directories:
   path: ytt/vendir/vsphere_cpi/_ytt_lib
 - contents:
   - git:
-      commitTitle: Adding antrea agent tweak configmap (#2683)
-      sha: a9353f7de25d8f2aa6baafacd295ce5c8d98d38b
+      commitTitle: Antrea disable UDP tunnel offload (#2723)
+      sha: daa90ee40f373474c7714e72182b7ad784c2ffaf
       tags:
-      - v0.10.0-dev.4-23-ga9353f7d
+      - v0.10.0-dev.4-36-gdaa90ee4
     path: .
   path: ytt/vendir/cni/_ytt_lib
 - contents:

--- a/pkg/v1/providers/vendir.yml
+++ b/pkg/v1/providers/vendir.yml
@@ -14,7 +14,7 @@ directories:
   - path: .
     git:
       url: git@github.com:vmware-tanzu/tce.git
-      ref: a9353f7de25d8f2aa6baafacd295ce5c8d98d38b
+      ref: daa90ee40f373474c7714e72182b7ad784c2ffaf
     includePaths:
     - addons/packages/antrea/1.2.3/bundle/config/**/*
     - addons/packages/calico/3.19.1/bundle/config/**/*

--- a/pkg/v1/providers/ytt/02_addons/cni/antrea/antrea_addon_data.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/cni/antrea/antrea_addon_data.lib.yaml
@@ -53,6 +53,7 @@ antrea:
     noSNAT: #@ data.values.ANTREA_NO_SNAT
     #@ end
     tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+    disableUdpTunnelOffload: #@ data.values.ANTREA_DISABLE_UDP_TUNNEL_OFFLOAD
     featureGates:
       #@ if data.values.NSXT_POD_ROUTING_ENABLED:
       AntreaProxy: true

--- a/pkg/v1/providers/ytt/lib/config_variable_association.star
+++ b/pkg/v1/providers/ytt/lib/config_variable_association.star
@@ -278,6 +278,7 @@ return {
 "ANTREA_POLICY": ["vsphere", "aws", "azure", "docker"],
 "ANTREA_NODEPORTLOCAL": ["vsphere", "aws", "azure", "docker"],
 "ANTREA_TRACEFLOW": ["vsphere", "aws", "azure", "docker"],
+"ANTREA_DISABLE_UDP_TUNNEL_OFFLOAD": ["vsphere", "aws", "azure", "docker"],
 
 "PROVIDER_TYPE": ["vsphere", "aws", "azure", "tkg-service-vsphere", "docker"],
 "TKG_CLUSTER_ROLE": ["vsphere", "aws", "azure", "tkg-service-vsphere", "docker"],

--- a/pkg/v1/providers/ytt/vendir/cni/_ytt_lib/addons/packages/antrea/1.2.3/bundle/config/overlay/antrea_overlay.yaml
+++ b/pkg/v1/providers/ytt/vendir/cni/_ytt_lib/addons/packages/antrea/1.2.3/bundle/config/overlay/antrea_overlay.yaml
@@ -219,12 +219,31 @@ tlsCipherSuites: #@ values.antrea.config.tlsCipherSuites
 #! legacyCRDMirroring: true
 #@ end
 
+
+#@ def antrea_agent_tweaker_conf():
+
+#! Enable disableUdpTunnelOffload will disable udp tunnel offloading feature on kubernetes node's default interface.
+#! By default, no actions will be taken.
+disableUdpTunnelOffload: #@ values.antrea.config.disableUdpTunnelOffload
+#@ end
+
+
+#! Antrea agent and controller configuration
 #@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name": "antrea-config-822fk25299"}})
 ---
 kind: ConfigMap
 data:
   antrea-agent.conf: #@ yaml.encode(antrea_agent_conf())
   antrea-controller.conf: #@ yaml.encode(antrea_controller_conf())
+
+
+#! Antrea agent tweaker configuration
+#@overlay/match by=overlay.subset({"kind":"ConfigMap","metadata":{"name": "antrea-agent-tweaker-g56hc6fh8t"}})
+---
+kind: ConfigMap
+data:
+  antrea-agent-tweaker.conf: #@ yaml.encode(antrea_agent_tweaker_conf())
+
 
 #@overlay/match by=overlay.subset({"kind":"Deployment","metadata":{"name": "antrea-controller"}})
 ---

--- a/pkg/v1/providers/ytt/vendir/cni/_ytt_lib/addons/packages/antrea/1.2.3/bundle/config/values.yaml
+++ b/pkg/v1/providers/ytt/vendir/cni/_ytt_lib/addons/packages/antrea/1.2.3/bundle/config/values.yaml
@@ -9,6 +9,7 @@ antrea:
     serviceCIDRv6: null
     trafficEncapMode: encap
     noSNAT: false
+    disableUdpTunnelOffload: false
     #! Setting defaultMTU to null since antrea-agent will discover the MTU of the Node's primary interface and
     #! also adjust MTU to accommodate for tunnel encapsulation overhead.
     defaultMTU: null


### PR DESCRIPTION
### What this PR does / why we need it
Antrea options in the configMap for agent-tweaker must be configurable via overlay.

### Which issue(s) this PR fixes
xref https://github.com/vmware-tanzu/community-edition/issues/2724

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Introduces ANTREA_DISABLE_UDP_TUNNEL_OFFLOAD for UDP tunnel offload feature configuration.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access

