### PR TITLE
Detect go modules for linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 
 include ./common.mk
 
+SHELL := /usr/bin/env bash
+
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
@@ -24,6 +26,7 @@ ADDONS_DIR := addons
 YTT_TESTS_DIR := pkg/v1/providers/tests
 PACKAGES_SCRIPTS_DIR := $(abspath hack/packages/scripts)
 UI_DIR := pkg/v1/tkg/web
+GO_MODULES=$(shell find . -path "*/go.mod" | grep -v "^./pinniped" | xargs -I _ dirname _)
 
 # Add tooling binaries here and in hack/tools/Makefile
 GOLANGCI_LINT      := $(TOOLS_BIN_DIR)/golangci-lint
@@ -514,16 +517,12 @@ yamllint:
 	hack/check/check-yaml.sh
 
 go-lint: tools ## Run linting of go source
-	# Linter runs per module, add each one here. Basically, and path
-	# that contains a go.mod file.
-
-	# Linting for the addons...
-	$(GOLANGCI_LINT) run -v
-	cd $(ADDONS_DIR); $(GOLANGCI_LINT) run -v
-	cd $(ADDONS_DIR)/pinniped/post-deploy/; $(GOLANGCI_LINT) run -v
-
-	# Linting for the YTT generation test code...
-	cd $(YTT_TESTS_DIR); $(GOLANGCI_LINT) run -v
+	@for i in $(GO_MODULES); do \
+		echo "-- Linting $$i --"; \
+		pushd $${i}; \
+		$(GOLANGCI_LINT) run -v --timeout=10m || exit 1; \
+		popd; \
+	done
 
 doc-lint: tools ## Run linting checks for docs
 	$(VALE) --config=.vale/config.ini --glob='*.md' ./
@@ -534,11 +533,12 @@ doc-lint: tools ## Run linting checks for docs
 
 .PHONY: modules
 modules: ## Runs go mod to ensure modules are up to date.
-	$(GO) mod tidy
-	cd $(ADDONS_DIR); $(GO) mod tidy
-	cd $(ADDONS_DIR)/pinniped/post-deploy/; $(GO) mod tidy
-	cd $(TOOLS_DIR); $(GO) mod tidy
-	cd $(YTT_TESTS_DIR); $(GO) mod tidy
+	@for i in $(GO_MODULES); do \
+		echo "-- Tidying $$i --"; \
+		pushd $${i}; \
+		$(GO) mod tidy || exit 1; \
+		popd; \
+	done
 
 .PHONY: verify
 verify: ## Run all verification scripts

--- a/hack/tools/main.go
+++ b/hack/tools/main.go
@@ -1,0 +1,8 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// This file is only present to make the linter happy.
+
+package main
+
+func main() {}


### PR DESCRIPTION
### What this PR does / why we need it

We've had the issue that any time we need to add a new go module to the
repo, the person adding it needs to remember to include it in the
Makefile as an additional location for the `go-lint` and `modules`
target since those operate on a per-module level.

This updates those targets so they automatically iterate through all
detected directories containing a `go.mod` file. That way when someone
adds new modules in the future, they don't need to be as aware of this
linting limitation.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1785 

### Describe testing done for PR

Ran `make go-lint` and `make modules` locally.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access

