### PR TITLE
Check out current source for linting

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -89,6 +89,9 @@ jobs:
         go-version: '1.17'
       id: go
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
     - name: Run lint checks
       run: |
         make lint


### PR DESCRIPTION
### What this PR does / why we need it

It was noticed in another PR that changes to the linter target were not
picked up, missing some issues. On investigation, it was found that this
was a configuration issue in the Lint job. GitHub Actions need to
explicitly check out the code of the PR to pick up the proposed changes,
so even though the PR made changes, they were not reflected in the
results of the job.

This adds the checkout action to the Lint job to make sure it always
runs against the proposed changes.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1793 