### PR TITLE
CLI: Add pre-download verification for HTTP plugin artifacts

### DIFF
--- a/pkg/v1/cli/pluginmanager/manager_test.go
+++ b/pkg/v1/cli/pluginmanager/manager_test.go
@@ -613,3 +613,30 @@ func configureAndTestVerifyRegistry(testImage, defaultRegistry, customImageRepos
 	os.Setenv(constants.AllowedRegistries, "")
 	return err
 }
+
+func TestVerifyArtifactLocation(t *testing.T) {
+	tcs := []struct {
+		name   string
+		uri    string
+		errStr string
+	}{
+		{
+			name: "trusted location",
+			uri:  "https://storage.googleapis.com/tanzu-cli-advanced-plugins/artifacts/latest/tanzu-foo-darwin-amd64",
+		},
+		{
+			name:   "untrusted location",
+			uri:    "https://storage.googleapis.com/tanzu-cli-advanced-plugins-artifacts/latest/tanzu-foo-darwin-amd64",
+			errStr: "untrusted artifact location detected with URI \"https://storage.googleapis.com/tanzu-cli-advanced-plugins-artifacts/latest/tanzu-foo-darwin-amd64\". Allowed locations are [https://storage.googleapis.com/tanzu-cli-advanced-plugins/]",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verifyArtifactLocation(tc.uri)
+			if tc.errStr != "" {
+				assert.EqualError(t, err, tc.errStr)
+			}
+		})
+	}
+}

--- a/pkg/v1/config/defaults.go
+++ b/pkg/v1/config/defaults.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -100,7 +101,7 @@ func GetDefaultStandaloneDiscoveryLocalPath() string {
 // GetTrustedRegistries returns the list of trusted registries that can be used for
 // downloading the CLIPlugins
 func GetTrustedRegistries() []string {
-	trustedRegistries := []string{}
+	var trustedRegistries []string
 
 	// Add default registry to trusted registries
 	if DefaultStandaloneDiscoveryRepository != "" {
@@ -120,4 +121,20 @@ func GetTrustedRegistries() []string {
 	}
 
 	return trustedRegistries
+}
+
+func getHTTPURIForGCPPluginRepository(repo configv1alpha1.GCPPluginRepository) string {
+	return fmt.Sprintf("https://storage.googleapis.com/%s/", repo.BucketName)
+}
+
+// GetTrustedArtifactLocations returns the list of trusted URI prefixes that can
+// be trusted for downloading the CLIPlugins. Currently, this includes only the
+// "tanzu-cli-advanced-plugins" GCP bucket where TMC plugins are stored. Other
+// exceptions can be added as and when necessary.
+func GetTrustedArtifactLocations() []string {
+	trustedLocations := []string{
+		getHTTPURIForGCPPluginRepository(AdvancedGCPBucketRepository),
+	}
+
+	return trustedLocations
 }


### PR DESCRIPTION
### What this PR does / why we need it
Currently, this trusts any local path and the "tanzu-cli-advanced-plugins" GCP bucket where TMC plugins are stored. Other exceptions can be added as and when necessary.

Also, switches the default behavior from allow to deny.

This is needed to tighten the security hooks and disallow installation of plugins from untrusted locations in case a user logs into an untrusted cluster.

### Which issue(s) this PR fixes
Follow up to #1500, which regressed due to #1358

### Describe testing done for PR
Unit tested.

### Release note
```release-note
Discovered plugins will fail to install unless they are in a trusted location.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer
There could be a use case for adding more trusted locations. But since this feature is used only by TMC plugins currently, we can add that capability later.