### PR TITLE
Fix refresh osimage

### DIFF
--- a/pkg/v1/tkg/web/src/app/views/landing/aws-wizard/os-image-step/aws-os-image-step.component.ts
+++ b/pkg/v1/tkg/web/src/app/views/landing/aws-wizard/os-image-step/aws-os-image-step.component.ts
@@ -1,6 +1,7 @@
 // Angular imports
 import { Component, OnInit } from '@angular/core';
 // App imports
+import AppServices from '../../../../shared/service/appServices';
 import { AWSVirtualMachine } from '../../../../swagger/models';
 import {
     OsImageProviderInputs,
@@ -14,20 +15,31 @@ import { TanzuEventType } from '../../../../shared/service/Messenger';
     styleUrls: ['../../wizard/shared/components/steps/os-image-step/os-image-step.component.scss']
 })
 export class AwsOsImageStepComponent extends SharedOsImageStepDirective<AWSVirtualMachine> implements OnInit {
+    private currentRegion: string;
+
+    ngOnInit() {
+        super.ngOnInit();
+        // subscribe to the AWS_REGION_CHANGED event so that we can capture the current region. We need it so that if
+        // the user wants to refresh the os images available, we have the region id for the backend call to get the os images
+        AppServices.messenger.subscribe<string>(TanzuEventType.AWS_REGION_CHANGED, event => {
+            this.currentRegion = event.payload;
+        });
+    }
+
     protected supplyProviderInputs(): OsImageProviderInputs {
         return {
+            createOsImageEventPayload: this.createOsImageEventPayload.bind(this),
             event: TanzuEventType.AWS_GET_OS_IMAGES,
+            eventImportFileFailure: TanzuEventType.AWS_CONFIG_FILE_IMPORT_ERROR,
+            eventImportFileSuccess: TanzuEventType.AWS_CONFIG_FILE_IMPORTED,
             osImageTooltipContent: 'Select a base OS image that you have already imported ' +
                 'into your AWS account. If no compatible OS image is present, import one into ' +
                 'AWS and click the Refresh button'
         };
     }
 
-    protected supplyImportFileSuccessEvent(): TanzuEventType {
-        return TanzuEventType.AWS_CONFIG_FILE_IMPORTED;
-    }
-
-    protected supplyImportFileFailureEvent(): TanzuEventType {
-        return TanzuEventType.AWS_CONFIG_FILE_IMPORT_ERROR;
+    // returns a payload that can be used with the AWS_GET_OS_IMAGES event to refresh the os images from the backend
+    private createOsImageEventPayload() {
+        return { region: this.currentRegion };
     }
 }

--- a/pkg/v1/tkg/web/src/app/views/landing/azure-wizard/os-image-step/azure-os-image-step.component.ts
+++ b/pkg/v1/tkg/web/src/app/views/landing/azure-wizard/os-image-step/azure-os-image-step.component.ts
@@ -14,18 +14,12 @@ export class AzureOsImageStepComponent extends SharedOsImageStepDirective<AzureV
     protected supplyProviderInputs(): OsImageProviderInputs {
         return {
             event: TanzuEventType.AZURE_GET_OS_IMAGES,
+            eventImportFileFailure: TanzuEventType.AZURE_CONFIG_FILE_IMPORT_ERROR,
+            eventImportFileSuccess: TanzuEventType.AZURE_CONFIG_FILE_IMPORTED,
             noImageAlertMessage: '',
             osImageTooltipContent: 'Select a base OS image that you have already imported ' +
                 'into your Azure account. If no compatible OS image is present, import one into ' +
                 'Azure and click the Refresh button',
         };
-    }
-
-    protected supplyImportFileSuccessEvent(): TanzuEventType {
-        return TanzuEventType.AZURE_CONFIG_FILE_IMPORTED;
-    }
-
-    protected supplyImportFileFailureEvent(): TanzuEventType {
-        return TanzuEventType.AZURE_CONFIG_FILE_IMPORT_ERROR;
     }
 }

