### PR TITLE
Use k8s default namespace from kubeconfig

### DIFF
--- a/cmd/cli/plugin/package/package_available.go
+++ b/cmd/cli/plugin/package/package_available.go
@@ -23,11 +23,13 @@ var packageAvailableCmd = &cobra.Command{
 }
 
 func init() {
-	packageAvailableCmd.PersistentFlags().StringVarP(&packageAvailableOp.Namespace, "namespace", "n", "default", "Namespace of packages, optional")
+	packageAvailableCmd.PersistentFlags().StringVarP(&packageAvailableOp.Namespace, "namespace", "n", defaultString, "Namespace of packages, optional")
 	packageAvailableCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table), optional")
 }
 
 func packagingAvailabilityCheck(_ *cobra.Command, _ []string) error {
+	packageAvailableOp.Namespace = getNamespaceFromKubeconfig(packageAvailableOp.Namespace)
+
 	found, err := isPackagingAPIAvailable(kubeConfig)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to check for the availability of '%s' API", tkgpackagedatamodel.PackagingAPIName))

--- a/cmd/cli/plugin/package/package_available_get.go
+++ b/cmd/cli/plugin/package/package_available_get.go
@@ -74,6 +74,7 @@ func packageAvailableGet(cmd *cobra.Command, args []string) error {
 	if packageAvailableOp.AllNamespaces {
 		packageAvailableOp.Namespace = ""
 	}
+	packageAvailableOp.Namespace = getNamespaceFromKubeconfig(packageAvailableOp.Namespace)
 
 	if packageAvailableOp.GenerateDefaultValuesFile || packageAvailableOp.ValuesSchema {
 		if pkgVersion == "" {

--- a/cmd/cli/plugin/package/package_available_get_test.go
+++ b/cmd/cli/plugin/package/package_available_get_test.go
@@ -138,7 +138,7 @@ type: object
 var _ = Describe("PackageAvailableGet", func() {
 	var (
 		kappClient   *fakes.KappClient
-		pkgNamespace = "default"
+		pkgNamespace = defaultString
 		pkgName      = "external-dns.tanzu.vmware.com"
 		pkgVersion   = "1.2.1+vmware.1-tkg.2-zshippable"
 	)

--- a/cmd/cli/plugin/package/package_available_list.go
+++ b/cmd/cli/plugin/package/package_available_list.go
@@ -43,6 +43,7 @@ func packageAvailableList(cmd *cobra.Command, args []string) error {
 	if packageAvailableOp.AllNamespaces {
 		packageAvailableOp.Namespace = ""
 	}
+	packageAvailableOp.Namespace = getNamespaceFromKubeconfig(packageAvailableOp.Namespace)
 
 	if len(args) == 0 {
 		t, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat,

--- a/cmd/cli/plugin/package/package_available_list_test.go
+++ b/cmd/cli/plugin/package/package_available_list_test.go
@@ -23,7 +23,7 @@ var _ = Describe("PackageAvailableList", func() {
 		var (
 			incorrectVersion = "incorrect-version-format"
 			pkgName          = "cert-manager.tanzu.vmware.com"
-			pkgNamespace     = "default"
+			pkgNamespace     = defaultString
 		)
 
 		BeforeEach(func() {

--- a/cmd/cli/plugin/package/package_install.go
+++ b/cmd/cli/plugin/package/package_install.go
@@ -31,7 +31,7 @@ func init() {
 	packageInstallCmd.Flags().StringVarP(&packageInstallOp.PackageName, "package-name", "p", "", "Name of the package to be installed")
 	packageInstallCmd.Flags().StringVarP(&packageInstallOp.Version, "version", "v", "", "Version of the package to be installed")
 	packageInstallCmd.Flags().BoolVarP(&packageInstallOp.CreateNamespace, "create-namespace", "", false, "Create namespace if the target namespace does not exist, optional")
-	packageInstallCmd.Flags().StringVarP(&packageInstallOp.Namespace, "namespace", "n", "default", "Namespace indicates the location of the repository from which the package is retrieved")
+	packageInstallCmd.Flags().StringVarP(&packageInstallOp.Namespace, "namespace", "n", defaultString, "Namespace indicates the location of the repository from which the package is retrieved")
 	packageInstallCmd.Flags().StringVarP(&packageInstallOp.ServiceAccountName, "service-account-name", "", "", "Name of an existing service account used to install underlying package contents, optional")
 	packageInstallCmd.Flags().StringVarP(&packageInstallOp.ValuesFile, "values-file", "f", "", "The path to the configuration values file, optional")
 	packageInstallCmd.Flags().BoolVarP(&packageInstallOp.Wait, "wait", "", true, "Wait for the package reconciliation to complete, optional. To disable wait, specify --wait=false")
@@ -43,6 +43,8 @@ func init() {
 
 func packageInstall(cmd *cobra.Command, args []string) error {
 	packageInstallOp.PkgInstallName = args[0]
+
+	packageInstallOp.Namespace = getNamespaceFromKubeconfig(packageInstallOp.Namespace)
 
 	pkgClient, err := tkgpackageclient.NewTKGPackageClient(kubeConfig)
 	if err != nil {

--- a/cmd/cli/plugin/package/package_installed_create.go
+++ b/cmd/cli/plugin/package/package_installed_create.go
@@ -21,7 +21,7 @@ func init() {
 	packageInstalledCreateCmd.Flags().StringVarP(&packageInstallOp.PackageName, "package-name", "p", "", "Name of the package to be installed")
 	packageInstalledCreateCmd.Flags().StringVarP(&packageInstallOp.Version, "version", "v", "", "Version of the package to be installed")
 	packageInstalledCreateCmd.Flags().BoolVarP(&packageInstallOp.CreateNamespace, "create-namespace", "", false, "Create namespace if the target namespace does not exist, optional")
-	packageInstalledCreateCmd.Flags().StringVarP(&packageInstallOp.Namespace, "namespace", "n", "default", "Target namespace to install the package, optional")
+	packageInstalledCreateCmd.Flags().StringVarP(&packageInstallOp.Namespace, "namespace", "n", defaultString, "Target namespace to install the package, optional")
 	packageInstalledCreateCmd.Flags().StringVarP(&packageInstallOp.ServiceAccountName, "service-account-name", "", "", "Name of an existing service account used to install underlying package contents, optional")
 	packageInstalledCreateCmd.Flags().StringVarP(&packageInstallOp.ValuesFile, "values-file", "f", "", "The path to the configuration values file, optional")
 	packageInstalledCreateCmd.Flags().BoolVarP(&packageInstallOp.Wait, "wait", "", true, "Wait for the package reconciliation to complete, optional")

--- a/cmd/cli/plugin/package/package_installed_delete.go
+++ b/cmd/cli/plugin/package/package_installed_delete.go
@@ -26,7 +26,7 @@ var packageInstalledDeleteCmd = &cobra.Command{
 }
 
 func init() {
-	packageInstalledDeleteCmd.Flags().StringVarP(&packageInstalledOp.Namespace, "namespace", "n", "default", "Target namespace from which the package should be deleted, optional")
+	packageInstalledDeleteCmd.Flags().StringVarP(&packageInstalledOp.Namespace, "namespace", "n", defaultString, "Target namespace from which the package should be deleted, optional")
 	packageInstalledDeleteCmd.Flags().DurationVarP(&packageInstalledOp.PollInterval, "poll-interval", "", tkgpackagedatamodel.DefaultPollInterval, "Time interval between subsequent polls of package deletion status, optional")
 	packageInstalledDeleteCmd.Flags().DurationVarP(&packageInstalledOp.PollTimeout, "poll-timeout", "", tkgpackagedatamodel.DefaultPollTimeout, "Timeout value for polls of package deletion status, optional")
 	packageInstalledDeleteCmd.Flags().BoolVarP(&packageInstalledOp.SkipPrompt, "yes", "y", false, "Delete installed package without asking for confirmation, optional")
@@ -35,6 +35,8 @@ func init() {
 
 func packageUninstall(cmd *cobra.Command, args []string) error {
 	packageInstalledOp.PkgInstallName = args[0]
+
+	packageInstalledOp.Namespace = getNamespaceFromKubeconfig(packageInstalledOp.Namespace)
 
 	if !packageInstalledOp.SkipPrompt {
 		if err := cli.AskForConfirmation(fmt.Sprintf("Deleting installed package '%s' in namespace '%s'. Are you sure?",

--- a/cmd/cli/plugin/package/package_installed_get.go
+++ b/cmd/cli/plugin/package/package_installed_get.go
@@ -29,7 +29,7 @@ var packageInstalledGetCmd = &cobra.Command{
 }
 
 func init() {
-	packageInstalledGetCmd.Flags().StringVarP(&packageInstalledOp.Namespace, "namespace", "n", "default", "Namespace for installed package CR, optional")
+	packageInstalledGetCmd.Flags().StringVarP(&packageInstalledOp.Namespace, "namespace", "n", defaultString, "Namespace for installed package CR, optional")
 	packageInstalledGetCmd.Flags().StringVarP(&packageInstalledOp.ValuesFile, "values-file", "f", "", "The path to the configuration values file, optional")
 	packageInstalledGetCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table), optional")
 	packageInstalledCmd.AddCommand(packageInstalledGetCmd)
@@ -43,6 +43,8 @@ func packageInstalledGet(cmd *cobra.Command, args []string) error {
 
 	pkgName = args[0]
 	packageInstalledOp.PkgInstallName = pkgName
+	packageInstalledOp.Namespace = getNamespaceFromKubeconfig(packageInstalledOp.Namespace)
+
 	t, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), getOutputFormat(),
 		fmt.Sprintf("Retrieving installation details for %s...", pkgName), true)
 	if err != nil {

--- a/cmd/cli/plugin/package/package_installed_list.go
+++ b/cmd/cli/plugin/package/package_installed_list.go
@@ -26,7 +26,7 @@ var packageInstalledListCmd = &cobra.Command{
 
 func init() {
 	packageInstalledListCmd.Flags().BoolVarP(&packageInstalledOp.AllNamespaces, "all-namespaces", "A", false, "If present, list packages across all namespaces, optional")
-	packageInstalledListCmd.Flags().StringVarP(&packageInstalledOp.Namespace, "namespace", "n", "default", "Namespace for installed package CR, optional")
+	packageInstalledListCmd.Flags().StringVarP(&packageInstalledOp.Namespace, "namespace", "n", defaultString, "Namespace for installed package CR, optional")
 	packageInstalledListCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table), optional")
 	packageInstalledCmd.AddCommand(packageInstalledListCmd)
 }
@@ -39,6 +39,8 @@ func packageInstalledList(cmd *cobra.Command, args []string) error {
 	if packageInstalledOp.AllNamespaces {
 		packageInstalledOp.Namespace = ""
 	}
+	packageInstalledOp.Namespace = getNamespaceFromKubeconfig(packageInstalledOp.Namespace)
+
 	t, err := component.NewOutputWriterWithSpinner(cmd.OutOrStdout(), outputFormat,
 		"Retrieving installed packages...", true)
 	if err != nil {

--- a/cmd/cli/plugin/package/package_installed_update.go
+++ b/cmd/cli/plugin/package/package_installed_update.go
@@ -27,7 +27,7 @@ func init() {
 	packageInstalledUpdateCmd.Flags().StringVarP(&packageInstalledOp.ValuesFile, "values-file", "f", "", "The path to the configuration values file, optional")
 	packageInstalledUpdateCmd.Flags().BoolVarP(&packageInstalledOp.Install, "install", "", false, "Install package if the installed package does not exist, optional")
 	packageInstalledUpdateCmd.Flags().StringVarP(&packageInstalledOp.PackageName, "package-name", "p", "", "The public name for the package, optional")
-	packageInstalledUpdateCmd.Flags().StringVarP(&packageInstalledOp.Namespace, "namespace", "n", "default", "The namespace to locate the installed package which needs to be updated")
+	packageInstalledUpdateCmd.Flags().StringVarP(&packageInstalledOp.Namespace, "namespace", "n", defaultString, "The namespace to locate the installed package which needs to be updated")
 	packageInstalledUpdateCmd.Flags().BoolVarP(&packageInstalledOp.Wait, "wait", "", true, "Wait for the package reconciliation to complete, optional. To disable wait, specify --wait=false")
 	packageInstalledUpdateCmd.Flags().DurationVarP(&packageInstalledOp.PollInterval, "poll-interval", "", tkgpackagedatamodel.DefaultPollInterval, "Time interval between subsequent polls of package reconciliation status, optional")
 	packageInstalledUpdateCmd.Flags().DurationVarP(&packageInstalledOp.PollTimeout, "poll-timeout", "", tkgpackagedatamodel.DefaultPollTimeout, "Timeout value for polls of package reconciliation status, optional")
@@ -36,6 +36,7 @@ func init() {
 
 func packageUpdate(cmd *cobra.Command, args []string) error {
 	packageInstalledOp.PkgInstallName = args[0]
+	packageInstalledOp.Namespace = getNamespaceFromKubeconfig(packageInstalledOp.Namespace)
 
 	if packageInstalledOp.Version == "" && packageInstalledOp.ValuesFile == "" {
 		return errors.New("please provide --version and/or --values-file for updating the installed package")

--- a/cmd/cli/plugin/package/repository.go
+++ b/cmd/cli/plugin/package/repository.go
@@ -21,5 +21,5 @@ var repositoryCmd = &cobra.Command{
 }
 
 func init() {
-	repositoryCmd.PersistentFlags().StringVarP(&repoOp.Namespace, "namespace", "n", "default", "Namespace for repository command, optional")
+	repositoryCmd.PersistentFlags().StringVarP(&repoOp.Namespace, "namespace", "n", defaultString, "Namespace for repository command, optional")
 }


### PR DESCRIPTION
If contexts are being used in the kubeconfig,
the default value of --namespace flag for
package install should respect the one define in the
kubernetes context

If the a kubernetes context is set in the kubeconfig, the namespace defined
for that context will be used as the default value (instead of "default")
in the case the --namespace flag is not provided by the user.  

Fixes #1351

### Describe testing done for PR
Verified that if no kubeconfig context is set  default value is "default"
Verified that if  context is set, the context.namespace is used as default value.



### Release note

```release-note
If the a kubernetes context is set in the kubeconfig, the namespace defined
for that context will be used as the default value (instead of "default")
in the case the --namespace flag is not provided by the user.  

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer


