### PR TITLE
Not using WithVersion no longer causes error and allows searching for any version

### DIFF
--- a/pkg/v1/sdk/capabilities/discovery/cluster_gvr.go
+++ b/pkg/v1/sdk/capabilities/discovery/cluster_gvr.go
@@ -4,15 +4,25 @@
 package discovery
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
-// Group represents any API group that may exist on a cluster, with ability to specify versions and resource to check for GVR.
+var (
+	// errInvalidWithResourceMethodArgument occurs when an empty string argument is passed into the WithResource method.
+	errInvalidWithResourceMethodArgument = errors.New("WithResource method must have non-empty string argument; omit method to indicate any resource")
+
+	// errInvalidWithVersionsMethodArgument occurs when empty string argument(s) are passed into the WithVersions method.
+	errInvalidWithVersionsMethodArgument = errors.New("WithVersions method must be comprised of non-empty string argument(s); omit method to indicate any version")
+)
+
+// Group represents any API group that may exist on a cluster.
 func Group(queryName, group string) *QueryGVR {
 	return &QueryGVR{
 		name:  queryName,
@@ -20,11 +30,24 @@ func Group(queryName, group string) *QueryGVR {
 	}
 }
 
+// nullString represents a string that may be null or not explicitly set.
+type nullString struct {
+	String string
+	IsSet  bool
+}
+
+func (s *nullString) set(value string) {
+	if s != nil {
+		s.String = value
+		s.IsSet = true
+	}
+}
+
 // QueryGVR provides insight to the clusters GVRs
 type QueryGVR struct {
 	name          string
 	group         string
-	resource      string
+	resource      nullString
 	versions      []string
 	unmatchedGVRs []string
 }
@@ -35,94 +58,232 @@ func (q *QueryGVR) Name() string {
 }
 
 // WithVersions checks if an API group with all the specified versions exist.
+// This method can be omitted to query any version.
 func (q *QueryGVR) WithVersions(versions ...string) *QueryGVR {
 	q.versions = versions
 	return q
 }
 
 // WithResource checks if an API group with the specified resource exists.
-// WithVersions needs to be used before calling this function.
+// This method can be omitted to query any resource.
 func (q *QueryGVR) WithResource(resource string) *QueryGVR {
-	q.resource = resource
+	q.resource.set(resource)
 	return q
 }
 
-// Run discovery
+// Run discovery.
 func (q *QueryGVR) Run(config *clusterQueryClientConfig) (bool, error) {
-	if q.group != "" && q.resource != "" && len(q.versions) == 0 {
-		return false, fmt.Errorf("cannot check for group and resource existence without version info; use WithVersion method")
-	}
-
-	var gvrs []schema.GroupVersionResource
-	if len(q.versions) > 0 {
-		for _, v := range q.versions {
-			gvrs = append(gvrs, schema.GroupVersionResource{Group: q.group, Version: v, Resource: q.resource})
-		}
-	} else {
-		gvrs = append(gvrs, schema.GroupVersionResource{Group: q.group})
-	}
-
-	groupList, err := config.discoveryClientset.ServerGroups()
-	if err != nil {
-		return false, err
+	if err := q.validate(config); err != nil {
+		return false, fmt.Errorf("failed GroupVersionResource API query validation: %w", err)
 	}
 
 	var unmatched []string
-	for _, gvr := range gvrs {
-		// Check group.
-		if !q.groupExists(gvr.Group, groupList) {
-			unmatched = append(unmatched, gvr.String())
-			continue
-		}
 
-		// Check version if specified.
-		if gvr.Version == "" {
-			continue
-		}
-
-		resources, err := config.discoveryClientset.ServerResourcesForGroupVersion(gvr.GroupVersion().String())
+	switch {
+	case q.versions == nil:
+		// q.WithVersions method was omitted and q.versions has not been set.
+		// Any version that matches group and/or resource is considered a match.
+		unmatchedGroupResource, err := q.unmatchedGroupResource(config)
 		if err != nil {
-			// Second condition is because fake discovery client does not return a proper NotFound error.
-			if apierrors.IsNotFound(err) || strings.Contains(err.Error(), fmt.Sprintf("GroupVersion %q not found", gvr.GroupVersion().String())) {
-				unmatched = append(unmatched, gvr.String())
-				continue
-			}
-			return false, err
+			return false, fmt.Errorf("failed to discover unmatched GroupResource: %w", err)
 		}
-
-		// Check resource if specified.
-		if gvr.Resource == "" {
-			continue
+		if unmatchedGroupResource != "" {
+			unmatched = append(unmatched, unmatchedGroupResource)
 		}
-		if !q.resourceExists(resources) {
-			unmatched = append(unmatched, gvr.String())
-			continue
+	case q.resource.String == "":
+		unmatchedGroupVersions, err := q.unmatchedGroupVersions(config)
+		if err != nil {
+			return false, fmt.Errorf("failed to discover unmatched GroupVersions: %w", err)
 		}
+		unmatched = append(unmatched, unmatchedGroupVersions...)
+	case q.resource.String != "":
+		unmatchedGVRs, err := q.unmatchedGroupVersionResources(config)
+		if err != nil {
+			return false, fmt.Errorf("failed to discover unmatched GroupVersionResources: %w", err)
+		}
+		unmatched = append(unmatched, unmatchedGVRs...)
 	}
 
 	q.unmatchedGVRs = unmatched
 	return len(unmatched) == 0, nil
 }
 
-func (q *QueryGVR) groupExists(group string, groupList *metav1.APIGroupList) bool {
-	for i := range groupList.Groups {
-		if strings.EqualFold(groupList.Groups[i].Name, group) {
+func (q *QueryGVR) validate(cfg *clusterQueryClientConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("clusterQueryClientConfig must not be nil")
+	}
+
+	var errs []error
+	if q.resource.IsSet && q.resource.String == "" {
+		errs = append(errs, errInvalidWithResourceMethodArgument)
+	}
+	if q.versions != nil && containsEmpty(q.versions) {
+		errs = append(errs, errInvalidWithVersionsMethodArgument)
+	}
+	return kerrors.NewAggregate(errs)
+}
+
+// containsEmpty looks for an empty string or items containing only white space(s)
+// in the given slice of strings.
+func containsEmpty(strs []string) bool {
+	for _, s := range strs {
+		s = strings.TrimSpace(s)
+		if s == "" {
 			return true
 		}
 	}
 	return false
+}
+
+func (q *QueryGVR) unmatchedGroupResource(cfg *clusterQueryClientConfig) (string, error) {
+	groups, resources, err := cfg.discoveryClientset.ServerGroupsAndResources()
+	if err != nil {
+		return "", fmt.Errorf("failed to discover server group and resource: %w", err)
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    q.group,
+		Resource: q.resource.String,
+	}
+
+	if !q.containsGroup(groups, q.group) {
+		return gvr.String(), nil
+	}
+
+	// Resource was not specified, meaning there are no unmatched resources.
+	if q.resource.String == "" {
+		return "", nil
+	}
+
+	rscList, err := q.resourceListInGroup(resources, q.group)
+	if err != nil {
+		return "", fmt.Errorf("failed to find resource list in %s group: %w", q.group, err)
+	}
+	if !q.resourceExists(rscList) {
+		return gvr.String(), nil
+	}
+
+	return "", nil
+}
+
+func (q *QueryGVR) unmatchedGroupVersions(cfg *clusterQueryClientConfig) ([]string, error) {
+	groupList, err := cfg.discoveryClientset.ServerGroups()
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover server groups: %w", err)
+	}
+
+	var unmatched []string
+
+	group := q.groupFromGroupList(groupList)
+	if group == nil {
+		// No group version matches because group could not be found.
+		for _, version := range q.versions {
+			unmatched = append(unmatched, schema.GroupVersionResource{
+				Group:    q.group,
+				Version:  version,
+				Resource: q.resource.String,
+			}.String())
+		}
+		return unmatched, nil
+	}
+
+	// Group was found. Find which query versions are not.
+	for _, queryVersion := range q.versions {
+		var matched bool
+		for _, discovery := range group.Versions {
+			if strings.EqualFold(discovery.Version, queryVersion) {
+				matched = true
+				continue
+			}
+		}
+		if !matched {
+			unmatched = append(unmatched, schema.GroupVersionResource{
+				Group:    q.group,
+				Version:  queryVersion,
+				Resource: q.resource.String,
+			}.String())
+		}
+	}
+	return unmatched, nil
+}
+
+func (q *QueryGVR) unmatchedGroupVersionResources(cfg *clusterQueryClientConfig) ([]string, error) {
+	var unmatched []string
+	for _, ver := range q.versions {
+		gvr := schema.GroupVersionResource{
+			Group:    q.group,
+			Version:  ver,
+			Resource: q.resource.String,
+		}
+		resources, err := cfg.discoveryClientset.ServerResourcesForGroupVersion(gvr.GroupVersion().String())
+		if err != nil {
+			// Second condition is because fake discovery client does not return a proper NotFound error.
+			if apierrors.IsNotFound(err) || strings.Contains(
+				err.Error(),
+				fmt.Sprintf("GroupVersion %q not found", gvr.GroupVersion().String()),
+			) {
+				unmatched = append(unmatched, gvr.String())
+			} else {
+				return nil, err
+			}
+		}
+		if !q.resourceExists(resources) {
+			unmatched = append(unmatched, gvr.String())
+		}
+	}
+	return unmatched, nil
+}
+
+// containsGroup looks for a group in a slice of APIGroup.
+func (q *QueryGVR) containsGroup(groups []*metav1.APIGroup, group string) bool {
+	for _, grp := range groups {
+		if strings.EqualFold(grp.Name, group) {
+			return true
+		}
+	}
+	return false
+}
+
+// resourceListInGroup looks within a slice of APIResourceList for an
+// APIResourceList that is in a specified group.
+func (q *QueryGVR) resourceListInGroup(resourceLists []*metav1.APIResourceList, group string) (*metav1.APIResourceList, error) {
+	for _, rscList := range resourceLists {
+		gv, err := schema.ParseGroupVersion(rscList.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+
+		if strings.EqualFold(gv.Group, group) {
+			return rscList, nil
+		}
+	}
+	return nil, nil
+}
+
+// groupFromGroupList looks for a particular group from an APIGroupList.
+func (q *QueryGVR) groupFromGroupList(groupList *metav1.APIGroupList) *metav1.APIGroup {
+	for i := range groupList.Groups {
+		if strings.EqualFold(groupList.Groups[i].Name, q.group) {
+			return &groupList.Groups[i]
+		}
+	}
+	return nil
 }
 
 func (q *QueryGVR) resourceExists(resources *metav1.APIResourceList) bool {
+	if resources == nil {
+		return false
+	}
+
 	for i := range resources.APIResources {
-		if resources.APIResources[i].Name == q.resource {
+		if resources.APIResources[i].Name == q.resource.String {
 			return true
 		}
 	}
 	return false
 }
 
-// Reason surfaces what didnt match
+// Reason surfaces what didn't match.
 func (q *QueryGVR) Reason() string {
 	return fmt.Sprintf("GVRs=%v status=unmatched presence=true", q.unmatchedGVRs)
 }

--- a/pkg/v1/sdk/capabilities/discovery/fake.go
+++ b/pkg/v1/sdk/capabilities/discovery/fake.go
@@ -14,8 +14,9 @@ import (
 // NewFakeClusterQueryClient returns a fake ClusterQueryClient for use in tests.
 func NewFakeClusterQueryClient(resources []*metav1.APIResourceList, scheme *runtime.Scheme, objs []runtime.Object) (*ClusterQueryClient, error) {
 	fakeDynamicClient := dynamicFake.NewSimpleDynamicClient(scheme, objs...)
-	fakeDiscoveryClient := &fakediscovery.FakeDiscovery{Fake: &k8stesting.Fake{
-		Resources: resources,
-	}}
+	fakeDiscoveryClient := &fakediscovery.FakeDiscovery{
+		Fake: &k8stesting.Fake{
+			Resources: resources,
+		}}
 	return NewClusterQueryClient(fakeDynamicClient, fakeDiscoveryClient)
 }

--- a/pkg/v1/sdk/capabilities/discovery/generate.go
+++ b/pkg/v1/sdk/capabilities/discovery/generate.go
@@ -25,7 +25,7 @@ func QueryTargetsToCapabilityResource(queryTargets []QueryTarget) (*runv1alpha1.
 				Name:     fmt.Sprintf("gvr-%d", rand.Int31()), //nolint:gosec
 				Group:    query.group,
 				Versions: query.versions,
-				Resource: query.resource,
+				Resource: query.resource.String,
 			}
 			gvrQueries = append(gvrQueries, q)
 		case *QueryObject:

--- a/pkg/v1/sdk/capabilities/discovery/tkg/resource_test.go
+++ b/pkg/v1/sdk/capabilities/discovery/tkg/resource_test.go
@@ -32,12 +32,12 @@ func TestHasTanzuRunGroup(t *testing.T) {
 		errExpected       bool
 		want              bool
 	}{
-		{"Tanzu run exists without version", discoveryClientWithTanzuRunGroup, []string{}, false, true},
+		{"Tanzu run exists without version if WithVersion method was omittied", discoveryClientWithTanzuRunGroup, nil, false, true},
 		{"Tanzu run exists with correct version", discoveryClientWithTanzuRunGroup, []string{"v1alpha1"}, false, true},
 		{"Tanzu run does not exist with incorrect version", discoveryClientWithTanzuRunGroup, []string{"v1"}, false, false},
 		{"Tanzu run exists with correct multiple versions", discoveryClientWithTanzuRunGroupMultipleVersions, []string{"v1alpha1", "v1"}, false, true},
 		{"Tanzu run does not exist with incorrect multiple versions", discoveryClientWithTanzuRunGroupMultipleVersions, []string{"v1alpha1", "v2"}, false, false},
-		{"Tanzu run does not exist", discoveryClientWithoutTanzuRunGroup, []string{}, false, false},
+		{"Tanzu run does not exist", discoveryClientWithoutTanzuRunGroup, nil, false, false},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: F. Gold <fgold@vmware.com>

### What this PR does / why we need it

This PR,

- allows for `WithVersions(...)` method to be omitted, even if `WithResource(...)` was used
- fixes a bug where using empty string version, `WithVersions("")` will return `Found: true` result even though a specified resource does not exist. Now, using an empty string in the `WithVersions` method will return an error
- using an empty string in the `WithResource` method, in other words, `WithResource("")` will return an error
- adds unit tests to test combinations of using WithVersions and WithResource methods

More details are in [this comment](https://github.com/vmware-tanzu/tanzu-framework/issues/1294#issuecomment-1042383302).

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #1294 .

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1294

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

When using capability discovery, allow searching for any version of an API resource by ~~both~~ the following way~~s~~:

(1) omitting WithVersions method
~~(2) using `WithVersions("")`~~

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
GVR Capability Discovery query now supports searching for any version of a resource by omitting the `WithVersions` method. In addition, `WithVersions` or `WithResource` methods return an error when an empty string is passed as an argument.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

~~I have made it such that using multiple empty strings as the only arguments in the WithVersions method acts just like using `WithVersion("")` and will return an error.~~

Using `WithVersions("")` or having an empty string in a list of versions like `WithVersions("v1", "v2beta", "")` will return an error.

I hope these changes will allow for not having to hard-code versions when looking for capabilities. More information in [this comment](https://github.com/vmware-tanzu/tanzu-framework/pull/1242#discussion_r762207075).

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
