### PR TITLE
Add script to download and install Tanzu Framework CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ providers.tar.gz
 /build
 /packages/package-values-sha256.yaml
 /packages/**/.imgpkg
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,3 @@ providers.tar.gz
 /build
 /packages/package-values-sha256.yaml
 /packages/**/.imgpkg
-
-.idea

--- a/docs/cli/getting-started.md
+++ b/docs/cli/getting-started.md
@@ -23,6 +23,7 @@ With [v0.14.0](https://github.com/vmware-tanzu/tanzu-framework/releases/tag/v0.1
 The API driven plugin discovery feature is enabled as default method to install the plugins. So, most users will just need to install the Tanzu CLI binary. The plugins can be installed and configured with `tanzu plugin sync` command. Learn more about this feature in the [design docs](../design/context-aware-plugin-discovery-design.md).
 
 ##### macOS/Linux
+###### Option 1: Manual download CLI binary from Github Releases
 
 - Download the latest tanzu-cli tarball from [release](https://github.com/vmware-tanzu/tanzu-framework/releases/latest) page (`tanzu-cli-darwin-amd64.tar.gz` or `tanzu-cli-linux-amd64.tar.gz`)
 
@@ -67,7 +68,17 @@ The API driven plugin discovery feature is enabled as default method to install 
   ```sh
   tanzu plugin list
   ```
+###### Option 2: Using install script
+You may download and install a release using the provided remote script piped into bash.
 
+```shell
+curl -H "Accept: application/vnd.github.v3.raw" \
+    -L https://api.github.com/repos/vmware-tanzu/tanzu-framework/contents/hack/fetch-install-tf.sh | \
+    bash -s 
+```
+- This script requires `curl`,`grep`,`tr` and `jq` in order to work.
+- The release will be downloaded to a temporary directory and then installation will proceed using the downloaded `tanzu` CLI binary.
+- _Note_: A GitHub personal access token may be provided to the script as the `GITHUB_TOKEN` environment variable. This bypasses GitHub API rate limiting but is not required. Follow the [GitHub documentation](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to acquire and use a personal access token.
 ##### Windows
 
 - Download the latest `tanzu-cli-windows-amd64.zip` from [release](https://github.com/vmware-tanzu/tanzu-framework/releases/latest) page

--- a/docs/cli/getting-started.md
+++ b/docs/cli/getting-started.md
@@ -23,7 +23,8 @@ With [v0.14.0](https://github.com/vmware-tanzu/tanzu-framework/releases/tag/v0.1
 The API driven plugin discovery feature is enabled as default method to install the plugins. So, most users will just need to install the Tanzu CLI binary. The plugins can be installed and configured with `tanzu plugin sync` command. Learn more about this feature in the [design docs](../design/context-aware-plugin-discovery-design.md).
 
 ##### macOS/Linux
-###### Option 1: Manual download CLI binary from Github Releases
+
+###### Option 1: Manual download CLI binary from GitHub Releases
 
 - Download the latest tanzu-cli tarball from [release](https://github.com/vmware-tanzu/tanzu-framework/releases/latest) page (`tanzu-cli-darwin-amd64.tar.gz` or `tanzu-cli-linux-amd64.tar.gz`)
 
@@ -68,17 +69,21 @@ The API driven plugin discovery feature is enabled as default method to install 
   ```sh
   tanzu plugin list
   ```
+  
 ###### Option 2: Using install script
+
 You may download and install a release using the provided remote script piped into bash.
 
 ```shell
 curl -H "Accept: application/vnd.github.v3.raw" \
     -L https://api.github.com/repos/vmware-tanzu/tanzu-framework/contents/hack/fetch-install-tf.sh | \
-    bash -s 
+    bash -s
 ```
+
 - This script requires `curl`,`grep`,`tr` and `jq` in order to work.
 - The release will be downloaded to a temporary directory and then installation will proceed using the downloaded `tanzu` CLI binary.
 - _Note_: A GitHub personal access token may be provided to the script as the `GITHUB_TOKEN` environment variable. This bypasses GitHub API rate limiting but is not required. Follow the [GitHub documentation](https://docs.github.com/en/github/authenticating-to-github/keeping-your-account-and-data-secure/creating-a-personal-access-token) to acquire and use a personal access token.
+
 ##### Windows
 
 - Download the latest `tanzu-cli-windows-amd64.zip` from [release](https://github.com/vmware-tanzu/tanzu-framework/releases/latest) page

--- a/hack/fetch-install-tf.sh
+++ b/hack/fetch-install-tf.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Inspired by - https://github.com/vmware-tanzu/community-edition/blob/main/hack/install.sh
+# Script to install tanzu framework
+# Usage: ./hack/install.sh /path/to/tanzu-framework/core/binary
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+#Identify the OS specific binary to be downloaded
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH="amd64"
+BASE_CLI_PACKAGE_NAME="tanzu-cli"
+COMPRESSION="tar.gz"
+BASE_CLI="tanzu-core"
+
+case "${OS}" in
+  linux|darwin)
+    BINARY="${BASE_CLI_PACKAGE_NAME}-${OS}-${ARCH}.${COMPRESSION}"
+    ;;
+  *)
+    echo "${OS} is unsupported"
+    exit 1
+    ;;
+esac
+
+#Validate if required tools are installed
+TOOLS=("curl" "jq")
+MISSING_TOOLS=()
+for tool in "${TOOLS[@]}";do
+  if ! type "${tool}" > /dev/null; then
+    MISSING_TOOLS+=("${tool}")
+  fi
+done
+if [ ${#MISSING_TOOLS[@]} -gt 0 ]; then
+    echo "Missing installation of required tool(s)- ${MISSING_TOOLS[*]}"
+    exit 1
+fi
+
+
+GH_REPO_ORG="vmware-tanzu"
+GH_REPO="tanzu-framework"
+GH_API="https://api.github.com"
+GH_REPO_API_BASE="${GH_API}/repos/${GH_REPO_ORG}/${GH_REPO}"
+GH_TAGS="${GH_REPO_API_BASE}/releases/latest"
+AUTH=""
+# Validate GitHub access token
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+    echo "Warning: No GITHUB_TOKEN variable defined - requests to the GitHub API may be rate limited"
+else
+    AUTH="Authorization: token ${GITHUB_TOKEN}"
+    curl -o /dev/null -sLH "${AUTH}" ${GH_REPO_API_BASE} || { echo "Error: Unauthenticated token or network issue!";  exit 1; }
+fi
+
+
+echo "Fetching information about the latest Tanzu Framework release."
+LATEST_RELEASE_RESPONSE=$(curl -sLH "${AUTH}" ${GH_TAGS} )
+BIN_DOWNLOAD_URL=$(echo "${LATEST_RELEASE_RESPONSE}" | jq -r ".assets[].browser_download_url" | grep "${BINARY}")
+LATEST_VERSION=$(echo "${LATEST_RELEASE_RESPONSE}" | jq -r ".tag_name")
+
+echo "The latest version of Tanzu Framework CLI '${LATEST_VERSION}' will be downloaded and installed."
+
+#Generate temp directory where cli will be downloaded
+TF_INSTALL_PATH=$(mktemp -d 2>/dev/null || mktemp -d -t 'tf-install-tmp')
+
+function cleanup {
+  echo "Cleanup temporary binary download path."
+  rm -rf "${TF_INSTALL_PATH}"
+}
+trap cleanup EXIT
+
+echo "Downloading '${BINARY}' from the latest Tanzu Framework Release."
+curl -sLH "${AUTH}" "${BIN_DOWNLOAD_URL}" > "${TF_INSTALL_PATH}/${BINARY}"
+mkdir "${TF_INSTALL_PATH}/${LATEST_VERSION}"
+tar -zxf "${TF_INSTALL_PATH}/${BINARY}" -C "${TF_INSTALL_PATH}" "${LATEST_VERSION}/${BASE_CLI}-${OS}_${ARCH}"
+
+GH_RAW_CONTENT="https://raw.githubusercontent.com"
+INSTALL_SCRIPT_URL="${GH_RAW_CONTENT}/${GH_REPO_ORG}/${GH_REPO}/${LATEST_VERSION}/hack/install.sh"
+curl -sLH "${AUTH}" "${INSTALL_SCRIPT_URL}" | bash -se - "${TF_INSTALL_PATH}/${LATEST_VERSION}/${BASE_CLI}-${OS}_${ARCH}"
+INSTALL_STATUS=$?
+if [ "${INSTALL_STATUS}" -eq 0 ]; then
+  echo "Successfully installed Tanzu CLI. You can verify the same by trying to check the version using 'tanzu version' command."
+else
+  echo "Failed to install the downloaded Tanzu CLI."
+  exit 1
+fi

--- a/hack/fetch-install-tf.sh
+++ b/hack/fetch-install-tf.sh
@@ -5,7 +5,7 @@
 
 # Inspired by - https://github.com/vmware-tanzu/community-edition/blob/main/hack/install.sh
 # Script to install tanzu framework
-# Usage: ./hack/install.sh /path/to/tanzu-framework/core/binary
+# Usage: hack/fetch-install-tf.sh
 
 set -o errexit
 set -o nounset

--- a/hack/fetch-install-tf.sh
+++ b/hack/fetch-install-tf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2021 VMware, Inc. All Rights Reserved.
+# Copyright 2022 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Inspired by - https://github.com/vmware-tanzu/community-edition/blob/main/hack/install.sh


### PR DESCRIPTION
Currently there is a lengthy way to install tanzu cli in the documentation. Provide an easier option to install tanzu cli by just calling a script which downloads the latest stable release and install the same and update the documentation to reflect the new way of installation.

### What this PR does / why we need it
This PR provides for a script which fetches the latest Tanzu Framework release CLI and installs the CLI binary and the plugins locally. Currently the script handles only MacOS and Linux flavours for AMD64 architecture. The documentation update reflects the new option to download and install the CLI.

### Which issue(s) this PR fixes

Fixes # [1640](https://github.com/vmware-tanzu/tanzu-framework/issues/1640)

### Describe testing done for PR

- On MacOS system ran the script to do a fresh installation
- On MacOS with already installed cli, made sure the script installs the latest one after deleting the cache and deleting the older version
- Followed the above two steps on Ubuntu 20.04

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Added a script to fetch and install the latest Tanzu Framework CLI binary for MacOS and Linux distributions. Updated the documentation to reflect the new approach to install the CLI.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

The script provided downloads the latest release from Github release page (using the Github API). Once downloaded, it calls then the existing install script in the hack directory to install the CLI and plugins.
