### PR TITLE
Fix file count error returned by OCIArtifact.Fetch

### DIFF
--- a/pkg/v1/cli/artifact/oci_test.go
+++ b/pkg/v1/cli/artifact/oci_test.go
@@ -1,0 +1,35 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package artifact
+
+import (
+	"testing"
+)
+
+func TestOCIArtifactWhenMultipleFilesFound(t *testing.T) {
+	expectedImageName := "foo"
+	artifact := NewOCIArtifact(expectedImageName)
+	o, _ := artifact.(*OCIArtifact)
+	o.getFilesMapFromImage = func(s string) (map[string][]byte, error) {
+		if s != expectedImageName {
+			t.Fatalf("Unexpected image in call to get files map. Expected '%s', got '%s'", expectedImageName, s)
+		}
+
+		// Return a fake map with 2 files.
+		return map[string][]byte{
+			"file1": nil,
+			"file2": nil,
+		}, nil
+	}
+
+	data, err := o.Fetch()
+
+	if len(data) != 0 {
+		t.Fatalf("Expected to receive a nil map, got '%+v'", data)
+	}
+
+	expectedErrorMessage := "oci artifact image for plugin is required to have only 1 file, but found 2"
+	if err.Error() != expectedErrorMessage {
+		t.Fatalf("Did not receive the expected error message. Expected '%s', got '%s'", expectedErrorMessage, err.Error())
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it

When the OCI bundle for a CLI plugin contains several files, the OCIArtifact.Fethc()
method bails out (as it only expects one file).

Since errors.Wrapf returns nil if the err passed in was nil, this would
manifest as a (nil []byte, nil error) return from the Fetch() function,
and the plugin installation would end up writing an empty file to disk,
finally leading to a failed plugin installation when the 'info'
subcommand was executed, but with no obvious error message about why.

### Which issue(s) this PR fixes

Omitted, I considered this a trivial fix.

### Describe testing done for PR

Added a unit test for this case.

`make test` succeeded.

### Release note

N/A

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

To add tests, I extended the OCIArtifact struct to allow injecting the Carvel helper
function to construct the file map.

#### Special notes for your reviewer

N/A