### PR TITLE
addons/pinniped/post-deploy: improve BUILDER_BASE_IMAGE support

### DIFF
--- a/addons/pinniped/post-deploy/hack/scripts/build-images.sh
+++ b/addons/pinniped/post-deploy/hack/scripts/build-images.sh
@@ -17,7 +17,20 @@ IMAGE_TAG="${VERSION//+/_}"
 FULL_IMAGE_NAME="${REPO_NAME}/${IMAGE_NAME}:${IMAGE_TAG}"
 FULL_IMAGE_TAR_NAME="${IMAGE_NAME}-${IMAGE_TAG}"
 
-docker build -t "${FULL_IMAGE_NAME}" -f "${ROOT_DIR}"/Dockerfile .
+# Build from publicly reachable source by default, but allow people to re-build images on
+# top of their own trusted images.
+BUILDER_BASE_IMAGE="${BUILDER_BASE_IMAGE:-}"
+if [[ -z "${BUILDER_BASE_IMAGE}" ]];
+then
+  docker build \
+    -t "${FULL_IMAGE_NAME}" \
+    -f "${ROOT_DIR}"/Dockerfile .
+else
+  docker build \
+    --build-arg BUILDER_BASE_IMAGE="${BUILDER_BASE_IMAGE}" \
+    -t "${FULL_IMAGE_NAME}" \
+    -f "${ROOT_DIR}"/Dockerfile .
+fi
 
 mkdir -p "${ROOT_DIR}"/artifacts/images
 cd "${ROOT_DIR}"/artifacts/images


### PR DESCRIPTION
Signed-off-by: Benjamin A. Petersen <ben@benjaminapetersen.me>

### What this PR does / why we need it

This fix ensures that the `hack/scripts/build-images.sh` script will pass `BUILDER_BASE_IMAGE` set as an env var down into the build context.  This ensures we can use a proxy registry when utilizing the script. 


### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
