### PR TITLE
Set caching location for golangci-lint

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -89,6 +89,14 @@ jobs:
         go-version: '1.17'
       id: go
 
+    - name: Cache linting
+      uses: actions/cache@v2
+      with:
+        path: ${{ runner.temp }}/lint_cache
+        key: ${{ runner.os }}-lint-cache
+
     - name: Run lint checks
+      env:
+        GOLANGCI_LINT_CACHE: ${{ runner.temp }}/lint_cache
       run: |
         make lint


### PR DESCRIPTION
### What this PR does / why we need it

In https://github.com/vmware-tanzu/tanzu-framework/pull/1399 we updated
our linting job to just call `make lint` instead of using the
golangci-lint GitHub Action. This was done to avoid an easily missed
dependency that any time a new go module was added to the codebase,
someone needed to be aware that they would also need to update the
action since the linting runs per-module. This change allowed us to
automatically discover all go modules and make sure that linting is run
on each, without needing the tribal knowledge of updating the action.

The down side of this is we lost some of the default caching that
happens in the golangci-lint action. Unless otherwise configured, the
action would cache to `~/.cache/go-build` so that subsequent runs
wouldn't take as long. This is needed as sometimes first run linting can
take a very long time, and even with the golangci-lint timeout set to 10
minutes, we are still hitting a timeout due to the limited resources in
the Action runners.