### PR TITLE
enable SilenceUsage: true, for commands management-cluster and cluster, and its sub-commands

### DIFF
--- a/addons/go.mod
+++ b/addons/go.mod
@@ -77,7 +77,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect
-	golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7 // indirect
+	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect

--- a/addons/go.sum
+++ b/addons/go.sum
@@ -2140,8 +2140,8 @@ golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7 h1:8IVLkfbr2cLhv0a/vKq4UFUcJym8RmDoDboxCFWEjYE=
-golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 h1:OH54vjqzRWmbJ62fjuhxy7AxFFgoHN0/DPc/UrL8cAs=
+golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/cmd/cli/plugin/cluster/available_upgrade.go
+++ b/cmd/cli/plugin/cluster/available_upgrade.go
@@ -20,18 +20,20 @@ import (
 )
 
 var availableUpgradesCmd = &cobra.Command{
-	Use:     "available-upgrades",
-	Short:   "Get upgrade information for a cluster",
-	Long:    `Get upgrade information for a cluster`,
-	Aliases: []string{"avup"},
+	Use:          "available-upgrades",
+	Short:        "Get upgrade information for a cluster",
+	Long:         `Get upgrade information for a cluster`,
+	Aliases:      []string{"avup"},
+	SilenceUsage: true,
 }
 
 var getAvailableUpgradesCmd = &cobra.Command{
-	Use:   "get CLUSTER_NAME",
-	Short: "Get all available upgrades for a cluster",
-	Long:  `Get all available upgrades for a cluster`,
-	Args:  cobra.ExactArgs(1),
-	RunE:  availableUpgrades,
+	Use:          "get CLUSTER_NAME",
+	Short:        "Get all available upgrades for a cluster",
+	Long:         `Get all available upgrades for a cluster`,
+	Args:         cobra.ExactArgs(1),
+	RunE:         availableUpgrades,
+	SilenceUsage: true,
 }
 
 type availableUpgradeOptions struct {

--- a/cmd/cli/plugin/cluster/create.go
+++ b/cmd/cli/plugin/cluster/create.go
@@ -50,9 +50,10 @@ type createClusterOptions struct {
 var cc = &createClusterOptions{}
 
 var createClusterCmd = &cobra.Command{
-	Use:   "create CLUSTER_NAME",
-	Short: "Create a cluster",
-	RunE:  create,
+	Use:          "create CLUSTER_NAME",
+	Short:        "Create a cluster",
+	RunE:         create,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/credentials.go
+++ b/cmd/cli/plugin/cluster/credentials.go
@@ -6,6 +6,7 @@ package main
 import "github.com/spf13/cobra"
 
 var credentialsCmd = &cobra.Command{
-	Use:   "credentials",
-	Short: "Cluster credentials operations",
+	Use:          "credentials",
+	Short:        "Cluster credentials operations",
+	SilenceUsage: true,
 }

--- a/cmd/cli/plugin/cluster/credentials_update.go
+++ b/cmd/cli/plugin/cluster/credentials_update.go
@@ -24,10 +24,11 @@ type updateCredentialsOptions struct {
 var updateCredentialsOpts = updateCredentialsOptions{}
 
 var credentialsUpdateCmd = &cobra.Command{
-	Use:   "update CLUSTER_NAME",
-	Short: "Update credentials for a cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  updateCredentials,
+	Use:          "update CLUSTER_NAME",
+	Short:        "Update credentials for a cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         updateCredentials,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/delete.go
+++ b/cmd/cli/plugin/cluster/delete.go
@@ -22,10 +22,11 @@ type deleteClustersOptions struct {
 var dc = &deleteClustersOptions{}
 
 var deleteClusterCmd = &cobra.Command{
-	Use:   "delete CLUSTER_NAME",
-	Short: "Delete a cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  deleteCmd,
+	Use:          "delete CLUSTER_NAME",
+	Short:        "Delete a cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         deleteCmd,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/delete_machinehealthcheck.go
+++ b/cmd/cli/plugin/cluster/delete_machinehealthcheck.go
@@ -21,11 +21,12 @@ type deleteMachineHealthCheckOptions struct {
 var deleteMHC = &deleteMachineHealthCheckOptions{}
 
 var deleteMachineHealthCheckCmd = &cobra.Command{
-	Use:   "delete CLUSTER_NAME",
-	Short: "Delete a MachineHealthCheck object of a cluster",
-	Long:  "Delete a MachineHealthCheck object of a cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  deleteMachineHealthCheck,
+	Use:          "delete CLUSTER_NAME",
+	Short:        "Delete a MachineHealthCheck object of a cluster",
+	Long:         "Delete a MachineHealthCheck object of a cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         deleteMachineHealthCheck,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/delete_machinehealthcheck_control_plane.go
+++ b/cmd/cli/plugin/cluster/delete_machinehealthcheck_control_plane.go
@@ -23,11 +23,12 @@ type deleteMachineHealthCheckCPOptions struct {
 var deleteMHCCP = &deleteMachineHealthCheckCPOptions{}
 
 var deleteMachineHealthCheckCPCmd = &cobra.Command{
-	Use:   "delete CLUSTER_NAME",
-	Short: "Delete a MachineHealthCheck object",
-	Long:  "Delete a MachineHealthCheck object of the control plane of a cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  deleteMachineHealthCheckCP,
+	Use:          "delete CLUSTER_NAME",
+	Short:        "Delete a MachineHealthCheck object",
+	Long:         "Delete a MachineHealthCheck object of the control plane of a cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         deleteMachineHealthCheckCP,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/delete_machinehealthcheck_node.go
+++ b/cmd/cli/plugin/cluster/delete_machinehealthcheck_node.go
@@ -23,11 +23,12 @@ type deleteMachineHealthCheckNodeOptions struct {
 var deleteMHCNode = &deleteMachineHealthCheckNodeOptions{}
 
 var deleteMachineHealthCheckNodeCmd = &cobra.Command{
-	Use:   "delete CLUSTER_NAME",
-	Short: "Delete a MachineHealthCheck object",
-	Long:  "Delete a MachineHealthCheck object of the nodes of a cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  deleteMachineHealthCheckNode,
+	Use:          "delete CLUSTER_NAME",
+	Short:        "Delete a MachineHealthCheck object",
+	Long:         "Delete a MachineHealthCheck object of the nodes of a cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         deleteMachineHealthCheckNode,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/delete_node_pool.go
+++ b/cmd/cli/plugin/cluster/delete_node_pool.go
@@ -21,11 +21,12 @@ type deleteNodePoolOptions struct {
 var deleteNP = &deleteNodePoolOptions{}
 
 var deleteNodePoolCmd = &cobra.Command{
-	Use:   "delete CLUSTER_NAME",
-	Short: "Delete a NodePool object of a cluster",
-	Long:  "Delete a NodePool object of a cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  deleteNodePool,
+	Use:          "delete CLUSTER_NAME",
+	Short:        "Delete a NodePool object of a cluster",
+	Long:         "Delete a NodePool object of a cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         deleteNodePool,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/get.go
+++ b/cmd/cli/plugin/cluster/get.go
@@ -46,10 +46,11 @@ var cd = &getClustersOptions{}
 var cmdOutput io.Writer
 
 var getClustersCmd = &cobra.Command{
-	Use:   "get CLUSTER_NAME",
-	Short: "Get details from a cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  get,
+	Use:          "get CLUSTER_NAME",
+	Short:        "Get details from a cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         get,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/get_machinehealthcheck.go
+++ b/cmd/cli/plugin/cluster/get_machinehealthcheck.go
@@ -24,11 +24,12 @@ type getMachineHealthCheckOptions struct {
 var getMHC = &getMachineHealthCheckOptions{}
 
 var getMachineHealthCheckCmd = &cobra.Command{
-	Use:   "get CLUSTER_NAME",
-	Short: "Get a MachineHealthCheck object of a cluster",
-	Long:  "Get a MachineHealthCheck object for the given cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  getMachineHealthCheck,
+	Use:          "get CLUSTER_NAME",
+	Short:        "Get a MachineHealthCheck object of a cluster",
+	Long:         "Get a MachineHealthCheck object for the given cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         getMachineHealthCheck,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/get_machinehealthcheck_control_plane.go
+++ b/cmd/cli/plugin/cluster/get_machinehealthcheck_control_plane.go
@@ -24,11 +24,12 @@ type getMachineHealthCheckCPOptions struct {
 var getMHCCP = &getMachineHealthCheckCPOptions{}
 
 var getMachineHealthCheckCPCmd = &cobra.Command{
-	Use:   "get CLUSTER_NAME",
-	Short: "Get a MachineHealthCheck object",
-	Long:  "Get a MachineHealthCheck object of the control plane for the given cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  getMachineHealthCheckCP,
+	Use:          "get CLUSTER_NAME",
+	Short:        "Get a MachineHealthCheck object",
+	Long:         "Get a MachineHealthCheck object of the control plane for the given cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         getMachineHealthCheckCP,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/get_machinehealthcheck_node.go
+++ b/cmd/cli/plugin/cluster/get_machinehealthcheck_node.go
@@ -24,11 +24,12 @@ type getMachineHealthCheckNodeOptions struct {
 var getMHCNode = &getMachineHealthCheckNodeOptions{}
 
 var getMachineHealthCheckNodeCmd = &cobra.Command{
-	Use:   "get CLUSTER_NAME",
-	Short: "Get a MachineHealthCheck object of the nodes of a cluster",
-	Long:  "Get a MachineHealthCheck object of the nodes for the given cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  getMachineHealthCheckNode,
+	Use:          "get CLUSTER_NAME",
+	Short:        "Get a MachineHealthCheck object of the nodes of a cluster",
+	Long:         "Get a MachineHealthCheck object of the nodes for the given cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         getMachineHealthCheckNode,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/get_node_pools.go
+++ b/cmd/cli/plugin/cluster/get_node_pools.go
@@ -29,10 +29,11 @@ type listNodePoolOptions struct {
 var lnp = &listNodePoolOptions{}
 
 var listNodePoolsCmd = &cobra.Command{
-	Use:   "list [CLUSTER_NAME]",
-	Short: "List node pools",
-	Args:  cobra.ExactArgs(1),
-	RunE:  listNodePools,
+	Use:          "list [CLUSTER_NAME]",
+	Short:        "List node pools",
+	Args:         cobra.ExactArgs(1),
+	RunE:         listNodePools,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/kubeconfig.go
+++ b/cmd/cli/plugin/cluster/kubeconfig.go
@@ -8,6 +8,7 @@ import (
 )
 
 var clusterKubeconfigCmd = &cobra.Command{
-	Use:   "kubeconfig",
-	Short: "Cluster kubeconfig operations",
+	Use:          "kubeconfig",
+	Short:        "Cluster kubeconfig operations",
+	SilenceUsage: true,
 }

--- a/cmd/cli/plugin/cluster/kubeconfig_get.go
+++ b/cmd/cli/plugin/cluster/kubeconfig_get.go
@@ -36,8 +36,9 @@ var getClusterKubeconfigCmd = &cobra.Command{
 
     # Get workload cluster admin kubeconfig
     tanzu cluster kubeconfig get CLUSTER_NAME --admin`,
-	Args: cobra.ExactArgs(1),
-	RunE: getKubeconfig,
+	Args:         cobra.ExactArgs(1),
+	RunE:         getKubeconfig,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/list.go
+++ b/cmd/cli/plugin/cluster/list.go
@@ -25,9 +25,10 @@ type listClusterOptions struct {
 var lc = &listClusterOptions{}
 
 var listClustersCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List clusters",
-	RunE:  list,
+	Use:          "list",
+	Short:        "List clusters",
+	RunE:         list,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/machinehealthcheck.go
+++ b/cmd/cli/plugin/cluster/machinehealthcheck.go
@@ -15,10 +15,11 @@ const (
 )
 
 var machineHealthCheckCmd = &cobra.Command{
-	Use:     "machinehealthcheck",
-	Short:   "MachineHealthCheck operations for a cluster",
-	Long:    `Get, set, or delete a MachineHealthCheck object for a Tanzu Kubernetes cluster`,
-	Aliases: []string{"mhc"},
+	Use:          "machinehealthcheck",
+	Short:        "MachineHealthCheck operations for a cluster",
+	Long:         `Get, set, or delete a MachineHealthCheck object for a Tanzu Kubernetes cluster`,
+	Aliases:      []string{"mhc"},
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/machinehealthcheck_control_plane.go
+++ b/cmd/cli/plugin/cluster/machinehealthcheck_control_plane.go
@@ -8,7 +8,8 @@ import (
 )
 
 var machineHealthCheckControlPlaneCmd = &cobra.Command{
-	Use:   "control-plane",
-	Short: "MachineHealthCheck operations for the control plane a cluster",
-	Long:  `Get, set, or delete a MachineHealthCheck object for the control plane of a Tanzu Kubernetes cluster`,
+	Use:          "control-plane",
+	Short:        "MachineHealthCheck operations for the control plane a cluster",
+	Long:         `Get, set, or delete a MachineHealthCheck object for the control plane of a Tanzu Kubernetes cluster`,
+	SilenceUsage: true,
 }

--- a/cmd/cli/plugin/cluster/machinehealthcheck_node.go
+++ b/cmd/cli/plugin/cluster/machinehealthcheck_node.go
@@ -8,7 +8,8 @@ import (
 )
 
 var machineHealthCheckNodeCmd = &cobra.Command{
-	Use:   "node",
-	Short: "MachineHealthCheck operations for the nodes of a cluster",
-	Long:  `Get, set, or delete a MachineHealthCheck object for the nodes of a Tanzu Kubernetes cluster`,
+	Use:          "node",
+	Short:        "MachineHealthCheck operations for the nodes of a cluster",
+	Long:         `Get, set, or delete a MachineHealthCheck object for the nodes of a Tanzu Kubernetes cluster`,
+	SilenceUsage: true,
 }

--- a/cmd/cli/plugin/cluster/main.go
+++ b/cmd/cli/plugin/cluster/main.go
@@ -34,7 +34,7 @@ func main() {
 
 	p.Cmd.PersistentFlags().Int32VarP(&logLevel, "verbose", "v", 0, "Number for the log level verbosity(0-9)")
 	p.Cmd.PersistentFlags().StringVar(&logFile, "log-file", "", "Log file path")
-
+	p.Cmd.SilenceUsage = true
 	p.AddCommands(
 		createClusterCmd,
 		listClustersCmd,

--- a/cmd/cli/plugin/cluster/node_pool.go
+++ b/cmd/cli/plugin/cluster/node_pool.go
@@ -8,6 +8,7 @@ import (
 )
 
 var clusterNodePoolCmd = &cobra.Command{
-	Use:   "node-pool",
-	Short: "Cluster node-pool operations",
+	Use:          "node-pool",
+	Short:        "Cluster node-pool operations",
+	SilenceUsage: true,
 }

--- a/cmd/cli/plugin/cluster/scale.go
+++ b/cmd/cli/plugin/cluster/scale.go
@@ -24,10 +24,11 @@ type scaleClustersOptions struct {
 var sc = &scaleClustersOptions{}
 
 var scaleClusterCmd = &cobra.Command{
-	Use:   "scale CLUSTER_NAME",
-	Short: "Scale a cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  scale,
+	Use:          "scale CLUSTER_NAME",
+	Short:        "Scale a cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         scale,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/set_machinehealthcheck.go
+++ b/cmd/cli/plugin/cluster/set_machinehealthcheck.go
@@ -25,11 +25,12 @@ type setMachineHealthCheckOptions struct {
 var setMHC = &setMachineHealthCheckOptions{}
 
 var setMachineHealthCheckCmd = &cobra.Command{
-	Use:   "set CLUSTER_NAME",
-	Short: "Create or update a MachineHealthCheck for a cluster",
-	Long:  "Create or update a MachineHealthCheck for a cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  setMachineHealthCheck,
+	Use:          "set CLUSTER_NAME",
+	Short:        "Create or update a MachineHealthCheck for a cluster",
+	Long:         "Create or update a MachineHealthCheck for a cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         setMachineHealthCheck,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/set_machinehealthcheck_control_plane.go
+++ b/cmd/cli/plugin/cluster/set_machinehealthcheck_control_plane.go
@@ -25,11 +25,12 @@ type setMachineHealthCheckCPOptions struct {
 var setMHCCP = &setMachineHealthCheckCPOptions{}
 
 var setMachineHealthCheckCPCmd = &cobra.Command{
-	Use:   "set CLUSTER_NAME",
-	Short: "Create or update a MachineHealthCheck for a cluster",
-	Long:  "Create or update a MachineHealthCheck for a cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  setMachineHealthCheckCP,
+	Use:          "set CLUSTER_NAME",
+	Short:        "Create or update a MachineHealthCheck for a cluster",
+	Long:         "Create or update a MachineHealthCheck for a cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         setMachineHealthCheckCP,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/set_machinehealthcheck_node.go
+++ b/cmd/cli/plugin/cluster/set_machinehealthcheck_node.go
@@ -25,11 +25,12 @@ type setMachineHealthCheckNodeOptions struct {
 var setMHCNode = &setMachineHealthCheckNodeOptions{}
 
 var setMachineHealthCheckNodeCmd = &cobra.Command{
-	Use:   "set CLUSTER_NAME",
-	Short: "Create or update a MachineHealthCheck for a cluster",
-	Long:  "Create or update a MachineHealthCheck for a cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  setMachineHealthCheckNode,
+	Use:          "set CLUSTER_NAME",
+	Short:        "Create or update a MachineHealthCheck for a cluster",
+	Long:         "Create or update a MachineHealthCheck for a cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         setMachineHealthCheckNode,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/set_node_pool.go
+++ b/cmd/cli/plugin/cluster/set_node_pool.go
@@ -25,10 +25,11 @@ type clusterSetNodePoolCmdOptions struct {
 var setNodePoolOptions clusterSetNodePoolCmdOptions
 
 var clusterSetNodePoolCmd = &cobra.Command{
-	Use:   "set CLUSTER_NAME",
-	Short: "Set node pool for cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runSetNodePool,
+	Use:          "set CLUSTER_NAME",
+	Short:        "Set node pool for cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         runSetNodePool,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/cluster/test/cluster_silentmode.go
+++ b/cmd/cli/plugin/cluster/test/cluster_silentmode.go
@@ -1,0 +1,45 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	clitest "github.com/vmware-tanzu/tanzu-framework/pkg/v1/test/cli"
+)
+
+var (
+	createClusterNegTestSilentMode        *clitest.Test
+	deleteClusterNegTestSilentMode        *clitest.Test
+	availableUpgradesGetNegTestSilentMode *clitest.Test
+	credUpdateNegTestSilentMode           *clitest.Test
+	clusterGetTestSilentMode              *clitest.Test
+	clusterKubeconfGetSilentMode          *clitest.Test
+	clusterMHGet                          *clitest.Test
+	clusterNodePoolSetSilentMode          *clitest.Test
+	clusterNodePoolListSilentMode         *clitest.Test
+	clusterNodePoolDeleteSilentMode       *clitest.Test
+	clusterScaleSilentMode                *clitest.Test
+	clusterUpgradeSilentMode              *clitest.Test
+)
+
+var FuncToExecAndValidateStdError = func(t *clitest.Test) error {
+	if err := t.ExecNotContainsStdErrorString(usage); err != nil {
+		return err
+	}
+	return nil
+}
+
+func initClusterSilentModeUsecases() {
+	createClusterNegTestSilentMode = clitest.NewTest("create cluster", "cluster create", FuncToExecAndValidateStdError)
+	deleteClusterNegTestSilentMode = clitest.NewTest("delete cluster", "cluster delete", FuncToExecAndValidateStdError)
+	availableUpgradesGetNegTestSilentMode = clitest.NewTest("cluster available-upgrades get", "cluster available-upgrades get", FuncToExecAndValidateStdError)
+	clusterGetTestSilentMode = clitest.NewTest("cluster get", "cluster get", FuncToExecAndValidateStdError)
+	credUpdateNegTestSilentMode = clitest.NewTest("cluster credentials update", "cluster credentials update", FuncToExecAndValidateStdError)
+	clusterKubeconfGetSilentMode = clitest.NewTest("cluster kubeconfig get", "cluster kubeconfig get", FuncToExecAndValidateStdError)
+	clusterMHGet = clitest.NewTest("cluster machinehealthcheck node get", "cluster machinehealthcheck node get", FuncToExecAndValidateStdError)
+	clusterNodePoolSetSilentMode = clitest.NewTest("cluster node-pool set", "cluster node-pool set", FuncToExecAndValidateStdError)
+	clusterNodePoolListSilentMode = clitest.NewTest("cluster node-pool list", "cluster node-pool list", FuncToExecAndValidateStdError)
+	clusterNodePoolDeleteSilentMode = clitest.NewTest("cluster node-pool delete", "cluster node-pool delete", FuncToExecAndValidateStdError)
+	clusterScaleSilentMode = clitest.NewTest("cluster scale", "cluster scale", FuncToExecAndValidateStdError)
+	clusterUpgradeSilentMode = clitest.NewTest("cluster upgrade", "cluster upgrade", FuncToExecAndValidateStdError)
+}

--- a/cmd/cli/plugin/cluster/test/management_cluster.go
+++ b/cmd/cli/plugin/cluster/test/management_cluster.go
@@ -1,0 +1,67 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"sigs.k8s.io/yaml"
+
+	clitest "github.com/vmware-tanzu/tanzu-framework/pkg/v1/test/cli"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+)
+
+var (
+	createManagementClusterTest                *clitest.Test
+	deleteManagementCusterTest                 *clitest.Test
+	managementClusterUnAvailableSubCommandTest *clitest.Test
+	mcCeipSetSilent                            *clitest.Test
+	mcCreateNonExistsFlag                      *clitest.Test
+)
+
+const (
+	usage = "Usage:"
+)
+
+func initManagementCluster() {
+	mcConfigFile, err := os.CreateTemp("", tconf.ManagementClusterName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	managementClusterUnAvailableSubCommandTest = clitest.NewTest("create management-cluster", "management-cluster UnAvailableSubCommand", FuncToExecAndValidateStdError)
+	mcCeipSetSilent = clitest.NewTest("management-cluster ceip-participation set", "management-cluster ceip-participation set", FuncToExecAndValidateStdError)
+	mcCreateNonExistsFlag = clitest.NewTest("management-cluster create -nonExistsFlag", "management-cluster create -nonExistsFlag", FuncToExecAndValidateStdError)
+
+	createMcCommand := fmt.Sprintf("management-cluster create -v3 -f %s", mcConfigFile.Name())
+	createManagementClusterTest = clitest.NewTest("create management-cluster", createMcCommand, func(t *clitest.Test) error {
+		defer os.Remove(mcConfigFile.Name())
+
+		configVars := make(map[string]string)
+		configVars[constants.ConfigVariableClusterName] = tconf.ManagementClusterName
+		configVars[constants.ConfigVariableClusterPlan] = "dev"
+		configVars[constants.ConfigVariableInfraProvider] = tconf.InfrastructureName
+		configVars[constants.ConfigVariableCNI] = "calico"
+
+		out, err := yaml.Marshal(configVars)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(mcConfigFile.Name(), out, 0644); err != nil {
+			return err
+		}
+		if err := t.ExecContainsErrorString("Management cluster created!"); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	deleteManagementCusterTest = clitest.NewTest("delete management-cluster", "management-cluster delete -v3 -y --force", func(t *clitest.Test) error {
+		if err := t.Exec(); err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/cmd/cli/plugin/cluster/upgrade.go
+++ b/cmd/cli/plugin/cluster/upgrade.go
@@ -69,7 +69,8 @@ var upgradeClusterCmd = &cobra.Command{
     --os-name ubuntu --os-version 20.04 --os-arch amd64
     --os-name ubuntu --os-version 18.04 --os-arch amd64
 `,
-	RunE: upgrade,
+	RunE:         upgrade,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/managementcluster/ceip.go
+++ b/cmd/cli/plugin/managementcluster/ceip.go
@@ -6,7 +6,8 @@ package main
 import "github.com/spf13/cobra"
 
 var ceipCmd = &cobra.Command{
-	Use:   "ceip-participation",
-	Short: "Get or set ceip participation",
-	Long:  `Get or set ceip participation`,
+	Use:          "ceip-participation",
+	Short:        "Get or set ceip participation",
+	Long:         `Get or set ceip participation`,
+	SilenceUsage: true,
 }

--- a/cmd/cli/plugin/managementcluster/create.go
+++ b/cmd/cli/plugin/managementcluster/create.go
@@ -71,6 +71,7 @@ var createCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runInit()
 	},
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/managementcluster/credentials.go
+++ b/cmd/cli/plugin/managementcluster/credentials.go
@@ -6,6 +6,7 @@ package main
 import "github.com/spf13/cobra"
 
 var credentialsCmd = &cobra.Command{
-	Use:   "credentials",
-	Short: "Update Credentials for Management Cluster",
+	Use:          "credentials",
+	Short:        "Update Credentials for Management Cluster",
+	SilenceUsage: true,
 }

--- a/cmd/cli/plugin/managementcluster/credentials_update.go
+++ b/cmd/cli/plugin/managementcluster/credentials_update.go
@@ -34,6 +34,7 @@ var credentialsUpdateCmd = &cobra.Command{
 
 		return updateClusterCredentials(clusterName)
 	},
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/managementcluster/delete.go
+++ b/cmd/cli/plugin/managementcluster/delete.go
@@ -34,6 +34,7 @@ var deleteRegionCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runForCurrentMC(runDeleteRegion)
 	},
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/managementcluster/get.go
+++ b/cmd/cli/plugin/managementcluster/get.go
@@ -87,6 +87,7 @@ var getClusterCmd = &cobra.Command{
 		}
 		return runForCurrentMC(getClusterDetails)
 	},
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/managementcluster/get_ceip.go
+++ b/cmd/cli/plugin/managementcluster/get_ceip.go
@@ -17,6 +17,7 @@ var getCeipCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runGetCEIP(cmd)
 	},
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/managementcluster/import.go
+++ b/cmd/cli/plugin/managementcluster/import.go
@@ -39,6 +39,7 @@ var importCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runImport(importOption.file)
 	},
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/managementcluster/kubeconfig.go
+++ b/cmd/cli/plugin/managementcluster/kubeconfig.go
@@ -8,6 +8,7 @@ import (
 )
 
 var clusterKubeconfigCmd = &cobra.Command{
-	Use:   "kubeconfig",
-	Short: "Kubeconfig of management cluster",
+	Use:          "kubeconfig",
+	Short:        "Kubeconfig of management cluster",
+	SilenceUsage: true,
 }

--- a/cmd/cli/plugin/managementcluster/kubeconfig_get.go
+++ b/cmd/cli/plugin/managementcluster/kubeconfig_get.go
@@ -36,7 +36,8 @@ var getClusterKubeconfigCmd = &cobra.Command{
 	
 	# Get management cluster admin kubeconfig
 	tanzu management-cluster kubeconfig get --admin`,
-	RunE: getKubeconfig,
+	RunE:         getKubeconfig,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/managementcluster/permissions.go
+++ b/cmd/cli/plugin/managementcluster/permissions.go
@@ -6,13 +6,15 @@ package main
 import "github.com/spf13/cobra"
 
 var permissionsCmd = &cobra.Command{
-	Use:   "permissions",
-	Short: "Configure permissions on cloud providers",
+	Use:          "permissions",
+	Short:        "Configure permissions on cloud providers",
+	SilenceUsage: true,
 }
 
 var awsPermissionsCmd = &cobra.Command{
-	Use:   "aws",
-	Short: "Configure permissions on AWS",
+	Use:          "aws",
+	Short:        "Configure permissions on AWS",
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/managementcluster/permissions_aws_generate.go
+++ b/cmd/cli/plugin/managementcluster/permissions_aws_generate.go
@@ -10,10 +10,11 @@ import (
 )
 
 var generateAWSCloudFormationTemplateCmd = &cobra.Command{
-	Use:   "generate-cloudformation-template",
-	Short: "Generate AWS CloudFormation Template",
-	Long:  `Generate AWS CloudFormation Template`,
-	RunE:  generateCloudFormationTemplate,
+	Use:          "generate-cloudformation-template",
+	Short:        "Generate AWS CloudFormation Template",
+	Long:         `Generate AWS CloudFormation Template`,
+	RunE:         generateCloudFormationTemplate,
+	SilenceUsage: true,
 }
 
 func init() {

--- a/cmd/cli/plugin/managementcluster/permissions_aws_set.go
+++ b/cmd/cli/plugin/managementcluster/permissions_aws_set.go
@@ -8,10 +8,11 @@ import (
 )
 
 var setAWSPermissionsCmd = &cobra.Command{
-	Use:   "set",
-	Short: "Configure permissions on AWS",
-	Long:  `Configure permissions on AWS`,
-	RunE:  setAWSPermissions,
+	Use:          "set",
+	Short:        "Configure permissions on AWS",
+	Long:         `Configure permissions on AWS`,
+	RunE:         setAWSPermissions,
+	SilenceUsage: true,
 }
 
 type awsPermissionsOptions struct {

--- a/cmd/cli/plugin/managementcluster/set_ceip.go
+++ b/cmd/cli/plugin/managementcluster/set_ceip.go
@@ -11,17 +11,18 @@ var isProd string
 var labels string
 
 var setCeipCmd = &cobra.Command{
-	Use:   "set OPT_IN_BOOL",
-	Short: "Set the opt-in preference for CEIP",
-	Long:  "Set the opt-in preference for CEIP of the current management cluster",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runSetCeip,
+	Use:          "set OPT_IN_BOOL",
+	Short:        "Set the opt-in preference for CEIP",
+	Long:         "Set the opt-in preference for CEIP of the current management cluster",
+	Args:         cobra.ExactArgs(1),
+	RunE:         runSetCeip,
+	SilenceUsage: true,
 }
 
 func init() {
 	setCeipCmd.Flags().StringVarP(&isProd, "isProd", "", "", "use --isProd false to write telemetry data to the staging datastore")
 	setCeipCmd.Flags().MarkHidden("isProd") //nolint
-	setCeipCmd.Flags().StringVarP(&labels, "labels", "", "", "use --labels=entitlement-account-number=\"num1\",env-type=\"env\" to self-identify the customer's account number and environmment")
+	setCeipCmd.Flags().StringVarP(&labels, "labels", "", "", "use --labels=entitlement-account-number=\"num1\",env-type=\"env\" to self-identify the customer's account number and environment")
 	ceipCmd.AddCommand(setCeipCmd)
 }
 

--- a/cmd/cli/plugin/managementcluster/upgrade.go
+++ b/cmd/cli/plugin/managementcluster/upgrade.go
@@ -49,6 +49,7 @@ var upgradeRegionCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runForCurrentMC(runUpgradeRegion)
 	},
+	SilenceUsage: true,
 }
 
 type upgradeRegionOptions struct {

--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,7 @@ require (
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
-	golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7 // indirect
+	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220224211638-0e9765cccd65 // indirect
 	golang.org/x/tools v0.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2237,8 +2237,8 @@ golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7 h1:8IVLkfbr2cLhv0a/vKq4UFUcJym8RmDoDboxCFWEjYE=
-golang.org/x/sys v0.0.0-20220307203707-22a9840ba4d7/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 h1:OH54vjqzRWmbJ62fjuhxy7AxFFgoHN0/DPc/UrL8cAs=
+golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/v1/test/cli/framework.go
+++ b/pkg/v1/test/cli/framework.go
@@ -447,6 +447,17 @@ func (t *Test) ExecContainsErrorString(contains string) error {
 	return nil
 }
 
+// ExecContainsStdErrorString executes the command and checks if the StdError contains the given string.
+func (t *Test) ExecNotContainsStdErrorString(contains string) error {
+	err := ExecNotContainsStdErrorString(t.Command, contains)
+	if err != nil {
+		t.Result.Error(err)
+		return err
+	}
+	t.Result.Success()
+	return nil
+}
+
 // ExecContainsErrorString checks that the given command stdErr output contains the string
 func ExecContainsErrorString(command, contains string) error {
 	_, stdErr, err := Exec(command)
@@ -454,6 +465,24 @@ func ExecContainsErrorString(command, contains string) error {
 		return err
 	}
 	return ContainsString(stdErr, contains)
+}
+
+// ExecContainsStdErrorString checks that the given command stdErr output contains the string
+func ExecNotContainsStdErrorString(command, contains string) error {
+	_, stdErr, err := Exec(command)
+	if err != nil && stdErr == nil {
+		return err
+	}
+	return NotContainsString(stdErr, contains)
+}
+
+// NotContainsString checks that the given buffer not contains the string if contains then throws error.
+func NotContainsString(stdOut *bytes.Buffer, contains string) error {
+	so := stdOut.String()
+	if strings.Contains(so, contains) {
+		return fmt.Errorf("stdOut %q contains %q", so, contains)
+	}
+	return nil
 }
 
 // ContainsString checks that the given buffer contains the string.

--- a/pkg/v1/tkg/cmd/set_ceip.go
+++ b/pkg/v1/tkg/cmd/set_ceip.go
@@ -39,7 +39,7 @@ var setCeipCmd = &cobra.Command{
 func init() {
 	setCeipCmd.Flags().StringVarP(&isProd, "isProd", "", "", "use --isProd false to write telemetry data to the staging datastore")
 	setCeipCmd.Flags().MarkHidden("isProd") //nolint
-	setCeipCmd.Flags().StringVarP(&labels, "labels", "", "", "use --labels=entitlement-account-number=\"num1\",env-type=\"env\" to self-identify the customer's account number and environmment")
+	setCeipCmd.Flags().StringVarP(&labels, "labels", "", "", "use --labels=entitlement-account-number=\"num1\",env-type=\"env\" to self-identify the customer's account number and environment")
 	setCmd.AddCommand(setCeipCmd)
 }
 


### PR DESCRIPTION
### What this PR does / why we need it
Currently, the usage message is printed every time irrespective of the reason (error, missing arguments, incorrect sub-commands, incorrect flags, internal errors, external errors, etc), which is not a good user experience, it confuses the end user because even user gives the correct command and fails because of some external errors but still prints usage info.
This is because the SilenceUsage cobra command attribute is not enabled for the top-level commands and their sub-commands. 
By enabling the SilenceUsage, it does not print command usage information for issues like missing arguments, internal or external errors. 
These changes are done only for management-cluster and cluster, and their sub-commands only. 
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1907 

### Describe testing done for PR
Unit test cases are written for management-cluster and cluster commands and their sub-commands, to check the Usage info not printed for use cases like incorrect sub-commands, incorrect flags.

Functional testing has been done for management-cluster and cluster commands, and their sub-commands, to validate usage info not printed for the use cases like incorrect sub-commands, incorrect flags, internal and external errors.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
