### PR TITLE
[release-0.11] Fix upgrade when latest TKR is passed on already upgrade cluster

### DIFF
--- a/cmd/cli/plugin/cluster/upgrade.go
+++ b/cmd/cli/plugin/cluster/upgrade.go
@@ -176,6 +176,12 @@ func getValidTKRVersionForUpgradeGivenFullTKRName(clusterName, namespace string,
 		return tkrForUpgrade.Spec.Version, nil
 	}
 
+	// If existing TKR on the cluster and the one requested are same
+	// continue the upgrade using the given TKR
+	if tkrName == tkrForUpgrade.GetName() {
+		return tkrForUpgrade.Spec.Version, nil
+	}
+
 	// get the TKR associated with the cluster
 	tkr, err := getMatchingTkrForTkrName(tkrs, tkrName)
 	if err != nil {

--- a/cmd/cli/plugin/cluster/upgrade_test.go
+++ b/cmd/cli/plugin/cluster/upgrade_test.go
@@ -231,7 +231,31 @@ var _ = Describe("getValidTKRVersionForUpgradeGivenFullTKRName", func() {
 			})
 		})
 
+		Context("when existing TKR associated with cluster and user provided TKR is same and no new upgrades are available for the given TKR during upgrade, it should return provided TKR", func() {
+
+			BeforeEach(func() {
+				availableUpgrades := fmt.Sprintf("TKR(s) with later version is available: %s,%s,%s", "v1.18.8---vmware.1-tkg.1", "v1.18.17---vmware.2-tkg.1", "v1.18.14---vmware.1-tkg.1-rc.1")
+				tkr1 := getFakeTKR("v1.17.18---vmware.1-tkg.2", "v1.17.18+vmware.1", corev1.ConditionTrue, availableUpgrades)
+				tkr2 := getFakeTKR("v1.18.8---vmware.1-tkg.1", "v1.18.8+vmware.1", corev1.ConditionTrue, "")
+				tkr3 := getFakeTKR("v1.18.17---vmware.2-tkg.1", "v1.18.17+vmware.2", corev1.ConditionTrue, "")
+				tkr4 := getFakeTKR("v1.18.14---vmware.1-tkg.1-rc.1", "v1.18.14+vmware.1", corev1.ConditionTrue, "")
+				tkr5 := getFakeTKR("v1.18.17---vmware.1-tkg.2", "v1.18.17+vmware.1", corev1.ConditionTrue, "")
+				tkrs = []runv1alpha1.TanzuKubernetesRelease{tkr1, tkr4, tkr3, tkr2, tkr5}
+
+				tkrForUpgrade = tkr5
+
+				clusterLabels = map[string]string{
+					"tanzuKubernetesRelease": "v1.18.17---vmware.1-tkg.2",
+				}
+			})
+			It("should return not return error", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(latestTKRVersion).To(Equal("v1.18.17+vmware.1-tkg.2"))
+			})
+		})
+
 	})
+
 	Context("When cluster doesn't have TKR version label", func() {
 		BeforeEach(func() {
 			clusterLabels = map[string]string{}


### PR DESCRIPTION
### What this PR does / why we need it
- Fixes the workload cluster upgrade issue when cluster is already on
  latest TKR and user passes the same TKR with `--tkr` flag with `tanzu
  cluster upgrade` command.

Original PR: #1853

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/1852


### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixed the workload cluster upgrade issue when cluster is already on latest TKR and user passes the same TKR with `--tkr` flag with `tanzu  cluster upgrade` command
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
