### PR TITLE
Update DoSetMachineDeployment to fix np name issue

### DIFF
--- a/pkg/v1/tkg/client/machine_deployment.go
+++ b/pkg/v1/tkg/client/machine_deployment.go
@@ -122,22 +122,28 @@ func DoSetMachineDeployment(clusterClient clusterclient.Client, options *SetMach
 		return apierrors.NewNotFound(schema.GroupResource{Resource: "MachineDeployment"}, "")
 	}
 
-	nameMatcher, err := regexp.Compile(fmt.Sprintf("((%s)?-)?(%s)",
-		regexp.QuoteMeta(options.ClusterName), regexp.QuoteMeta(options.Name)))
-	if err != nil {
-		return errors.Wrap(err, "failed to parse node pool name")
-	}
-
 	baseMD := workerMDs[0]
 	update := false
 	for i := range workerMDs {
-		if nameMatcher.MatchString(workerMDs[i].Name) {
+		if workerMDs[i].Name == options.Name {
 			baseMD = workerMDs[i]
 			update = true
 			break
 		}
 		if workerMDs[i].Name == options.BaseMachineDeployment {
 			baseMD = workerMDs[i]
+		}
+	}
+	if !update {
+		for i := range workerMDs {
+			if workerMDs[i].Name == options.ClusterName+"-"+options.Name {
+				baseMD = workerMDs[i]
+				update = true
+				break
+			}
+			if workerMDs[i].Name == options.BaseMachineDeployment {
+				baseMD = workerMDs[i]
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes an issue where DoSetMachineDeployment will select the incorrect
machinedeployment based on its name.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1776 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixes an issue where the incorrect node pool will be updated when the name is a substring of another node pool.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