--- a/pkg/v1/tkg/web/src/app/views/landing/vsphere-wizard/vsphere-os-image-step/vsphere-os-image-step.component.ts
+++ b/pkg/v1/tkg/web/src/app/views/landing/vsphere-wizard/vsphere-os-image-step/vsphere-os-image-step.component.ts
@@ -1,8 +1,11 @@
 // Angular imports
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 // App imports
-import { FieldMapUtilities } from '../../wizard/shared/field-mapping/FieldMapUtilities';
-import { OsImageProviderInputs, SharedOsImageStepDirective } from '../../wizard/shared/components/steps/os-image-step/os-image-step.component';
+import AppServices from '../../../../shared/service/appServices';
+import {
+    OsImageProviderInputs,
+    SharedOsImageStepDirective
+} from '../../wizard/shared/components/steps/os-image-step/os-image-step.component';
 import { StepMapping } from '../../wizard/shared/field-mapping/FieldMapping';
 import { TanzuEventType } from '../../../../shared/service/Messenger';
 import { VsphereOsImageStepMapping } from './vsphere-os-image-step.fieldmapping';
@@ -13,12 +16,21 @@ import { VSphereVirtualMachine } from '../../../../swagger/models';
     templateUrl: '../../wizard/shared/components/steps/os-image-step/os-image-step.component.html',
     styleUrls: ['../../wizard/shared/components/steps/os-image-step/os-image-step.component.scss']
 })
-export class VsphereOsImageStepComponent extends SharedOsImageStepDirective<VSphereVirtualMachine> {
+export class VsphereOsImageStepComponent extends SharedOsImageStepDirective<VSphereVirtualMachine> implements OnInit {
     private tkrVersionString: string;
+    private currentDataCenter: string; // the currently selected data center
 
     constructor() {
         super();
         this.tkrVersion.subscribe(value => { this.tkrVersionString = value; });
+    }
+
+    ngOnInit() {
+        super.ngOnInit();
+        // subscribe to the VSPHERE_DATACENTER_CHANGED event so that we can capture the current data center. We need it so that if
+        // the user wants to refresh the os images available, we have the datacenter id for the backend call to get the os images
+        AppServices.messenger.subscribe<string>(TanzuEventType.VSPHERE_DATACENTER_CHANGED,
+                event => this.currentDataCenter = event.payload);
     }
 
     // NOTE: there is an implicit assumption here that the tkrVersion Observable will have delivered a value before
@@ -35,11 +47,19 @@ export class VsphereOsImageStepComponent extends SharedOsImageStepDirective<VSph
         const nonTemplateAlertMessage = 'Your selected OS image must be converted to a VM template. ' +
             'You may click the refresh icon to reload the OS image list once this has been done.'
         return {
+            createOsImageEventPayload: this.createOsImageEventPayload.bind(this),
             event: TanzuEventType.VSPHERE_GET_OS_IMAGES,
+            eventImportFileFailure: TanzuEventType.VSPHERE_CONFIG_FILE_IMPORT_ERROR,
+            eventImportFileSuccess: TanzuEventType.VSPHERE_CONFIG_FILE_IMPORTED,
             noImageAlertMessage: noImageAlertMessage,
             osImageTooltipContent: osImageTooltipContent,
             nonTemplateAlertMessage: nonTemplateAlertMessage,
         };
+    }
+
+    // returns a payload that can be used with the VSPHERE_GET_OS_IMAGES event to refresh the os images from the backend
+    private createOsImageEventPayload() {
+        return { dc: this.currentDataCenter };
     }
 
     protected getImageFromStoredValue(osImageValue: string): VSphereVirtualMachine {
@@ -50,13 +70,5 @@ export class VsphereOsImageStepComponent extends SharedOsImageStepDirective<VSph
 
     protected supplyStepMapping(): StepMapping {
         return VsphereOsImageStepMapping;
-    }
-
-    protected supplyImportFileSuccessEvent(): TanzuEventType {
-        return TanzuEventType.VSPHERE_CONFIG_FILE_IMPORTED;
-    }
-
-    protected supplyImportFileFailureEvent(): TanzuEventType {
-        return TanzuEventType.VSPHERE_CONFIG_FILE_IMPORT_ERROR;
     }
 }


### PR DESCRIPTION
### What this PR does / why we need it
Fixes os image refresh, where (for some providers) we were not sending the appropriate payload when user clicked to refresh the list of os images

Fixes #1808 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
