### PR TITLE
Separate long and short CLI descriptions

### DIFF
--- a/cmd/cli/plugin/cluster/delete_machinehealthcheck_control_plane.go
+++ b/cmd/cli/plugin/cluster/delete_machinehealthcheck_control_plane.go
@@ -24,7 +24,7 @@ var deleteMHCCP = &deleteMachineHealthCheckCPOptions{}
 
 var deleteMachineHealthCheckCPCmd = &cobra.Command{
 	Use:   "delete CLUSTER_NAME",
-	Short: "Delete a MachineHealthCheck object of the control plane of a cluster",
+	Short: "Delete a MachineHealthCheck object",
 	Long:  "Delete a MachineHealthCheck object of the control plane of a cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE:  deleteMachineHealthCheckCP,

--- a/cmd/cli/plugin/cluster/delete_machinehealthcheck_node.go
+++ b/cmd/cli/plugin/cluster/delete_machinehealthcheck_node.go
@@ -24,7 +24,7 @@ var deleteMHCNode = &deleteMachineHealthCheckNodeOptions{}
 
 var deleteMachineHealthCheckNodeCmd = &cobra.Command{
 	Use:   "delete CLUSTER_NAME",
-	Short: "Delete a MachineHealthCheck object of the nodes of a cluster",
+	Short: "Delete a MachineHealthCheck object",
 	Long:  "Delete a MachineHealthCheck object of the nodes of a cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE:  deleteMachineHealthCheckNode,

--- a/cmd/cli/plugin/cluster/get_machinehealthcheck_control_plane.go
+++ b/cmd/cli/plugin/cluster/get_machinehealthcheck_control_plane.go
@@ -25,7 +25,7 @@ var getMHCCP = &getMachineHealthCheckCPOptions{}
 
 var getMachineHealthCheckCPCmd = &cobra.Command{
 	Use:   "get CLUSTER_NAME",
-	Short: "Get a MachineHealthCheck object of the control plane of a cluster",
+	Short: "Get a MachineHealthCheck object",
 	Long:  "Get a MachineHealthCheck object of the control plane for the given cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE:  getMachineHealthCheckCP,

--- a/cmd/cli/plugin/managementcluster/get_ceip.go
+++ b/cmd/cli/plugin/managementcluster/get_ceip.go
@@ -12,7 +12,7 @@ import (
 var getCeipCmd = &cobra.Command{
 	Use:     "get",
 	Aliases: []string{"ceip", "ceip-participations"},
-	Short:   "Get the current CEIP opt-in status of the current management cluster",
+	Short:   "Get the current CEIP opt-in status",
 	Long:    "Get the current CEIP opt-in status of the current management cluster",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGetCEIP(cmd)

--- a/cmd/cli/plugin/managementcluster/import.go
+++ b/cmd/cli/plugin/managementcluster/import.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"sigs.k8s.io/cluster-api/cmd/clusterctl/cmd"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/region"
@@ -27,10 +26,8 @@ var importOption = &importOptions{}
 // TODO: add integration tests
 var importCmd = &cobra.Command{
 	Use:   "import",
-	Short: "Import Tanzu Kubernetes Grid management clusters from TKG settings file",
-	Long: cmd.LongDesc(`
-			Import Tanzu Kubernetes Grid management cluster from TKG settings file
-		`),
+	Short: "Import Tanzu Kubernetes Grid management clusters",
+	Long:  "Import Tanzu Kubernetes Grid management cluster from TKG settings file",
 
 	Example: `
     # Import management cluster config from default config file	

--- a/cmd/cli/plugin/managementcluster/set_ceip.go
+++ b/cmd/cli/plugin/managementcluster/set_ceip.go
@@ -12,7 +12,7 @@ var labels string
 
 var setCeipCmd = &cobra.Command{
 	Use:   "set OPT_IN_BOOL",
-	Short: "Set the opt-in preference for CEIP of the current management cluster",
+	Short: "Set the opt-in preference for CEIP",
 	Long:  "Set the opt-in preference for CEIP of the current management cluster",
 	Args:  cobra.ExactArgs(1),
 	RunE:  runSetCeip,

--- a/cmd/cli/plugin/package/package_available_get.go
+++ b/cmd/cli/plugin/package/package_available_get.go
@@ -24,7 +24,8 @@ import (
 
 var packageAvailableGetCmd = &cobra.Command{
 	Use:   "get PACKAGE_NAME or PACKAGE_NAME/VERSION",
-	Short: "Get details for an available package or the openAPI schema of a package with a specific version",
+	Short: "Get details for an available package",
+	Long:  "Get details for an available package or the openAPI schema of a package with a specific version",
 	Args:  cobra.ExactArgs(1),
 	Example: `
     # Get package details for a package without specifying the version

--- a/cmd/cli/plugin/secret/registry_secret_add.go
+++ b/cmd/cli/plugin/secret/registry_secret_add.go
@@ -28,7 +28,8 @@ const errEmptyValue = "the value for %s flag should not be empty"
 
 var registrySecretAddCmd = &cobra.Command{
 	Use:   "add SECRET_NAME --server REGISTRY_SERVER --username USERNAME --password PASSWORD",
-	Short: "Creates a v1/Secret resource of type kubernetes.io/dockerconfigjson. In case of specifying the --export-to-all-namespaces flag, a SecretExport resource will also get created",
+	Short: "Creates a v1/Secret resource",
+	Long:  "Creates a v1/Secret resource of type kubernetes.io/dockerconfigjson. In case of specifying the --export-to-all-namespaces flag, a SecretExport resource will also get created.",
 	Example: `
     # Add a registry secret
     tanzu secret registry add test-secret --server projects-stg.registry.vmware.com --username test-user --password-file test-file

--- a/cmd/cli/plugin/secret/registry_secret_delete.go
+++ b/cmd/cli/plugin/secret/registry_secret_delete.go
@@ -17,7 +17,8 @@ import (
 
 var registrySecretDeleteCmd = &cobra.Command{
 	Use:   "delete SECRET_NAME",
-	Short: "Deletes v1/Secret resource of type kubernetes.io/dockerconfigjson and the associated SecretExport from the cluster",
+	Short: "Deletes a v1/Secret resource",
+	Long:  "Deletes a v1/Secret resource of type kubernetes.io/dockerconfigjson and the associated SecretExport from the cluster",
 	Example: `
     # Delete a registry secret
     tanzu registry secret delete test-secret`,

--- a/cmd/cli/plugin/secret/registry_secret_list.go
+++ b/cmd/cli/plugin/secret/registry_secret_list.go
@@ -18,7 +18,8 @@ import (
 
 var registrySecretListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "Lists all v1/Secret of type kubernetes.io/dockerconfigjson and checks for the associated SecretExport with the same name",
+	Short: "Lists all v1/Secrets",
+	Long:  "Lists all v1/Secret of type kubernetes.io/dockerconfigjson and checks for the associated SecretExport with the same name",
 	Args:  cobra.NoArgs,
 	Example: `
     # List registry secrets across all namespaces

--- a/cmd/cli/plugin/secret/registry_secret_update.go
+++ b/cmd/cli/plugin/secret/registry_secret_update.go
@@ -17,7 +17,8 @@ import (
 
 var registrySecretUpdateCmd = &cobra.Command{
 	Use:   "update SECRET_NAME --username USERNAME --password PASSWORD",
-	Short: "Updates the v1/Secret resource of type kubernetes.io/dockerconfigjson. In case of specifying the --export-to-all-namespaces flag, the SecretExport resource will also get updated. Otherwise, there will be no changes in the SecretExport resource",
+	Short: "Updates the v1/Secret resource",
+	Long:  "Updates the v1/Secret resource of type kubernetes.io/dockerconfigjson. In case of specifying the --export-to-all-namespaces flag, the SecretExport resource will also get updated. Otherwise, there will be no changes in the SecretExport resource.",
 	Example: `
     # Update a registry secret. There will be no changes in the associated SecretExport resource
     tanzu registry secret update test-secret --username test-user --password-file test-file

--- a/pkg/v1/builder/command/publish.go
+++ b/pkg/v1/builder/command/publish.go
@@ -24,7 +24,7 @@ var (
 // PublishCmd publishes plugin resources
 var PublishCmd = &cobra.Command{
 	Use:   "publish",
-	Short: "publish operations",
+	Short: "Publish operations",
 	RunE:  publishPlugins,
 }
 

--- a/pkg/v1/cli/command/core/config.go
+++ b/pkg/v1/cli/command/core/config.go
@@ -74,7 +74,8 @@ var getConfigCmd = &cobra.Command{
 
 var setConfigCmd = &cobra.Command{
 	Use:   "set <path> <value>",
-	Short: "Set config values at the given path. path values: [unstable-versions, cli.edition, features.global.<feature>, features.<plugin>.<feature>, env.<variable>]",
+	Short: "Set config values at the given path",
+	Long:  "Set config values at the given path. path values: [unstable-versions, cli.edition, features.global.<feature>, features.<plugin>.<feature>, env.<variable>]",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 2 {
 			return errors.Errorf("both path and value are required")
@@ -274,7 +275,7 @@ var listServersCmd = &cobra.Command{
 
 var deleteServersCmd = &cobra.Command{
 	Use:   "delete SERVER_NAME",
-	Short: "delete a server from the config",
+	Short: "Delete a server from the config",
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
@@ -310,7 +311,8 @@ var deleteServersCmd = &cobra.Command{
 
 var unsetConfigCmd = &cobra.Command{
 	Use:   "unset <path>",
-	Short: "Unset config values at the given path. path values: [features.global.<feature>, features.<plugin>.<feature>, env.global.<variable>, env.<plugin>.<variable>]",
+	Short: "Unset config values at the given path",
+	Long:  "Unset config values at the given path. path values: [features.global.<feature>, features.<plugin>.<feature>, env.global.<variable>, env.<plugin>.<variable>]",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
 			return errors.Errorf("path is required")

--- a/pkg/v1/cli/command/core/discovery_source.go
+++ b/pkg/v1/cli/command/core/discovery_source.go
@@ -24,7 +24,8 @@ var (
 
 var discoverySourceCmd = &cobra.Command{
 	Use:   "source",
-	Short: "Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.",
+	Short: "Manage plugin discovery sources",
+	Long:  "Manage plugin discovery sources. Discovery source provides metadata about the list of available plugins, their supported versions and how to download them.",
 }
 
 func init() {
@@ -87,7 +88,8 @@ func outputFromDiscoverySources(discoverySources []configv1alpha1.PluginDiscover
 
 var addDiscoverySourceCmd = &cobra.Command{
 	Use:   "add",
-	Short: "Add a discovery source. Supported discovery types are: oci, local",
+	Short: "Add a discovery source",
+	Long:  "Add a discovery source. Supported discovery types are: oci, local",
 	Example: `
     # Add a local discovery source. If URI is relative path,
     # $HOME/.config/tanzu-plugins will be considered based path

--- a/pkg/v1/tkg/cmd/add_region.go
+++ b/pkg/v1/tkg/cmd/add_region.go
@@ -18,7 +18,7 @@ var (
 	ar           = &addRegionOptions{}
 	addRegionCmd = &cobra.Command{
 		Use:     "management-cluster",
-		Short:   "Add an existing management cluster to the config file",
+		Short:   "Add an existing management cluster",
 		Long:    "Add an existing management cluster to the config file",
 		Aliases: []string{"mc"},
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/v1/tkg/cmd/config.go
+++ b/pkg/v1/tkg/cmd/config.go
@@ -9,8 +9,8 @@ import (
 
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "Generate Cluster API provider configuration and cluster plans for creating Tanzu Kubernetes clusters",
-	Long:  `Generate Cluster API provider configuration and cluster plans for creating Tanzu Kubernetes clusters`,
+	Short: "Generate Cluster API provider configuration",
+	Long:  "Generate Cluster API provider configuration and cluster plans for creating Tanzu Kubernetes clusters",
 }
 
 func init() {

--- a/pkg/v1/tkg/cmd/get_ceip.go
+++ b/pkg/v1/tkg/cmd/get_ceip.go
@@ -14,7 +14,7 @@ var outputFormat string
 var getCeipCmd = &cobra.Command{
 	Use:     "ceip-participation",
 	Aliases: []string{"ceip", "ceip-participations"},
-	Short:   "Get the current CEIP opt-in status of the current management cluster",
+	Short:   "Get the current CEIP opt-in status",
 	Long:    "Get the current CEIP opt-in status of the current management cluster",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGetCEIP(cmd)

--- a/pkg/v1/tkg/cmd/get_kubernetes_versions.go
+++ b/pkg/v1/tkg/cmd/get_kubernetes_versions.go
@@ -14,7 +14,7 @@ import (
 var getkvCmd = &cobra.Command{
 	Use:     "kubernetesversions",
 	Aliases: []string{"kv", "kubernetesversion"},
-	Short:   "Get the list of supported kubernetes versions for workload clusters",
+	Short:   "Get the list of supported kubernetes versions",
 	Long:    "Get the list of supported kubernetes versions for workload clusters",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGetTKR(cmd)

--- a/pkg/v1/tkg/cmd/set_ceip.go
+++ b/pkg/v1/tkg/cmd/set_ceip.go
@@ -14,7 +14,7 @@ var (
 
 var setCeipCmd = &cobra.Command{
 	Use:     "ceip-participation OPT_IN_BOOL",
-	Short:   "Set the opt-in preference for CEIP of the current management cluster",
+	Short:   "Set the opt-in preference for CEIP",
 	Long:    "Set the opt-in preference for CEIP of the current management cluster",
 	Aliases: []string{"ceip", "ceip-participations"},
 	Args:    cobra.ExactArgs(1),


### PR DESCRIPTION
### What this PR does / why we need it

There were several CLI commands that were setting very long strings as
their "Short" description, and either duplicating it as the "Long"
description or leaving the Long to default. This causes harder to read
formatting issues when looking at command help output.

This updates these instances to use a more concise short description,
separating out a Long description where there is more detailed
information to show.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1600 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Ran `parent_cmd -h` for a few and verified the listed output for subcommands was well formatted.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
CLI usage information now formats subcommand descriptions to be more readable.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access