### PR TITLE
Run all lint checks as part of the lint Action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -83,26 +83,18 @@ jobs:
         make configure-bom
         make test
 
-  golangci-lint:
+  check:
     name: Lint
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        working-directory:
-          - ""
-          - addons
-          - addons/pinniped/post-deploy
-          - pkg/v1/providers/tests
     steps:
     - uses: actions/checkout@v2
 
-    - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v2
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
       with:
-        version: v1.43.0
-        args: --timeout=10m -v
-        working-directory: ${{matrix.working-directory}}
+        go-version: '1.16'
+      id: go
 
-    - name: Run vale doc linter
+    - name: Run lint checks
       run: |
-        make doc-lint
+        make lint

--- a/Makefile
+++ b/Makefile
@@ -511,8 +511,8 @@ lint: tools go-lint doc-lint ## Run linting checks
 	hack/check-license.sh
 
 go-lint: tools ## Run linting of go source
-	# Linter runs per module, add each one here and make sure they match
-	# in .github/workflows/main.yaml for CI coverage
+	# Linter runs per module, add each one here. Basically, and path
+	# that contains a go.mod file.
 
 	# Linting for the addons...
 	$(GOLANGCI_LINT) run -v

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Inspired by - https://github.com/vmware-tanzu/community-edition/blob/main/hack/install.sh

--- a/hack/test-release-artifacts.sh
+++ b/hack/test-release-artifacts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021 VMware Tanzu Community Edition contributors. All Rights Reserved.
+# Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Script to test release artifacts on MacOS and Linux OS


### PR DESCRIPTION
### What this PR does / why we need it

The current GitHub Action for linting only runs golangci-lint and the
doc-lint target on the matrix of local package paths. We have additional
linting checks that need to be run like the check for license headers.

The current state also requires providing the paths to each local module
in both the Makefile target and the Action definition.

To make this simpler and make sure all of our defined lint checks are
run, this updates the linting Action definition to just call our `make
lint` target so everything is controlled from the one place.

This also addresses a couple licence header issues that were identified
by running the full lint check.

### Describe testing done for PR

Ran `make lint` locally and made sure output showed everything was being run and there were no issues.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```