### PR TITLE
Update checkout action to v3 release

### DIFF
--- a/.github/workflows/dev_tag_retrieval_pr.yaml
+++ b/.github/workflows/dev_tag_retrieval_pr.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Fetch current version
         id: get_version

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
         node-version: 16.x
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |
@@ -81,7 +81,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go 1.x
       uses: actions/setup-go@v2

--- a/.github/workflows/plugin_tests.yaml
+++ b/.github/workflows/plugin_tests.yaml
@@ -29,7 +29,9 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: yaml-lint
       uses: ibiqlik/action-yamllint@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
         node-version: 16.x
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/release_staging.yaml
+++ b/.github/workflows/release_staging.yaml
@@ -23,7 +23,7 @@ jobs:
         node-version: 16.x
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/security_codeql.yaml
+++ b/.github/workflows/security_codeql.yaml
@@ -22,7 +22,7 @@ jobs:
         node-version: 16.x
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/test-release-artifacts-linux-macos.yaml
+++ b/.github/workflows/test-release-artifacts-linux-macos.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Test Release Artifacts on MacOS and Linux OS
         env:

--- a/.github/workflows/test-release-artifacts-windows.yaml
+++ b/.github/workflows/test-release-artifacts-windows.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Test Release Artifacts on Windows OS
         env:

--- a/.github/workflows/tkg_integration_tests.yaml
+++ b/.github/workflows/tkg_integration_tests.yaml
@@ -30,7 +30,7 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |
@@ -95,7 +95,7 @@ jobs:
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/tkgpackage_integration_test.yaml
+++ b/.github/workflows/tkgpackage_integration_test.yaml
@@ -31,7 +31,9 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Get dependencies
         run: |


### PR DESCRIPTION
### What this PR does / why we need it

There is a newer v3 release of the `actions/checkout` GitHub action.
This updates all usage of this action to use the latest version to pick
up fixes and improvements.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Related #1793

### Describe testing done for PR

Difficult to test locally, so testing is going to need to be done by getting results of the actions that run.