### PR TITLE
Add Support for REST based Discovery and GCP URI artifacts for CLI plugin discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-containerregistry v0.6.0
 	github.com/googleapis/gnostic v0.5.5
+	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
 	github.com/gosuri/uitable v0.0.4
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0

--- a/pkg/v1/cli/artifact/gcp.go
+++ b/pkg/v1/cli/artifact/gcp.go
@@ -14,14 +14,18 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/common"
 )
 
-// GCPArtifact provides a Google Cloud Storage bucket with an optional base path (or
-// object prefix).
+const (
+	uriSchemeGCP = "gcp"
+)
+
+// GCPArtifact provides an artifact stored in Google Cloud Storage.
+// Sample URI: gcp://tanzu-plugins/darwin/amd64/cli/login/v0.10.0-dev/tanzu-login-darwin_amd64
 type GCPArtifact struct {
 	// Bucket is a Google Cloud Storage bucket.
-	// E.g., tanzu-cli
+	// E.g., tanzu-plugins
 	Bucket string `json:"bucket"`
-	// ArtifactPath is a URI path that is prefixed to the object name/path.
-	// E.g., plugins/cluster
+	// ArtifactPath is a URI path that points to an object in the bucket.
+	// E.g., darwin/amd64/cli/login/v0.10.0-dev/tanzu-login-darwin_amd64
 	ArtifactPath string `json:"basePath"`
 }
 

--- a/pkg/v1/cli/artifact/interface.go
+++ b/pkg/v1/cli/artifact/interface.go
@@ -5,6 +5,11 @@
 // from different sources
 package artifact
 
+import (
+	"net/url"
+	"path/filepath"
+)
+
 // Artifact is an interface to download a single plugin binary.
 type Artifact interface {
 	// Fetch the binary for a plugin version.
@@ -12,7 +17,19 @@ type Artifact interface {
 }
 
 // NewURIArtifact creates new artifacts based on the URI
-func NewURIArtifact(uri string) Artifact {
+func NewURIArtifact(uri string) (Artifact, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	switch u.Scheme {
+	case uriSchemeGCP:
+		return NewGCPArtifact(u.Host, u.Path), nil
+	case uriSchemeLocal:
+		return NewLocalArtifact(filepath.Join(u.Host, u.Path)), nil
 	// TODO: Support other artifact types
-	return NewLocalArtifact(uri)
+	default:
+		return NewLocalArtifact(uri), nil
+	}
 }

--- a/pkg/v1/cli/artifact/local.go
+++ b/pkg/v1/cli/artifact/local.go
@@ -12,7 +12,12 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/common"
 )
 
-// LocalArtifact defines local artifact path
+const (
+	uriSchemeLocal = "file"
+)
+
+// LocalArtifact defines local artifact path.
+// Sample URI: file://home/user/workspace/tanzu-framework/artifacts/darwin/amd64/cli/login/v0.10.0-dev/tanzu-login-darwin_amd64
 type LocalArtifact struct {
 	// Path is path to local binary artifact
 	// if path is not an absolute path search under

--- a/pkg/v1/cli/discovery/interface.go
+++ b/pkg/v1/cli/discovery/interface.go
@@ -41,6 +41,8 @@ func CreateDiscoveryFromV1alpha1(pd v1alpha1.PluginDiscovery) (Discovery, error)
 		return NewLocalDiscovery(pd.Local.Name, pd.Local.Path), nil
 	case pd.Kubernetes != nil:
 		return NewKubernetesDiscovery(pd.Kubernetes.Name, pd.Kubernetes.Path, pd.Kubernetes.Context), nil
+	case pd.REST != nil:
+		return NewRESTDiscovery(pd.REST.Name, pd.REST.Endpoint, pd.REST.BasePath), nil
 	}
 	return nil, errors.New("unknown plugin discovery source")
 }

--- a/pkg/v1/cli/discovery/interface_test.go
+++ b/pkg/v1/cli/discovery/interface_test.go
@@ -56,4 +56,13 @@ func Test_CreateDiscoveryFromV1alpha1(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(common.DiscoveryTypeKubernetes, discovery.Type())
 	assert.Equal("fake-k8s", discovery.Name())
+
+	// When REST discovery is provided
+	pd = v1alpha1.PluginDiscovery{
+		REST: &v1alpha1.GenericRESTDiscovery{Name: "fake-rest"},
+	}
+	discovery, err = CreateDiscoveryFromV1alpha1(pd)
+	assert.Nil(err)
+	assert.Equal(common.DiscoveryTypeREST, discovery.Type())
+	assert.Equal("fake-rest", discovery.Name())
 }

