### PR TITLE
CLI: Add post-download verification for plugins

### DIFF
--- a/pkg/v1/cli/pluginmanager/test/local/discovery/context/cluster.yaml
+++ b/pkg/v1/cli/pluginmanager/test/local/discovery/context/cluster.yaml
@@ -7,17 +7,17 @@ spec:
   artifacts:
     v0.2.0:
       - uri: v0.2.0/tanzu-cluster-darwin_amd64
-        digest: 330c8ba8330314a318ee025a459878a056a3d0e59f1c22054bbcead1918f328c
+        digest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         os: darwin
         arch: amd64
         type: local
       - uri: v0.2.0/tanzu-cluster-linux_amd64
-        digest: 330c8ba8330314a318ee025a459878a056a3d0e59f1c22054bbcead1918f328c
+        digest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         os: linux
         arch: amd64
         type: local
       - uri: v0.2.0/tanzu-cluster-windows_amd64
-        digest: 330c8ba8330314a318ee025a459878a056a3d0e59f1c22054bbcead1918f328c
+        digest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         os: windows
         arch: amd64
         type: local

--- a/pkg/v1/cli/pluginmanager/test/local/discovery/default/management-cluster.yaml
+++ b/pkg/v1/cli/pluginmanager/test/local/discovery/default/management-cluster.yaml
@@ -7,17 +7,17 @@ spec:
   artifacts:
     v0.2.0:
       - uri: v0.2.0/tanzu-management-cluster-darwin_amd64
-        digest: 5df2a0d87d6c562f0ea11c688ac52532aa28d744cabc7994ff0537f64b3b3320
+        digest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         os: darwin
         arch: amd64
         type: local
       - uri: v0.2.0/tanzu-management-cluster-linux_amd64
-        digest: 5df2a0d87d6c562f0ea11c688ac52532aa28d744cabc7994ff0537f64b3b3320
+        digest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         os: linux
         arch: amd64
         type: local
       - uri: v0.2.0/tanzu-management-cluster-windows_amd64
-        digest: 5df2a0d87d6c562f0ea11c688ac52532aa28d744cabc7994ff0537f64b3b3320
+        digest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         os: windows
         arch: amd64
         type: local

--- a/pkg/v1/cli/pluginmanager/test/local/discovery/standalone/login.yaml
+++ b/pkg/v1/cli/pluginmanager/test/local/discovery/standalone/login.yaml
@@ -7,17 +7,17 @@ spec:
   artifacts:
     v0.2.0:
       - uri: v0.2.0/tanzu-login-darwin_amd64
-        digest: 5df2a0d87d6c562f0ea11c688ac52532aa28d744cabc7994ff0537f64b3b3320
+        digest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         os: darwin
         arch: amd64
         type: local
       - uri: v0.2.0/tanzu-login-linux_amd64
-        digest: 5df2a0d87d6c562f0ea11c688ac52532aa28d744cabc7994ff0537f64b3b3320
+        digest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         os: linux
         arch: amd64
         type: local
       - uri: v0.2.0/tanzu-login-windows_amd64
-        digest: 5df2a0d87d6c562f0ea11c688ac52532aa28d744cabc7994ff0537f64b3b3320
+        digest: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
         os: windows
         arch: amd64
         type: local


### PR DESCRIPTION
### What this PR does / why we need it
Compare the source digest of the plugin against the SHA-256 hash of the downloaded binary to ensure that the binary was not altered during transit.

### Which issue(s) this PR fixes
Fixes #1680

### Describe testing done for PR
Unit tested

### Release note
```release-note
Verify the integrity of the CLI plugins on download
```

### PR Checklist
- [x] Squash the commits into one or a small number of logical commits
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access

### Additional information

#### Special notes for your reviewer
