### PR TITLE
kind: Add TKG_KIND_AUDITING variable to enable kind audit logs Maybe useful in debugging other issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	k8s.io/api v0.22.2
 	k8s.io/apiextensions-apiserver v0.22.2
 	k8s.io/apimachinery v0.22.2
+	k8s.io/apiserver v0.22.2
 	k8s.io/client-go v0.22.2
 	k8s.io/klog/v2 v2.10.0
 	k8s.io/kubectl v0.22.2
@@ -229,7 +230,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.63.2 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	k8s.io/apiserver v0.22.2 // indirect
 	k8s.io/cluster-bootstrap v0.22.2 // indirect
 	k8s.io/component-base v0.22.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20210929172449-94abcedd1aa4 // indirect

--- a/pkg/v1/tkg/constants/config_variables.go
+++ b/pkg/v1/tkg/constants/config_variables.go
@@ -148,6 +148,8 @@ const (
 	ConfigVariableControlPlaneNodeNameservers = "CONTROL_PLANE_NODE_NAMESERVERS"
 	ConfigVariableWorkerNodeNameservers       = "WORKER_NODE_NAMESERVERS"
 
+	ConfigVariableKindAuditing = "TKG_KIND_AUDITING"
+
 	// Below config variables are added based on init and create command flags
 
 	ConfigVariableClusterPlan             = "CLUSTER_PLAN"

--- a/pkg/v1/tkg/fakes/config/config_kind_audit.yaml
+++ b/pkg/v1/tkg/fakes/config/config_kind_audit.yaml
@@ -1,0 +1,20 @@
+TKG_KIND_AUDITING: true
+providers:
+  - name: cluster-api
+    url: providers/cluster-api/v0.0.0/core-components.yaml
+    type: CoreProvider
+  - name: aws
+    url: providers/infrastructure-aws/v0.5.1/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere
+    url: providers/infrastructure-vsphere/v0.6.2/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere-pacific
+    url: providers/infrastructure-tkg-service-vsphere/v1.0.0/unused.yaml
+    type: InfrastructureProvider
+  - name: kubeadm
+    url: providers/bootstrap-kubeadm/v0.3.2/bootstrap-components.yaml
+    type: BootstrapProvider
+  - name: kubeadm
+    url: providers/control-plane-kubeadm/v0.3.2/control-plane-components.yaml
+    type: ControlPlaneProvider

--- a/pkg/v1/tkg/fakes/config/config_kind_audit_false.yaml
+++ b/pkg/v1/tkg/fakes/config/config_kind_audit_false.yaml
@@ -1,0 +1,20 @@
+TKG_KIND_AUDITING: false
+providers:
+  - name: cluster-api
+    url: providers/cluster-api/v0.0.0/core-components.yaml
+    type: CoreProvider
+  - name: aws
+    url: providers/infrastructure-aws/v0.5.1/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere
+    url: providers/infrastructure-vsphere/v0.6.2/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere-pacific
+    url: providers/infrastructure-tkg-service-vsphere/v1.0.0/unused.yaml
+    type: InfrastructureProvider
+  - name: kubeadm
+    url: providers/bootstrap-kubeadm/v0.3.2/bootstrap-components.yaml
+    type: BootstrapProvider
+  - name: kubeadm
+    url: providers/control-plane-kubeadm/v0.3.2/control-plane-components.yaml
+    type: ControlPlaneProvider

--- a/pkg/v1/tkg/kind/client.go
+++ b/pkg/v1/tkg/kind/client.go
@@ -7,15 +7,22 @@ package kind
 import (
 	"fmt"
 	"os"
+	"path"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/rs/xid"
 	"gopkg.in/yaml.v2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	audit "k8s.io/apiserver/pkg/apis/audit/v1"
+	kubeadmv1beta1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/types/upstreamv1beta1"
 	kindv1 "sigs.k8s.io/kind/pkg/apis/config/v1alpha4"
 	"sigs.k8s.io/kind/pkg/cluster"
 	"sigs.k8s.io/kind/pkg/errors"
+	k8syaml "sigs.k8s.io/yaml"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/clientconfighelpers"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
@@ -30,6 +37,7 @@ const (
 	kindClusterNamePrefix       = "tkg-kind-"
 	kindClusterWaitForReadyTime = 2 * time.Minute
 	kindRegistryCAPath          = "/etc/containerd/tkg-registry-ca.crt"
+	kindAuditPath               = "/tmp/audit"
 )
 
 var (
@@ -37,11 +45,101 @@ var (
 		HostPath:      "/var/run/docker.sock",
 		ContainerPath: "/var/run/docker.sock",
 	}
+
+	auditConfiguration = audit.Policy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "audit.k8s.io/v1",
+			Kind:       "Policy",
+		},
+		OmitStages: []audit.Stage{audit.StageRequestReceived},
+		Rules: []audit.PolicyRule{
+			{
+				Level: audit.LevelRequestResponse,
+				Resources: []audit.GroupResources{
+					{
+						Group:     "",
+						Resources: []string{"pods"},
+					},
+				},
+			},
+			{
+				Level: audit.LevelMetadata,
+				Resources: []audit.GroupResources{
+					{
+						Group:     "",
+						Resources: []string{"pods/logs", "pods/status"},
+					},
+				},
+			},
+			{
+				Level:           audit.LevelNone,
+				UserGroups:      []string{"system:authenticated"},
+				NonResourceURLs: []string{"/api*", "/version"},
+			},
+			{
+				Level:      audit.LevelRequest,
+				Namespaces: []string{"kube-system"},
+				Resources: []audit.GroupResources{
+					{
+						Group:     "",
+						Resources: []string{"configmaps"},
+					},
+				},
+			},
+			{
+				Level: audit.LevelMetadata,
+				Resources: []audit.GroupResources{
+					{
+						Group:     "",
+						Resources: []string{"secrets", "configmaps"},
+					},
+				},
+			},
+			{
+				Level: audit.LevelRequest,
+				Resources: []audit.GroupResources{
+					{
+						Group:     "",
+						Resources: []string{"extensions"},
+					},
+					{
+						Group: "cert-manager.io",
+					},
+				},
+			},
+			{
+				Level:      audit.LevelMetadata,
+				OmitStages: []audit.Stage{audit.StageRequestReceived},
+			},
+		},
+	}
+
+	auditKubeadmConfigPatch = &kubeadmv1beta1.ClusterConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ClusterConfiguration",
+		},
+		APIServer: kubeadmv1beta1.APIServer{
+			ControlPlaneComponent: kubeadmv1beta1.ControlPlaneComponent{
+				ExtraArgs: map[string]string{
+					"audit-log-path":    path.Join(kindAuditPath, "audit.log"),
+					"audit-policy-file": path.Join(kindAuditPath, "audit-configuration.yaml"),
+				},
+				ExtraVolumes: []kubeadmv1beta1.HostPathMount{
+					{
+						Name:      "audit",
+						HostPath:  kindAuditPath,
+						MountPath: kindAuditPath,
+					},
+				},
+			},
+		},
+	}
 )
 
 type newKindNodeInput struct {
-	role   kindv1.NodeRole
-	caPath string
+	role      kindv1.NodeRole
+	caPath    string
+	auditPath string
 }
 
 func newKindNode(input newKindNodeInput) kindv1.Node {
@@ -55,6 +153,14 @@ func newKindNode(input newKindNodeInput) kindv1.Node {
 			kindv1.Mount{
 				HostPath:      input.caPath,
 				ContainerPath: kindRegistryCAPath,
+			},
+		)
+	}
+	if input.auditPath != "" {
+		node.ExtraMounts = append(node.ExtraMounts,
+			kindv1.Mount{
+				HostPath:      input.auditPath,
+				ContainerPath: kindAuditPath,
 			},
 		)
 	}
