### PR TITLE
Fix the race condition in spinner caused by active() check

### DIFF
--- a/cmd/cli/plugin/package/display_utils.go
+++ b/cmd/cli/plugin/package/display_utils.go
@@ -33,9 +33,7 @@ func DisplayProgress(initialMsg string, pp *tkgpackagedatamodel.PackageProgress)
 	}
 
 	writeProgressToSpinner := func(s *spinner.Spinner, msg string) error {
-		if s.Active() {
-			s.Stop()
-		}
+		s.Stop()
 		if s, err = newSpinner(); err != nil {
 			return err
 		}
@@ -48,9 +46,7 @@ func DisplayProgress(initialMsg string, pp *tkgpackagedatamodel.PackageProgress)
 	s.Suffix = fmt.Sprintf(" %s", initialMsg)
 	s.Start()
 	defer func() {
-		if s.Active() {
-			s.Stop()
-		}
+		s.Stop()
 	}()
 	for {
 		select {


### PR DESCRIPTION
### What this PR does / why we need it
s.Active() doesn't have a mutex lock in it's implementation, so it will introduce race condition. Causing redundant new lines in the output.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
Tested the package plugin with a local build

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Bug fix: fix erase of previous progress messages and redundant new lines in package plugin output
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
