### PR TITLE
[release-0.11]: Cherry-pick 1302: Fix panic on creating nodepools

### DIFF
--- a/pkg/v1/tkg/client/machine_deployment.go
+++ b/pkg/v1/tkg/client/machine_deployment.go
@@ -172,9 +172,7 @@ func DoSetMachineDeployment(clusterClient clusterclient.Client, options *SetMach
 		options.Name = fmt.Sprintf("%s-%s", options.ClusterName, options.Name)
 		machineTemplateName := fmt.Sprintf("%s-mt", options.Name)
 		kcTemplate.Name = fmt.Sprintf("%s-kct", options.Name)
-		if kcTemplate.Spec.Template.Spec.Files != nil && len(kcTemplate.Spec.Template.Spec.Files) > 0 {
-			kcTemplate.Spec.Template.Spec.Files[0].ContentFrom.Secret.Name = machineTemplateName + "-azure-json"
-		}
+		updateAzureSecret(kcTemplate, machineTemplateName)
 
 		var labelsArg []string
 		if options.Labels != nil {
@@ -669,4 +667,14 @@ func NormalizeNodePoolName(workers []capi.MachineDeployment, clusterName string)
 	}
 
 	return workers, nil
+}
+
+func updateAzureSecret(kcTemplate *v1beta1.KubeadmConfigTemplate, machineTemplateName string) {
+	if kcTemplate.Spec.Template.Spec.Files != nil && len(kcTemplate.Spec.Template.Spec.Files) > 0 {
+		for i := range kcTemplate.Spec.Template.Spec.Files {
+			if kcTemplate.Spec.Template.Spec.Files[i].Path == "/etc/kubernetes/azure.json" {
+				kcTemplate.Spec.Template.Spec.Files[i].ContentFrom.Secret.Name = machineTemplateName + "-azure-json"
+			}
+		}
+	}
 }


### PR DESCRIPTION
### What this PR does / why we need it
This change fixes a panic that occurs when trying to create a node pool
in an environment with multiple files applied to the
kubeadmconfigtemplate.

Cherry-pick: https://github.com/vmware-tanzu/tanzu-framework/pull/1302

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Related to #1778 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixed a panic in node-pool set when extra files are applied to kubeadmconfigtemplates
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