--- a/pkg/v1/cli/discovery/kubernetes.go
+++ b/pkg/v1/cli/discovery/kubernetes.go
@@ -91,7 +91,10 @@ func (k *KubernetesDiscovery) GetDiscoveredPlugins(clusterClient clusterclient.C
 
 	// Convert all CLIPlugin resources to Discovered object
 	for i := range cliplugins {
-		dp := DiscoveredFromK8sV1alpha1(&cliplugins[i])
+		dp, err := DiscoveredFromK8sV1alpha1(&cliplugins[i])
+		if err != nil {
+			return nil, err
+		}
 		dp.Source = k.name
 		dp.DiscoveryType = k.Type()
 		plugins = append(plugins, dp)

--- a/pkg/v1/cli/discovery/oci.go
+++ b/pkg/v1/cli/discovery/oci.go
@@ -93,7 +93,10 @@ func processDiscoveryManifestData(data []byte, discoveryName string) ([]plugin.D
 			return nil, errors.Wrap(err, "could not decode discovery manifests")
 		}
 
-		dp := DiscoveredFromK8sV1alpha1(&p)
+		dp, err := DiscoveredFromK8sV1alpha1(&p)
+		if err != nil {
+			return nil, err
+		}
 		dp.Source = discoveryName
 		dp.DiscoveryType = common.DiscoveryTypeOCI
 		if dp.Name != "" {

--- a/pkg/v1/cli/discovery/rest.go
+++ b/pkg/v1/cli/discovery/rest.go
@@ -1,0 +1,193 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/Masterminds/semver"
+
+	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/common"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/distribution"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/plugin"
+)
+
+var defaultTimeout = 5 * time.Second
+
+// Plugin contains information about a Tanzu CLI plugin discovered via a REST API.
+type Plugin struct {
+	// Name of the plugin.
+	Name string `json:"name"`
+
+	// Description is the plugin's description.
+	Description string `json:"description"`
+
+	// Recommended version that Tanzu CLI should use if available.
+	// The value should be a valid semantic version as defined in
+	// https://semver.org/. E.g., 2.0.1
+	RecommendedVersion string `json:"recommendedVersion"`
+
+	// Artifacts contains an artifact list for every supported version.
+	Artifacts map[string]cliv1alpha1.ArtifactList `json:"artifacts"`
+
+	// Optional specifies whether the plugin is mandatory or optional
+	// If optional, the plugin will not get auto-downloaded as part of
+	// `tanzu login` or `tanzu plugin sync` command
+	// To view the list of plugin, user can use `tanzu plugin list` and
+	// to download a specific plugin run, `tanzu plugin install <plugin-name>`
+	Optional bool `json:"optional"`
+}
+
+// DescribePluginResponse defines the response from Describe Plugin API.
+type DescribePluginResponse struct {
+	Plugin Plugin `json:"plugin"`
+}
+
+// ListPluginsResponse defines the response from List Plugins API.
+type ListPluginsResponse struct {
+	Plugins []Plugin `json:"plugins"`
+}
+
+// RESTDiscovery is an artifact discovery utilizing CLIPlugin API in kubernetes cluster
+type RESTDiscovery struct {
+	// name of the discovery.
+	name string
+	// endpoint is the REST API server endpoint.
+	// E.g., api.my-domain.local
+	endpoint string
+	// basePath is the base URL path of the plugin discovery API.
+	// E.g., /v1alpha1/cli/plugins
+	basePath string
+	// client is the HTTP client used to make the REST API call.
+	client *http.Client
+}
+
+// NewRESTDiscovery returns a new kubernetes repository
+func NewRESTDiscovery(name, endpoint, basePath string) Discovery {
+	return &RESTDiscovery{
+		name:     name,
+		endpoint: endpoint,
+		basePath: basePath,
+		client:   http.DefaultClient,
+	}
+}
+func (d *RESTDiscovery) doRequest(req *http.Request, v interface{}) error {
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Accept", "application/json; charset=utf-8")
+
+	res, err := d.client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("API error, status code: %d", res.StatusCode)
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(v); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// List available plugins.
+func (d *RESTDiscovery) List() ([]plugin.Discovered, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s", d.endpoint, d.basePath), http.NoBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var res ListPluginsResponse
+	if err := d.doRequest(req, &res); err != nil {
+		return nil, err
+	}
+
+	// Convert all CLIPlugin resources to Discovered object
+	plugins := make([]plugin.Discovered, 0)
+	for i := range res.Plugins {
+		dp, err := DiscoveredFromREST(&res.Plugins[i])
+		if err != nil {
+			return nil, err
+		}
+		dp.Source = d.name
+		plugins = append(plugins, dp)
+	}
+
+	return plugins, nil
+}
+
+// Describe a plugin.
+func (d *RESTDiscovery) Describe(name string) (p plugin.Discovered, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s/%s", d.endpoint, d.basePath, name), http.NoBody)
+	if err != nil {
+		return p, err
+	}
+
+	var res DescribePluginResponse
+	if err := d.doRequest(req, &res); err != nil {
+		return p, err
+	}
+
+	// Convert the CLIPlugin resource to Discovered object
+	p, err = DiscoveredFromREST(&res.Plugin)
+	if err != nil {
+		return p, err
+	}
+	p.Source = d.name
+
+	return p, nil
+}
+
+// Name of the repository.
+func (d *RESTDiscovery) Name() string {
+	return d.name
+}
+
+// Type of the repository.
+func (d *RESTDiscovery) Type() string {
+	return common.DiscoveryTypeREST
+}
+
+// DiscoveredFromREST returns discovered plugin object from a REST API.
+func DiscoveredFromREST(p *Plugin) (plugin.Discovered, error) {
+	dp := plugin.Discovered{
+		Name:               p.Name,
+		Description:        p.Description,
+		RecommendedVersion: p.RecommendedVersion,
+		Optional:           p.Optional,
+	}
+	dp.SupportedVersions = make([]string, 0)
+	for v := range p.Artifacts {
+		dp.SupportedVersions = append(dp.SupportedVersions, v)
+	}
+
+	// sort the supported versions in semver 2.0 order
+	vs := make([]*semver.Version, len(dp.SupportedVersions))
+	for i, r := range dp.SupportedVersions {
+		v, err := semver.NewVersion(r)
+		if err != nil {
+			return dp, fmt.Errorf("error parsing supported versions for plugin %s: %s", p.Name, err)
+		}
+		vs[i] = v
+	}
+	sort.Sort(semver.Collection(vs))
+
+	dp.Distribution = distribution.ArtifactsFromK8sV1alpha1(p.Artifacts)
+	return dp, nil
+}

--- a/pkg/v1/cli/discovery/rest_test.go
+++ b/pkg/v1/cli/discovery/rest_test.go
@@ -1,0 +1,166 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+
+	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
+	plugin2 "github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/plugin"
+)
+
+const (
+	basePath = "/v1alpha1/cli/plugins"
+)
+
+var (
+	pluginFoo = Plugin{
+		Name:               "foo",
+		Description:        "A plugin for Foo",
+		RecommendedVersion: "1.0.0",
+		Artifacts: map[string]cliv1alpha1.ArtifactList{
+			"0.0.1": {
+				{
+					URI:    "https://storage.googleapis.com/storage/v1/b/tanzu-plugins/o/foo-0.0.1-darwin-amd64",
+					Digest: "test digest",
+					OS:     "darwin",
+					Arch:   "amd64",
+				},
+				{
+					URI:    "https://storage.googleapis.com/storage/v1/b/tanzu-plugins/o/foo-0.0.1-linux-amd64",
+					Digest: "test digest",
+					OS:     "linux",
+					Arch:   "amd64",
+				},
+				{
+					URI:    "https://storage.googleapis.com/storage/v1/b/tanzu-plugins/o/foo-0.0.1-windows-amd64.exe",
+					Digest: "test digest",
+					OS:     "windows",
+					Arch:   "amd64",
+				},
+			},
+			"1.0.0": {
+				{
+					URI:    "https://storage.googleapis.com/storage/v1/b/tanzu-plugins/o/foo-1.0.0-darwin-amd64",
+					Digest: "test digest",
+					OS:     "darwin",
+					Arch:   "amd64",
+				},
+				{
+					URI:    "https://storage.googleapis.com/storage/v1/b/tanzu-plugins/o/foo-1.0.0-linux-amd64",
+					Digest: "test digest",
+					OS:     "linux",
+					Arch:   "amd64",
+				},
+				{
+					URI:    "https://storage.googleapis.com/storage/v1/b/tanzu-plugins/o/foo-1.0.0-windows-amd64.exe",
+					Digest: "test digest",
+					OS:     "windows",
+					Arch:   "amd64",
+				},
+			},
+		},
+		Optional: false,
+	}
+	pluginBar = Plugin{
+		Name:               "bar",
+		Description:        "A plugin for Bar",
+		RecommendedVersion: "0.0.1",
+		Artifacts: map[string]cliv1alpha1.ArtifactList{
+			"0.0.1": {
+				{
+					URI:    "https://storage.googleapis.com/storage/v1/b/tanzu-plugins/o/bar-0.0.1-darwin-amd64",
+					Digest: "test digest",
+					OS:     "darwin",
+					Arch:   "amd64",
+				},
+				{
+					URI:    "https://storage.googleapis.com/storage/v1/b/tanzu-plugins/o/bar-0.0.1-linux-amd64",
+					Digest: "test digest",
+					OS:     "linux",
+					Arch:   "amd64",
+				},
+				{
+					URI:    "https://storage.googleapis.com/storage/v1/b/tanzu-plugins/o/bar-0.0.1-windows-amd64.exe",
+					Digest: "test digest",
+					OS:     "windows",
+					Arch:   "amd64",
+				},
+			},
+		},
+		Optional: true,
+	}
+	plugins = []Plugin{pluginFoo, pluginBar}
+)
+
+func createTestServer() *httptest.Server {
+	m := mux.NewRouter()
+	m.HandleFunc(basePath, func(w http.ResponseWriter, _ *http.Request) {
+		res := ListPluginsResponse{plugins}
+		b, err := json.Marshal(res)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+
+		_, err = w.Write(b)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+	m.HandleFunc(fmt.Sprintf("%s/%s", basePath, "{plugin}"), func(w http.ResponseWriter, req *http.Request) {
+		v := mux.Vars(req)
+		name := v["plugin"]
+		var plugin Plugin
+		for _, p := range plugins {
+			if p.Name == name {
+				plugin = p
+				break
+			}
+		}
+		res := DescribePluginResponse{plugin}
+		b, err := json.Marshal(res)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+
+		_, err = w.Write(b)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+	return httptest.NewServer(m)
+}
+
+func TestRESTDiscovery(t *testing.T) {
+	s := createTestServer()
+	defer s.Close()
+
+	d := NewRESTDiscovery("test", s.URL, basePath)
+
+	expList := make([]plugin2.Discovered, len(plugins))
+	for i := range plugins {
+		p, err := DiscoveredFromREST(&plugins[i])
+		assert.NoError(t, err)
+		p.Source = "test"
+		expList[i] = p
+	}
+	actList, err := d.List()
+	assert.NoError(t, err)
+	assert.Equal(t, expList, actList)
+
+	plugin, err := d.Describe("foo")
+	assert.NoError(t, err)
+	assert.Equal(t, expList[0], plugin)
+
+	plugin, err = d.Describe("bar")
+	assert.NoError(t, err)
+	assert.Equal(t, expList[1], plugin)
+}

--- a/pkg/v1/cli/distribution/artifact.go
+++ b/pkg/v1/cli/distribution/artifact.go
@@ -69,7 +69,11 @@ func (aMap Artifacts) Fetch(version, os, arch string) ([]byte, error) {
 		return artifact.NewOCIArtifact(a.Image).Fetch()
 	}
 	if a.URI != "" {
-		return artifact.NewURIArtifact(a.URI).Fetch()
+		u, err := artifact.NewURIArtifact(a.URI)
+		if err != nil {
+			return nil, err
+		}
+		return u.Fetch()
 	}
 
 	return nil, errors.Errorf("invalid artifact for version:%s, os:%s, "+


### PR DESCRIPTION
### What this PR does / why we need it

### Which issue(s) this PR fixes
Fixes #1357

### Describe testing done for PR
Added unit tests

### Release note
```release-note
Add Support for REST based Discovery and GCP URI artifacts for CLI plugin discovery
```

### PR Checklist
- [x] Squash the commits into one or a small number of logical commits
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access

### Additional information

#### Special notes for your reviewer
The integration of the REST discovery in global server context will follow later.