### PR TITLE
default to the correct cidrs for KinD for ipv6,ipv4

### DIFF
--- a/pkg/v1/tkg/fakes/config/config_ipv6_ipv4.yaml
+++ b/pkg/v1/tkg/fakes/config/config_ipv6_ipv4.yaml
@@ -1,0 +1,20 @@
+providers:
+  - name: cluster-api
+    url: providers/cluster-api/v0.0.0/core-components.yaml
+    type: CoreProvider
+  - name: aws
+    url: providers/infrastructure-aws/v0.5.1/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere
+    url: providers/infrastructure-vsphere/v0.6.2/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere-pacific
+    url: providers/infrastructure-tkg-service-vsphere/v1.0.0/unused.yaml
+    type: InfrastructureProvider
+  - name: kubeadm
+    url: providers/bootstrap-kubeadm/v0.3.2/bootstrap-components.yaml
+    type: BootstrapProvider
+  - name: kubeadm
+    url: providers/control-plane-kubeadm/v0.3.2/control-plane-components.yaml
+    type: ControlPlaneProvider
+TKG_IP_FAMILY: "ipv6,ipv4"

--- a/pkg/v1/tkg/kind/client.go
+++ b/pkg/v1/tkg/kind/client.go
@@ -342,7 +342,10 @@ func (k *KindClusterProxy) getKindNetworkingConfig() kindv1.Networking {
 	podSubnet, err := k.options.Readerwriter.Get(constants.ConfigVariableClusterCIDR)
 	if err != nil {
 		switch ipFamily {
-		case constants.DualStackPrimaryIPv4Family:
+		// We expect the IPv4,IPv6 order for the CIDR in both cases for KinD until
+		// we bump to a version of the kind library that includes a fix for this issue:
+		// https://github.com/kubernetes-sigs/kind/issues/2484
+		case constants.DualStackPrimaryIPv4Family, constants.DualStackPrimaryIPv6Family:
 			podSubnet = constants.DefaultDualStackPrimaryIPv4ClusterCIDR
 		case constants.IPv6Family:
 			podSubnet = constants.DefaultIPv6ClusterCIDR
@@ -353,7 +356,10 @@ func (k *KindClusterProxy) getKindNetworkingConfig() kindv1.Networking {
 	serviceSubnet, err := k.options.Readerwriter.Get(constants.ConfigVariableServiceCIDR)
 	if err != nil {
 		switch ipFamily {
-		case constants.DualStackPrimaryIPv4Family:
+		// We expect the IPv4,IPv6 order for the CIDR in both cases for KinD until
+		// we bump to a version of the kind library that includes a fix for this issue:
+		// https://github.com/kubernetes-sigs/kind/issues/2484
+		case constants.DualStackPrimaryIPv4Family, constants.DualStackPrimaryIPv6Family:
 			serviceSubnet = constants.DefaultDualStackPrimaryIPv4ServiceCIDR
 		case constants.IPv6Family:
 			serviceSubnet = constants.DefaultIPv6ServiceCIDR
@@ -384,7 +390,7 @@ func (k *KindClusterProxy) getKindIPFamily() kindv1.ClusterIPFamily {
 		return kindv1.IPv4Family
 	case constants.IPv6Family:
 		return kindv1.IPv6Family
-	case constants.DualStackPrimaryIPv4Family:
+	case constants.DualStackPrimaryIPv4Family, constants.DualStackPrimaryIPv6Family:
 		return kindv1.DualStackFamily
 	default:
 		return ""

--- a/pkg/v1/tkg/kind/client_test.go
+++ b/pkg/v1/tkg/kind/client_test.go
@@ -32,6 +32,7 @@ var (
 	configPathIPv6                        = "../fakes/config/config_ipv6.yaml"
 	configPathIPv4                        = "../fakes/config/config_ipv4.yaml"
 	configPathIPv4IPv6                    = "../fakes/config/config_ipv4_ipv6.yaml"
+	configPathIPv6IPv4                    = "../fakes/config/config_ipv6_ipv4.yaml"
 	configPathCIDR                        = "../fakes/config/config_cluster_service_cidr.yaml"
 	registryHostname                      = "registry.mydomain.com"
 )
@@ -222,6 +223,26 @@ var _ = Describe("Kind Client", func() {
 	Context("When TKG_IP_FAMILY is ipv4,ipv6", func() {
 		BeforeEach(func() {
 			setupTestingFiles(configPathIPv4IPv6, testingDir, defaultBoMFileForTesting)
+			kindClient = buildKindClient()
+			_, kindConfig, err = kindClient.GetKindNodeImageAndConfig()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("generates a config with ipfamily set to dual", func() {
+			Expect(kindConfig.Networking.IPFamily).To(Equal(kindv1.DualStackFamily))
+		})
+
+		Context("When CLUSTER_CIDR and SERVICE_CIDR are not set", func() {
+			It("generates a config with default pod and service subnet", func() {
+				Expect(kindConfig.Networking.PodSubnet).To(Equal("100.96.0.0/11,fd00:100:96::/48"))
+				Expect(kindConfig.Networking.ServiceSubnet).To(Equal("100.64.0.0/13,fd00:100:64::/108"))
+			})
+		})
+	})
+
+	Context("When TKG_IP_FAMILY is ipv6,ipv4", func() {
+		BeforeEach(func() {
+			setupTestingFiles(configPathIPv6IPv4, testingDir, defaultBoMFileForTesting)
 			kindClient = buildKindClient()
 			_, kindConfig, err = kindClient.GetKindNodeImageAndConfig()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### What this PR does / why we need it
When configured for `ipv6,ipv4` dualstack the CLI will now default to the correct CIDRs and IPFamily when creating a KinD bootstrap cluster.

Without this PR users would need to configure the CIDRs or create a bootstrap cluster themselves.

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Unit tests were written to cover the cases.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix issue with automatic bootstrap cluster creation when TKG_IP_FAMILY is set to "ipv6,ipv4"
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
