### PR TITLE
Adds function to continuously manage webhook TLS certificates

### DIFF
--- a/addons/controllers/suite_test.go
+++ b/addons/controllers/suite_test.go
@@ -79,7 +79,7 @@ var (
 	cancel        context.CancelFunc
 	certPath      string
 	keyPath       string
-	// clientset     *kubernetes.Clientset
+	tmpDir        string
 )
 
 func TestAddonController(t *testing.T) {
@@ -164,7 +164,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(dynamicClient).ToNot(BeNil())
 
-	tmpDir, err := os.MkdirTemp("/tmp", "webhooktest")
+	tmpDir, err = os.MkdirTemp("/tmp", "webhooktest")
 	Expect(err).ToNot(HaveOccurred())
 	certPath = path.Join(tmpDir, "tls.cert")
 	keyPath = path.Join(tmpDir, "tls.key")

--- a/addons/controllers/webhooks_test.go
+++ b/addons/controllers/webhooks_test.go
@@ -1,0 +1,153 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	cert2 "k8s.io/client-go/util/cert"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/webhooks"
+)
+
+const (
+	oneDay   = time.Hour * 24
+	oneWeek  = time.Hour * 24 * 7
+	zeroTime = time.Second * 0
+)
+
+var setupLog = ctrl.Log.WithName("controllers").WithName("Addon")
+
+var _ = Describe("when webhook TLS is being continuously managed", func() {
+	Context("if check frequency time is reached", func() {
+		It("tls certificates should be validated and rotated if invalid", func() {
+			privCtx := context.Background()
+			cacelCtx, cancelFn := context.WithCancel(privCtx)
+			rotationTime := time.Second
+			managementFrequency := rotationTime / 2
+			webhookTLS := webhooks.WebhookTLS{
+				Ctx:           cacelCtx,
+				K8sConfig:     k8sConfig,
+				CertPath:      certPath,
+				KeyPath:       keyPath,
+				Name:          webhookScrtName,
+				ServiceName:   webhookServiceName,
+				LabelSelector: "webhook-cert=self-managed",
+				Logger:        setupLog,
+				Namespace:     addonNamespace,
+				RotationTime:  rotationTime,
+			}
+
+			err := webhookTLS.ManageCertificates(managementFrequency)
+			Expect(err).ToNot(HaveOccurred())
+			time.Sleep(managementFrequency + rotationTime) // we wait longer than one rotation to allow for certificate installation
+			firstCert, err := cert2.CertsFromFile(webhookTLS.CertPath)
+			Expect(err).ToNot(HaveOccurred())
+			firstCertPEM, err := cert2.EncodeCertificates(firstCert[0])
+			Expect(err).ToNot(HaveOccurred())
+
+			time.Sleep(2 * rotationTime) // wait enough time to ensure the certificate has been rotated.
+
+			secondCert, err := cert2.CertsFromFile(webhookTLS.CertPath)
+			Expect(err).ToNot(HaveOccurred())
+			secondCertPEM, err := cert2.EncodeCertificates(secondCert[0])
+			Expect(err).ToNot(HaveOccurred())
+
+			cancelFn()
+
+			//The certificates should be different due to rotation
+			Expect(secondCertPEM).ToNot(Equal(firstCertPEM))
+
+		})
+	})
+	Context("if rotation time is longer than one week", func() {
+		It("should set rotation to one week", func() {
+			rotationTime := oneWeek + oneDay
+			managementFrequency := rotationTime / 2
+			webhookTLS := webhooks.WebhookTLS{
+				Ctx:           context.Background(),
+				K8sConfig:     k8sConfig,
+				CertPath:      certPath,
+				KeyPath:       keyPath,
+				Name:          webhookScrtName,
+				ServiceName:   webhookServiceName,
+				LabelSelector: "webhook-cert=self-managed",
+				Logger:        setupLog,
+				Namespace:     addonNamespace,
+				RotationTime:  rotationTime,
+			}
+			err := webhookTLS.ManageCertificates(managementFrequency)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(webhookTLS.RotationTime).To(Equal(oneWeek))
+
+		})
+	})
+	Context("if rotation time is 0 or less than 0", func() {
+		It("should set rotation to one day", func() {
+			rotationTime := zeroTime
+			managementFrequency := oneDay //any value larger than 0 will work here
+			webhookTLS := webhooks.WebhookTLS{
+				Ctx:           context.Background(),
+				K8sConfig:     k8sConfig,
+				CertPath:      certPath,
+				KeyPath:       keyPath,
+				Name:          webhookScrtName,
+				ServiceName:   webhookServiceName,
+				LabelSelector: "webhook-cert=self-managed",
+				Logger:        setupLog,
+				Namespace:     addonNamespace,
+				RotationTime:  rotationTime,
+			}
+			err := webhookTLS.ManageCertificates(managementFrequency)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(webhookTLS.RotationTime).To(Equal(oneDay))
+
+		})
+	})
+	Context("if rotation time is one week", func() {
+		It("tls certificates should be validated and not rotated until one week", func() {
+			privCtx := context.Background()
+			cacelCtx, cancelFn := context.WithCancel(privCtx)
+			rotationTime := oneWeek
+			managementFrequency := time.Second / 2 //manage the certificates every 1/2 second for testing purposes
+			webhookTLS := webhooks.WebhookTLS{
+				Ctx:           cacelCtx,
+				K8sConfig:     k8sConfig,
+				CertPath:      certPath,
+				KeyPath:       keyPath,
+				Name:          webhookScrtName,
+				ServiceName:   webhookServiceName,
+				LabelSelector: "webhook-cert=self-managed",
+				Logger:        setupLog,
+				Namespace:     addonNamespace,
+				RotationTime:  rotationTime,
+			}
+
+			err := webhookTLS.ManageCertificates(managementFrequency)
+			Expect(err).ToNot(HaveOccurred())
+			time.Sleep(managementFrequency * 3) // manage the certificates three times
+			firstCert, err := cert2.CertsFromFile(webhookTLS.CertPath)
+			Expect(err).ToNot(HaveOccurred())
+			firstCertPEM, err := cert2.EncodeCertificates(firstCert[0])
+			Expect(err).ToNot(HaveOccurred())
+
+			time.Sleep(managementFrequency * 3) // manage the certificate three times
+			secondCert, err := cert2.CertsFromFile(webhookTLS.CertPath)
+			Expect(err).ToNot(HaveOccurred())
+			secondCertPEM, err := cert2.EncodeCertificates(secondCert[0])
+			Expect(err).ToNot(HaveOccurred())
+
+			cancelFn()
+
+			//The certificates should be the same since we did not hit one week rotation
+			Expect(secondCertPEM).To(Equal(firstCertPEM))
+
+		})
+	})
+
+})

