### PR TITLE
Make compatibility file resolution happen via config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ endif
 CUSTOM_NPM_REGISTRY ?= $(shell git config tkg.npmregistry)
 
 # TKG Compatibility Image repo and  path related configuration
+# These set the defaults after a fresh install in ~/.config/tanzu/config.yaml
+# Users can change these values by running commands like:
+# tanzu config set cli.edition tce
 ifndef TKG_DEFAULT_IMAGE_REPOSITORY
 TKG_DEFAULT_IMAGE_REPOSITORY = "projects-stg.registry.vmware.com/tkg"
 endif

--- a/apis/config/v1alpha1/clientconfig_types.go
+++ b/apis/config/v1alpha1/clientconfig_types.go
@@ -112,6 +112,12 @@ type CLIOptions struct {
 	UnstableVersionSelector VersionSelectorLevel `json:"unstableVersionSelector,omitempty" yaml:"unstableVersionSelector"`
 	// Edition
 	Edition EditionSelector `json:"edition,omitempty" yaml:"edition"`
+	// BOMRepo is the root repository URL used to resolve the compatibiilty file
+	// and bill of materials. An example URL is projects.registry.vmware.com/tkg.
+	BOMRepo string `json:"bomRepo,omitempty" yaml:"bomRepo"`
+	// CompatibilityFilePath is the path, from the BOM repo, to download and access the compatibility file.
+	// the compatibility file is used for resolving the bill of materials for creating clusters.
+	CompatibilityFilePath string `json:"compatibilityFilePath,omitempty" yaml:"compatibilityFilePath"`
 }
 
 // PluginDiscovery contains a specific distribution mechanism. Only one of the

