### PR TITLE
Provide Short and Long descriptions for plugin source

### DIFF
--- a/pkg/v1/cli/command/core/discovery_source.go
+++ b/pkg/v1/cli/command/core/discovery_source.go
@@ -24,7 +24,8 @@ var (
 
 var discoverySourceCmd = &cobra.Command{
 	Use:   "source",
-	Short: "Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.",
+	Short: "Manage plugin discovery sources",
+	Long:  "Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.",
 }
 
 func init() {


### PR DESCRIPTION
### What this PR does / why we need it

The `tanzu plugin source` command had a long description set as its
Short property, resulting in the help output of `tanzu plugin` being
formatted poorly.

This sets the existing description to be its Long property and uses a
more terse description for the Short value.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1600 

### Describe testing done for PR

Compared original output:

```sh
$ tanzu plugin -h
Manage CLI plugins

Usage:
  tanzu plugin [command]

Available Commands:
  clean       Clean the plugins
  delete      Delete a plugin
  describe    Describe a plugin
  install     Install a plugin
  list        List available plugins
  source      Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.
  sync        Sync the plugins
  upgrade     Upgrade a plugin

Flags:
  -h, --help   help for plugin
```

With new shorter output:

```sh
$ tanzu plugin -h
Manage CLI plugins

Usage:
  tanzu plugin [command]

Available Commands:
  clean       Clean the plugins
  delete      Delete a plugin
  describe    Describe a plugin
  install     Install a plugin
  list        List available plugins
  source      Manage plugin discovery sources
  sync        Sync the plugins
  upgrade     Upgrade a plugin
```

And made sure the longer description is output when asking for specific command help:

```sh
$ tanzu plugin source -h
Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.

Usage:
  tanzu plugin source [command]
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Help output for the subcommands under `tanzu plugin` have been fixed to provide a short description for `tanzu plugin source`.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
