### PR TITLE
Remove incorrect instructions for zsh completions

### DIFF
--- a/docs/cli/commands/tanzu_completion.md
+++ b/docs/cli/commands/tanzu_completion.md
@@ -34,9 +34,6 @@ tanzu completion [bash zsh]
 
 # Zsh instructions:
 
-  ## Load only for current session:
-  source <(tanzu completion zsh)
-
   ## Load for all new sessions:
   echo "autoload -U compinit; compinit" >> ~/.zshrc
   tanzu completion zsh > "${fpath[1]}/_tanzu"

--- a/pkg/v1/cli/command/core/completion.go
+++ b/pkg/v1/cli/command/core/completion.go
@@ -45,9 +45,6 @@ var (
 
 		# Zsh instructions:
 
-		  ## Load only for current session:
-		  source <(tanzu completion zsh)
-
 		  ## Load for all new sessions:
 		  echo "autoload -U compinit; compinit" >> ~/.zshrc
 		  tanzu completion zsh > "${fpath[1]}/_tanzu"`)


### PR DESCRIPTION
### What this PR does / why we need it

Removes incorrect zsh completions instructions. `source` is not supported by zsh or cobra

### Which issue(s) this PR fixes

Fixes #1714

### Describe testing done for PR
Build and viewed help message for `tanzu completion -h`

### Release note
```release-note
Removed incorrect zsh completions instructions. No longer recommend using "source"
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access
