### PR TITLE
Golangci-lint should not check function length for tests

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -123,6 +123,7 @@ issues:
       linters:
         - dupl
         - gocritic
+        - funlen
 
     # https://github.com/go-critic/go-critic/issues/926
     - linters:

--- a/addons/pinniped/post-deploy/pkg/configure/concierge/concierge_test.go
+++ b/addons/pinniped/post-deploy/pkg/configure/concierge/concierge_test.go
@@ -17,7 +17,6 @@ import (
 	kubetesting "k8s.io/client-go/testing"
 )
 
-// nolint:funlen
 func TestCreateOrUpdateJWTAuthenticator(t *testing.T) {
 	jwtAuthenticatorGVR := authv1alpha1.SchemeGroupVersion.WithResource("jwtauthenticators")
 

--- a/addons/pinniped/post-deploy/pkg/configure/configure_test.go
+++ b/addons/pinniped/post-deploy/pkg/configure/configure_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/addons/pinniped/post-deploy/pkg/inspect"
 )
 
-// nolint:funlen
 func TestPinniped(t *testing.T) {
 	const (
 		supervisorNamespace = "pinniped-supervisor" // vars.SupervisorNamespace default

--- a/addons/pinniped/post-deploy/pkg/configure/helper_test.go
+++ b/addons/pinniped/post-deploy/pkg/configure/helper_test.go
@@ -22,7 +22,6 @@ import (
 	kubetesting "k8s.io/client-go/testing"
 )
 
-// nolint:funlen
 func TestCreateOrUpdatePinnipedInfo(t *testing.T) {
 	const (
 		namespace = "kube-public"

--- a/addons/pinniped/post-deploy/pkg/configure/supervisor/supervisor_test.go
+++ b/addons/pinniped/post-deploy/pkg/configure/supervisor/supervisor_test.go
@@ -23,7 +23,6 @@ import (
 	kubetesting "k8s.io/client-go/testing"
 )
 
-// nolint:funlen
 func TestCreateOrUpdateFederationDomain(t *testing.T) {
 	federationDomainGVR := configv1alpha1.SchemeGroupVersion.WithResource("federationdomains")
 
@@ -142,7 +141,6 @@ func TestCreateOrUpdateFederationDomain(t *testing.T) {
 	}
 }
 
-// nolint:funlen
 func TestRecreateIDPForDex(t *testing.T) {
 	const (
 		dexServiceIP   = "1.2.3.4"

--- a/apis/config/v1alpha1/featuregate_webhook_test.go
+++ b/apis/config/v1alpha1/featuregate_webhook_test.go
@@ -88,7 +88,6 @@ func TestValidateFeatureImmutability(t *testing.T) {
 	}
 }
 
-//nolint:funlen
 func TestNamespaceConflicts(t *testing.T) {
 	scheme, err := getScheme()
 	if err != nil {

--- a/cmd/cli/plugin/pinniped-auth/login_test.go
+++ b/cmd/cli/plugin/pinniped-auth/login_test.go
@@ -27,7 +27,6 @@ const (
 	tanzuCLIBuildSHA     = "abc123"
 )
 
-//nolint:funlen
 func TestLoginOIDCCommand(t *testing.T) {
 	sessionsCacheFilePath := filepath.Join(mustGetConfigDir(), "sessions.yaml")
 	credentialCacheFilePath := filepath.Join(mustGetConfigDir(), "credentials.yaml")

--- a/pkg/v1/cli/catalog_test.go
+++ b/pkg/v1/cli/catalog_test.go
@@ -107,7 +107,6 @@ func testHasUpdate(t *testing.T, multi *MultiRepo, numPluginsDowngraded int) {
 	require.Equal(t, numPluginsRequiringUpdate, numPluginsDowngraded)
 }
 
-//nolint:funlen
 func TestCatalog(t *testing.T) {
 	newTestCatalog(t)
 

--- a/pkg/v1/sdk/features/featuregate/featuregate_test.go
+++ b/pkg/v1/sdk/features/featuregate/featuregate_test.go
@@ -78,7 +78,6 @@ func TestComputeFeatureStates(t *testing.T) {
 	}
 }
 
-//nolint:funlen
 func TestFeaturesActivatedInNamespacesMatchingSelector(t *testing.T) {
 	scheme, err := configv1alpha1.SchemeBuilder.Build()
 	if err != nil {


### PR DESCRIPTION
### What this PR does / why we need it

PR #1294 is failing golangci-lint check because one of my test functions has too many lines. Linters should not check function length in test files. Go style table tests should be able to have a lot of lines to account for many input variations.

I've modified the golang-ci linter configuration file to exclude checking function length in go test files.

I also see nine other test functions have the `//nolint:funlen` directive so it wasn't just me writing long tests. I removed those directives in this PR.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

I did not create an issue for this PR.

### Describe testing done for PR

I ran `make lint` and all lint checks pass.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
