### PR TITLE
clustergen model updates

### DIFF
--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_aws.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_aws.model
@@ -1,7 +1,7 @@
 --CONTROLPLANE-MACHINE-COUNT: "NOTPROVIDED", "1","3","5"
 --WORKER-MACHINE-COUNT:       "NOTPROVIDED", "3"
 --CONTROLPLANE-SIZE:          "NOTPROVIDED", "i3.xlarge"
---TKR:                        "NOTPROVIDED", "v1.21.5+vmware.1-tkg.1-zshippable"
+--TKR:                        "NOTPROVIDED", "v1.22.3+vmware.1-tkg.2-zshippable"
 --NAMESPACE:                  "NOTPROVIDED", "default", "test"
 --SIZE:                       "NOTPROVIDED", "t3.medium"
 --WORKER-SIZE:                "NOTPROVIDED", "m5.xlarge"

--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_azure.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_azure.model
@@ -1,7 +1,7 @@
 --CONTROLPLANE-MACHINE-COUNT: "NOTPROVIDED", "1","3","5"
 --WORKER-MACHINE-COUNT:       "NOTPROVIDED", "3"
 --CONTROLPLANE-SIZE:          "NOTPROVIDED", "i3.xlarge"
---TKR:                        "NOTPROVIDED", "v1.21.5+vmware.1-tkg.1-zshippable", "v0.0.0+no-azure-image", "v0.0.0+marketplace-image", "v0.0.0+marketplace-image-no-thirdpartyimage", "v0.0.0+shared-gallery-image"
+--TKR:                        "NOTPROVIDED", "v1.22.3+vmware.1-tkg.2-zshippable", "v0.0.0+no-azure-image", "v0.0.0+marketplace-image", "v0.0.0+marketplace-image-no-thirdpartyimage", "v0.0.0+shared-gallery-image"
 --NAMESPACE:                  "NOTPROVIDED", "default", "test"
 --SIZE:                       "NOTPROVIDED", "t3.medium"
 --WORKER-SIZE:                "NOTPROVIDED", "m5.xlarge"

--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
@@ -1,7 +1,7 @@
 --CONTROLPLANE-MACHINE-COUNT: "NOTPROVIDED"
 --WORKER-MACHINE-COUNT:       "NOTPROVIDED"
 --CONTROLPLANE-SIZE:          "NOTPROVIDED"
---TKR:                        "NOTPROVIDED", "v1.21.5+vmware.1-tkg.1-zshippable"
+--TKR:                        "NOTPROVIDED", "v1.22.3+vmware.1-tkg.2-zshippable"
 --NAMESPACE:                  "NOTPROVIDED"
 --SIZE:                       "NOTPROVIDED"
 --WORKER-SIZE:                "NOTPROVIDED"
@@ -95,6 +95,7 @@ TKG_HTTP_PROXY: "http://10.0.200.100", "http://[fc00:f853:ccd:e793::1]:3128"
 TKG_HTTPS_PROXY: "NA", "http://10.0.200.100", "http://[fc00:f853:ccd:e793::1]:3128"
 TKG_NO_PROXY: "NA", "10.0.200.1/24", "10.184.90.80"
 TKG_PROXY_CA_CERT: "NA", "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tClBST1hZIENBIENFUlQ="
+TKG_HTTP_PROXY_ENABLED: "true"
 
 # ip family
 TKG_IP_FAMILY: "NA", "", "ipv4", "ipv6"


### PR DESCRIPTION
Signed-off-by: Vui Lam <vui@vmware.com>

### What this PR does / why we need it

reduce negative test cases by
- update to a usable tkr version
- ensure TKG_HTTP_PROXY_ENABLED is set

converts 20 more testcases from invalid to valid ones

### Which issue(s) this PR fixes

Fixes #1377

### Describe testing done for PR

```
make clustergen
cat new/failed.txt | cut -d: -f2 | sort | grep -v failed | uniq -c

  81 NEG
  80 POS
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- x Squash the commits into one or a small number of logical commits
- x Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- x Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
