### PR TITLE
Add edition as annotation to managemenet cluster

### DIFF
--- a/pkg/v1/tkg/client/init.go
+++ b/pkg/v1/tkg/client/init.go
@@ -34,10 +34,11 @@ const (
 )
 
 const (
-	statusRunning       = "running"
-	statusFailed        = "failed"
-	statusSuccessful    = "successful"
-	vsphereVersionError = "the minimum vSphere version supported by Tanzu Kubernetes Grid is vSphere 6.7u3, please upgrade vSphere and try again"
+	editionAnnotationKey = "edition"
+	statusRunning        = "running"
+	statusFailed         = "failed"
+	statusSuccessful     = "successful"
+	vsphereVersionError  = "the minimum vSphere version supported by Tanzu Kubernetes Grid is vSphere 6.7u3, please upgrade vSphere and try again"
 )
 
 // management cluster init step constants
@@ -351,6 +352,12 @@ func (c *TkgClient) PatchClusterInitOperations(regionalClusterClient clusterclie
 	err := regionalClusterClient.PatchClusterObjectWithTKGVersion(options.ClusterName, targetClusterNamespace, c.tkgBomClient.GetCurrentTKGVersion())
 	if err != nil {
 		return errors.Wrap(err, "unable to patch TKG Version")
+	}
+
+	// Patch management cluster with the edition used to bootstrap it (e.g. tce or community-edition)
+	_, err = regionalClusterClient.PatchClusterObjectWithOptionalMetadata(options.ClusterName, targetClusterNamespace, "annotations", map[string]string{editionAnnotationKey: options.Edition})
+	if err != nil {
+		return errors.Wrap(err, "unable to patch edition under annotations")
 	}
 
 	// Patch management cluster with the provided optional metadata


### PR DESCRIPTION
### What this PR does / why we need it

This commit adds the edition as an annotation to management clusters
that are created. This is important for projects/products that might
introspect these management clusters and want to make decisions based on
whether the cluster was bootstrapped as TCE or Tanzu Standard cluster.

### Which issue(s) this PR fixes

Fixes: https://github.com/vmware-tanzu/tanzu-framework/issues/1259

### Describe testing done for PR

TODO(joshrosso)

### Release note

```release-note
Adds annotation (edition: ${EDITION}) to management cluster.
```