### PR TITLE
Retract v1.4.0-pre-alpha-* tags in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/vmware-tanzu/tanzu-framework
 
 go 1.17
 
+// Legacy tags before v0.1.0 was created
+retract [v1.4.0-pre-alpha-1, v1.4.0-pre-alpha-2]
+
 replace (
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/k14s/kbld => github.com/anujc25/carvel-kbld v0.31.0-update-vendir


### PR DESCRIPTION
### What this PR does / why we need it

They are legacy tags created before v0.1.0 was created. Since they are
higher semver-wise than the latest release (v0.15.0 at the time of this
commit), Go proxy thinks that is the highest release of this repo. After
the next release of framework which contains this commit, doing `go list
-m -versions` will not list the retracted versions.

Retracting these versions also means anyone adding an untagged commit of
framework as a dependency in their go.mod will not get a confusing
version that looks like `v1.4.0-pre-alpha-2.0.20220125212408-<SHA>`. It
will have a version that reflects the commit relative to the latest tag.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1556

### Describe testing done for PR

Replicated tanzu-framework's legacy and new tags in a [new repo](https://github.com/rajathagasthya/gomod-retract-experiment). Then tried to add HEAD commit of that repo as a dependency, which resulted in a version that is not based off legacy tags.

Before retraction:

```
$ go get github.com/rajathagasthya/gomod-retract-experiment@35e30fcfd7aeff28006e5b743f49442cbcf7f7bf
go: downloading github.com/rajathagasthya/gomod-retract-experiment v1.4.0-pre-alpha-3.0.20220125212408-35e30fcfd7ae
go get: upgraded github.com/google/go-cmp v0.5.6 => v0.5.7
go get: added github.com/rajathagasthya/gomod-retract-experiment v1.4.0-pre-alpha-3.0.20220125212408-35e30fcfd7ae
```

After retraction:

```
$ go get github.com/rajathagasthya/gomod-retract-experiment@870719c11da992ad28d4064e464a23b7c4235946
go: downloading github.com/rajathagasthya/gomod-retract-experiment v0.4.1-0.20220126222709-870719c11da9
go get: upgraded github.com/google/go-cmp v0.5.6 => v0.5.7
go get: added github.com/rajathagasthya/gomod-retract-experiment v0.4.1-0.20220126222709-870719c11da9
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Retracted legacy tags `v1.4.0-pre-alpha-1` and `v1.4.0-pre-alpha-2` in `go.mod`. `go list -m -versions` will no longer list those tags and consumers trying to `go get` those tags will see a warning.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
