### PR TITLE
Trivial grammatical fix for "does not exists"

### DIFF
--- a/docs/cli/tkgctl/components.md
+++ b/docs/cli/tkgctl/components.md
@@ -47,7 +47,7 @@ reference:
   * creating and/or updating TKG settings file at `$HOME/.config/tanzu/tkg/config.yaml`
     * adding/updating provider map based on user's file system path
     * adding/updating images map based on BoM file's image repository or based on `TKG_CUSTOM_IMAGE_REPOSITORY` config variable
-  * creating default(empty) cluster-config.yaml if it does not exists at `$HOME/.config/tanzu/tkg/cluster-config.yaml`
+  * creating default(empty) cluster-config.yaml if it does not exist at `$HOME/.config/tanzu/tkg/cluster-config.yaml`
 
 ## [tkgconfigpaths](/pkg/v1/tkg/tkgconfigpaths)
 

--- a/pkg/v1/cli/command/core/discovery_source_test.go
+++ b/pkg/v1/cli/command/core/discovery_source_test.go
@@ -116,7 +116,7 @@ func Test_deleteDiscoverySource(t *testing.T) {
 		},
 	}
 
-	// When discovery source does not exists
+	// When discovery source does not exist
 	_, err := deleteDiscoverySource(discoverySources, "source-does-not-exists")
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "discovery source \"source-does-not-exists\" does not exist")

--- a/pkg/v1/test/cli/framework_test.go
+++ b/pkg/v1/test/cli/framework_test.go
@@ -22,7 +22,7 @@ func TestCleanCommand(t *testing.T) {
 			res:     []string{"cluster", "create"},
 		},
 		{
-			name:    "cli name does not exists",
+			name:    "cli name does not exist",
 			command: "cluster create",
 			res:     []string{"cluster", "create"},
 		},

--- a/pkg/v1/tkg/client/client_suite_test.go
+++ b/pkg/v1/tkg/client/client_suite_test.go
@@ -685,7 +685,7 @@ var _ = Describe("ValidateAWSConfig", func() {
 		})
 	})
 
-	Context("When kubernetes version does not exists in any bom file", func() {
+	Context("When kubernetes version does not exist in any bom file", func() {
 		BeforeEach(func() {
 			tkgConfigPath = configFile4
 			tkrVersion = "v1.10.0+vmware.1-tkg.1"
@@ -695,7 +695,7 @@ var _ = Describe("ValidateAWSConfig", func() {
 		})
 	})
 
-	Context("When bom file exists for k8s version but region does not exists", func() {
+	Context("When bom file exists for k8s version but region does not exist", func() {
 		BeforeEach(func() {
 			bomFile = defaultTKGBoMFileForTesting
 			tkgConfigPath = configFile4

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -1024,7 +1024,7 @@ func (c *client) GetManagementClusterTKGVersion(mgmtClusterName, clusterNamespac
 		return "", errors.Wrap(err, "unable to get the cluster object")
 	}
 	version, exists := mcObject.Annotations[TKGVersionKey]
-	// if TKGVersionKey does not exists in annotation of the management cluster object
+	// if TKGVersionKey does not exist in annotation of the management cluster object
 	// assume this is v1.0.0 management cluster as TKGVERSION was not patched for
 	// v1.0.x release
 	if !exists {

--- a/pkg/v1/tkg/tkgctl/helpers.go
+++ b/pkg/v1/tkg/tkgctl/helpers.go
@@ -82,7 +82,7 @@ func (t *tkgctl) ensureClusterConfigFile(clusterConfigFile string) (string, erro
 
 	// create empty clusterConfigFile if not present
 	if _, err = os.Stat(clusterConfigFile); os.IsNotExist(err) {
-		log.V(3).Infof("cluster config file does not exists. Creating new one at '%v'", clusterConfigFile)
+		log.V(3).Infof("cluster config file does not exist. Creating new one at '%v'", clusterConfigFile)
 		err = os.WriteFile(clusterConfigFile, []byte{}, constants.ConfigFilePermissions)
 		if err != nil {
 			return "", errors.Wrap(err, "cannot initialize cluster config file")

--- a/pkg/v1/tkg/utils/capi_conditions.go
+++ b/pkg/v1/tkg/utils/capi_conditions.go
@@ -23,7 +23,7 @@ type Getter interface {
 	GetConditions() clusterv1alpha3.Conditions
 }
 
-// Get returns the condition with the given type, if the condition does not exists,
+// Get returns the condition with the given type, if the condition does not exist,
 // it returns nil.
 func Get(from Getter, t clusterv1alpha3.ConditionType) *clusterv1alpha3.Condition {
 	conditions := from.GetConditions()

--- a/pkg/v1/tkg/vc/client_test.go
+++ b/pkg/v1/tkg/vc/client_test.go
@@ -680,7 +680,7 @@ var _ = Describe("VC Client", func() {
 			})
 		})
 
-		Context("When provided template does not exists", func() {
+		Context("When provided template does not exist", func() {
 			BeforeEach(func() {
 				vmTemplate = "fake-template"
 				ovaVersions = []string{"v1.16.0+vmware.1-ova-latest"}


### PR DESCRIPTION
### What this PR does / why we need it

There were several cases where we had comments or strings stating "does
not exists". This corrects the grammar to "does not exist".