### PR TITLE
[release-0.11] Cherry-pick: Added validation to set Azure Client Secret (#1841)

### DIFF
--- a/pkg/v1/tkg/client/upgrade_region.go
+++ b/pkg/v1/tkg/client/upgrade_region.go
@@ -110,6 +110,12 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 		return err
 	}
 
+	// Validate required environment variables are set
+	log.Infof("Validating for the required environment variables to be set")
+	if err := c.validateEnvVariables(regionalClusterClient); err != nil {
+		return errors.Wrap(err, "required env variables are not set")
+	}
+
 	if err := c.configureVariablesForProvidersInstallation(regionalClusterClient); err != nil {
 		return errors.Wrap(err, "unable to configure variables for provider installation")
 	}

--- a/pkg/v1/tkg/client/utils.go
+++ b/pkg/v1/tkg/client/utils.go
@@ -11,6 +11,10 @@ import (
 	"regexp"
 	"time"
 
+	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
+
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgconfighelper"
 
 	"github.com/imdario/mergo"
@@ -379,4 +383,31 @@ func (c *TkgClient) getDefaultMachineCountForMC(plan string) (int, int) {
 		// do nothing. If config overrides are provided, they'll get overridden in the calling function
 	}
 	return controlPlaneMachineCount, workerMachineCount
+}
+
+func (c *TkgClient) validateEnvVariables(regionalClusterClient clusterclient.Client) error {
+	infraProviderName, err := getInfraNameFromRegionContext(regionalClusterClient)
+	if err != nil {
+		return errors.Wrap(err, "Unable to get infra provider from the context")
+	}
+
+	err = c.ValidateEnvVariables(infraProviderName)
+	if err != nil {
+		return errors.Wrap(err, "required env variables are not set")
+	}
+	return nil
+}
+
+func getInfraNameFromRegionContext(regionalClusterClient clusterclient.Client) (string, error) {
+	infraProvider, err := regionalClusterClient.GetRegionalClusterDefaultProviderName(clusterctlv1.InfrastructureProviderType)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get cluster provider information.")
+	}
+
+	infraProviderName, _, err := ParseProviderName(infraProvider)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse provider name")
+	}
+
+	return infraProviderName, nil
 }

--- a/pkg/v1/tkg/client/validate_upgrade.go
+++ b/pkg/v1/tkg/client/validate_upgrade.go
@@ -1,0 +1,35 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+)
+
+var (
+	azureVarsToBeValidated = []string{constants.ConfigVariableAzureClientSecret}
+)
+
+// ValidateEnvVariables validates the presence of required environment variables for a given IaaS
+func (c *TkgClient) ValidateEnvVariables(iaas string) error {
+	// This function only contains a validator for Azure environment variables for now
+	// This function can be used to add validators for environment variables pertaining to other IaaSes in the future
+	// as and when required
+	if iaas == AzureProviderName {
+		return c.validateAzureEnvVariables(azureVarsToBeValidated)
+	}
+	return nil
+}
+
+func (c *TkgClient) validateAzureEnvVariables(azureEnvVars []string) error {
+	for _, envVar := range azureEnvVars {
+		_, err := c.TKGConfigReaderWriter().Get(envVar)
+		if err != nil {
+			return fmt.Errorf("config Variable %s not set", envVar)
+		}
+	}
+	return nil
+}

