### PR TITLE
[release-0.11 cherry-pick]Fix the issue where upgrade operation fails for vSphere cluster if vSphere password contains single quote(')

### DIFF
--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -450,7 +450,11 @@ func (c *TkgClient) ConfigureAndValidateVSphereTemplate(vcClient vc.Client, tkrV
 // GetVSphereEndpoint gets vsphere client based on credentials set in config variables
 func (c *TkgClient) GetVSphereEndpoint(clusterClient clusterclient.Client) (vc.Client, error) {
 	if clusterClient != nil {
-		username, password, err := clusterClient.GetVCCredentialsFromSecret("")
+		regionContext, err := c.GetCurrentRegionContext()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get current region context")
+		}
+		username, password, err := clusterClient.GetVCCredentialsFromCluster(regionContext.ClusterName, constants.TkgNamespace)
 		if err != nil {
 			return nil, err
 		}
@@ -1601,7 +1605,11 @@ func (c *TkgClient) getFullTKGNoProxy(providerName string) (string, error) {
 }
 
 func (c *TkgClient) configureVsphereCredentialsFromCluster(clusterClient clusterclient.Client) error {
-	vsphereUsername, vspherePassword, err := clusterClient.GetVCCredentialsFromSecret("")
+	regionContext, err := c.GetCurrentRegionContext()
+	if err != nil {
+		return errors.Wrap(err, "failed to get current region context")
+	}
+	vsphereUsername, vspherePassword, err := clusterClient.GetVCCredentialsFromCluster(regionContext.ClusterName, constants.TkgNamespace)
 	if err != nil {
 		return errors.Wrap(err, "unable to get vsphere credentials from secret")
 	}

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -277,7 +277,10 @@ type Client interface {
 	// GetPacificTanzuKubernetesReleases returns the list of TanzuKubernetesRelease versions if TKr object is available in TKGS
 	GetPacificTanzuKubernetesReleases() ([]string, error)
 	// GetVCCredentialsFromSecret gets the vSphere username and password used to deploy the cluster
+	// Deprecated: use GetVCCredentialsFromCluster() method instead which would use both clustername and namespace to get the VC credentials
 	GetVCCredentialsFromSecret(string) (string, string, error)
+	// GetVCCredentialsFromCluster gets the vSphere username and password used to deploy the cluster
+	GetVCCredentialsFromCluster(string, string) (string, string, error)
 	// GetVCServer gets the vSphere server that used to deploy the cluster
 	GetVCServer() (string, error)
 	// GetAWSEncodedCredentialsFromSecret gets the AWS base64 credentials used to deploy the cluster

--- a/pkg/v1/tkg/clusterclient/templates.go
+++ b/pkg/v1/tkg/clusterclient/templates.go
@@ -15,7 +15,7 @@ func (c *client) GetVCClientAndDataCenter(clusterName, clusterNamespace, vsphere
 		return c.verificationClientFactory.GetVCClientAndDataCenter(clusterName, clusterNamespace, vsphereMachineTemplateObjectName)
 	}
 
-	vsphereUsername, vspherePassword, err := c.GetVCCredentialsFromSecret(clusterName)
+	vsphereUsername, vspherePassword, err := c.GetVCCredentialsFromCluster(clusterName, clusterNamespace)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "unable to retrieve vSphere credentials to retrieve VM Template")
 	}

--- a/pkg/v1/tkg/fakes/clusterclient.go
+++ b/pkg/v1/tkg/fakes/clusterclient.go
@@ -497,6 +497,22 @@ type ClusterClient struct {
 		result2 string
 		result3 error
 	}
+	GetVCCredentialsFromClusterStub        func(string, string) (string, string, error)
+	getVCCredentialsFromClusterMutex       sync.RWMutex
+	getVCCredentialsFromClusterArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	getVCCredentialsFromClusterReturns struct {
+		result1 string
+		result2 string
+		result3 error
+	}
+	getVCCredentialsFromClusterReturnsOnCall map[int]struct {
+		result1 string
+		result2 string
+		result3 error
+	}
 	GetVCCredentialsFromSecretStub        func(string) (string, string, error)
 	getVCCredentialsFromSecretMutex       sync.RWMutex
 	getVCCredentialsFromSecretArgsForCall []struct {
@@ -3346,6 +3362,74 @@ func (fake *ClusterClient) GetVCClientAndDataCenterReturnsOnCall(i int, result1 
 	}
 	fake.getVCClientAndDataCenterReturnsOnCall[i] = struct {
 		result1 vc.Client
+		result2 string
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *ClusterClient) GetVCCredentialsFromCluster(arg1 string, arg2 string) (string, string, error) {
+	fake.getVCCredentialsFromClusterMutex.Lock()
+	ret, specificReturn := fake.getVCCredentialsFromClusterReturnsOnCall[len(fake.getVCCredentialsFromClusterArgsForCall)]
+	fake.getVCCredentialsFromClusterArgsForCall = append(fake.getVCCredentialsFromClusterArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.GetVCCredentialsFromClusterStub
+	fakeReturns := fake.getVCCredentialsFromClusterReturns
+	fake.recordInvocation("GetVCCredentialsFromCluster", []interface{}{arg1, arg2})
+	fake.getVCCredentialsFromClusterMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *ClusterClient) GetVCCredentialsFromClusterCallCount() int {
+	fake.getVCCredentialsFromClusterMutex.RLock()
+	defer fake.getVCCredentialsFromClusterMutex.RUnlock()
+	return len(fake.getVCCredentialsFromClusterArgsForCall)
+}
+
+func (fake *ClusterClient) GetVCCredentialsFromClusterCalls(stub func(string, string) (string, string, error)) {
+	fake.getVCCredentialsFromClusterMutex.Lock()
+	defer fake.getVCCredentialsFromClusterMutex.Unlock()
+	fake.GetVCCredentialsFromClusterStub = stub
+}
+
+func (fake *ClusterClient) GetVCCredentialsFromClusterArgsForCall(i int) (string, string) {
+	fake.getVCCredentialsFromClusterMutex.RLock()
+	defer fake.getVCCredentialsFromClusterMutex.RUnlock()
+	argsForCall := fake.getVCCredentialsFromClusterArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *ClusterClient) GetVCCredentialsFromClusterReturns(result1 string, result2 string, result3 error) {
+	fake.getVCCredentialsFromClusterMutex.Lock()
+	defer fake.getVCCredentialsFromClusterMutex.Unlock()
+	fake.GetVCCredentialsFromClusterStub = nil
+	fake.getVCCredentialsFromClusterReturns = struct {
+		result1 string
+		result2 string
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *ClusterClient) GetVCCredentialsFromClusterReturnsOnCall(i int, result1 string, result2 string, result3 error) {
+	fake.getVCCredentialsFromClusterMutex.Lock()
+	defer fake.getVCCredentialsFromClusterMutex.Unlock()
+	fake.GetVCCredentialsFromClusterStub = nil
+	if fake.getVCCredentialsFromClusterReturnsOnCall == nil {
+		fake.getVCCredentialsFromClusterReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 string
+			result3 error
+		})
+	}
+	fake.getVCCredentialsFromClusterReturnsOnCall[i] = struct {
+		result1 string
 		result2 string
 		result3 error
 	}{result1, result2, result3}
@@ -6427,6 +6511,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.getTanzuKubernetesReleasesMutex.RUnlock()
 	fake.getVCClientAndDataCenterMutex.RLock()
 	defer fake.getVCClientAndDataCenterMutex.RUnlock()
+	fake.getVCCredentialsFromClusterMutex.RLock()
+	defer fake.getVCCredentialsFromClusterMutex.RUnlock()
 	fake.getVCCredentialsFromSecretMutex.RLock()
 	defer fake.getVCCredentialsFromSecretMutex.RUnlock()
 	fake.getVCServerMutex.RLock()


### PR DESCRIPTION
### What this PR does / why we need it
This PR fixes upgrade operation failing due to the unmarshaling error while trying to read the vSphere credentials from capv-manager-bootstrap-credentials secret if the vSphere password has single quotes.

The fix addresses the issue by 

- reading the credentials from cluster's(identityRef) secret(reading password from secret doesn't involve unmarshaling) before falling back to capv-manager-bootstrap-credentials secret. This fix should be good for majority of the cases, however there is a scenario(very unlikely) it would not address, where vSphere management cluster was created before cluster's secret was used.

Since `capv-manager-bootstrap-credentials` secret is an artifact from upstream, [vSphere provider Issue](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1460) is filed on upstream to support the vsphere password with single quotes and doesn't cause issue in unmarshaling. 

- use namespace along with cluster name while retreiving the credentials which would adddress the issue where the same secret name (created with cluster name) exists in different namespaces

reference PR for main branch:  https://github.com/vmware-tanzu/tanzu-framework/pull/1723 
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1721 

### Describe testing done for PR

Testing for all the scenarios was done as part of the PR# https://github.com/vmware-tanzu/tanzu-framework/pull/1723 which was merged in main

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix the issue where upgrade operation fails for vSphere provider if vSphere password contains single quote(')
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer
There is an upstream(vSphere provider) [ issue](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/1460) filed to provide a means to support VC password which has single quote('). If there is any fix/change in the upstream, we should update the logic to read the capv-manager-bootstrap-credentials secret.
<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