@@ -122,7 +228,7 @@ func (k *KindClusterProxy) CreateKindCluster() (string, error) {
 		k.options.ClusterName = kindClusterNamePrefix + xid.New().String()
 	}
 
-	log.V(3).Infof("Fetching configuration for kind node image...")
+	log.V(3).Info("Fetching configuration for kind node image...")
 	var config *kindv1.Cluster
 	var err error
 	k.options.NodeImage, config, err = k.GetKindNodeImageAndConfig()
@@ -130,7 +236,7 @@ func (k *KindClusterProxy) CreateKindCluster() (string, error) {
 		return "", errors.Wrap(err, "unable to get kind node image and configuration from BoM file")
 	}
 
-	log.V(3).Infof("Creating kind cluster: %s", k.options.ClusterName)
+	log.V(3).Info("Creating kind", "cluster-name", k.options.ClusterName)
 
 	// setup proxy envvars for kind clusrer if being configured in TKG
 	k.setupProxyConfigurationForKindCluster()
@@ -160,7 +266,7 @@ func (k *KindClusterProxy) CreateKindCluster() (string, error) {
 
 // DeleteKindCluster deletes existing kind cluster
 func (k *KindClusterProxy) DeleteKindCluster() error {
-	log.V(3).Infof("Deleting kind cluster: %s", k.options.ClusterName)
+	log.V(3).Info("Deleting kind cluster", "cluster-name", k.options.ClusterName)
 	// delete kind cluster with kind provider interface
 	if err := k.options.Provider.Delete(k.options.ClusterName, k.options.KubeConfigPath); err != nil {
 		return errors.Wrapf(err, "failed to delete kind cluster %s", k.options.ClusterName)
@@ -190,10 +296,18 @@ func (k *KindClusterProxy) GetKindNodeImageAndConfig() (string, *kindv1.Cluster,
 	}
 
 	kindConfigData := []byte(strings.Join(bomConfiguration.KindKubeadmConfigSpec, "\n"))
-	kindConfig := &kindv1.Cluster{}
+	kindConfig := &kindv1.Cluster{
+		KubeadmConfigPatches: []string{},
+	}
 	err = yaml.Unmarshal(kindConfigData, kindConfig)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "unable to parse kind configuration")
+	}
+
+	auditPath, err := k.applyAuditingConfiguration(kindConfig)
+
+	if err != nil {
+		return "", nil, errors.Wrap(err, "unable to apply auditing configuration")
 	}
 
 	kindNodeImageString := tkgconfigbom.GetFullImagePath(kindNodeImage, bomConfiguration.ImageConfig.ImageRepository) + ":" + kindNodeImage.Tag
@@ -204,7 +318,8 @@ func (k *KindClusterProxy) GetKindNodeImageAndConfig() (string, *kindv1.Cluster,
 	}
 
 	defaultNode := newKindNode(newKindNodeInput{
-		caPath: caCertFilePath,
+		caPath:    caCertFilePath,
+		auditPath: auditPath,
 	})
 
 	kindConfig.Nodes = []kindv1.Node{defaultNode}
@@ -220,7 +335,9 @@ func (k *KindClusterProxy) GetKindNodeImageAndConfig() (string, *kindv1.Cluster,
 		kindConfig.ContainerdConfigPatches = []string{kindRegistryConfig}
 	}
 
-	log.V(3).Infof("kindConfig: \n %v", kindConfig)
+	kindConfigString, _ := k8syaml.Marshal(kindConfig)
+
+	log.V(3).Info("Creating kind cluster with following options", "kindConfig", string(kindConfigString))
 	return kindNodeImageString, kindConfig, nil
 }
 
