### PR TITLE
Patch kube-vip for tkg 1.6

### DIFF
--- a/pkg/v1/tkg/client/upgrade_cluster_test.go
+++ b/pkg/v1/tkg/client/upgrade_cluster_test.go
@@ -781,7 +781,7 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 				err := yaml.Unmarshal([]byte(kubeVipPodString), &pod)
 				Expect(err).To(BeNil())
 
-				newPodString, err := ModifyKubeVipTimeOutAndSerialize(&pod, "30", "20", "4")
+				newPodString, err := ModifyKubeVipAndSerialize(&pod, "30", "20", "4")
 				Expect(err).To(BeNil())
 
 				Expect(newPodString).ToNot(BeNil())
@@ -795,6 +795,8 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 				Expect(err).To(BeNil())
 				Expect(len(newKCP.Spec.KubeadmConfigSpec.Files)).To(Equal(1))
 				Expect(newKCP.Spec.KubeadmConfigSpec.Files[0].Content).To(ContainSubstring("value: \"30\""))
+				Expect(newKCP.Spec.KubeadmConfigSpec.Files[0].Content).To(ContainSubstring("name: cp_enable"))
+				Expect(newKCP.Spec.KubeadmConfigSpec.Files[0].Content).To(ContainSubstring("NET_RAW"))
 			})
 		})
 	})


### PR DESCRIPTION
### What this PR does / why we need it
This PR enables patching of kube-vip for TKG 1.6. 
The following changes are made: 
1. Add `cp_enable` env variable
2. Replace arg `start` with `manager`.
3. Replace capability `SYS_TIME` with `NET_RAW`
4. Add `HostAliases`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer
From the tests, screenshot of the modified kube-vip pod
<img width="580" alt="image" src="https://user-images.githubusercontent.com/8296773/157558032-dd12f3c4-327c-41d1-87d3-cd3448117e63.png">
