### PR TITLE
Fix the imgpkg registy custom certificate validation and validation skipping issue

### DIFF
--- a/pkg/v1/tkr/controllers/source/tkr_source_controller.go
+++ b/pkg/v1/tkr/controllers/source/tkr_source_controller.go
@@ -524,10 +524,13 @@ func (r *reconciler) Start(ctx context.Context) error {
 		return errors.Wrap(err, "failed to configure the controller")
 	}
 
-	registryCertPath, err := getRegistryCertFile()
-	if err == nil {
-		if _, err = os.Stat(registryCertPath); err == nil {
-			r.registryOps.CACertPaths = []string{registryCertPath}
+	// Add custom CA cert paths only if VerifyCerts is enabled
+	if r.registryOps.VerifyCerts {
+		registryCertPath, err := getRegistryCertFile()
+		if err == nil {
+			if _, err = os.Stat(registryCertPath); err == nil {
+				r.registryOps.CACertPaths = []string{registryCertPath}
+			}
 		}
 	}
 

--- a/pkg/v1/tkr/pkg/registry/client.go
+++ b/pkg/v1/tkr/pkg/registry/client.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cppforlife/go-cli-ui/ui"
 	regname "github.com/google/go-containerregistry/pkg/name"
 	regv1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/k14s/imgpkg/pkg/imgpkg/cmd"
 	ctlimg "github.com/k14s/imgpkg/pkg/imgpkg/registry"
 	"github.com/pkg/errors"
@@ -52,7 +51,7 @@ func (r *registry) GetFile(imageWithTag, filename string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	d, err := remote.Get(ref)
+	d, err := r.registry.Get(ref)
 	if err != nil {
 		return nil, errors.Wrap(err, "Collecting images")
 	}
@@ -124,7 +123,7 @@ func (r *registry) GetFiles(imageWithTag string) (map[string][]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	d, err := remote.Get(ref)
+	d, err := r.registry.Get(ref)
 	if err != nil {
 		return nil, errors.Wrap(err, "Collecting images")
 	}


### PR DESCRIPTION
- Fixed the issue where imgpkg registry options were not being used during GetFile() and GetFiles()
  which caused certificate validation even though 'skip-verify-registry-cert' is set to true or
  custom ca cert is set.
- Also made changes in tkr-controller to add custom CA certs to the registry only if 'skip-verify-registry-cert' is set to false

Signed-off-by: PremKumar Kalle <pkalle@vmware.com>

### What this PR does / why we need it
This PR fixes the issue where imgpkg registry options were not being used during GetFile() and GetFiles()
which caused certificate validation even though 'skip-verify-registry-cert' is set to true orcustom ca cert is set.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1805, #1806

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Ran a local registry with self-signed certs and ran the TKR controller locally with `skip-verify-registry-cert=false` and the TKR controller failed with below errror which is expected
```
x509: certificate signed by unknown authority
```

Ran a local registry with self-signed certs and ran the TKR controller locally with `skip-verify-registry-cert=true` and the TKR controller ran successfully with out any cert issue. It successfully downloaded the tkr-compatibitility and tkrs.


Ran a local registry with self-signed certs and ran the TKR controller locally with `skip-verify-registry-cert=false` and custom image repositoy ca cert exported in `$HOME/regitry_certs` file and the TKR controller ran successfully with out any cert issue. It successfully downloaded the tkr-compatibitility and tkrs.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix the imgpkg registy custom certificate validation and validation skipping issue
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
