### PR TITLE
add overide of tkr-bom with DOWNLOAD_TKRS

### DIFF
--- a/hack/gen-publish-images-fromtar.sh
+++ b/hack/gen-publish-images-fromtar.sh
@@ -102,7 +102,9 @@ done
 
 # Iterate through TKR BoM file to create the complete Image name
 # and then pull, retag and push image to custom registry.
-list=$(imgpkg  tag  list -i ${actualImageRepository}/tkr-bom)
+# DOWNLOAD_TKRS is a space separated list of TKR names, as stored in registry
+# when set, the tkr-bom will be ignored.
+list=${DOWNLOAD_TKRS:-$(imgpkg  tag  list -i ${actualImageRepository}/tkr-bom)}
 for imageTag in ${list}; do
   if [[ ${imageTag} == v* ]]; then
     TKR_BOM_FILE="tkr-bom-${imageTag//_/+}.yaml"

--- a/hack/gen-publish-images-totar.sh
+++ b/hack/gen-publish-images-totar.sh
@@ -87,7 +87,9 @@ done
 
 # Iterate through TKR BoM file to create the complete Image name
 # and then pull, retag and push image to custom registry.
-list=$(imgpkg  tag  list -i ${actualImageRepository}/tkr-bom)
+# DOWNLOAD_TKRS is a space separated list of TKR names, as stored in registry
+# when set, the tkr-bom will be ignored.
+list=${DOWNLOAD_TKRS:-$(imgpkg  tag  list -i ${actualImageRepository}/tkr-bom)}
 for imageTag in ${list}; do
   if [[ ${imageTag} == v* ]]; then
     TKR_BOM_FILE="tkr-bom-${imageTag//_/+}.yaml"

--- a/hack/gen-publish-images.sh
+++ b/hack/gen-publish-images.sh
@@ -104,7 +104,9 @@ done
 
 # Iterate through TKR BoM file to create the complete Image name
 # and then pull, retag and push image to custom registry.
-list=$(imgpkg  tag  list -i ${actualImageRepository}/tkr-bom)
+# DOWNLOAD_TKRS is a space separated list of TKR names, as stored in registry
+# when set, the tkr-bom will be ignored.
+list=${DOWNLOAD_TKRS:-$(imgpkg  tag  list -i ${actualImageRepository}/tkr-bom)}
 for imageTag in ${list}; do
   if [[ ${imageTag} == v* ]]; then
     TKR_BOM_FILE="tkr-bom-${imageTag//_/+}.yaml"


### PR DESCRIPTION
### What this PR does / why we need it
Currently the download scripts will pull all images for all TKG version going back to 1.3.0, meaning new installs will download way more than is needed and the scripts take many hours to run. At the time of writing the scripts generates 478 unique imgpkg commands (cat script-output | grep imgpkg | sort | uniq |wc -l), whereas if following this procedure just to download the latest TKR needed for TKG 1.5.1 it generates 139 imgpkg commands. By implementing this fix it will improve the user experience and reduce the load on the VMware registry.

This PR, if accepted, will be followed up with a PR into the TKG docs to provide updated instructions how to explicitly define TKRs to download.
Instructions in fixes section.

### Which issue(s) this PR fixes
N/A

Fixes #
Adding the DOWNLOAD_TKRS variable allows the user to define the TKRs in a space separated list.
A user can run:
```
imgpkg pull -i ${TKG_IMAGE_REPO}/tkr-compatibility:v$(imgpkg  tag  list -i ${TKG_IMAGE_REPO}/tkr-compatibility |sed 's/v//' |sort -rn |head -1) --output "tkr-tmp"; cat tkr-tmp/tkr-compatibility.yaml | sed 's/+_//' |sed 's/+/_/' | yq e - ; rm -rf tkr-tmp;
```
The output will display all TKRs per TKG release and display them in a format that is used by the script.
The user can then export DOWNLOAD_TKRS as a space separated list of the TKRs that they would like to download.
Using `export DOWNLOAD_TKRS="v1.22.5_vmware.1-tkg.3"` will just download the TKR images need for TKG 1.5.1.

### Describe testing done for PR
Have run through all airgapped scripts to confirm behaviour as expected.

### Release note
```release-note
n/a as only affects the hacks scripts.
```

### PR Checklist
- [x] Squash the commits into one or a small number of logical commits
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

Please reach out to me on VMW Slack if discussions are needed.
