### PR TITLE
Configure Kind subnets for dualstack ipv6 primary

### DIFF
--- a/pkg/v1/tkg/fakes/config/config_ipv6_ipv4_with_cidrs.yaml
+++ b/pkg/v1/tkg/fakes/config/config_ipv6_ipv4_with_cidrs.yaml
@@ -1,0 +1,22 @@
+providers:
+  - name: cluster-api
+    url: providers/cluster-api/v0.0.0/core-components.yaml
+    type: CoreProvider
+  - name: aws
+    url: providers/infrastructure-aws/v0.5.1/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere
+    url: providers/infrastructure-vsphere/v0.6.2/infrastructure-components.yaml
+    type: InfrastructureProvider
+  - name: vsphere-pacific
+    url: providers/infrastructure-tkg-service-vsphere/v1.0.0/unused.yaml
+    type: InfrastructureProvider
+  - name: kubeadm
+    url: providers/bootstrap-kubeadm/v0.3.2/bootstrap-components.yaml
+    type: BootstrapProvider
+  - name: kubeadm
+    url: providers/control-plane-kubeadm/v0.3.2/control-plane-components.yaml
+    type: ControlPlaneProvider
+TKG_IP_FAMILY: "ipv6,ipv4"
+CLUSTER_CIDR: fd00:100:96::/48,100.96.0.0/11
+SERVICE_CIDR: fd00::/48,1.2.3.4/16


### PR DESCRIPTION
### What this PR does / why we need it
Kind currently only supports ipv4 primary dualstack. To deploy ipv6
primary dualstack management clusters we need to configure Kind subnets to use
ipv4 primary ordering.

These changes can be reverted when the next version of kind is released and integrated into TF.


Fixes #

### Describe testing done for PR

Manually built the cli and plugins and deployed a management cluster.

```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
