### PR TITLE
Remove bold formatting from table output

### DIFF
--- a/pkg/v1/cli/component/output.go
+++ b/pkg/v1/cli/component/output.go
@@ -220,11 +220,6 @@ func renderTable(ow *outputwriter) {
 	table.SetColWidth(colWidth)
 	table.SetTablePadding("\t\t")
 	table.SetHeader(ow.keys)
-	colors := []tablewriter.Colors{}
-	for range ow.keys {
-		colors = append(colors, []int{tablewriter.Bold})
-	}
-	table.SetHeaderColor(colors...)
 	table.AppendBulk(ow.values)
 	table.Render()
 }


### PR DESCRIPTION
### What this PR does / why we need it

The current output formatting for table output bolds the header text.
This has been shown to cause issues when running commands under the
`watch` command or in environments where the terminal is not a full tty.

This change removes the bold formatting. Many other command lines that
emit table output, such as kubectl, do not bold the headers. So the
easiest solution for us is to just stop doing so.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Related: #352 
Related: #1066 
Related: https://github.com/vmware-tanzu/community-edition/pull/2376#issuecomment-1009002218

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Ran local tests.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Header lines in table output will no longer be formatted bold.
```