### PR TITLE
Don't skip cert validation on `tanzu [management-]cluster kubeconfig get`

### DIFF
--- a/cmd/cli/plugin/managementcluster/kubeconfig_get.go
+++ b/cmd/cli/plugin/managementcluster/kubeconfig_get.go
@@ -65,19 +65,19 @@ func getClusterKubeconfig(server *v1alpha1.Server) error {
 		return err
 	}
 
-	if getKCOptions.adminKubeconfig {
-		return getAdminKubeconfig(tkgctlClient, server)
-	}
-	return getPinnipedKubeconfig(tkgctlClient)
-}
-
-func getAdminKubeconfig(tkgctlClient tkgctl.TKGClient, server *v1alpha1.Server) error {
 	mcClustername, err := tkgutils.GetClusterNameFromKubeconfigAndContext(server.ManagementClusterOpts.Path,
 		server.ManagementClusterOpts.Context)
 	if err != nil {
 		return errors.Wrap(err, "failed to get management cluster name from kubeconfig")
 	}
 
+	if getKCOptions.adminKubeconfig {
+		return getAdminKubeconfig(tkgctlClient, mcClustername)
+	}
+	return getPinnipedKubeconfig(tkgctlClient, mcClustername)
+}
+
+func getAdminKubeconfig(tkgctlClient tkgctl.TKGClient, mcClustername string) error {
 	getClusterCredentialsOptions := tkgctl.GetWorkloadClusterCredentialsOptions{
 		ClusterName: mcClustername,
 		Namespace:   TKGSystemNamespace,
@@ -86,8 +86,10 @@ func getAdminKubeconfig(tkgctlClient tkgctl.TKGClient, server *v1alpha1.Server) 
 	return tkgctlClient.GetCredentials(getClusterCredentialsOptions)
 }
 
-func getPinnipedKubeconfig(tkgctlClient tkgctl.TKGClient) error {
+func getPinnipedKubeconfig(tkgctlClient tkgctl.TKGClient, mcClustername string) error {
 	getClusterPinnipedInfoOptions := tkgctl.GetClusterPinnipedInfoOptions{
+		ClusterName:         mcClustername,
+		Namespace:           TKGSystemNamespace,
 		IsManagementCluster: true,
 	}
 

--- a/pkg/v1/tkg/client/get_cluster_pinniped_info.go
+++ b/pkg/v1/tkg/client/get_cluster_pinniped_info.go
@@ -5,18 +5,13 @@ package client
 
 import (
 	"fmt"
-	"net"
-	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/region"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/utils"
 )
@@ -71,22 +66,14 @@ func (c *TkgClient) GetClusterPinnipedInfo(options GetClusterPinnipedInfoOptions
 func (c *TkgClient) GetWCClusterPinnipedInfo(regionalClusterClient clusterclient.Client,
 	curRegion region.RegionContext, options GetClusterPinnipedInfoOptions) (*ClusterPinnipedInfo, error) {
 
-	clusterAPIServerURL, err := c.getClusterAPIServerURL(regionalClusterClient, options.ClusterName, options.Namespace)
+	wcClusterInfo, err := getClusterInfo(regionalClusterClient, options.ClusterName, options.Namespace)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get cluster apiserver url from cluster objects")
-	}
-	clusterInfo, err := utils.GetClusterInfoFromCluster(clusterAPIServerURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get cluster-info from cluster")
+		return nil, errors.Wrap(err, "failed to get workload cluster information")
 	}
 	// for workload cluster pinniped-info should be available on management cluster
-	mcServerURL, err := utils.GetClusterServerFromKubeconfigAndContext(curRegion.SourceFilePath, curRegion.ContextName)
+	mcClusterInfo, err := getClusterInfo(regionalClusterClient, curRegion.ClusterName, TKGsystemNamespace)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to get cluster apiserver url")
-	}
-	mcClusterInfo, err := utils.GetClusterInfoFromCluster(mcServerURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get management cluster-info")
+		return nil, errors.Wrap(err, "failed to get management cluster information")
 	}
 	managementClusterPinnipedInfo, err := utils.GetPinnipedInfoFromCluster(mcClusterInfo)
 	if err != nil {
@@ -96,7 +83,7 @@ func (c *TkgClient) GetWCClusterPinnipedInfo(regionalClusterClient clusterclient
 		return nil, errors.New("failed to get pinniped-info from management cluster")
 	}
 
-	workloadClusterPinnipedInfo, err := utils.GetPinnipedInfoFromCluster(clusterInfo)
+	workloadClusterPinnipedInfo, err := utils.GetPinnipedInfoFromCluster(wcClusterInfo)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get pinniped-info from workload cluster")
 	}
@@ -112,7 +99,7 @@ func (c *TkgClient) GetWCClusterPinnipedInfo(regionalClusterClient clusterclient
 
 	return &ClusterPinnipedInfo{
 		ClusterName:  options.ClusterName,
-		ClusterInfo:  clusterInfo,
+		ClusterInfo:  wcClusterInfo,
 		PinnipedInfo: pinnipedInfo,
 	}, nil
 }
@@ -167,31 +154,4 @@ func getClusterInfo(
 	}
 
 	return cluster, nil
-}
-
-func (c *TkgClient) getClusterAPIServerURL(regionalClusterClient clusterclient.Client, clusterName, namespace string) (string, error) {
-	var apiServerHost string
-	var apiServerPort string
-	var cluster capi.Cluster
-	err := regionalClusterClient.GetResource(&cluster, clusterName, namespace, nil, nil)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			errMsg := fmt.Sprintf("cluster '%s' is not present in namespace '%s' ", clusterName, namespace)
-			log.V(4).Info(errMsg)
-			return "", errors.New(errMsg)
-		}
-		return "", errors.Wrap(err, "failed to get 'cluster' resource")
-	}
-
-	if cluster.Spec.ControlPlaneEndpoint.Host == "" {
-		return "", errors.New("controlplane endpoint 'host' was not set in 'cluster' resource")
-	}
-
-	if cluster.Spec.ControlPlaneEndpoint.Port == 0 {
-		return "", errors.New("controlplane endpoint 'port' was not set in 'cluster' resource")
-	}
-
-	apiServerHost = cluster.Spec.ControlPlaneEndpoint.Host
-	apiServerPort = strconv.Itoa(int(cluster.Spec.ControlPlaneEndpoint.Port))
-	return net.JoinHostPort(apiServerHost, apiServerPort), nil
 }


### PR DESCRIPTION
### What this PR does / why we need it

* Previously, during the `tanzu [management-]cluster kubeconfig get` codepath, we were getting cluster information via the `cluster-info` `ConfigMap` without validating our TLS connection to the cluster
* Now, we use the cluster's kubeconfig `Secret` to get the cluster information and we do validate our TLS connection to the cluster

### Which issue(s) this PR fixes

None

### Describe testing done for PR

* Built the CLI locally with `make build-install-cli-local` and generated MC and WC kubeconfigs against a VC cluster

### Release note

```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access

#### Special notes for your reviewer

* I tried the split the commits up so that they are logically more reviewable, but I imagine we should squash them before we merge since one commit contains necessary updates to the unit tests to get them to pass again after the implementation change
* This is what @prkalle and I have been talking about :)