--- a/pkg/v1/webhooks/certificates.go
+++ b/pkg/v1/webhooks/certificates.go
@@ -11,25 +11,28 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	certutil "k8s.io/client-go/util/cert"
 	"k8s.io/client-go/util/keyutil"
+	"k8s.io/client-go/util/retry"
 	"knative.dev/pkg/webhook/certificates/resources"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func addCertsToWebhookConfigs(ctx context.Context, client kubernetes.Interface, labelSelector string, secret *corev1.Secret) error {
+func addCertsToWebhookConfigs(ctx context.Context, k8sclient kubernetes.Interface, labelSelector string, secret *corev1.Secret) error {
 	if labelSelector == "" {
 		return fmt.Errorf("label selector not provided for webhook configurations udpate")
 	}
-	allValidatingWebhookConfigurations, err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	allValidatingWebhookConfigurations, err := k8sclient.AdmissionregistrationV1().ValidatingWebhookConfigurations().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return err
 	}
 	for idx := range allValidatingWebhookConfigurations.Items {
 		configName := allValidatingWebhookConfigurations.Items[idx].Name
-		validatingWebhookConfiguration, err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, configName, metav1.GetOptions{})
+		validatingWebhookConfiguration, err := k8sclient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Get(ctx, configName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -37,18 +40,18 @@ func addCertsToWebhookConfigs(ctx context.Context, client kubernetes.Interface, 
 		for idx := range validatingWebhookConfiguration.Webhooks {
 			validatingWebhookConfiguration.Webhooks[idx].ClientConfig.CABundle = secret.Data[resources.CACert]
 		}
-		if _, err := client.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(ctx, validatingWebhookConfiguration, metav1.UpdateOptions{}); err != nil {
+		if _, err := k8sclient.AdmissionregistrationV1().ValidatingWebhookConfigurations().Update(ctx, validatingWebhookConfiguration, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("error updating CA cert of ValidatingWebhookConfiguration %s: %v", configName, err)
 		}
 	}
 
-	allMutatingWebhookConfigurations, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+	allMutatingWebhookConfigurations, err := k8sclient.AdmissionregistrationV1().MutatingWebhookConfigurations().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return err
 	}
 	for idx := range allMutatingWebhookConfigurations.Items {
 		configName := allMutatingWebhookConfigurations.Items[idx].Name
-		mutatingWebhookConfiguration, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, configName, metav1.GetOptions{})
+		mutatingWebhookConfiguration, err := k8sclient.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(ctx, configName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
@@ -56,7 +59,7 @@ func addCertsToWebhookConfigs(ctx context.Context, client kubernetes.Interface, 
 		for idx := range mutatingWebhookConfiguration.Webhooks {
 			mutatingWebhookConfiguration.Webhooks[idx].ClientConfig.CABundle = secret.Data[resources.CACert]
 		}
-		if _, err := client.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(ctx, mutatingWebhookConfiguration, metav1.UpdateOptions{}); err != nil {
+		if _, err := k8sclient.AdmissionregistrationV1().MutatingWebhookConfigurations().Update(ctx, mutatingWebhookConfiguration, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("error updating CA cert of MutatingWebhookConfiguration %s: %v", configName, err)
 		}
 	}
@@ -85,12 +88,20 @@ func InstallNewCertificates(ctx context.Context, k8sConfig *rest.Config, certPat
 		return nil, err
 	}
 
-	client, err := kubernetes.NewForConfig(k8sConfig)
+	k8sclient, err := client.New(k8sConfig, client.Options{})
+	if err != nil {
+		return nil, err
+	}
+	err = updateOrCreateTLSSecret(ctx, k8sclient, secret)
 	if err != nil {
 		return nil, err
 	}
 
-	err = addCertsToWebhookConfigs(ctx, client, labelSelector, secret)
+	clientSet, err := kubernetes.NewForConfig(k8sConfig)
+	if err != nil {
+		return nil, err
+	}
+	err = addCertsToWebhookConfigs(ctx, clientSet, labelSelector, secret)
 	if err != nil {
 		return nil, err
 	}
@@ -99,6 +110,9 @@ func InstallNewCertificates(ctx context.Context, k8sConfig *rest.Config, certPat
 }
 
 func ValidateTLSSecret(tlsSecret *corev1.Secret, certGracePeriod time.Duration) error {
+	if tlsSecret == nil {
+		return fmt.Errorf("webhook certificate secret is empty")
+	}
 	if _, haskey := tlsSecret.Data[resources.ServerKey]; !haskey {
 		return fmt.Errorf("webhook certificate secret is missing key %q", resources.ServerKey)
 	}
@@ -119,6 +133,34 @@ func ValidateTLSSecret(tlsSecret *corev1.Secret, certGracePeriod time.Duration) 
 	}
 	if time.Now().Add(certGracePeriod).After(certData.NotAfter) {
 		return fmt.Errorf("webhook certificate expired on %q", certData.NotAfter)
+	}
+	return nil
+}
+
+// write secret to cluster
+func updateOrCreateTLSSecret(ctx context.Context, k8sclient client.Client, tlsSecret *corev1.Secret) error {
+	if tlsSecret == nil {
+		return nil
+	}
+	currentSecret := &corev1.Secret{}
+	err := k8sclient.Get(ctx, client.ObjectKey{
+		Namespace: tlsSecret.Namespace,
+		Name:      tlsSecret.Name}, currentSecret)
+	if apierrors.IsNotFound(err) {
+		err = k8sclient.Create(ctx, tlsSecret)
+		if err != nil {
+			return err
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return k8sclient.Update(ctx, tlsSecret)
+	})
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/v1/webhooks/certificates_test.go
+++ b/pkg/v1/webhooks/certificates_test.go
@@ -50,7 +50,8 @@ var _ = BeforeSuite(func() {
 
 var _ = AfterSuite(func() {
 	By("remove test resources")
-	os.RemoveAll(tmpDir)
+	_ = os.RemoveAll(tmpDir) // ignore errors since we check directory status next
+
 	_, err := os.Stat(tmpDir)
 	Expect(os.IsNotExist(err))
 

--- a/pkg/v1/webhooks/webhooks.go
+++ b/pkg/v1/webhooks/webhooks.go
@@ -1,0 +1,115 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package webhooks provides functions to manage webhook TLS certificates
+package webhooks
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/rest"
+	"knative.dev/pkg/webhook/certificates/resources"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type WebhookTLS struct {
+	Ctx           context.Context
+	K8sConfig     *rest.Config
+	CertPath      string
+	KeyPath       string
+	Name          string
+	ServiceName   string
+	LabelSelector string
+	Logger        logr.Logger
+	secret        *corev1.Secret
+	Namespace     string
+	RotationTime  time.Duration
+}
+
+const (
+	oneWeek = time.Hour * 24 * 7
+	oneDay  = time.Hour * 24
+)
+
+func (w *WebhookTLS) UpdateOrCreate() error {
+	if w.RotationTime > oneWeek {
+		w.Logger.Info("rotation time will be set to maximum allowed value of one Week")
+		w.RotationTime = oneWeek
+	}
+	if w.RotationTime <= time.Second*0 {
+		w.Logger.Info("rotation may not be 0 or less than 0, setting rotation to one day")
+		w.RotationTime = oneDay
+	}
+
+	gracePeriod := oneWeek - w.RotationTime // Because of check above, graceperiod will never be less than 0.
+
+	clusterClient, err := client.New(w.K8sConfig, client.Options{})
+	if err != nil {
+		return err
+	}
+	currentSecret := &corev1.Secret{}
+	err = clusterClient.Get(w.Ctx, client.ObjectKey{
+		Namespace: w.Namespace,
+		Name:      w.Name}, currentSecret)
+	if err == nil {
+		w.secret = currentSecret
+	} else if !apierrors.IsNotFound(err) { // secret not found = "Create" case.
+		return err
+	}
+
+	err = ValidateTLSSecret(w.secret, gracePeriod)
+	if err != nil {
+		w.Logger.Info("invalid webhook tls secret: " + err.Error())
+		w.Logger.Info("installing new certificates")
+		w.secret, err = InstallNewCertificates(w.Ctx, w.K8sConfig, w.CertPath, w.KeyPath, w.Name, w.Namespace, w.ServiceName, w.LabelSelector)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *WebhookTLS) ServerCert() []byte {
+	return w.secret.Data[resources.ServerCert]
+}
+
+func (w *WebhookTLS) ServerKey() []byte {
+	return w.secret.Data[resources.ServerKey]
+}
+
+func (w *WebhookTLS) CACert() []byte {
+	return w.secret.Data[resources.CACert]
+}
+
+func (w *WebhookTLS) ManageCertificates(frequency time.Duration) error {
+	err := w.UpdateOrCreate()
+	if err != nil {
+		return err
+	}
+	ticker := time.NewTicker(frequency)
+
+	go w.manageTLSCertificates(ticker)
+
+	return nil
+}
+
+func (w *WebhookTLS) manageTLSCertificates(ticker *time.Ticker) {
+	for {
+		select {
+		case <-w.Ctx.Done():
+			return
+
+		case <-ticker.C:
+			err := w.UpdateOrCreate()
+			if err != nil {
+				errMsg := strings.Join([]string{"Failed to manage Webhook TLS:", w.Name, "in", w.Namespace, "with", w.LabelSelector}, " ")
+				w.Logger.Error(err, errMsg)
+			}
+		}
+	}
+}


### PR DESCRIPTION
- New self signed server certificates, key, and ca cert are created
  and placed in a k8s opaque secret.
- The server certificate and key are written to the specified path
- Webhook Mutating and Validating configurations are augmented with new CA bundle
- The new certificates are monitored for validity and rotated when appropriate.

An example of integrationg in addons/main.go

```
#define WebhookTLS struct will all relevant information: 

	webhookTLS := webhooks.WebhookTLS{
		Ctx:           ctx,
		K8sConfig:     k8sConfig,
		CertPath:      "/tmp/somedirectory/tls.cert",    // or use default value ofr mgr.Option{CertDir: }
		KeyPath:       "/tmp/somedirectory/tls.key",
		Name:         "tls-secret",
		ServiceName:   "webhook-tls",
		LabelSelector: "webhook-cert=self-managed",  // this is the label that will be used to select the webhook configs
		Logger:        setupLog,
		Namespace:     addonNamespace,
		RotationTime: time.Hour * 24,        // time.Duration in which certificates will be rotated. Max one week.
	}

     # go function: 
     checkFrequency = time.Hour // Check certificates every hour
     err := webhookTLS.ManageCertificates(managementFrequency)
     if err != nil {
       #do something about/with err because certificate management failed to start
     }


    # Start manager with ctrl.Options { ... CertDir: "/tmp/somedirectory" }
```



<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1583

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Adds function to continuously manage webhook TLS certificates
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