--- a/pkg/v1/tkg/client/validate_upgrade_test.go
+++ b/pkg/v1/tkg/client/validate_upgrade_test.go
@@ -1,0 +1,86 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+
+	"os"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgconfigbom"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgconfigreaderwriter"
+)
+
+var _ = Describe("Validate", func() {
+	var (
+		tkgClient             *client.TkgClient
+		tkgConfigReaderWriter tkgconfigreaderwriter.TKGConfigReaderWriter
+		featureFlagClient     *fakes.FeatureFlagClient
+	)
+	BeforeEach(func() {
+		tkgBomClient := new(fakes.TKGConfigBomClient)
+		tkgBomClient.GetDefaultTkrBOMConfigurationReturns(&tkgconfigbom.BOMConfiguration{
+			Release: &tkgconfigbom.ReleaseInfo{Version: "v1.3"},
+			Components: map[string][]*tkgconfigbom.ComponentInfo{
+				"kubernetes": {{Version: "v1.20"}},
+			},
+		}, nil)
+		tkgBomClient.GetDefaultTkgBOMConfigurationReturns(&tkgconfigbom.BOMConfiguration{
+			Release: &tkgconfigbom.ReleaseInfo{Version: "v1.23"},
+		}, nil)
+
+		configDir := os.TempDir()
+
+		configFile, err := os.CreateTemp(configDir, "cluster-config-*.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(configFile.Sync()).To(Succeed())
+		Expect(configFile.Close()).To(Succeed())
+
+		tkgConfigReaderWriter, err = tkgconfigreaderwriter.NewReaderWriterFromConfigFile(configFile.Name(), configFile.Name())
+		Expect(err).NotTo(HaveOccurred())
+		readerWriter, err := tkgconfigreaderwriter.NewWithReaderWriter(tkgConfigReaderWriter)
+		Expect(err).NotTo(HaveOccurred())
+
+		tkgConfigUpdater := new(fakes.TKGConfigUpdaterClient)
+		tkgConfigUpdater.CheckInfrastructureVersionStub = func(providerName string) (string, error) {
+			return providerName, nil
+		}
+
+		featureFlagClient = &fakes.FeatureFlagClient{}
+		featureFlagClient.IsConfigFeatureActivatedReturns(true, nil)
+
+		options := client.Options{
+			ReaderWriterConfigClient: readerWriter,
+			TKGConfigUpdater:         tkgConfigUpdater,
+			TKGBomClient:             tkgBomClient,
+			RegionManager:            new(fakes.RegionManager),
+			FeatureFlagClient:        featureFlagClient,
+		}
+		tkgClient, err = client.New(options)
+		Expect(err).NotTo(HaveOccurred())
+	})
+	Context("Validate presence of Azure env variables during upgrade", func() {
+		It("Azure client secret has not been set", func() {
+			err := os.Unsetenv(constants.ConfigVariableAzureClientSecret)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = tkgClient.ValidateEnvVariables(client.AzureProviderName)
+			Expect(err).To(HaveOccurred())
+		})
+		It("Azure client secret has been set", func() {
+			tkgClient.TKGConfigReaderWriter().Set(constants.ConfigVariableAzureClientSecret, "foo-bar")
+			err := tkgClient.ValidateEnvVariables(client.AzureProviderName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("IaaS is AWS. This is a no-op currently", func() {
+			err := tkgClient.ValidateEnvVariables(client.AWSProviderName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
Signed-off-by: Sudarshan <asudarshan@vmware.com>

### What this PR does / why we need it
This cherry-picks 24b6ead3e7c21887b879e6b3c027221df3697c3f to release-0.11 because we want this to be a part of v0.11.4

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
This is the testing I had done in the original PR - https://github.com/vmware-tanzu/tanzu-framework/pull/1841
Manual Testing
1. Created a 1.4.2 Cluster
2. Built tanzu cli locally with the changes from this PR
3. Tried to upgrade the cluster from 1.4.2 to 1.5.1 using the changes in this PR. The upgrade failed with the following error
```
./artifacts/darwin/amd64/cli/management-cluster/v0.11.2/tanzu-management-cluster-darwin_amd64 upgrade
Upgrading management cluster 'tkg-mgmt-azure-20220315142236' to TKG version 'v1.5.1' with Kubernetes version 'v1.22.5+vmware.1'. Are you sure? [y/N]: y
Validating for the required environment variables to be set
Error: required env variables are not set: Config Variable AZURE_CLIENT_SECRET not set
```

4. Set AZURE_CLIENT_SECRET
5. Tried upgrading the cluster again. The cluster upgraded successfully
```
/artifacts/darwin/amd64/cli/management-cluster/v0.11.2/tanzu-management-cluster-darwin_amd64 get
Downloading the TKG Bill of Materials (BOM) file from 'projects.registry.vmware.com/tkg/tkg-bom:v1.5.1'
Downloading the TKr Bill of Materials (BOM) file from 'projects.registry.vmware.com/tkg/tkr-bom:v1.22.5_vmware.1-tkg.3'
  NAME                           NAMESPACE   STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES       PLAN
  tkg-mgmt-azure-20220315142236  tkg-system  running  1/1           1/1      v1.22.5+vmware.1  management  dev


Details:

NAME                                                                              READY  SEVERITY  REASON  SINCE  MESSAGE
/tkg-mgmt-azure-20220315142236                                                    True                     35m
├─ClusterInfrastructure - AzureCluster/tkg-mgmt-azure-20220315142236              True                     150m
├─ControlPlane - KubeadmControlPlane/tkg-mgmt-azure-20220315142236-control-plane  True                     35m
│ └─Machine/tkg-mgmt-azure-20220315142236-control-plane-f5jb7                     True                     43m
└─Workers
  └─MachineDeployment/tkg-mgmt-azure-20220315142236-md-0                          True                     53m
    └─Machine/tkg-mgmt-azure-20220315142236-md-0-6b6688f8b8-f76zh                 True                     23m


Providers:

  NAMESPACE                          NAME                   TYPE                    PROVIDERNAME  VERSION  WATCHNAMESPACE
  capi-kubeadm-bootstrap-system      bootstrap-kubeadm      BootstrapProvider       kubeadm       v1.0.1
  capi-kubeadm-control-plane-system  control-plane-kubeadm  ControlPlaneProvider    kubeadm       v1.0.1
  capi-system                        cluster-api            CoreProvider            cluster-api   v1.0.1
  capz-system                        infrastructure-azure   InfrastructureProvider  azure         v1.0.1

kubectl get machines -A
NAMESPACE    NAME                                                  CLUSTER                         NODENAME                                                          PROVIDERID                                                                                                                                                                                       PHASE     AGE   VERSION
tkg-system   tkg-mgmt-azure-20220315142236-control-plane-f5jb7     tkg-mgmt-azure-20220315142236   tkg-mgmt-azure-20220315142236-control-plane-v1-22-5-vmwarev6r6q   azure:///subscriptions/9d35c6fa-8c43-4b65-9d7a-f5d3f6fb453a/resourceGroups/test-mc/providers/Microsoft.Compute/virtualMachines/tkg-mgmt-azure-20220315142236-control-plane-v1-22-5-vmwarev6r6q   Running   52m   v1.22.5+vmware.1
tkg-system   tkg-mgmt-azure-20220315142236-md-0-6b6688f8b8-f76zh   tkg-mgmt-azure-20220315142236   tkg-mgmt-azure-20220315142236-md-0-v1-22-5-vmware-1-sm5od-qqlfq   azure:///subscriptions/9d35c6fa-8c43-4b65-9d7a-f5d3f6fb453a/resourceGroups/test-mc/providers/Microsoft.Compute/virtualMachines/tkg-mgmt-azure-20220315142236-md-0-v1-22-5-vmware-1-sm5od-qqlfq   Running   24m   v1.22.5+vmware.1
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixes upgrade bug in Azure where upgrade used to fail if AZURE_CLIENT_SECRET was not set. 
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
