### PR TITLE
Use log.Infof for formatted log string

### DIFF
--- a/pkg/v1/tkg/client/utils.go
+++ b/pkg/v1/tkg/client/utils.go
@@ -346,15 +346,15 @@ func (c *TkgClient) getMachineCountForMC(plan string) (int, int) {
 		if cpc%2 == 1 {
 			controlPlaneMachineCount = cpc
 		} else {
-			log.Info("Using default value for CONTROL_PLANE_MACHINE_COUNT= %d. Reason: Provided value is an even number", controlPlaneMachineCount)
+			log.Infof("Using default value for CONTROL_PLANE_MACHINE_COUNT = %d. Reason: Provided value is an even number", controlPlaneMachineCount)
 		}
 	} else {
-		log.Info("Using default value for CONTROL_PLANE_MACHINE_COUNT= %d. Reason: %s", controlPlaneMachineCount, err.Error())
+		log.Infof("Using default value for CONTROL_PLANE_MACHINE_COUNT = %d. Reason: %s", controlPlaneMachineCount, err.Error())
 	}
 	if wc, err := tkgconfighelper.GetIntegerVariableFromConfig(constants.ConfigVariableWorkerMachineCount, c.TKGConfigReaderWriter()); err == nil {
 		workerMachineCount = wc
 	} else {
-		log.Info("Using default value for WORKER_MACHINE_COUNT= %d. Reason: %s", workerMachineCount, err.Error())
+		log.Infof("Using default value for WORKER_MACHINE_COUNT = %d. Reason: %s", workerMachineCount, err.Error())
 	}
 
 	return controlPlaneMachineCount, workerMachineCount


### PR DESCRIPTION
### What this PR does / why we need it

There were a few cases where log.Info() was being used, while the
intention was to use log.Infof(). The Info() call can take a variable
number of arguments, but they are expected to be a set of key/value
pairs that will be formatted and printed. If the number of formatting
arguments is odd, or if the expected key is not a string type, this
would case a somewhat confusing error to be emitted stating "key is not
a string".

This updates the few found cases so they get the expected formatting of
output.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1521 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Ran through `tanzu management-cluster create` and verified the expected output to the terminal.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```