### PR TITLE
Fix node pool delete logic

### DIFF
--- a/pkg/v1/tkg/client/machine_deployment_test.go
+++ b/pkg/v1/tkg/client/machine_deployment_test.go
@@ -5,7 +5,6 @@ package client_test
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -325,71 +324,65 @@ func GetDummyPacificCluster() tkgsv1alpha2.TanzuKubernetesCluster {
 	return tkc
 }
 
-const (
-	prependMDName1 = "test-cluster-md-0"
-	prependMDName2 = "test-cluster-md-1"
-	md1Name        = "md-0"
-	md2Name        = "md-1"
-	clusterName    = "test-cluster"
-)
+var _ = Describe("NormalizeNodePoolName", func() {
+	var (
+		workers []capi.MachineDeployment
+		err     error
+		mds     []capi.MachineDeployment
+	)
+	const (
+		prependMDName1 = "test-cluster-md-0"
+		prependMDName2 = "test-cluster-md-1"
+		md1Name        = "md-0"
+		md2Name        = "md-1"
+		clusterName    = "test-cluster"
+	)
 
-func Test_NormalizeNodePoolName_WithPrepend(t *testing.T) {
-	mds := []capi.MachineDeployment{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: prependMDName1,
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: prependMDName2,
-			},
-		},
-	}
-
-	workers, _ := NormalizeNodePoolName(mds, clusterName)
-
-	if err != nil {
-		t.Fatal("Unexpected error normalzing node pool names")
-	}
-
-	if workers[0].Name != md1Name {
-		t.Errorf("Expected first machine deployment name to be %s, was %s", md1Name, workers[0].Name)
-	}
-
-	if workers[1].Name != md2Name {
-		t.Errorf("Expected second machine deployment name to be %s, was %s", md2Name, workers[1].Name)
-	}
-}
-
-func Test_NormalizeNodePoolName_WithoutPrepend(t *testing.T) {
-	mds := []capi.MachineDeployment{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: md1Name,
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: md2Name,
-			},
-		},
-	}
-
-	workers, _ := NormalizeNodePoolName(mds, clusterName)
-
-	if err != nil {
-		t.Fatal("Unexpected error normalzing node pool names")
-	}
-
-	if workers[0].Name != md1Name {
-		t.Errorf("Expected first machine deployment name to be %s, was %s", md1Name, workers[0].Name)
-	}
-
-	if workers[1].Name != md2Name {
-		t.Errorf("Expected second machine deployment name to be %s, was %s", md2Name, workers[1].Name)
-	}
-}
+	JustBeforeEach(func() {
+		workers, err = NormalizeNodePoolName(mds, clusterName)
+		Expect(err).ToNot(HaveOccurred())
+	})
+	When("Machine Deployment names aren't prepended with cluster name", func() {
+		BeforeEach(func() {
+			mds = []capi.MachineDeployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: md1Name,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: md2Name,
+					},
+				},
+			}
+		})
+		It("should do keep the machine deployment names the same", func() {
+			Expect(workers[0].Name).To(Equal(md1Name))
+			Expect(workers[1].Name).To(Equal(md2Name))
+		})
+	})
+	When("Machine Deployment names are prepended with the cluster name", func() {
+		BeforeEach(func() {
+			mds = []capi.MachineDeployment{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: prependMDName1,
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: prependMDName2,
+					},
+				},
+			}
+		})
+		It("should strip the cluster name prepend", func() {
+			Expect(workers[0].Name).To(Equal(md1Name))
+			Expect(workers[1].Name).To(Equal(md2Name))
+		})
+	})
+})
 
 var _ = Describe("Machine Deployment", func() {
 	const (
@@ -408,7 +401,6 @@ var _ = Describe("Machine Deployment", func() {
 	)
 	BeforeEach(func() {
 		clusterClient = fakes.ClusterClient{}
-
 	})
 	Context("DoDeleteMachineDeployment", func() {
 		var options DeleteMachineDeploymentOptions
@@ -599,6 +591,20 @@ var _ = Describe("Machine Deployment", func() {
 						It("should throw an error", func() {
 							Expect(err).To(HaveOccurred())
 							Expect(err).Should(MatchError(fmt.Sprintf("unable to delete machine template %s-%s-mt: ", options.ClusterName, options.Name)))
+						})
+					})
+					When("Deleting a node pool with a name that is a subset of another node pool name", func() {
+						BeforeEach(func() {
+							md2.Name = "np-1"
+							clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
+							clusterClient.DeleteResourceReturns(nil)
+						})
+						It("should delete the machine deployment with the exact matching name", func() {
+							Expect(clusterClient.DeleteResourceCallCount()).To(Equal(3))
+							mdObj := clusterClient.DeleteResourceArgsForCall(0)
+							md, ok := mdObj.(*capi.MachineDeployment)
+							Expect(ok).To(BeTrue())
+							Expect(md.Name).To(Equal("np-1"))
 						})
 					})
 					When("there is an error deleting the kubeadmconfig template", func() {


### PR DESCRIPTION
Updates node pool delete logic. Looks for machine deployment by full
node pool name first. This is necessary because the 1.4.0 node pool API
used the provided node pool name directly on the machine deployment. If
the node pool is not found by full name then we check for machine
deployment with the given node pool name prepended with the cluster
name. This was added in 1.4.1 to support TMC and avoid name conflicts
where different clusters under the same management cluster could not have
the same node pool names. Machine deployment names should now all be
prepended with the cluster name.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1776 

### Describe testing done for PR
Added new unit test to check that the correct node pool is being deleted.
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixes an issue where node pool delete could delete the incorrect node pool if the node pool named passed to delete is a substring of another node pool name.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
