### PR TITLE
Replace satori/go.uuid with existing dependency google/uuid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
 	github.com/google/go-containerregistry v0.6.0
+	github.com/google/uuid v1.3.0
 	github.com/googleapis/gnostic v0.5.5
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
@@ -72,7 +73,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/xid v1.2.1
 	github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b
-	github.com/satori/go.uuid v1.2.0
 	github.com/sergi/go-diff v1.2.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/afero v1.6.0
@@ -171,7 +171,6 @@ require (
 	github.com/google/go-github/v33 v33.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/hashicorp/go-version v1.3.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1551,7 +1551,6 @@ github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b/go.mod h1:8458kAa
 github.com/sanathkr/yaml v0.0.0-20170819201035-0056894fa522 h1:fOCp11H0yuyAt2wqlbJtbyPzSgaxHTv8uN1pMpkG1t8=
 github.com/sanathkr/yaml v0.0.0-20170819201035-0056894fa522/go.mod h1:tQTYKOQgxoH3v6dEmdHiz4JG+nbxWwM5fgPQUpSZqVQ=
 github.com/sassoftware/go-rpmutils v0.0.0-20190420191620-a8f1baeba37b/go.mod h1:am+Fp8Bt506lA3Rk3QCmSqmYmLMnPDhdDUcosQCAx+I=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=

--- a/pkg/v1/config/clientconfig_test.go
+++ b/pkg/v1/config/clientconfig_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/tj/assert"
 
@@ -23,7 +23,7 @@ func cleanupDir(dir string) {
 }
 
 func randString() string {
-	return uuid.NewV4().String()[:5]
+	return uuid.NewString()[:5]
 }
 
 func TestClientConfig(t *testing.T) {

--- a/pkg/v1/test/cli/framework.go
+++ b/pkg/v1/test/cli/framework.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/aunum/log"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/google/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
@@ -229,7 +229,7 @@ const NamePrefix = "cli-test"
 
 // GenerateName returns a name for a cli test.
 func GenerateName() string {
-	testName := fmt.Sprintf("%s-%s", NamePrefix, uuid.NewV4().String()[:8])
+	testName := fmt.Sprintf("%s-%s", NamePrefix, uuid.NewString()[:8])
 	return testName
 }
 


### PR DESCRIPTION


### What this PR does / why we need it
satori repo is abandoned. google/uuid has a package uuid
that supports a similar func NewString() that returns
string and panics on any error

Fixes #1543

### Describe testing done for PR

Ran all relevant make commands to ensure tests passed and build was successful

### Release note

```release-note
Replace satori/go.uuid with existing dependency google/uuid
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer
PR created based on feedback from [#1544 ](https://github.com/vmware-tanzu/tanzu-framework/pull/1544#discussion_r791195031)

