### PR TITLE
Remove v1beta1 references from autoscaler deployment yaml

### DIFF
--- a/pkg/v1/providers/ytt/03_customizations/autoscaler/enable_autoscaler.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/autoscaler/enable_autoscaler.yaml
@@ -88,7 +88,7 @@ spec:
         key: node-role.kubernetes.io/master
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: #@ "{}-autoscaler-workload".format(data.values.CLUSTER_NAME)
 roleRef:
@@ -101,7 +101,7 @@ subjects:
   namespace: #@ data.values.NAMESPACE
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: #@ "{}-autoscaler-management".format(data.values.CLUSTER_NAME)
 roleRef:
@@ -120,7 +120,7 @@ metadata:
   namespace: #@ data.values.NAMESPACE
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-autoscaler-workload
 rules:
@@ -208,7 +208,7 @@ rules:
   - update
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-autoscaler-management
 rules:

--- a/pkg/v1/tkg/test/tkgctl/shared/autoscaler.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/autoscaler.go
@@ -58,7 +58,6 @@ func E2EAutoscalerSpec(context context.Context, inputGetter func() E2EAutoscaler
 	})
 
 	It("autoscaler should scale up/down the workers", func() {
-		Skip("Skipping autoscaler tests")
 		By(fmt.Sprintf("Creating a workload cluster %q", clusterName))
 		options := framework.CreateClusterOptions{
 			ClusterName:          clusterName,


### PR DESCRIPTION
### What this PR does / why we need it
Autoscaler deployment yaml still has references to `rbac.authorization.k8s.io/v1beta1` APIs which are deprecated in k8s v1.22. This PR updates such references to `rbac.authorization.k8s.io/v1`.

This PR also enables autoscaler tests.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1391

### Describe testing done for PR
Created a workload cluster by enabling cluster autoscaler and made sure that the autoscaler pod is running for the workload cluster created.

```
default                             test-as-wc3-cluster-autoscaler                  1/1     1            1           13m
```

Also made sure that the autoscaler integration tests ran and passed in the PR gating pipeline.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixed issue with autoscaler deployment on clusters using k8s version v1.22.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
