### PR TITLE
Remove double compile of core from builder

### DIFF
--- a/pkg/v1/builder/command/cli.go
+++ b/pkg/v1/builder/command/cli.go
@@ -177,13 +177,6 @@ func compileCore(corePath string, arch cli.Arch) cli.Plugin {
 		os.Exit(1)
 	}
 
-	// TODO (pbarker): should copy.
-	err = buildTargets(corePath, filepath.Join(artifactsDir, cli.CoreName, cli.VersionLatest), cli.CoreName, arch, "", "")
-	if err != nil {
-		log.Errorf("error: %v", err)
-		os.Exit(1)
-	}
-
 	b, err := yaml.Marshal(cli.CoreDescriptor)
 	if err != nil {
 		log.Errorf("error: %v", err)


### PR DESCRIPTION
### What this PR does / why we need it

The `builder cli compile` command currently builds the "core" tanzu
binary twice - once with the passed in version number, and once with the
version set to "latest".

It looks like this "latest" version may have been for a purpose that was
never fully realized, and there are no current uses of this extra
binary. The signing process we have explicitly ignores this artifact as
well.

This is a minor savings, but since we do not use or need this "latest"
binary, this updates the builder command to only compile once for the
version requested.

### Describe testing done for PR

Performed local builds, verified there were no errors uncovered by not having a "latest" version of `tanzu`.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Build process will no longer create a `tanzu` binary with the version set to "latest".
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access
