### PR TITLE
Fix the issue where upgrade operation fails for vSphere cluster if vSphere password contains single quote(')

### DIFF
--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -447,7 +447,11 @@ func (c *TkgClient) ConfigureAndValidateVSphereTemplate(vcClient vc.Client, tkrV
 // GetVSphereEndpoint gets vsphere client based on credentials set in config variables
 func (c *TkgClient) GetVSphereEndpoint(clusterClient clusterclient.Client) (vc.Client, error) {
 	if clusterClient != nil {
-		username, password, err := clusterClient.GetVCCredentialsFromSecret("")
+		regionContext, err := c.GetCurrentRegionContext()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get current region context")
+		}
+		username, password, err := clusterClient.GetVCCredentialsFromCluster(regionContext.ClusterName, constants.TkgNamespace)
 		if err != nil {
 			return nil, err
 		}
@@ -1598,7 +1602,11 @@ func (c *TkgClient) getFullTKGNoProxy(providerName string) (string, error) {
 }
 
 func (c *TkgClient) configureVsphereCredentialsFromCluster(clusterClient clusterclient.Client) error {
-	vsphereUsername, vspherePassword, err := clusterClient.GetVCCredentialsFromSecret("")
+	regionContext, err := c.GetCurrentRegionContext()
+	if err != nil {
+		return errors.Wrap(err, "failed to get current region context")
+	}
+	vsphereUsername, vspherePassword, err := clusterClient.GetVCCredentialsFromCluster(regionContext.ClusterName, constants.TkgNamespace)
 	if err != nil {
 		return errors.Wrap(err, "unable to get vsphere credentials from secret")
 	}

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -277,7 +277,10 @@ type Client interface {
 	// GetPacificTanzuKubernetesReleases returns the list of TanzuKubernetesRelease versions if TKr object is available in TKGS
 	GetPacificTanzuKubernetesReleases() ([]string, error)
 	// GetVCCredentialsFromSecret gets the vSphere username and password used to deploy the cluster
+	// Deprecated: use GetVCCredentialsFromCluster() method instead which would use both clustername and namespace to get the VC credentials
 	GetVCCredentialsFromSecret(string) (string, string, error)
+	// GetVCCredentialsFromCluster gets the vSphere username and password used to deploy the cluster
+	GetVCCredentialsFromCluster(string, string) (string, string, error)
 	// GetVCServer gets the vSphere server that used to deploy the cluster
 	GetVCServer() (string, error)
 	// GetAWSEncodedCredentialsFromSecret gets the AWS base64 credentials used to deploy the cluster

--- a/pkg/v1/tkg/clusterclient/clusterclient_test.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient_test.go
@@ -91,7 +91,8 @@ const (
 	osWindows    = "windows"
 )
 
-const cpiCreds = `#@data/values
+const (
+	cpiCreds = `#@data/values
 #@overlay/match-child-defaults missing_ok=True
 ---
 vsphereCPI:
@@ -103,9 +104,13 @@ vsphereCPI:
   username: test@test.com
   password: test!23`
 
-const creds = `password: password
+	creds = `password: password
 username: username
 `
+	vSphereBootstrapCredentialSecret = "capv-manager-bootstrap-credentials"
+	defaultUserName                  = "username"
+	defaultPassword                  = "password"
+)
 
 type Replicas struct {
 	SpecReplica     int32
@@ -1864,8 +1869,8 @@ var _ = Describe("Cluster Client", func() {
 		)
 
 		BeforeEach(func() {
-			username = "username"
-			password = "password"
+			username = defaultUserName
+			password = defaultPassword
 
 			reInitialize()
 			kubeConfigPath := getConfigFilePath("config1.yaml")
@@ -2017,6 +2022,120 @@ var _ = Describe("Cluster Client", func() {
 					err = clstClient.UpdateVsphereCsiConfigSecret("clusterName", "", username, password)
 					Expect(err).ToNot(BeNil())
 				})
+			})
+		})
+	})
+	Describe("Get Vsphere Credentials from cluster", func() {
+		var (
+			username    string
+			password    string
+			gotUserName string
+			gotPassword string
+		)
+		BeforeEach(func() {
+			username = defaultUserName
+			password = defaultPassword
+
+			reInitialize()
+			kubeConfigPath := getConfigFilePath("config1.yaml")
+			clstClient, err = NewClient(kubeConfigPath, "", clusterClientOptions)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("When the secret with cluster name in cluster's namespace exists", func() {
+			It("should return the credentials from the secret", func() {
+				clientset.GetCalls(func(ctx context.Context, name types.NamespacedName, secret crtclient.Object) error {
+					data := map[string][]byte{
+						"username": []byte(username),
+						"password": []byte(password),
+					}
+					secret.(*corev1.Secret).Data = data
+					return nil
+				})
+
+				gotUserName, gotPassword, err = clstClient.GetVCCredentialsFromCluster("clusterName", "namespace")
+				Expect(err).To(BeNil())
+				Expect(gotUserName).To(Equal(username))
+				Expect(gotPassword).To(Equal(password))
+			})
+		})
+		Context("When the secret with cluster name in cluster's namespace exists", func() {
+			It("should return the credentials from the secret even if the password has special yaml character", func() {
+				clientset.GetCalls(func(ctx context.Context, name types.NamespacedName, secret crtclient.Object) error {
+					password = `%pass'word`
+					data := map[string][]byte{
+						"username": []byte(username),
+						"password": []byte(password),
+					}
+					secret.(*corev1.Secret).Data = data
+					return nil
+				})
+
+				gotUserName, gotPassword, err = clstClient.GetVCCredentialsFromCluster("clusterName", "namespace")
+				Expect(err).To(BeNil())
+				Expect(gotUserName).To(Equal(username))
+				Expect(gotPassword).To(Equal(password))
+			})
+		})
+		Context("When the secret with cluster name in cluster's namespace doesn't exists", func() {
+			It("should return return error if UpdateCapvManagerBootstrapCredentialsSecret secret is not present", func() {
+				clientset.GetCalls(func(ctx context.Context, name types.NamespacedName, secret crtclient.Object) error {
+					return apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "Secret"}, "not found")
+				})
+
+				gotUserName, gotPassword, err = clstClient.GetVCCredentialsFromCluster("clusterName", "namespace")
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(ContainSubstring("unable to retrieve vSphere credentials from capv-manager-bootstrap-credentials secret"))
+			})
+
+			It("should return return error if UpdateCapvManagerBootstrapCredentialsSecret secret data fails to unmarshal", func() {
+				clientset.GetCalls(func(ctx context.Context, name types.NamespacedName, secret crtclient.Object) error {
+					if name.Name != vSphereBootstrapCredentialSecret {
+						return apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "Secret"}, "not found")
+					}
+					secretData := map[string][]byte{
+						"credentials.yaml": []byte("username: 'username'\npassword: 'pass'word'\n"), // pasword value has single quote
+					}
+					secret.(*corev1.Secret).Data = secretData
+					return nil
+				})
+
+				gotUserName, gotPassword, err = clstClient.GetVCCredentialsFromCluster("clusterName", "namespace")
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(ContainSubstring("failed to unmarshal vSphere credentials"))
+			})
+			It("should return return error if UpdateCapvManagerBootstrapCredentialsSecret secret data doesn't have 'credentails.yaml' data", func() {
+				clientset.GetCalls(func(ctx context.Context, name types.NamespacedName, secret crtclient.Object) error {
+					if name.Name != vSphereBootstrapCredentialSecret {
+						return apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "Secret"}, "not found")
+					}
+					secretData := map[string][]byte{
+						"non-credentials.yaml": []byte("username: 'username'\npassword: 'password'\n"),
+					}
+					secret.(*corev1.Secret).Data = secretData
+					return nil
+				})
+
+				gotUserName, gotPassword, err = clstClient.GetVCCredentialsFromCluster("clusterName", "namespace")
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(ContainSubstring("Unable to obtain credentials.yaml field from capv-manager-bootstrap-credentials secret's data"))
+			})
+			It("should return the credentials from UpdateCapvManagerBootstrapCredentialsSecret secret", func() {
+				clientset.GetCalls(func(ctx context.Context, name types.NamespacedName, secret crtclient.Object) error {
+					if name.Name != vSphereBootstrapCredentialSecret {
+						return apierrors.NewNotFound(schema.GroupResource{Group: "", Resource: "Secret"}, "not found")
+					}
+					secretData := map[string][]byte{
+						"credentials.yaml": []byte(creds),
+					}
+					secret.(*corev1.Secret).Data = secretData
+					return nil
+				})
+
+				gotUserName, gotPassword, err = clstClient.GetVCCredentialsFromCluster("clusterName", "namespace")
+				Expect(err).To(BeNil())
+				Expect(gotUserName).To(Equal(username))
+				Expect(gotPassword).To(Equal(password))
 			})
 		})
 	})

