### PR TITLE
fix local docker registry port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -709,7 +709,7 @@ package-bundles: management-package-bundles ## Build tar bundles for multiple pa
 
 .PHONY: management-package-bundles
 management-package-bundles: tools management-imgpkg-lock-output ## Build tar bundles for packages
-	PACKAGE_REPOSITORY="management" $(PACKAGES_SCRIPTS_DIR)/package-utils.sh create_package_bundles localhost:5000
+	PACKAGE_REPOSITORY="management" $(PACKAGES_SCRIPTS_DIR)/package-utils.sh create_package_bundles localhost:5001
 
 .PHONY: package-repo-bundle
 package-repo-bundle: ## Build tar bundles for package repo with given package-values.yaml file
@@ -739,7 +739,7 @@ clean-registry: ## Stops and removes local docker registry
 
 .PHONY: local-registry
 local-registry: clean-registry ## Starts up a local docker registry
-	docker run -d -p 5000:5000 --name registry registry:2
+	docker run -d -p 5001:5000 --name registry registry:2
 
 .PHONY: trivy-scan
 trivy-scan: ## Trivy scan images used in packages

--- a/hack/packages/scripts/package-utils.sh
+++ b/hack/packages/scripts/package-utils.sh
@@ -90,7 +90,7 @@ function generate_package_bundles_sha256() {
 function create_package_repo_bundles() {
   if [ -z "$PACKAGE_VALUES_FILE" ];
   then
-    generate_package_bundles_sha256 localhost:5000
+    generate_package_bundles_sha256 localhost:5001
     PACKAGE_VALUES_FILE="${PROJECT_ROOT}/packages/package-values-sha256.yaml"
   fi
 


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates the local docker registry port to 5001 as 5000 port used by the control center in macOS Monterey.

### Which issue(s) this PR fixes
Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/1743

### Describe testing done for PR

make local-registry
PACKAGE_REGISTRY=management make package-bundles
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
