### PR TITLE
Remove patch version check from workload create

### DIFF
--- a/pkg/v1/tkg/client/cluster.go
+++ b/pkg/v1/tkg/client/cluster.go
@@ -720,8 +720,7 @@ func (c *TkgClient) ValidateManagementClusterVersionWithCLI(regionalClusterClien
 	}
 
 	if curMCSemVersion.Major() != defaultTKGSemVersion.Major() ||
-		curMCSemVersion.Minor() != defaultTKGSemVersion.Minor() ||
-		curMCSemVersion.Patch() != defaultTKGSemVersion.Patch() {
+		curMCSemVersion.Minor() != defaultTKGSemVersion.Minor() {
 		return errors.Errorf("version mismatch between management cluster and cli version. Please upgrade your management cluster to the latest to continue")
 	}
 

--- a/pkg/v1/tkg/client/cluster_test.go
+++ b/pkg/v1/tkg/client/cluster_test.go
@@ -1,0 +1,98 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package client_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/region"
+)
+
+var _ = Describe("ValidateManagementClusterVersionWithCLI", func() {
+	const (
+		clusterName = "test-cluster"
+		v140        = "v1.4.0"
+		v141        = "v1.4.1"
+		v150        = "v1.5.0"
+	)
+	var (
+		regionalClient fakes.ClusterClient
+		tkgBomClient   fakes.TKGConfigBomClient
+		regionManager  fakes.RegionManager
+		c              *TkgClient
+		err            error
+	)
+	JustBeforeEach(func() {
+		err = c.ValidateManagementClusterVersionWithCLI(&regionalClient)
+	})
+	BeforeEach(func() {
+		regionManager = fakes.RegionManager{}
+		regionManager.GetCurrentContextReturns(region.RegionContext{
+			ClusterName: clusterName,
+			Status:      region.Success,
+		}, nil)
+
+		regionalClient = fakes.ClusterClient{}
+		regionalClient.ListResourcesStub = func(i interface{}, lo ...client.ListOption) error {
+			list := i.(*v1alpha3.ClusterList)
+			*list = v1alpha3.ClusterList{
+				Items: []v1alpha3.Cluster{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name:      clusterName,
+							Namespace: "default",
+						},
+					},
+				},
+			}
+			return nil
+		}
+
+		c, err = New(Options{
+			TKGConfigUpdater: &fakes.TKGConfigUpdaterClient{},
+			TKGBomClient:     &tkgBomClient,
+			RegionManager:    &regionManager,
+		})
+	})
+	Context("v1.4.0 management cluster", func() {
+		BeforeEach(func() {
+			regionalClient.GetManagementClusterTKGVersionReturns(v140, nil)
+		})
+
+		When("management cluster version matches cli version", func() {
+			BeforeEach(func() {
+				tkgBomClient = fakes.TKGConfigBomClient{}
+				tkgBomClient.GetDefaultTKGReleaseVersionReturns(v140, nil)
+			})
+			It("should validate without error", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("cli version is a patch version ahead of management cluster", func() {
+			BeforeEach(func() {
+				tkgBomClient = fakes.TKGConfigBomClient{}
+				tkgBomClient.GetDefaultTKGReleaseVersionReturns(v141, nil)
+			})
+			It("should validate without error", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("cli version is a minor version ahead of management cluster", func() {
+			BeforeEach(func() {
+				tkgBomClient = fakes.TKGConfigBomClient{}
+				tkgBomClient.GetDefaultTKGReleaseVersionReturns(v150, nil)
+			})
+			It("should return an error", func() {
+				Expect(err).Should(MatchError("version mismatch between management cluster and cli version. Please upgrade your management cluster to the latest to continue"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
Loosens the validation requirement that cli patch version matches the
management cluster version.

### What this PR does / why we need it
This PR allows a tanzu cli to create clusters using a management cluster that does not match the patch version of the cli.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1508 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Loosens version check when creating workload clusters. Management cluster and cli need not match in patch version.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