@@ -436,4 +553,41 @@ func (k *KindClusterProxy) setupProxyConfigurationForKindCluster() {
 		noProxyList := strings.Split(noProxy, ",")
 		os.Setenv(constants.NoProxy, strings.Join(append(noProxyList, fmt.Sprintf("%s-control-plane", k.options.ClusterName)), ","))
 	}
+}
+
+func (k *KindClusterProxy) applyAuditingConfiguration(kindCluster *kindv1.Cluster) (string, error) {
+	kindAuditing, err := k.options.Readerwriter.Get(constants.ConfigVariableKindAuditing)
+	var auditEnabled bool
+	if err != nil {
+		return "", nil
+	}
+	auditEnabled, err = strconv.ParseBool(kindAuditing)
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to parse value of %s", constants.ConfigVariableKindAuditing)
+	}
+	if !auditEnabled {
+		return "", nil
+	}
+	auditDirPath, err := os.MkdirTemp("", "tkg-audit-*")
+	if err != nil {
+		return "", errors.Wrap(err, fmt.Sprintf("failed to create audit directory %s", auditDirPath))
+	}
+	log.Info("Bootstrap cluster audit logs configured", "audit-directory", auditDirPath)
+	auditConfigFilePath := path.Join(auditDirPath, "audit-configuration.yaml")
+	auditDat, err := k8syaml.Marshal(auditConfiguration)
+	if err != nil {
+		return "", errors.Wrap(err, "error marshaling audit configuration")
+	}
+	err = os.WriteFile(auditConfigFilePath, auditDat, 0o644)
+	if err != nil {
+		return "", errors.Wrap(err, fmt.Sprintf("failed to write audit configuration file %s", auditConfigFilePath))
+	}
+
+	marshaledPatch, err := k8syaml.Marshal(auditKubeadmConfigPatch)
+	stringPatch := string(marshaledPatch)
+	if err != nil {
+		return "", errors.Wrap(err, "could not generate kubeadmconfigpatch")
+	}
+	kindCluster.KubeadmConfigPatches = append(kindCluster.KubeadmConfigPatches, stringPatch)
+	return auditDirPath, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable audit logging on the kind cluster when the `TKG_KIND_AUDITING=true`, so as to help debug issues with bootstrapping with cert-manager or other eventualities.


**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Describe testing done for PR**:
Logging successfully set up

**Special notes for your reviewer**:

**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
-->
```release-note
Setting TKG_KIND_AUDITING=true will enable audit logging for the kind bootstrap cluster
```
**New PR Checklist**

- [x] Ensure PR contains only public links or terms
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Squash the commits in this branch before merge to preserve our git history
- [x] If this PR is just an idea or POC, use a [Draft PR](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests) instead of a full PR
- [x] Add appropriate [kind label](../docs/release/kind-labels.md) according to what type of issue is being addressed.
