### PR TITLE
Fix the TKR BOM download to respect the `TKG_DEFAULT_IMAGE_REPOSITORY…

### DIFF
--- a/pkg/v1/tkg/tkgconfigbom/bom_test.go
+++ b/pkg/v1/tkg/tkgconfigbom/bom_test.go
@@ -135,6 +135,28 @@ var (
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})
+			Context("when downloading the TKG BOM file and TKr BOM file from custom repository is success ", func() {
+				BeforeEach(func() {
+					os.Setenv("TKG_CUSTOM_IMAGE_REPOSITORY", "fake-custom.registry.vmware.com/tkg")
+					tkgdata, err := os.ReadFile("../fakes/config/bom/tkg-bom-v1.3.1.yaml")
+					Expect(err).ToNot(HaveOccurred())
+					tkrdata, err := os.ReadFile("../fakes/config/bom/tkg-bom-v1.3.1.yaml")
+					Expect(err).ToNot(HaveOccurred())
+					fakeRegistry.GetFileReturnsOnCall(0, tkgdata, nil)
+					fakeRegistry.GetFileReturnsOnCall(1, tkrdata, nil)
+				})
+				AfterEach(func() {
+					os.Unsetenv("TKG_CUSTOM_IMAGE_REPOSITORY")
+				})
+				It("should return success and the registry url path for the TKG BOM and TKr BOM files should use custom repository", func() {
+					err := bomClient.DownloadDefaultBOMFilesFromRegistry("projects-stg.registry.vmware.com/tkg", fakeRegistry)
+					Expect(err).ToNot(HaveOccurred())
+					tkgBOMImagepath, _ := fakeRegistry.GetFileArgsForCall(0)
+					tkrBOMImagepath, _ := fakeRegistry.GetFileArgsForCall(1)
+					Expect(tkgBOMImagepath).To(HavePrefix("fake-custom.registry.vmware.com/tkg/tkg-bom"))
+					Expect(tkrBOMImagepath).To(HavePrefix("fake-custom.registry.vmware.com/tkg/tkr-bom"))
+				})
+			})
 		})
 		Describe("Downloading the TKG Compatibility file from registry", func() {
 			BeforeEach(func() {


### PR DESCRIPTION
…` set during compile time

### What this PR does / why we need it
CLI should honour the `TKG_DEFAULT_IMAGE_REPOSITORY`  URL set during compile time instead of depending on TKG BOM file's imageConfig.imageRepository for TKR BOM file download.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #1683 

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1683 

### Describe testing done for PR

Unit tested and tested the TKG and TKR BOM downloads after clearing the $HOME/.config/tanzu/tkg/bom and $HOME/.config/tanzu/tkg/compatibility
```
$ tanzu mc create  -v 6
Downloading TKG compatibility file from 'projects-stg.registry.vmware.com/tkg/framework-zshippable/tkg-compatibility'
Downloading the TKG Bill of Materials (BOM) file from 'projects-stg.registry.vmware.com/tkg/tkg-bom:v1.6.0-zshippable'
Downloading the TKr Bill of Materials (BOM) file from 'projects-stg.registry.vmware.com/tkg/tkr-bom:v1.22.5_vmware.1-tkg.2-zshippable'
cluster config file not provided using default config file at '/Users/pkalle/.config/tanzu/tkg/cluster-config.yaml'
CEIP Opt-in status: true

Validating the pre-requisites...
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix the TKR BOM download to respect the TKG_DEFAULT_IMAGE_REPOSITORY set during compile time
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
