### PR TITLE
Allow only trusted registries and fix issue regarding installing plugins in internet restricted from OCI source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cheggaaa/pb v1.0.29 // indirect
 	github.com/containerd/containerd v1.5.7 // indirect
+	github.com/containerd/stargz-snapshotter/estargz v0.7.0 // indirect
 	github.com/coredns/caddy v1.1.1 // indirect
 	github.com/coredns/corefile-migration v1.0.13 // indirect
 	github.com/cppforlife/cobrautil v0.0.0-20200514214827-bb86e6965d72 // indirect
@@ -166,6 +167,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.0.0 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
+	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/go-github/v33 v33.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
@@ -180,6 +182,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/k14s/starlark-go v0.0.0-20200720175618-3a5c849cc368 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/klauspost/compress v1.13.0 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-colorable v0.1.11 // indirect

--- a/pkg/v1/cli/carvelhelpers/package.go
+++ b/pkg/v1/cli/carvelhelpers/package.go
@@ -15,7 +15,7 @@ import (
 // Downloads package to temporary directory and processes the package by
 // implementing equivalent functionality as the command: `ytt -f <path> | kbld -f -`
 func ProcessCarvelPackage(image string) ([]byte, error) {
-	configDir, err := ReadImageAndSaveFilesToTempDir(image)
+	configDir, err := DownloadImageBundleAndSaveFilesToTempDir(image)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get resource files from discovery")
 	}

--- a/pkg/v1/cli/distribution/artifact.go
+++ b/pkg/v1/cli/distribution/artifact.go
@@ -90,6 +90,11 @@ func (aMap Artifacts) GetDigest(version, os, arch string) (string, error) {
 	return a.Digest, nil
 }
 
+// DescribeArtifact returns the artifact resource based plugin metadata
+func (aMap Artifacts) DescribeArtifact(version, os, arch string) (Artifact, error) {
+	return aMap.GetArtifact(version, os, arch)
+}
+
 // ArtifactFromK8sV1alpha1 returns Artifact from k8sV1alpha1
 func ArtifactFromK8sV1alpha1(a cliv1alpha1.Artifact) Artifact { //nolint:gocritic
 	return Artifact{

--- a/pkg/v1/cli/distribution/interface.go
+++ b/pkg/v1/cli/distribution/interface.go
@@ -14,4 +14,7 @@ type Distribution interface {
 
 	// GetDigest returns the SHA256 hash of the binary for a plugin version.
 	GetDigest(version, os, arch string) (string, error)
+
+	// DescribeArtifact returns the artifact resource based plugin metadata
+	DescribeArtifact(version, os, arch string) (Artifact, error)
 }

--- a/pkg/v1/config/defaults.go
+++ b/pkg/v1/config/defaults.go
@@ -96,3 +96,28 @@ func GetDefaultStandaloneDiscoveryLocalPath() string {
 	}
 	return DefaultStandaloneDiscoveryLocalPath
 }
+
+// GetTrustedRegistries returns the list of trusted registries that can be used for
+// downloading the CLIPlugins
+func GetTrustedRegistries() []string {
+	trustedRegistries := []string{}
+
+	// Add default registry to trusted registries
+	if DefaultStandaloneDiscoveryRepository != "" {
+		trustedRegistries = append(trustedRegistries, DefaultStandaloneDiscoveryRepository)
+	}
+
+	// If custom image repository is defined add it to the list of trusted registries
+	if customImageRepo := os.Getenv(constants.ConfigVariableCustomImageRepository); customImageRepo != "" {
+		trustedRegistries = append(trustedRegistries, customImageRepo)
+	}
+
+	// If ALLOWED_REGISTRY environment variable is specified, allow those registries as well
+	if allowedRegistry := os.Getenv(constants.AllowedRegistries); allowedRegistry != "" {
+		for _, r := range strings.Split(allowedRegistry, ",") {
+			trustedRegistries = append(trustedRegistries, strings.TrimSpace(r))
+		}
+	}
+
+	return trustedRegistries
+}

--- a/pkg/v1/tkg/constants/env_variables.go
+++ b/pkg/v1/tkg/constants/env_variables.go
@@ -15,3 +15,7 @@ const (
 const (
 	SuppressProvidersUpdate = "SUPPRESS_PROVIDERS_UPDATE"
 )
+
+const (
+	AllowedRegistries = "ALLOWED_REGISTRY"
+)

--- a/pkg/v1/tkr/fakes/registy.go
+++ b/pkg/v1/tkr/fakes/registy.go
@@ -8,6 +8,18 @@ import (
 )
 
 type Registry struct {
+	DownloadBundleStub        func(string, string) error
+	downloadBundleMutex       sync.RWMutex
+	downloadBundleArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	downloadBundleReturns struct {
+		result1 error
+	}
+	downloadBundleReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GetFileStub        func(string, string) ([]byte, error)
 	getFileMutex       sync.RWMutex
 	getFileArgsForCall []struct {
@@ -50,6 +62,68 @@ type Registry struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *Registry) DownloadBundle(arg1 string, arg2 string) error {
+	fake.downloadBundleMutex.Lock()
+	ret, specificReturn := fake.downloadBundleReturnsOnCall[len(fake.downloadBundleArgsForCall)]
+	fake.downloadBundleArgsForCall = append(fake.downloadBundleArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.DownloadBundleStub
+	fakeReturns := fake.downloadBundleReturns
+	fake.recordInvocation("DownloadBundle", []interface{}{arg1, arg2})
+	fake.downloadBundleMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *Registry) DownloadBundleCallCount() int {
+	fake.downloadBundleMutex.RLock()
+	defer fake.downloadBundleMutex.RUnlock()
+	return len(fake.downloadBundleArgsForCall)
+}
+
+func (fake *Registry) DownloadBundleCalls(stub func(string, string) error) {
+	fake.downloadBundleMutex.Lock()
+	defer fake.downloadBundleMutex.Unlock()
+	fake.DownloadBundleStub = stub
+}
+
+func (fake *Registry) DownloadBundleArgsForCall(i int) (string, string) {
+	fake.downloadBundleMutex.RLock()
+	defer fake.downloadBundleMutex.RUnlock()
+	argsForCall := fake.downloadBundleArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *Registry) DownloadBundleReturns(result1 error) {
+	fake.downloadBundleMutex.Lock()
+	defer fake.downloadBundleMutex.Unlock()
+	fake.DownloadBundleStub = nil
+	fake.downloadBundleReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *Registry) DownloadBundleReturnsOnCall(i int, result1 error) {
+	fake.downloadBundleMutex.Lock()
+	defer fake.downloadBundleMutex.Unlock()
+	fake.DownloadBundleStub = nil
+	if fake.downloadBundleReturnsOnCall == nil {
+		fake.downloadBundleReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.downloadBundleReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *Registry) GetFile(arg1 string, arg2 string) ([]byte, error) {
@@ -248,6 +322,8 @@ func (fake *Registry) ListImageTagsReturnsOnCall(i int, result1 []string, result
 func (fake *Registry) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.downloadBundleMutex.RLock()
+	defer fake.downloadBundleMutex.RUnlock()
 	fake.getFileMutex.RLock()
 	defer fake.getFileMutex.RUnlock()
 	fake.getFilesMutex.RLock()

--- a/pkg/v1/tkr/pkg/registry/interface.go
+++ b/pkg/v1/tkr/pkg/registry/interface.go
@@ -14,4 +14,7 @@ type Registry interface {
 	GetFile(imageWithTag string, filename string) ([]byte, error)
 	// GetFiles get all the files content bundled in the given image:tag.
 	GetFiles(imageWithTag string) (map[string][]byte, error)
+	// DownloadBundle downloads OCI bundle similar to `imgpkg pull -b` command
+	// It is recommended to use this function when downloading imgpkg bundle
+	DownloadBundle(imageName, outputDir string) error
 }


### PR DESCRIPTION
### What this PR does / why we need it
- This PR adds verification regarding the source of the OCI image which we are downloading plugin binary.
- This change will only allow registries that are trusted by default or provided with the `ALLOWED_REGISTRY` environment variable.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1504, #1505

### Describe testing done for PR
- Manual testing with different combinations of default registry, custom registry, and allows-registry env variable
- Added unit tests

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Allow only trusted registries when installing plugins from OCI source
Fixed issue regarding installing plugins on internet restricted environment from OCI source
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
