### PR TITLE
Configure TKG_HTTP_PROXY_ENABLED variable if proxy is set during upgrade

### DIFF
--- a/pkg/v1/tkg/client/upgrade_addon.go
+++ b/pkg/v1/tkg/client/upgrade_addon.go
@@ -327,6 +327,7 @@ func (c *TkgClient) setProxyConfiguration(clusterClusterClient clusterclient.Cli
 
 	if httpProxy := configmap.Data["httpProxy"]; httpProxy != "" {
 		c.TKGConfigReaderWriter().Set(constants.TKGHTTPProxy, httpProxy)
+		c.TKGConfigReaderWriter().Set(constants.TKGHTTPProxyEnabled, trueString)
 	}
 
 	if httpsProxy := configmap.Data["httpsProxy"]; httpsProxy != "" {


### PR DESCRIPTION
- As part of PR https://github.com/vmware-tanzu/tanzu-framework/pull/793
  a validation around this variable was added.
- Configuring this variable during addons upgrade as validation is
  failing the upgrade because of the missing config variable

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1468

### Describe testing done for PR

- Added unit tests around configuring `TKG_HTTP_PROXY_ENABLED` during ugprade
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix cluster upgrade failure error for proxied environment related to config variable `TKG_HTTP_PROXY_ENABLED` not set
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
