### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+# Dependabot config for go mod version upgrades
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "addons/pinniped/post-deploy/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "hack/packages/kbld-image-replace/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "hack/tools/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "gomod"
+    directory: "pkg/v1/providers/tests/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "pkg/v1/tkg/web/e2e/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "pkg/v1/tkg/web/node-server/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "pkg/v1/tkg/web/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
### What this PR does / why we need it

This adds configuration for the GitHub Dependabot. With this
configuration, Dependabot will automatically propose updates for
dependencies. We can then choose whether to merge those updates, or if
there is some reason to wait, keep the PR around or close it. At least
this way we are aware of possible updates so we can be less reactionary
towards security and other update needs.

Based on work @jpmcb has done for the `community-edition` repo.

More details and thorough documentation can be found here:
https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/enabling-and-disabling-dependabot-version-updates

#### Special notes for your reviewer

Unfortunately not easy to test locally. Once merged, this will run daily dependabot checks. If we find there are dependencies missing, we can update the dependabot.yaml file to include them. If we find this is causing more noise than the benefit it provides, we can quickly revert this change.
