### PR TITLE
Handle `context-aware-cli-for-plugin` feature flag with `tanzu init` …

### DIFF
--- a/pkg/v1/cli/command/core/update.go
+++ b/pkg/v1/cli/command/core/update.go
@@ -4,6 +4,7 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -14,6 +15,7 @@ import (
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 )
 
 var yesUpdate bool
@@ -31,6 +33,10 @@ var updateCmd = &cobra.Command{
 		"group": string(cliv1alpha1.SystemCmdGroup),
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if config.IsFeatureActivated(config.FeatureContextAwareCLIForPlugins) {
+			return errors.New("CLI self-update is currently not supported. For updating plugins please use the `tanzu plugin sync` command")
+		}
+
 		// clean the catalog cache when updating the cli
 		if err := cli.CleanCatalogCache(); err != nil {
 			log.Debugf("Failed to clean the Plugin descriptors cache %v", err)


### PR DESCRIPTION
…and `tanzu update` commands

### What this PR does / why we need it

- `tanzu init` will sync/update all available plugins for the user based on `context-aware-cli-for-plugin` feature
- `tanzu update` command is not supported when `context-aware-cli-for-plugin` feature flag is enabled. This is to avoid relying on the GCP bucket to download the core and plugin binaries as we don't want to rely on the GCP bucket when `context-aware-cli-for-plugins` feature flag is enabled.
- 
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1411

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix `tanzu init` and `tanzu update` command not respecting `context-aware-cli-for-plugins` feature flag
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
