### PR TITLE
Add cluster audit logging

### DIFF
--- a/pkg/v1/tkg/constants/files.go
+++ b/pkg/v1/tkg/constants/files.go
@@ -34,4 +34,6 @@ const (
 	TKGClusterConfigFileDirForUI           = "clusterconfigs"
 	TKGRegistryCertFile                    = "registry_certs"
 	TKGRegistryTrustedRootCAFileForWindows = ".registry_trusted_root_certs_win"
+
+	LogFolderName = "logs"
 )

--- a/pkg/v1/tkg/log/interface.go
+++ b/pkg/v1/tkg/log/interface.go
@@ -140,6 +140,12 @@ func SetFile(fileName string) {
 	logWriter.SetFile(fileName)
 }
 
+// SetAuditLog sets the log file that should capture all logging activity. This
+// file will contain all logging regardless of set verbosity level.
+func SetAuditLog(fileName string) {
+	logWriter.SetAuditLog(fileName)
+}
+
 // SetChannel sets the channel to writer
 // if channel is set, writer will forward log messages to this log channel
 func SetChannel(channel chan<- []byte) {

--- a/pkg/v1/tkg/tkgconfigpaths/client.go
+++ b/pkg/v1/tkg/tkgconfigpaths/client.go
@@ -49,4 +49,7 @@ type Client interface {
 
 	// GetConfigDefaultsFilePath returns config_default.yaml file path under TKG directory
 	GetConfigDefaultsFilePath() (string, error)
+
+	// GetLogDirectory returns the directory path where log files should be stored by default.
+	GetLogDirectory() (string, error)
 }

--- a/pkg/v1/tkg/tkgconfigpaths/filepaths.go
+++ b/pkg/v1/tkg/tkgconfigpaths/filepaths.go
@@ -132,6 +132,7 @@ func (c *client) GetConfigDefaultsFilePath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(tkgDir, constants.TKGConfigDefaultFileName), nil
+}
 
 // GetLogDirectory returns the directory path where log files should be stored by default.
 func (c *client) GetLogDirectory() (string, error) {

--- a/pkg/v1/tkg/tkgconfigpaths/filepaths.go
+++ b/pkg/v1/tkg/tkgconfigpaths/filepaths.go
@@ -132,4 +132,12 @@ func (c *client) GetConfigDefaultsFilePath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(tkgDir, constants.TKGConfigDefaultFileName), nil
+
+// GetLogDirectory returns the directory path where log files should be stored by default.
+func (c *client) GetLogDirectory() (string, error) {
+	tkgDir, err := c.GetTKGDirectory()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(tkgDir, constants.LogFolderName), nil
 }

--- a/pkg/v1/tkg/tkgctl/create_cluster.go
+++ b/pkg/v1/tkg/tkgctl/create_cluster.go
@@ -65,6 +65,10 @@ func (t *tkgctl) CreateCluster(cc CreateClusterOptions) error {
 		return err
 	}
 
+	if logPath, err := t.getAuditLogPath(cc.ClusterName); err == nil {
+		log.SetAuditLog(logPath)
+	}
+
 	// Always do blocking cluster create
 	waitForCluster := true
 

--- a/pkg/v1/tkg/tkgctl/delete_cluster.go
+++ b/pkg/v1/tkg/tkgctl/delete_cluster.go
@@ -20,6 +20,11 @@ type DeleteClustersOptions struct {
 
 // DeleteCluster deletes workload cluster
 func (t *tkgctl) DeleteCluster(options DeleteClustersOptions) error {
+	// Make sure activity is captured in the audit log in case of deletion failure.
+	if logPath, err := t.getAuditLogPath(options.ClusterName); err == nil {
+		log.SetAuditLog(logPath)
+	}
+
 	// if --yes is set, kick off the delete process without waiting for confirmation
 	if !options.SkipPrompt {
 		if err := askForConfirmation(fmt.Sprintf("Deleting workload cluster '%s'. Are you sure?", options.ClusterName)); err != nil {
@@ -42,6 +47,10 @@ func (t *tkgctl) DeleteCluster(options DeleteClustersOptions) error {
 	}
 
 	log.Infof("Workload cluster '%s' is being deleted \n", options.ClusterName)
+
+	// Clean up the audit log since we were successful
+	t.removeAuditLog(options.ClusterName)
+	log.SetAuditLog("")
 
 	return nil
 }

--- a/pkg/v1/tkg/tkgctl/delete_region.go
+++ b/pkg/v1/tkg/tkgctl/delete_region.go
@@ -25,6 +25,11 @@ type DeleteRegionOptions struct {
 
 // DeleteRegion deletes management cluster
 func (t *tkgctl) DeleteRegion(options DeleteRegionOptions) error {
+	// Make sure activity is captured in the audit log in case of deletion failure.
+	if logPath, err := t.getAuditLogPath(options.ClusterName); err == nil {
+		log.SetAuditLog(logPath)
+	}
+
 	var err error
 
 	// delete region requires minimum 15 minutes timeout
@@ -59,6 +64,10 @@ func (t *tkgctl) DeleteRegion(options DeleteRegionOptions) error {
 	}
 
 	log.Infof("\nManagement cluster deleted!\n")
+
+	// Clean up the audit log since we were successful
+	t.removeAuditLog(options.ClusterName)
+	log.SetAuditLog("")
 
 	return nil
 }

--- a/pkg/v1/tkg/tkgctl/init.go
+++ b/pkg/v1/tkg/tkgctl/init.go
@@ -56,11 +56,8 @@ func (t *tkgctl) Init(options InitRegionOptions) error {
 	if err != nil {
 		return err
 	}
+
 	err = ensureConfigImages(t.configDir, t.tkgConfigUpdaterClient)
-	if err != nil {
-		return err
-	}
-	options.CoreProvider, options.BootstrapProvider, options.ControlPlaneProvider, err = t.tkgBomClient.GetDefaultClusterAPIProviders()
 	if err != nil {
 		return err
 	}
@@ -73,6 +70,15 @@ func (t *tkgctl) Init(options InitRegionOptions) error {
 	ceipOptIn, err := strconv.ParseBool(options.CeipOptIn)
 	if err != nil {
 		ceipOptIn = false
+	}
+
+	if logPath, err := t.getAuditLogPath(options.ClusterName); err == nil {
+		log.SetAuditLog(logPath)
+	}
+
+	options.CoreProvider, options.BootstrapProvider, options.ControlPlaneProvider, err = t.tkgBomClient.GetDefaultClusterAPIProviders()
+	if err != nil {
+		return err
 	}
 
 	// init requires minimum 15 minutes timeout

--- a/pkg/v1/tkg/tkgctl/upgrade_cluster.go
+++ b/pkg/v1/tkg/tkgctl/upgrade_cluster.go
@@ -39,6 +39,10 @@ func (t *tkgctl) UpgradeCluster(options UpgradeClusterOptions) error {
 	var err error
 	var k8sVersion string
 
+	if logPath, err := t.getAuditLogPath(options.ClusterName); err == nil {
+		log.SetAuditLog(logPath)
+	}
+
 	// upgrade requires minimum 15 minutes timeout
 	minTimeoutReq := 15 * time.Minute
 	if options.Timeout < minTimeoutReq {

--- a/pkg/v1/tkg/tkgctl/upgrade_region.go
+++ b/pkg/v1/tkg/tkgctl/upgrade_region.go
@@ -36,6 +36,10 @@ type UpgradeRegionOptions struct {
 func (t *tkgctl) UpgradeRegion(options UpgradeRegionOptions) error {
 	var err error
 
+	if logPath, err := t.getAuditLogPath(options.ClusterName); err == nil {
+		log.SetAuditLog(logPath)
+	}
+
 	// upgrade requires minimum 15 minutes timeout
 	minTimeoutReq := 15 * time.Minute
 	if options.Timeout < minTimeoutReq {


### PR DESCRIPTION
### What this PR does / why we need it

This adds new functionality where an audit log will be create for all
management clusters on create. This will capture all logging activity,
regardless of set log verbosity. This can be used to help troubleshoot
bootstrap and other failures by having everything that happened during
deployment available in a timestamped log.

If the management cluster is upgraded, we will attempt to capture
upgrade logging activity to the log so it is captured in case it is
needed later.

This file is kept around until deleted by the user or until management
cluster deletion. The delete operation will log everything to this audit
log in case of deletion failure. If that fails, the user and/or support
person can review the log file to help troubleshoot. On successful
deletion of the cluster the audit log file will be removed.

Updated to also include audit logging for workload cluster creation.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1524

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

- Deployed management clusters and observed content being captured in the audit log.
- Deployed workload cluster and observed content being captured in the log.
- Delete workload cluster, verified cluster's audit log captured process output and was removed on successful completion.
- Deleted management clusters and verified deletion activity was logged, and that audit log file was removed on successful completion of delete operation.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Management  and workload cluster creation activity is now captured in $HOME/.config/tanzu/tkg/logs/$CLUSTER_NAME for later troubleshooting or review. This file will be removed on cluster deletion.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
