### PR TITLE
Fail plugin verification by default

### DIFF
--- a/pkg/v1/cli/pluginmanager/manager.go
+++ b/pkg/v1/cli/pluginmanager/manager.go
@@ -721,7 +721,11 @@ func verifyPlugin(p *plugin.Discovered) error {
 	if artifactInfo.Image != "" {
 		return verifyRegistry(artifactInfo.Image)
 	}
-	return nil
+	if artifactInfo.URI != "" {
+		// TODO implement verification
+		return errors.Errorf("untrusted uri detected %q", artifactInfo.URI)
+	}
+	return errors.Errorf("unable to verify plugin %q of unknown source", p.Name)
 }
 
 // verifyRegistry verifies the authenticity of the registry from where cli is


### PR DESCRIPTION
### What this PR does / why we need it

Plugins that live in a new medium need to be verified before they can be
installed. This switches the default behavior from allow to deny. It
also adds a TODO where verification for URL sources can be implemented.

### Which issue(s) this PR fixes

Follow up to #1500, which regressed due to #1358

### Describe testing done for PR

None. I expect this to fail as implement.

### Release note

```release-note
Discovered plugins will fail to install unless verified.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

I'm not in a position to properly implement verification for URI sources, someone with more domain knowledge will need to build on this PR.