### PR TITLE
Improve windows cluster

### DIFF
--- a/pkg/v1/providers/ytt/03_customizations/03_windows/register_antrea_cleanup.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/03_windows/register_antrea_cleanup.yaml
@@ -9,10 +9,16 @@ spec:
     spec:
       files:
       #@overlay/append
+      - path: C:\k\antrea_cleanup.ps1
+        content: |
+          stop-service antrea-agent -ErrorAction SilentlyContinue
+          C:\k\antrea\Clean-AntreaNetwork.ps1
+      #@overlay/append
       - path: C:\k\register_antrea_cleanup.ps1
         content: |
           $methodScript = "C:\k\antrea\Clean-AntreaNetwork.ps1"
           if (Test-Path "$methodScript") {
+              $cleanScriptPath = "C:\k\antrea_cleanup.ps1"
               $method = "Shutdown"
               $RegPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Group Policy"
               $RegScriptsPath = "$RegPath\Scripts\$method\0"
@@ -44,7 +50,7 @@ spec:
               $ExecTime = $BinaryString.Split(',') | ForEach-Object {"0x$_"}
               $items = @("$RegScriptsPath\0", "$RegSmScriptsPath\0")
               foreach ($item in $items) {
-                  New-ItemProperty -path "$item" -name Script -propertyType String -value $methodScript -force
+                  New-ItemProperty -path "$item" -name Script -propertyType String -value $cleanScriptPath -force
                   New-ItemProperty -path "$item" -name Parameters -propertyType String -value $method -force
                   New-ItemProperty -path "$item" -name IsPowershell -propertyType DWord -value 1 -force
                   New-ItemProperty -path "$item" -name ExecTime -propertyType Binary -value ([byte[]]$ExecTime) -force


### PR DESCRIPTION
Stop antrea-agent before cleanup.

Delay running antrea-agent to avoid conflict with kubelet.

### What this PR does / why we need it
This change is to improve windows node, we need run cleanup for antrea before windows rebooting, but antrea-agent service may be still running, to avoid the race, let's stop the service first.


### Which issue(s) this PR fixes
we didn't stop antrea-agent service before cleanup, the cleanup process may conflict with antrea-agent service

<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
create windows cluster many times, reboot windows node many times.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
