### PR TITLE
Reduce cyclomatic complexity in clusterbootstrap_controller.go

### DIFF
--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -175,8 +175,6 @@ func (r *ClusterBootstrapReconciler) Reconcile(ctx context.Context, req ctrl.Req
 }
 
 // reconcileNormal reconciles the ClusterBootstrap object
-// TODO: Fix the gocyclo linter issue: https://github.com/vmware-tanzu/tanzu-framework/issues/1761
-//nolint: gocyclo
 func (r *ClusterBootstrapReconciler) reconcileNormal(cluster *clusterapiv1beta1.Cluster, log logr.Logger) (ctrl.Result, error) {
 	// get or clone or patch from template
 	clusterBootstrap, err := r.createOrPatchClusterBootstrapFromTemplate(cluster, log)
@@ -210,19 +208,7 @@ func (r *ClusterBootstrapReconciler) reconcileNormal(cluster *clusterapiv1beta1.
 		return ctrl.Result{}, err
 	}
 
-	if err := r.reconcileSystemNamespace(remoteClient); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	// Create the ServiceAccount on remote cluster, so it could be referenced in PackageInstall CR for kapp-controller
-	// reconciliation.
-	if _, err := r.createOrPatchAddonServiceAccountOnRemote(cluster, remoteClient); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	// Create the ClusterRole on remote cluster, and bind it to the ServiceAccount created in above. kapp-controller
-	// reconciliation needs privileges.
-	if err := r.createOrPatchAddonRBACOnRemote(cluster, remoteClient); err != nil {
+	if err := r.prepareRemoteCluster(cluster, remoteClient); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -231,13 +217,14 @@ func (r *ClusterBootstrapReconciler) reconcileNormal(cluster *clusterapiv1beta1.
 	var corePackages []*runtanzuv1alpha3.ClusterBootstrapPackage
 	corePackages = append(corePackages, clusterBootstrap.Spec.CPI, clusterBootstrap.Spec.CSI)
 	corePackages = append(corePackages, clusterBootstrap.Spec.CNIs...)
+
+	// The following filtering out of nil items is not necessary in production
+	// as we do not expect CNI, CPI, CSI to be nil and webhook should handle
+	// the validations against those fields. This nil filter is mainly to allow
+	// local envtest run when any above component is missing.
+	corePackages = removeCorePackagesNils(corePackages)
+
 	for _, corePackage := range corePackages {
-		// The following nil check is redundant, we do not expect CNI, CPI, CSI to be nil and webhook should handle
-		// the validations against those fields. Having this nil check is mainly to allow local envtest run when
-		// any above component is missing.
-		if corePackage == nil {
-			continue
-		}
 		// There are different ways to have all the resources created or patched on remote cluster. Current solution is
 		// to handle packages in sequence order. I.e., Create all resources for CNI first, and then CPI, CSI. It is also
 		// possible to create all resources in a different order or in parallel. We will consider to use goroutines to create
@@ -552,6 +539,32 @@ func (r *ClusterBootstrapReconciler) reconcileSystemNamespace(clusterClient clie
 		r.Log.Info("created namespace", "namespace", r.Config.SystemNamespace)
 	}
 	return nil
+}
+
+func (r *ClusterBootstrapReconciler) prepareRemoteCluster(cluster *clusterapiv1beta1.Cluster, clusterClient client.Client) error {
+	if err := r.reconcileSystemNamespace(clusterClient); err != nil {
+		return err
+	}
+
+	// Create the ServiceAccount on remote cluster, so it could be referenced in PackageInstall CR for kapp-controller
+	// reconciliation.
+	if _, err := r.createOrPatchAddonServiceAccountOnRemote(cluster, clusterClient); err != nil {
+		return err
+	}
+
+	// Create the ClusterRole on remote cluster, and bind it to the ServiceAccount created in above. kapp-controller
+	// reconciliation needs privileges.
+	return r.createOrPatchAddonRBACOnRemote(cluster, clusterClient)
+}
+
+func removeCorePackagesNils(pkgs []*runtanzuv1alpha3.ClusterBootstrapPackage) []*runtanzuv1alpha3.ClusterBootstrapPackage {
+	var filtered []*runtanzuv1alpha3.ClusterBootstrapPackage
+	for _, pkg := range pkgs {
+		if pkg != nil {
+			filtered = append(filtered, pkg)
+		}
+	}
+	return filtered
 }
 
 // createOrPatchAddonServiceAccountOnRemote creates or patches the addon ServiceAccount on remote cluster.


### PR DESCRIPTION
Signed-off-by: F. Gold <fgold@vmware.com>

### What this PR does / why we need it

Reduce cyclomatic complexity in clusterbootstrap_controller.go's reconcileNormal(...) function. Go linter check was failing due to cyclomatic complexity being at 18. With this PR's changes, the number is down to 15, allowing lint checks to pass (requires <16).

- Functions that checked and prepared a remote cluster were moved to another function.
- A nil check was removed from a for loop by filtering out any nils from a slice.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1761 

### Describe testing done for PR

- `make lint` passes from project root
- `go test ./...` passes in `addons/controllers`

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
