### PR TITLE
fix kubeconfig used by feature plugin

### DIFF
--- a/docs/cli/plugin_implementation_guide.md
+++ b/docs/cli/plugin_implementation_guide.md
@@ -182,6 +182,9 @@ Using `make build-install-local` installs the plugins for the user, but it inter
 tanzu plugin install <plugin-name> --local ./artifacts/published/${HOSTOS}-${HOSTARCH}
 ```
 
+If your plugin talks to a Tanzu cluster, a helper function `GetCurrentClusterConfig` defined in
+[config](../../pkg/v1/config) package can be used to get the logged in Tanzu cluster's config.
+
 Plugins are installed into `$XDG_DATA_HOME`, [read more](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
 
 The CLI can be updated to the latest version of all plugins using:

--- a/pkg/v1/config/clientconfig.go
+++ b/pkg/v1/config/clientconfig.go
@@ -16,6 +16,9 @@ import (
 
 	configv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/common"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // This block is for global feature constants, to allow them to be used more broadly
@@ -513,7 +516,7 @@ func SetCurrentServer(name string) error {
 	return nil
 }
 
-// GetCurrentServer sets the current server.
+// GetCurrentServer gets the current server.
 func GetCurrentServer() (s *configv1alpha1.Server, err error) {
 	cfg, err := GetClientConfig()
 	if err != nil {
@@ -617,4 +620,26 @@ func GetEdition() (string, error) {
 		return string(cfg.ClientOptions.CLI.Edition), nil
 	}
 	return "", nil
+}
+
+// GetCurrentClusterConfig gets the config of current logged in cluster
+func GetCurrentClusterConfig() (*rest.Config, error) {
+	server, err := GetCurrentServer()
+	if err != nil {
+		return nil, err
+	}
+	restConfig, err := getRestConfigWithContext(server.ManagementClusterOpts.Context, server.ManagementClusterOpts.Path)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get rest config: %w", err)
+	}
+	return restConfig, nil
+}
+
+// getRestConfigWithContext returns config using the passed context
+func getRestConfigWithContext(context, kubeconfigPath string) (*rest.Config, error) {
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPath},
+		&clientcmd.ConfigOverrides{
+			CurrentContext: context,
+		}).ClientConfig()
 }

--- a/pkg/v1/sdk/features/client/client.go
+++ b/pkg/v1/sdk/features/client/client.go
@@ -7,11 +7,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	k8sconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	configv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
 )
@@ -62,9 +63,10 @@ func getFeatureGateClient() (client.Client, error) {
 		return nil, err
 	}
 
-	if restConfig, err = k8sconfig.GetConfig(); err != nil {
+	if restConfig, err = config.GetCurrentClusterConfig(); err != nil {
 		return nil, err
 	}
+
 	crClient, err := client.New(restConfig, client.Options{Scheme: scheme})
 	if err != nil {
 		return nil, fmt.Errorf("unable to create cluster client: %w", err)


### PR DESCRIPTION
### What this PR does / why we need it
This PR makes changes to the feature plugin to use the config of a logged in Tanzu cluster


### Which issue(s) this PR fixes
Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/1479

### Describe testing done for PR
Created a management cluster and tried feature plugin to activate and deactivate features

### Release note
```release-note
Updated Feature plugin to use config of a logged in Tanzu cluster
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
