### PR TITLE
Enable CSI topology feature for K8S 1.22 and above

### DIFF
--- a/pkg/v1/providers/ytt/02_addons/csi/csi_addon_data.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/csi/csi_addon_data.lib.yaml
@@ -1,5 +1,26 @@
 #@ load("@ytt:data", "data")
+#@ load("@ytt:assert", "assert")
 #@ load("/lib/helpers.star", "get_bom_data_for_tkr_name", "get_image_repo_for_component", "get_no_proxy")
+
+
+#! `topology-catogories` label is only available in CSI 2.4 and newer
+#! Set enableTopologyCatogories to be true for TKR 1.22 and newer
+#@ def enableTopologyCatogories():
+#@ bomData = get_bom_data_for_tkr_name()
+#@ elements = bomData.release.version.split(".")
+#@ if len(elements) < 3 or not elements[0].startswith("v"):
+#@    assert.fail("Failed to parse TKR version for CSI package")
+#@ end
+#@ major = int(elements[0][1:])
+#@ minor = int(elements[1])
+#@ if major > 1:
+#@    return True
+#@ end
+#@ if major == 1 and minor >= 22:
+#@    return True
+#@ end
+#@    return False
+#@ end
 
 #@ def vsphere_csi_data_values():
 #@ bomData = get_bom_data_for_tkr_name()
@@ -56,6 +77,7 @@ vsphereCSI:
   http_proxy: #@ data.values.TKG_HTTP_PROXY
   https_proxy: #@ data.values.TKG_HTTPS_PROXY
   no_proxy: #@ get_no_proxy()
+  useTopologyCategories: #@ enableTopologyCatogories()
   #@ if data.values.CLUSTER_PLAN == "dev":
   deployment_replicas: 1
   #@ else:


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

### What this PR does / why we need it

CSI 2.4 introduced a ned label `topology-categories` that is not available in previous release, and it also can't be used in upgrade case when CSI enbaled beta multi-AZ feature before.

Only enable this `topology-categories` CSI feature in fresh install of K8S 1.22 and above. (K8S below 1.22 doesn't use CSI 2.4)

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes # CSI 2.4 multi-AZ feature upgrade issue

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
- [x] Manual testing
- [ ] Downstream pipeline

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
CSI package fixes the upgrade issue for multi-AZ topology feature.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
