### PR TITLE
Fix error/warning displayed when CLIPlugin CRD is not installed with `tanzu plugin` commands

### DIFF
--- a/pkg/v1/cli/discovery/kubernetes.go
+++ b/pkg/v1/cli/discovery/kubernetes.go
@@ -6,6 +6,7 @@ package discovery
 import (
 	"time"
 
+	"github.com/aunum/log"
 	"github.com/pkg/errors"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/common"
@@ -56,15 +57,30 @@ func (k *KubernetesDiscovery) Name() string {
 	return k.name
 }
 
-// Manifest returns the manifest for a local repository.
+// Manifest returns the manifest for a kubernetes repository.
 func (k *KubernetesDiscovery) Manifest() ([]plugin.Discovered, error) {
-	plugins := make([]plugin.Discovered, 0)
-
 	// Create cluster client
 	clusterClientOptions := clusterclient.Options{GetClientInterval: 2 * time.Second, GetClientTimeout: 5 * time.Second}
 	clusterClient, err := clusterclient.NewClient(k.kubeconfigPath, k.kubecontext, clusterClientOptions)
 	if err != nil {
 		return nil, err
+	}
+
+	return k.GetDiscoveredPlugins(clusterClient)
+}
+
+// GetDiscoveredPlugins returns the list of discovered plugin from a kubernetes cluster
+func (k *KubernetesDiscovery) GetDiscoveredPlugins(clusterClient clusterclient.Client) ([]plugin.Discovered, error) {
+	plugins := make([]plugin.Discovered, 0)
+
+	exists, err := clusterClient.VerifyCLIPluginCRD()
+	if !exists || err != nil {
+		logMsg := "Skipping context-aware plugin discovery because CLIPlugin CRD not present on the logged in cluster. "
+		if err != nil {
+			logMsg += err.Error()
+		}
+		log.Debug(logMsg)
+		return nil, nil
 	}
 
 	// get all cliplugins resources available on the cluster

--- a/pkg/v1/cli/discovery/kubernetes_test.go
+++ b/pkg/v1/cli/discovery/kubernetes_test.go
@@ -1,0 +1,100 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery_test
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/discovery"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/plugin"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+	fakehelper "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes/helper"
+)
+
+func TestClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Discovery Suite")
+}
+
+var _ = Describe("Unit tests for kubernetes discovery", func() {
+	var (
+		err                  error
+		currentClusterClient *fakes.ClusterClient
+		kd                   *discovery.KubernetesDiscovery
+		plugins              []plugin.Discovered
+		cliplugins           []v1alpha1.CLIPlugin
+	)
+
+	Describe("When Getting Discovered plugins from k8s cluster", func() {
+		BeforeEach(func() {
+			currentClusterClient = &fakes.ClusterClient{}
+			kd = &discovery.KubernetesDiscovery{}
+		})
+
+		JustBeforeEach(func() {
+			plugins, err = kd.GetDiscoveredPlugins(currentClusterClient)
+		})
+
+		Context("When CLIPlugin CRD verification throws error", func() {
+			BeforeEach(func() {
+				currentClusterClient.VerifyCLIPluginCRDReturns(false, errors.New("fake error"))
+			})
+			It("return empty plugin list without an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(plugins)).To(Equal(0))
+			})
+		})
+		Context("When CLIPlugin CRD verification returns false and no error", func() {
+			BeforeEach(func() {
+				currentClusterClient.VerifyCLIPluginCRDReturns(false, nil)
+			})
+			It("return empty plugin list without an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(plugins)).To(Equal(0))
+			})
+		})
+		Context("When CLIPlugin CRD verification returns true with error", func() {
+			BeforeEach(func() {
+				currentClusterClient.VerifyCLIPluginCRDReturns(true, errors.New("fake error"))
+			})
+			It("return empty plugin list without an error", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(plugins)).To(Equal(0))
+			})
+		})
+
+		Context("When ListCLIPluginResources returns error", func() {
+			BeforeEach(func() {
+				currentClusterClient.VerifyCLIPluginCRDReturns(true, nil)
+				currentClusterClient.ListCLIPluginResourcesReturns(nil, errors.New("fake error"))
+			})
+			It("return empty plugin list with an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(len(plugins)).To(Equal(0))
+			})
+		})
+		Context("When ListCLIPluginResources list of CLIPlugin resources", func() {
+			BeforeEach(func() {
+				cliplugin1 := fakehelper.NewCLIPlugin(fakehelper.TestCLIPluginOption{Name: "plugin1", Description: "plugin1 desc", RecommendedVersion: "v0.0.1"})
+				cliplugin2 := fakehelper.NewCLIPlugin(fakehelper.TestCLIPluginOption{Name: "plugin2", Description: "plugin2 desc", RecommendedVersion: "v0.0.2"})
+				cliplugins = append(cliplugins, cliplugin1, cliplugin2)
+				currentClusterClient.VerifyCLIPluginCRDReturns(true, nil)
+				currentClusterClient.ListCLIPluginResourcesReturns(cliplugins, nil)
+			})
+			It("return ordered list of plugins without error", func() {
+				Expect(len(plugins)).To(Equal(2))
+				Expect(plugins[0].Name).To(Equal("plugin1"))
+				Expect(plugins[0].RecommendedVersion).To(Equal("v0.0.1"))
+				Expect(plugins[1].Name).To(Equal("plugin2"))
+				Expect(plugins[1].RecommendedVersion).To(Equal("v0.0.2"))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+})

--- a/pkg/v1/tkg/fakes/clusterclient.go
+++ b/pkg/v1/tkg/fakes/clusterclient.go
@@ -974,6 +974,18 @@ type ClusterClient struct {
 	useContextReturnsOnCall map[int]struct {
 		result1 error
 	}
+	VerifyCLIPluginCRDStub        func() (bool, error)
+	verifyCLIPluginCRDMutex       sync.RWMutex
+	verifyCLIPluginCRDArgsForCall []struct {
+	}
+	verifyCLIPluginCRDReturns struct {
+		result1 bool
+		result2 error
+	}
+	verifyCLIPluginCRDReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	WaitForAVIResourceCleanUpStub        func(string, string) error
 	waitForAVIResourceCleanUpMutex       sync.RWMutex
 	waitForAVIResourceCleanUpArgsForCall []struct {
@@ -5677,6 +5689,62 @@ func (fake *ClusterClient) UseContextReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *ClusterClient) VerifyCLIPluginCRD() (bool, error) {
+	fake.verifyCLIPluginCRDMutex.Lock()
+	ret, specificReturn := fake.verifyCLIPluginCRDReturnsOnCall[len(fake.verifyCLIPluginCRDArgsForCall)]
+	fake.verifyCLIPluginCRDArgsForCall = append(fake.verifyCLIPluginCRDArgsForCall, struct {
+	}{})
+	stub := fake.VerifyCLIPluginCRDStub
+	fakeReturns := fake.verifyCLIPluginCRDReturns
+	fake.recordInvocation("VerifyCLIPluginCRD", []interface{}{})
+	fake.verifyCLIPluginCRDMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ClusterClient) VerifyCLIPluginCRDCallCount() int {
+	fake.verifyCLIPluginCRDMutex.RLock()
+	defer fake.verifyCLIPluginCRDMutex.RUnlock()
+	return len(fake.verifyCLIPluginCRDArgsForCall)
+}
+
+func (fake *ClusterClient) VerifyCLIPluginCRDCalls(stub func() (bool, error)) {
+	fake.verifyCLIPluginCRDMutex.Lock()
+	defer fake.verifyCLIPluginCRDMutex.Unlock()
+	fake.VerifyCLIPluginCRDStub = stub
+}
+
+func (fake *ClusterClient) VerifyCLIPluginCRDReturns(result1 bool, result2 error) {
+	fake.verifyCLIPluginCRDMutex.Lock()
+	defer fake.verifyCLIPluginCRDMutex.Unlock()
+	fake.VerifyCLIPluginCRDStub = nil
+	fake.verifyCLIPluginCRDReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ClusterClient) VerifyCLIPluginCRDReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.verifyCLIPluginCRDMutex.Lock()
+	defer fake.verifyCLIPluginCRDMutex.Unlock()
+	fake.VerifyCLIPluginCRDStub = nil
+	if fake.verifyCLIPluginCRDReturnsOnCall == nil {
+		fake.verifyCLIPluginCRDReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.verifyCLIPluginCRDReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *ClusterClient) WaitForAVIResourceCleanUp(arg1 string, arg2 string) error {
 	fake.waitForAVIResourceCleanUpMutex.Lock()
 	ret, specificReturn := fake.waitForAVIResourceCleanUpReturnsOnCall[len(fake.waitForAVIResourceCleanUpArgsForCall)]
@@ -6517,6 +6585,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.updateVsphereIdentityRefSecretMutex.RUnlock()
 	fake.useContextMutex.RLock()
 	defer fake.useContextMutex.RUnlock()
+	fake.verifyCLIPluginCRDMutex.RLock()
+	defer fake.verifyCLIPluginCRDMutex.RUnlock()
 	fake.waitForAVIResourceCleanUpMutex.RLock()
 	defer fake.waitForAVIResourceCleanUpMutex.RUnlock()
 	fake.waitForAutoscalerDeploymentMutex.RLock()

--- a/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
+++ b/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
@@ -27,6 +27,7 @@ import (
 	cabpkv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
+	"github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
 	tkgsv1alpha2 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
@@ -576,4 +577,18 @@ func GetFakePinnipedInfo(pinnipedInfo PinnipedInfo) string {
 	}`
 	pinnipedInfoJSON = fmt.Sprintf(pinnipedInfoJSON, string(data))
 	return pinnipedInfoJSON
+}
+
+// NewCLIPlugin returns new NewCLIPlugin object
+func NewCLIPlugin(options TestCLIPluginOption) v1alpha1.CLIPlugin {
+	cliplugin := v1alpha1.CLIPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: options.Name,
+		},
+		Spec: v1alpha1.CLIPluginSpec{
+			Description:        options.Description,
+			RecommendedVersion: options.RecommendedVersion,
+		},
+	}
+	return cliplugin
 }

--- a/pkg/v1/tkg/fakes/helper/types.go
+++ b/pkg/v1/tkg/fakes/helper/types.go
@@ -139,3 +139,10 @@ type TestMachineHealthCheckOption struct {
 	Namespace   string
 	ClusterName string
 }
+
+// TestCLIPluginOption describes options for CLIPlugin
+type TestCLIPluginOption struct {
+	Name               string
+	Description        string
+	RecommendedVersion string
+}


### PR DESCRIPTION
### What this PR does / why we need it

- When Tanzu CLI is used to talk with old management-cluster where the
  CLIPlugin CRD is not available, currently, it throws an error/warning
  a message with each `tanzu plugin` command if a user is logged in to a
  cluster
- This change fixes the issue by verifying the presence of CRD before
  querying for available plugins

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1392

### Describe testing done for PR
- Manual testing was done by testing the `tanzu plugin` command against v1.4.0 as well as v1.5.0 clusters.
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix error/warning displayed when CLIPlugin CRD is not installed with `tanzu plugin` commands
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