--- a/pkg/v1/tkg/clusterclient/templates.go
+++ b/pkg/v1/tkg/clusterclient/templates.go
@@ -15,7 +15,7 @@ func (c *client) GetVCClientAndDataCenter(clusterName, clusterNamespace, vsphere
 		return c.verificationClientFactory.GetVCClientAndDataCenter(clusterName, clusterNamespace, vsphereMachineTemplateObjectName)
 	}
 
-	vsphereUsername, vspherePassword, err := c.GetVCCredentialsFromSecret(clusterName)
+	vsphereUsername, vspherePassword, err := c.GetVCCredentialsFromCluster(clusterName, clusterNamespace)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "unable to retrieve vSphere credentials to retrieve VM Template")
 	}

--- a/pkg/v1/tkg/fakes/clusterclient.go
+++ b/pkg/v1/tkg/fakes/clusterclient.go
@@ -497,6 +497,22 @@ type ClusterClient struct {
 		result2 string
 		result3 error
 	}
+	GetVCCredentialsFromClusterStub        func(string, string) (string, string, error)
+	getVCCredentialsFromClusterMutex       sync.RWMutex
+	getVCCredentialsFromClusterArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	getVCCredentialsFromClusterReturns struct {
+		result1 string
+		result2 string
+		result3 error
+	}
+	getVCCredentialsFromClusterReturnsOnCall map[int]struct {
+		result1 string
+		result2 string
+		result3 error
+	}
 	GetVCCredentialsFromSecretStub        func(string) (string, string, error)
 	getVCCredentialsFromSecretMutex       sync.RWMutex
 	getVCCredentialsFromSecretArgsForCall []struct {
@@ -3383,6 +3399,74 @@ func (fake *ClusterClient) GetVCClientAndDataCenterReturnsOnCall(i int, result1 
 	}
 	fake.getVCClientAndDataCenterReturnsOnCall[i] = struct {
 		result1 vc.Client
+		result2 string
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *ClusterClient) GetVCCredentialsFromCluster(arg1 string, arg2 string) (string, string, error) {
+	fake.getVCCredentialsFromClusterMutex.Lock()
+	ret, specificReturn := fake.getVCCredentialsFromClusterReturnsOnCall[len(fake.getVCCredentialsFromClusterArgsForCall)]
+	fake.getVCCredentialsFromClusterArgsForCall = append(fake.getVCCredentialsFromClusterArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.GetVCCredentialsFromClusterStub
+	fakeReturns := fake.getVCCredentialsFromClusterReturns
+	fake.recordInvocation("GetVCCredentialsFromCluster", []interface{}{arg1, arg2})
+	fake.getVCCredentialsFromClusterMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *ClusterClient) GetVCCredentialsFromClusterCallCount() int {
+	fake.getVCCredentialsFromClusterMutex.RLock()
+	defer fake.getVCCredentialsFromClusterMutex.RUnlock()
+	return len(fake.getVCCredentialsFromClusterArgsForCall)
+}
+
+func (fake *ClusterClient) GetVCCredentialsFromClusterCalls(stub func(string, string) (string, string, error)) {
+	fake.getVCCredentialsFromClusterMutex.Lock()
+	defer fake.getVCCredentialsFromClusterMutex.Unlock()
+	fake.GetVCCredentialsFromClusterStub = stub
+}
+
+func (fake *ClusterClient) GetVCCredentialsFromClusterArgsForCall(i int) (string, string) {
+	fake.getVCCredentialsFromClusterMutex.RLock()
+	defer fake.getVCCredentialsFromClusterMutex.RUnlock()
+	argsForCall := fake.getVCCredentialsFromClusterArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *ClusterClient) GetVCCredentialsFromClusterReturns(result1 string, result2 string, result3 error) {
+	fake.getVCCredentialsFromClusterMutex.Lock()
+	defer fake.getVCCredentialsFromClusterMutex.Unlock()
+	fake.GetVCCredentialsFromClusterStub = nil
+	fake.getVCCredentialsFromClusterReturns = struct {
+		result1 string
+		result2 string
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *ClusterClient) GetVCCredentialsFromClusterReturnsOnCall(i int, result1 string, result2 string, result3 error) {
+	fake.getVCCredentialsFromClusterMutex.Lock()
+	defer fake.getVCCredentialsFromClusterMutex.Unlock()
+	fake.GetVCCredentialsFromClusterStub = nil
+	if fake.getVCCredentialsFromClusterReturnsOnCall == nil {
+		fake.getVCCredentialsFromClusterReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 string
+			result3 error
+		})
+	}
+	fake.getVCCredentialsFromClusterReturnsOnCall[i] = struct {
+		result1 string
 		result2 string
 		result3 error
 	}{result1, result2, result3}
@@ -6511,6 +6595,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.getTanzuKubernetesReleasesMutex.RUnlock()
 	fake.getVCClientAndDataCenterMutex.RLock()
 	defer fake.getVCClientAndDataCenterMutex.RUnlock()
+	fake.getVCCredentialsFromClusterMutex.RLock()
+	defer fake.getVCCredentialsFromClusterMutex.RUnlock()
 	fake.getVCCredentialsFromSecretMutex.RLock()
 	defer fake.getVCCredentialsFromSecretMutex.RUnlock()
 	fake.getVCServerMutex.RLock()


### PR DESCRIPTION
### What this PR does / why we need it
This PR fixes upgrade operation failing due to the unmarshaling error while trying to read the vSphere credentials from capv-manager-bootstrap-credentials secret if the vSphere password has single quotes.

The fix addresses the issue by 

- reading the credentials from cluster's(identityRef) secret(reading password from secret doesn't involve unmarshaling) before falling back to capv-manager-bootstrap-credentials secret. This fix should be good for majority of the cases, however there is a scenario(very unlikely) it would not address, where vSphere management cluster was created before cluster's secret was used.

Since `capv-manager-bootstrap-credentials` secret is an artifact from upstream, [vSphere provider Issue](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1460) is filed on upstream to support the vsphere password with single quotes and doesn't cause issue in unmarshaling. 

- use namespace along with cluster name while retreiving the credentials which would adddress the issue where the same secret name (created with cluster name) exists in different namespaces

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1721 

### Describe testing done for PR

Created management cluster successfully
```
<snap>...
You can now access the management cluster test-vc-pwdfix-sai-mc by running 'kubectl config use-context test-vc-pwdfix-sai-mc-admin@test-vc-pwdfix-sai-mc'
Deleting kind cluster: tkg-kind-c8gmtabqk3vfe03s5550

Management cluster created!

You can now create your first workload cluster by running the following:

  tanzu cluster create [name] -f [file]

  kubectl get apps -A

Checking for required plugins...
Installing plugin 'cluster:v0.18.0-dev'
Installing plugin 'feature:v0.18.0-dev'
Installing plugin 'kubernetes-release:v0.18.0-dev'
Installing plugin 'login:v0.18.0-dev'
Successfully installed all required plugins
pkalle-a01:mirrors_github_tanzu-framework pkalle$

```

Upgrade the management cluster to the same version
```
Management cluster 'test-vc-pwdfix-sai-mc' successfully upgraded to TKG version 'v1.6.0-zshippable' with kubernetes version 'v1.22.5+vmware.1'
Checking for required plugins...
All required plugins are already installed and up-to-date
```

Created workload cluster on a different vsphere(multi-tenancy) and it was successful
```
$ tanzu cluster create test-pwdfix-sai-wc -f /Users/pkalle/.config/tanzu/tkg/clusterconfigs/multi_tenancy_vsphere.yaml -v 6 --tkr v1.21.8---vmware.1-tkg.3-zshippable
compatibility file (/Users/pkalle/.config/tanzu/tkg/compatibility/tkg-compatibility.yaml) already exists, skipping download
BOM files inside /Users/pkalle/.config/tanzu/tkg/bom already exists, skipping download
Using namespace from config:
Validating configuration...
……
Successfully reconciled package: metrics-server

Workload cluster 'test-pwdfix-sai-wc' created

```

Upgraded the workload cluster created on different VC and it was successful
```
$ tanzu cluster upgrade test-pwdfix-sai-wc -v6
compatibility file (/Users/pkalle/.config/tanzu/tkg/compatibility/tkg-compatibility.yaml) already exists, skipping download
BOM files inside /Users/pkalle/.config/tanzu/tkg/bom already exists, skipping download
Upgrading workload cluster 'test-pwdfix-sai-wc' to kubernetes version 'v1.22.5+vmware.1'. Are you sure? [y/N]: y
Creating management cluster client...

….

Successfully reconciled package: secretgen-controller
Successfully reconciled package: vsphere-csi
Successfully reconciled package: vsphere-cpi
Successfully reconciled package: antrea
Successfully reconciled package: metrics-server
Cluster 'test-pwdfix-sai-wc' successfully upgraded to kubernetes version 'v1.22.5+vmware.1'
```

Deleted the above workload cluster and it was successful
```
$ tanzu cluster delete test-pwdfix-sai-wc
Deleting workload cluster 'test-pwdfix-sai-wc'. Are you sure? [y/N]: y
Workload cluster 'test-pwdfix-sai-wc' is being deleted

```

Deleted the managment cluster and it was successful
```
Deleting management cluster...
Management cluster 'test-vc-pwdfix-sai-mc' deleted.
Deleting the management cluster context from the kubeconfig file '/Users/pkalle/.kube/config'
warning: this removed your active context, use "kubectl config use-context" to select a different one

Management cluster deleted!
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
 Fix the issue where upgrade operation fails for vSphere provider if vSphere password contains single quote(')
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

There is an upstream(vSphere provider) [ issue](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1460) filed to provide a means to support VC password which has single quote('). If there is any fix/change in the upstream, we should update the logic to read the capv-manager-bootstrap-credentials secret.

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
