### PR TITLE
Fix validation for autoscaler deployment

### DIFF
--- a/pkg/v1/tkg/client/create_test.go
+++ b/pkg/v1/tkg/client/create_test.go
@@ -143,7 +143,7 @@ spec:
 				os.Setenv(constants.ConfigVariableEnableAutoscaler, "true")
 			})
 
-			It("should not wait for autoscaler deployment", func() {
+			It("should wait for autoscaler deployment", func() {
 				Expect(clusterClient.WaitForAutoscalerDeploymentCallCount()).To(Equal(1))
 			})
 		})

--- a/pkg/v1/tkg/client/create_test.go
+++ b/pkg/v1/tkg/client/create_test.go
@@ -4,6 +4,7 @@
 package client_test
 
 import (
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -112,6 +113,38 @@ spec:
 			It("kube config bytes are returned", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(kubeConfigBytes).To(Equal([]byte("fake kubeconfig data")))
+			})
+		})
+	})
+
+	Describe("WaitForAutoscalerDeployment", func() {
+		JustBeforeEach(func() {
+			tkgClient.WaitForAutoscalerDeployment(clusterClient, name, constants.DefaultNamespace)
+		})
+
+		Context("When the value for config variable 'ENABLE_AUTOSCALER' is not set", func() {
+			It("should not wait for autoscaler deployment", func() {
+				Expect(clusterClient.WaitForAutoscalerDeploymentCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("When the value for config variable 'ENABLE_AUTOSCALER' is set to 'false'", func() {
+			BeforeEach(func() {
+				os.Setenv(constants.ConfigVariableEnableAutoscaler, "false")
+			})
+
+			It("should not wait for autoscaler deployment", func() {
+				Expect(clusterClient.WaitForAutoscalerDeploymentCallCount()).To(Equal(0))
+			})
+		})
+
+		Context("When the value for config variable 'ENABLE_AUTOSCALER' is set to 'true'", func() {
+			BeforeEach(func() {
+				os.Setenv(constants.ConfigVariableEnableAutoscaler, "true")
+			})
+
+			It("should not wait for autoscaler deployment", func() {
+				Expect(clusterClient.WaitForAutoscalerDeploymentCallCount()).To(Equal(1))
 			})
 		})
 	})


### PR DESCRIPTION
### What this PR does / why we need it
Skip checking for autoscaler deployment, if cluster is created without autoscaler.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1397

### Describe testing done for PR
1. Created a cluster by setting 'ENABLE_AUTOSCALER=false' and made sure that the CLI does not wait for autoscaler.
2. Created a cluster by setting 'ENABLE_AUTOSCALER=true' and made sure that the CLI waits for autoscaler.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Skip checking for autoscaler deployment, if cluster is created without autoscaler.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
