### PR TITLE
Fix file count error returned by OCIArtifact.Fetch

### DIFF
--- a/pkg/v1/cli/artifact/oci_test.go
+++ b/pkg/v1/cli/artifact/oci_test.go
@@ -1,0 +1,35 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package artifact
+
+import (
+	"testing"
+)
+
+func TestOCIArtifactWhenMultipleFilesFound(t *testing.T) {
+	expectedImageName := "foo"
+	artifact := NewOCIArtifact(expectedImageName)
+	o, _ := artifact.(*OCIArtifact)
+	o.getFilesMapFromImage = func(s string) (map[string][]byte, error) {
+		if s != expectedImageName {
+			t.Fatalf("Unexpected image in call to get files map. Expected '%s', got '%s'", expectedImageName, s)
+		}
+
+		// Return a fake map with 2 files.
+		return map[string][]byte{
+			"file1": nil,
+			"file2": nil,
+		}, nil
+	}
+
+	data, err := o.Fetch()
+
+	if len(data) != 0 {
+		t.Fatalf("Expected to receive a nil map, got '%+v'", data)
+	}
+
+	expectedErrorMessage := "oci artifact image for plugin is required to have only 1 file, but found 2"
+	if err.Error() != expectedErrorMessage {
+		t.Fatalf("Did not receive the expected error message. Expected '%s', got '%s'", expectedErrorMessage, err.Error())
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it

When the OCI bundle for a CLI plugin contains several files, the OCIArtifact.Fethc()
method bails out (as it only expects one file).

Since errors.Wrapf returns nil if the err passed in was nil, this would
manifest as a (nil []byte, nil error) return from the Fetch() function,
and the plugin installation would end up writing an empty file to disk,
finally leading to a failed plugin installation when the 'info'
subcommand was executed, but with no obvious error message about why.

### Which issue(s) this PR fixes

Omitted, I considered this a trivial fix.

<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

### Describe testing done for PR
Added a unit test for this case.

make test succeeded.


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
N/A

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

To add tests, I extended the OCIArtifact struct to allow injecting the Carvel helper
function to construct the file map.


#### Special notes for your reviewer

This is identical to https://github.com/vmware-tanzu/tanzu-framework/pull/1439 - I reopened it since the CLA bot didn't seem to pick up changes in Github org membership.

N/A

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->


