### PR TITLE
List context server name in `plugin source list`

### DIFF
--- a/pkg/v1/cli/command/core/discovery_source.go
+++ b/pkg/v1/cli/command/core/discovery_source.go
@@ -68,10 +68,15 @@ var listDiscoverySourceCmd = &cobra.Command{
 
 		// Get context scoped discoveries
 		server, err := config.GetCurrentServer()
-		if err == nil && server != nil && server.DiscoverySources != nil {
-			outputFromDiscoverySources(server.DiscoverySources, common.PluginScopeContext, output)
+		if err == nil && server != nil {
+			var serverDiscoverySources []configv1alpha1.PluginDiscovery
+			if server.DiscoverySources == nil {
+				serverDiscoverySources = config.GetDiscoverySources(server.Name)
+			} else {
+				serverDiscoverySources = server.DiscoverySources
+			}
+			outputFromDiscoverySources(serverDiscoverySources, common.PluginScopeContext, output)
 		}
-
 		output.Render()
 
 		return nil


### PR DESCRIPTION
Allows to list Context-aware plugin source's for command `tanzu plugin source list`

### What this PR does / why we need it

### Which issue(s) this PR fixes

Fixes #1472 

### Describe testing done for PR

In the `tanzu plugin source list` flow, When the Discovery source is empty for the current server, then it generates the discovery source based on other parameters, which are already implemented, we are reusing it in this flow.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```NONE```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

