### PR TITLE
Removed slash from the custom image repo being read in as hostname

### DIFF
--- a/pkg/v1/tkg/kind/client.go
+++ b/pkg/v1/tkg/kind/client.go
@@ -238,12 +238,7 @@ func (k *KindClusterProxy) getKindRegistryConfig() (string, error) {
 		return "", caCertErr
 	}
 
-	hostname := ""
-	if customRepository != "" {
-		hostname = strings.Split(customRepository, "/")[0]
-	} else {
-		hostname = k.options.DefaultImageRepo
-	}
+	hostname := k.ResolveHostname(customRepository)
 
 	registryTLSConfig := criRegistryTLSConfig{
 		InsecureSkipVerify: tkgconfigClient.IsCustomRepositorySkipTLSVerify(),

--- a/pkg/v1/tkg/kind/utils.go
+++ b/pkg/v1/tkg/kind/utils.go
@@ -1,0 +1,17 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kind provides kind cluster functionalities
+package kind
+
+import "strings"
+
+func (k *KindClusterProxy) ResolveHostname(repositoryPath string) string {
+	hostname := ""
+	if repositoryPath != "" {
+		hostname = strings.Split(repositoryPath, "/")[0]
+	} else {
+		hostname = strings.Split(k.options.DefaultImageRepo, "/")[0]
+	}
+	return hostname
+}

--- a/pkg/v1/tkg/kind/utils_test.go
+++ b/pkg/v1/tkg/kind/utils_test.go
@@ -1,0 +1,37 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kind
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	kindClusterProxy KindClusterProxy
+)
+
+var _ = Describe("Kind Client", func() {
+	BeforeEach(func() {
+		kindClusterProxy = KindClusterProxy{
+			options: &KindClusterOptions{DefaultImageRepo: "test-repo/tkg"},
+		}
+	})
+	Describe("Only image repository hostname should be used", func() {
+		Context("Custom Image Repository not set", func() {
+			It("Default hostname from the imagerepos in the TKG BOM should be returned", func() {
+				hostName := kindClusterProxy.ResolveHostname("")
+				Expect(hostName).To(Equal("test-repo"))
+			})
+		})
+
+		Context("Custom Image Repository is set", func() {
+			It("Default hostname from the imagerepos in the TKG BOM should be returned", func() {
+				customImageRepo := "test-custom-repo/tkg"
+				hostName := kindClusterProxy.ResolveHostname(customImageRepo)
+				Expect(hostName).To(Equal("test-custom-repo"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
### What this PR does / why we need it
This PR fixes a bug where the user was not able to create a management cluster on vSphere with proxy enabled without setting the `TKG_CUSTOM_IMAGE_REPOSITORY` environment variable

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
Manual Testing done
1. Built tanzu-cli locally with the changes in this PR
2. Started creating a management cluster on vSphere environment with proxy enabled
3. Checked the containerd config file on the kind cluster
```
$ docker exec -it a9981efbf74d /bin/sh
# cat /etc/containerd/config.toml
version = 2

[plugins]
  [plugins."io.containerd.grpc.v1.cri"]
    restrict_oom_score_adj = false
    sandbox_image = "projects.registry.vmware.com/tkg/pause:3.6"
    tolerate_missing_hugepages_controller = true
    [plugins."io.containerd.grpc.v1.cri".containerd]
      default_runtime_name = "runc"
      discard_unpacked_layers = true
      snapshotter = "overlayfs"
      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
          base_runtime_spec = "/etc/containerd/cri-base.json"
          runtime_type = "io.containerd.runc.v2"
        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
          runtime_type = "io.containerd.runc.v2"
    [plugins."io.containerd.grpc.v1.cri".registry]
      [plugins."io.containerd.grpc.v1.cri".registry.configs]
        [plugins."io.containerd.grpc.v1.cri".registry.configs."projects-stg.registry.vmware.com"]
          [plugins."io.containerd.grpc.v1.cri".registry.configs."projects-stg.registry.vmware.com".tls]
            ca_file = "/etc/containerd/tkg-registry-ca.crt"
            insecure_skip_verify = false

[proxy_plugins]
  [proxy_plugins.fuse-overlayfs]
    address = "/run/containerd-fuse-overlayfs.sock"
    type = "snapshot"
```
4. Verified that `/tkg` is not present in the url of the image repo of the containerd config file
5. The management cluster was installed successfully

Negative Test Case with the v0.11.2 build
1. Installed tanzu-cli v0.11.2
2. Started creating a management cluster on vSphere environment with proxy enabled
3. Checked the containerd config file on the kind cluster
```
docker exec -it 5f8ae0632c78 /bin/sh
# cat /etc/containerd/config.toml
version = 2

[plugins]
  [plugins."io.containerd.grpc.v1.cri"]
    restrict_oom_score_adj = false
    sandbox_image = "projects.registry.vmware.com/tkg/pause:3.5"
    tolerate_missing_hugepages_controller = true
    [plugins."io.containerd.grpc.v1.cri".containerd]
      default_runtime_name = "runc"
      discard_unpacked_layers = true
      snapshotter = "overlayfs"
      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
          runtime_type = "io.containerd.runc.v2"
        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.test-handler]
          runtime_type = "io.containerd.runc.v2"
    [plugins."io.containerd.grpc.v1.cri".registry]
      [plugins."io.containerd.grpc.v1.cri".registry.configs]
        [plugins."io.containerd.grpc.v1.cri".registry.configs."projects.registry.vmware.com/tkg"]
          [plugins."io.containerd.grpc.v1.cri".registry.configs."projects.registry.vmware.com/tkg".tls]
            ca_file = "/etc/containerd/tkg-registry-ca.crt"
            insecure_skip_verify = false

[proxy_plugins]
  [proxy_plugins.fuse-overlayfs]
    address = "/run/containerd-fuse-overlayfs.sock"
    type = "snapshot"
```
4. Verified that the image-repo url contains the undesired `/tkg` in it
5. The management-cluster creation failed, the error message seen in the console output was
```
Fetching providers
Installing cert-manager Version="v1.5.3"
Waiting for cert-manager to be available...
Deleting kind cluster: tkg-kind-c90glpsbcv46me014190
Error: unable to set up management cluster: unable to initialize providers: timed out waiting for the condition, this can be possible because of the outbound connectivity issue. Please check deployed nodes for outbound connectivity.
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix the image repo url being read by default
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
