### PR TITLE
postNodeUpgrade won't upgrade standard-package-repo on tce (#1760)

### DIFF
--- a/pkg/v1/tkg/client/upgrade_cluster.go
+++ b/pkg/v1/tkg/client/upgrade_cluster.go
@@ -375,7 +375,9 @@ func (c *TkgClient) upgradeAddonPostNodeUpgrade(regionalClusterClient clustercli
 
 	addonsToBeUpgraded := []string{
 		"metadata/tkg",
-		"addons-management/standard-package-repo",
+	}
+	if tanzuEdition != "tce" {
+		addonsToBeUpgraded = append(addonsToBeUpgraded, "addons-management/standard-package-repo")
 	}
 	upgradeClusterMetadataOptions := &UpgradeAddonOptions{
 		AddonNames:        addonsToBeUpgraded,


### PR DESCRIPTION
This change updates the upgradeAddonPostNodeUpgrade method to exclude
updating the standard-package-repo when the cluster is a TCE cluster.
The standard-package-repo does not exist on TCE clusters.

Co-authored-by: Nick Tenczar <ntenczar@vmware.com>

### What this PR does / why we need it
Backport of PR 1760
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1749 

### Describe testing done for PR
I created a vSphere management cluster setting the build edition to TCE. I then ran management-cluster upgrade with log level nine. I confirmed in the logs that all of the required packages were upgraded and that the standard-package-repo was not upgrade.
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
