### PR TITLE
update airgap script in a physically airgapped environment

### DIFF
--- a/hack/gen-publish-images-totar.sh
+++ b/hack/gen-publish-images-totar.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 TANZU_BOM_DIR=${HOME}/.config/tanzu/tkg/bom
 INSTALL_INSTRUCTIONS='See https://github.com/mikefarah/yq#install for installation instructions'
 TKG_IMAGE_REPO=${TKG_IMAGE_REPO:-''}
+TKG_BOM_IMAGE_TAG=${TKG_BOM_IMAGE_TAG:-''}
 
 
 echodual() {
@@ -48,7 +49,7 @@ actualImageRepository="$TKG_IMAGE_REPO"
 list=$(imgpkg  tag  list -i "${actualImageRepository}"/tkg-bom)
 for imageTag in ${list}; do
   tanzucliversion=$(tanzu version | head -n 1 | cut -c10-15)
-  if [[ ${imageTag} == ${tanzucliversion}* ]]; then
+  if [[ ${imageTag} == ${tanzucliversion}* ]] || [[ ${imageTag} == ${TKG_BOM_IMAGE_TAG} ]]; then
     TKG_BOM_FILE="tkg-bom-${imageTag//_/+}.yaml"
     imgpkg pull --image "${actualImageRepository}/tkg-bom:${imageTag}" --output "tmp" > /dev/null 2>&1
     echodual "Processing TKG BOM file ${TKG_BOM_FILE}"
@@ -67,7 +68,7 @@ for imageTag in ${list}; do
     get_comp_images="yq e '.components[\"${comp}\"][]  | select(has(\"images\"))|.images[] | .imagePath + \":\" + .tag' "\"tmp/\"$TKG_BOM_FILE""
 
     flags="-i"
-    if [ $comp = "tkg-standard-packages" ]; then
+    if [ $comp = "tkg-standard-packages" ] || [ $comp = "standalone-plugins-package" ] || [ $comp = "tanzu-framework-management-packages" ]; then
       flags="-b"
     fi
     eval $get_comp_images | while read -r image; do


### PR DESCRIPTION
it is not always the case that tkg-bom tag match the tanzu-cli version,
so we need to update the airgap script in the `physically airgapped environment`

changes:
1. in `hack/gen-publish-images-totar.sh`
    - add the option to set env var about TKG-BOM tag
    - special imgpkg flag for `standalone-plugins-package` and `tanzu-framework-management-packages`
    (I have made same changes in `hack/gen-publish-images.sh`)
 2. in `hack/gen-publish-images-fromtar.sh`
   - add the option to set env var about TKG-BOM tag
   - remove the unused `flag` var
   
   
 tested the script locally by setting **TKG_BOM_IMAGE_TAG**  to `v1.5.0`