--- a/pkg/v1/cli/command/core/config.go
+++ b/pkg/v1/cli/command/core/config.go
@@ -182,9 +182,14 @@ func setEdition(cfg *configv1alpha1.ClientConfig, edition string) error {
 	editionOption := configv1alpha1.EditionSelector(edition)
 
 	switch editionOption {
-	case configv1alpha1.EditionCommunity,
-		configv1alpha1.EditionStandard:
+	case configv1alpha1.EditionCommunity, configv1alpha1.EditionStandard:
 		cfg.SetEditionSelector(editionOption)
+		// when community edition is set, configure the compatibility file to use
+		// community edition's.
+		err := cfg.SetCompatibilityFile(editionOption)
+		if err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("unknown edition: %s; should be one of [%s, %s]", editionOption, configv1alpha1.EditionStandard, configv1alpha1.EditionCommunity)
 	}

--- a/pkg/v1/tkg/fakes/tkgconfigbomclient.go
+++ b/pkg/v1/tkg/fakes/tkgconfigbomclient.go
@@ -9,10 +9,11 @@ import (
 )
 
 type TKGConfigBomClient struct {
-	DownloadDefaultBOMFilesFromRegistryStub        func(registry.Registry) error
+	DownloadDefaultBOMFilesFromRegistryStub        func(string, registry.Registry) error
 	downloadDefaultBOMFilesFromRegistryMutex       sync.RWMutex
 	downloadDefaultBOMFilesFromRegistryArgsForCall []struct {
-		arg1 registry.Registry
+		arg1 string
+		arg2 registry.Registry
 	}
 	downloadDefaultBOMFilesFromRegistryReturns struct {
 		result1 error
@@ -20,10 +21,12 @@ type TKGConfigBomClient struct {
 	downloadDefaultBOMFilesFromRegistryReturnsOnCall map[int]struct {
 		result1 error
 	}
-	DownloadTKGCompatibilityFileFromRegistryStub        func(registry.Registry) error
+	DownloadTKGCompatibilityFileFromRegistryStub        func(string, string, registry.Registry) error
 	downloadTKGCompatibilityFileFromRegistryMutex       sync.RWMutex
 	downloadTKGCompatibilityFileFromRegistryArgsForCall []struct {
-		arg1 registry.Registry
+		arg1 string
+		arg2 string
+		arg3 registry.Registry
 	}
 	downloadTKGCompatibilityFileFromRegistryReturns struct {
 		result1 error
@@ -230,18 +233,19 @@ type TKGConfigBomClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *TKGConfigBomClient) DownloadDefaultBOMFilesFromRegistry(arg1 registry.Registry) error {
+func (fake *TKGConfigBomClient) DownloadDefaultBOMFilesFromRegistry(arg1 string, arg2 registry.Registry) error {
 	fake.downloadDefaultBOMFilesFromRegistryMutex.Lock()
 	ret, specificReturn := fake.downloadDefaultBOMFilesFromRegistryReturnsOnCall[len(fake.downloadDefaultBOMFilesFromRegistryArgsForCall)]
 	fake.downloadDefaultBOMFilesFromRegistryArgsForCall = append(fake.downloadDefaultBOMFilesFromRegistryArgsForCall, struct {
-		arg1 registry.Registry
-	}{arg1})
+		arg1 string
+		arg2 registry.Registry
+	}{arg1, arg2})
 	stub := fake.DownloadDefaultBOMFilesFromRegistryStub
 	fakeReturns := fake.downloadDefaultBOMFilesFromRegistryReturns
-	fake.recordInvocation("DownloadDefaultBOMFilesFromRegistry", []interface{}{arg1})
+	fake.recordInvocation("DownloadDefaultBOMFilesFromRegistry", []interface{}{arg1, arg2})
 	fake.downloadDefaultBOMFilesFromRegistryMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
@@ -255,17 +259,17 @@ func (fake *TKGConfigBomClient) DownloadDefaultBOMFilesFromRegistryCallCount() i
 	return len(fake.downloadDefaultBOMFilesFromRegistryArgsForCall)
 }
 
-func (fake *TKGConfigBomClient) DownloadDefaultBOMFilesFromRegistryCalls(stub func(registry.Registry) error) {
+func (fake *TKGConfigBomClient) DownloadDefaultBOMFilesFromRegistryCalls(stub func(string, registry.Registry) error) {
 	fake.downloadDefaultBOMFilesFromRegistryMutex.Lock()
 	defer fake.downloadDefaultBOMFilesFromRegistryMutex.Unlock()
 	fake.DownloadDefaultBOMFilesFromRegistryStub = stub
 }
 
-func (fake *TKGConfigBomClient) DownloadDefaultBOMFilesFromRegistryArgsForCall(i int) registry.Registry {
+func (fake *TKGConfigBomClient) DownloadDefaultBOMFilesFromRegistryArgsForCall(i int) (string, registry.Registry) {
 	fake.downloadDefaultBOMFilesFromRegistryMutex.RLock()
 	defer fake.downloadDefaultBOMFilesFromRegistryMutex.RUnlock()
 	argsForCall := fake.downloadDefaultBOMFilesFromRegistryArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *TKGConfigBomClient) DownloadDefaultBOMFilesFromRegistryReturns(result1 error) {
@@ -291,18 +295,20 @@ func (fake *TKGConfigBomClient) DownloadDefaultBOMFilesFromRegistryReturnsOnCall
 	}{result1}
 }
 
-func (fake *TKGConfigBomClient) DownloadTKGCompatibilityFileFromRegistry(arg1 registry.Registry) error {
+func (fake *TKGConfigBomClient) DownloadTKGCompatibilityFileFromRegistry(arg1 string, arg2 string, arg3 registry.Registry) error {
 	fake.downloadTKGCompatibilityFileFromRegistryMutex.Lock()
 	ret, specificReturn := fake.downloadTKGCompatibilityFileFromRegistryReturnsOnCall[len(fake.downloadTKGCompatibilityFileFromRegistryArgsForCall)]
 	fake.downloadTKGCompatibilityFileFromRegistryArgsForCall = append(fake.downloadTKGCompatibilityFileFromRegistryArgsForCall, struct {
-		arg1 registry.Registry
-	}{arg1})
+		arg1 string
+		arg2 string
+		arg3 registry.Registry
+	}{arg1, arg2, arg3})
 	stub := fake.DownloadTKGCompatibilityFileFromRegistryStub
 	fakeReturns := fake.downloadTKGCompatibilityFileFromRegistryReturns
-	fake.recordInvocation("DownloadTKGCompatibilityFileFromRegistry", []interface{}{arg1})
+	fake.recordInvocation("DownloadTKGCompatibilityFileFromRegistry", []interface{}{arg1, arg2, arg3})
 	fake.downloadTKGCompatibilityFileFromRegistryMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -316,17 +322,17 @@ func (fake *TKGConfigBomClient) DownloadTKGCompatibilityFileFromRegistryCallCoun
 	return len(fake.downloadTKGCompatibilityFileFromRegistryArgsForCall)
 }
 
-func (fake *TKGConfigBomClient) DownloadTKGCompatibilityFileFromRegistryCalls(stub func(registry.Registry) error) {
+func (fake *TKGConfigBomClient) DownloadTKGCompatibilityFileFromRegistryCalls(stub func(string, string, registry.Registry) error) {
 	fake.downloadTKGCompatibilityFileFromRegistryMutex.Lock()
 	defer fake.downloadTKGCompatibilityFileFromRegistryMutex.Unlock()
 	fake.DownloadTKGCompatibilityFileFromRegistryStub = stub
 }
 
-func (fake *TKGConfigBomClient) DownloadTKGCompatibilityFileFromRegistryArgsForCall(i int) registry.Registry {
+func (fake *TKGConfigBomClient) DownloadTKGCompatibilityFileFromRegistryArgsForCall(i int) (string, string, registry.Registry) {
 	fake.downloadTKGCompatibilityFileFromRegistryMutex.RLock()
 	defer fake.downloadTKGCompatibilityFileFromRegistryMutex.RUnlock()
 	argsForCall := fake.downloadTKGCompatibilityFileFromRegistryArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *TKGConfigBomClient) DownloadTKGCompatibilityFileFromRegistryReturns(result1 error) {

--- a/pkg/v1/tkg/tkgconfigbom/bom_test.go
+++ b/pkg/v1/tkg/tkgconfigbom/bom_test.go
@@ -100,7 +100,7 @@ var (
 					fakeRegistry.GetFileReturns(nil, errors.New("fake GetFile error for TKG BOM file"))
 				})
 				It("returns an error", func() {
-					err := bomClient.DownloadDefaultBOMFilesFromRegistry(fakeRegistry)
+					err := bomClient.DownloadDefaultBOMFilesFromRegistry("", fakeRegistry)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("failed to download the BOM file from image name"))
 					Expect(err.Error()).To(ContainSubstring("fake GetFile error for TKG BOM file"))
@@ -115,7 +115,7 @@ var (
 					fakeRegistry.GetFileReturnsOnCall(1, nil, errors.New("fake GetFile error for TKr BOM file"))
 				})
 				It("should return an error", func() {
-					err := bomClient.DownloadDefaultBOMFilesFromRegistry(fakeRegistry)
+					err := bomClient.DownloadDefaultBOMFilesFromRegistry("", fakeRegistry)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("failed to download the BOM file from image name"))
 					Expect(err.Error()).To(ContainSubstring("fake GetFile error for TKr BOM file"))
@@ -131,7 +131,7 @@ var (
 					fakeRegistry.GetFileReturnsOnCall(1, tkrdata, nil)
 				})
 				It("should return success", func() {
-					err := bomClient.DownloadDefaultBOMFilesFromRegistry(fakeRegistry)
+					err := bomClient.DownloadDefaultBOMFilesFromRegistry("", fakeRegistry)
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})
@@ -157,7 +157,7 @@ var (
 					fakeRegistry.ListImageTagsReturns(nil, errors.New("fake ListImageTags error for TKG Compatibility Image"))
 				})
 				It("returns an error", func() {
-					err := bomClient.DownloadTKGCompatibilityFileFromRegistry(fakeRegistry)
+					err := bomClient.DownloadTKGCompatibilityFileFromRegistry("", "", fakeRegistry)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("failed to list TKG compatibility image tags"))
 					Expect(err.Error()).To(ContainSubstring("fake ListImageTags error for TKG Compatibility Image"))
@@ -173,7 +173,7 @@ var (
 					// })
 				})
 				It("should return an error", func() {
-					err := bomClient.DownloadTKGCompatibilityFileFromRegistry(fakeRegistry)
+					err := bomClient.DownloadTKGCompatibilityFileFromRegistry("", "", fakeRegistry)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("failed to get valid image tags for TKG compatibility image"))
 
@@ -189,7 +189,7 @@ var (
 					})
 				})
 				It("should return an error", func() {
-					err := bomClient.DownloadTKGCompatibilityFileFromRegistry(fakeRegistry)
+					err := bomClient.DownloadTKGCompatibilityFileFromRegistry("", "", fakeRegistry)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("failed to download the TKG Compatibility file from image name"))
 					Expect(err.Error()).To(ContainSubstring("fake GetFile error for TKG Compatibility file"))
@@ -203,7 +203,7 @@ var (
 					fakeRegistry.GetFileReturns([]byte(testTKGCompatabilityFileContent), nil)
 				})
 				It("should return success", func() {
-					err := bomClient.DownloadTKGCompatibilityFileFromRegistry(fakeRegistry)
+					err := bomClient.DownloadTKGCompatibilityFileFromRegistry("", "", fakeRegistry)
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})

--- a/pkg/v1/tkg/tkgconfigbom/client.go
+++ b/pkg/v1/tkg/tkgconfigbom/client.go
@@ -53,9 +53,9 @@ type Client interface {
 	IsCustomRepositorySkipTLSVerify() bool
 	GetAutoscalerImageForK8sVersion(k8sVersion string) (string, error)
 	// Downloads the default BOM files from the registry
-	DownloadDefaultBOMFilesFromRegistry(registry.Registry) error
+	DownloadDefaultBOMFilesFromRegistry(bomRepo string, bomRegistry registry.Registry) error
 	// Downloads the TKG Compatibility file from the registry
-	DownloadTKGCompatibilityFileFromRegistry(registry.Registry) error
+	DownloadTKGCompatibilityFileFromRegistry(repo string, resource string, bomRegistry registry.Registry) error
 	// Initializes the registry for downloading the bom files
 	InitBOMRegistry() (registry.Registry, error)
 	// GetDefaultTKRVersion return default TKr version from default TKG BOM file

--- a/pkg/v1/tkg/tkgconfigupdater/ensure.go
+++ b/pkg/v1/tkg/tkgconfigupdater/ensure.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgconfigbom"
@@ -138,7 +139,10 @@ func (c *client) EnsureTKGCompatibilityFile(forceUpdate bool) error {
 		return errors.Wrap(err, "failed to initialize the BOM registry to download default TKG compatibility file ")
 	}
 
-	err = c.tkgBomClient.DownloadTKGCompatibilityFileFromRegistry(bomRegistry)
+	repo, _ := config.GetDefaultRepo()
+	path, _ := config.GetCompatibilityFilePath()
+
+	err = c.tkgBomClient.DownloadTKGCompatibilityFileFromRegistry(repo, path, bomRegistry)
 	if err != nil {
 		return errors.Wrap(err, "failed to download TKG compatibility file from the registry")
 	}
@@ -195,7 +199,9 @@ func (c *client) EnsureBOMFiles(forceUpdate bool) error {
 		return errors.Wrap(err, "failed to initialize the BOM registry to download default bom files ")
 	}
 
-	err = c.tkgBomClient.DownloadDefaultBOMFilesFromRegistry(bomRegistry)
+	repo, _ := config.GetDefaultRepo()
+
+	err = c.tkgBomClient.DownloadDefaultBOMFilesFromRegistry(repo, bomRegistry)
 	if err != nil {
 		return errors.Wrap(err, "failed to download default bom files from the registry")
 	}


### PR DESCRIPTION
## What this PR does / why we need it

It is critical that tanzu `management-cluster` and `cluster` plugins can work against different editions without re-compiling binaries. Today, they require re-compilation due to setting default via LD_FLAGS. This PR continues to support defaulting via LD_FLAGS, but propagates these values into `${HOME}/.config/tanzu/config.yaml`. This enables the switching of values based on setting editions.

In `config.yaml` the following `clientOptions.cli` fields are introduced:

```yaml
apiVersion: config.tanzu.vmware.com/v1alpha1
clientOptions:                                                                                                                                 
  cli:                                                                                                                                         
    bomRepo: projects-stg.registry.vmware.com/tkg                                                                                              
    compatibilityFilePath: framework-zshippable/tkg-compatibility 
```

`bomRepo` is the repository (prefix) for resolving the compatibility file and (TKG) BOM.
`compatibilityFilePath` is the path (project) where the compatibility file is found. The full URI will be resolved as: `bomRepo` + "/" + `compatibilityFilePath`.

## Describe testing done for PR

1. Run `make build-install-cli-all ENVS=linux-amd64`.
2. Run `cat ~/.config/tanzu/config.yaml`

    ```yaml
    $ cat ~/.config/tanzu/config.yaml 
    apiVersion: config.tanzu.vmware.com/v1alpha1
    clientOptions:
      cli:
        bomRepo: projects-stg.registry.vmware.com/tkg
        compatibilityFilePath: framework-zshippable/tkg-compatibility
        discoverySources:
        - local:
            name: default-local
            path: standalone
        - local:
            name: admin-local
            path: admin
        edition: tkg
        repositories:
        - gcpPluginRepository:
            bucketName: tanzu-cli-framework
            name: core
        unstableVersionSelector: none
      features:
        cluster:
          custom-nameservers: "false"
          dual-stack-ipv4-primary: "false"
          dual-stack-ipv6-primary: "false"
        global:
          context-aware-cli-for-plugins: "true"
        management-cluster:
          custom-nameservers: "false"
          dual-stack-ipv4-primary: "false"
          dual-stack-ipv6-primary: "false"
          export-from-confirm: "true"
          import: "false"
          network-separation-beta: "false"
          standalone-cluster-mode: "false"
    kind: ClientConfig
    metadata:
      creationTimestamp: null
    ```

3. Verify correct files are downloaded.

    ```sh
    Downloading TKG compatibility file from 'projects-stg.registry.vmware.com/tkg/framework-zshippable/tkg-compatibility'
    Downloading the TKG Bill of Materials (BOM) file from 'projects-stg.registry.vmware.com/tkg/tkg-bom:v1.6.0-zshippable'
    Downloading the TKr Bill of Materials (BOM) file from 'projects-stg.registry.vmware.com/tkg/tkr-bom:v1.22.5_vmware.1-tkg.2-zshippable'
    ```

### Switch the edition to TCE

1. Set the edition.

    ```sh
    $ tanzu config set cli.edition tce
    ℹ  Edition changed. Clearing compatibility file at /home/josh/.config/tanzu/tkg/compatibility/tkg-compatibility.yaml
    ```

1. Examine `~/.config/tanzu/config.yaml`.

    ```yaml
    apiVersion: config.tanzu.vmware.com/v1alpha1
    clientOptions:
      cli:
        bomRepo: projects.registry.vmware.com/tce
        compatibilityFilePath: tkg-compatibility
        discoverySources:
        - local:
            name: default-local
            path: standalone
        - local:
            name: admin-local
            path: admin
        edition: tce
        repositories:
        - gcpPluginRepository:
            bucketName: tanzu-cli-framework
            name: core
        unstableVersionSelector: none
      features:
        cluster:
          custom-nameservers: "false"
          dual-stack-ipv4-primary: "false"
          dual-stack-ipv6-primary: "false"
        global:
          context-aware-cli-for-plugins: "true"
        management-cluster:
          custom-nameservers: "false"
          dual-stack-ipv4-primary: "false"
          dual-stack-ipv6-primary: "false"
          export-from-confirm: "true"
          import: "false"
          network-separation-beta: "false"
          standalone-cluster-mode: "false"
    kind: ClientConfig
    metadata:
      creationTimestamp: null
    ```

1. Verify correct files are downloaded.

    ```sh
    Downloading TKG compatibility file from 'projects.registry.vmware.com/tce/tkg-compatibility'
    Downloading the TKG Bill of Materials (BOM) file from 'projects.registry.vmware.com/tce/tkg-bom:v1.4.1'
    Downloading the TKr Bill of Materials (BOM) file from 'projects.registry.vmware.com/tkg/tkr-bom:v1.21.2_vmware.1-tkg.2'
    the old providers folder /home/josh/.config/tanzu/tkg/providers is backed up to /home/josh/.config/tanzu/tkg/providers-20220207061309-gzu5wz8j
    ```

### Which issue(s) this PR fixes

Fixes: https://github.com/vmware-tanzu/tanzu-framework/issues/1602

### Release note

```release-note
Compatibility file can now be set via config value rather than exclusively at build time.
```