### PR TITLE
Add defaults for KappController CRD

### DIFF
--- a/apis/run/v1alpha3/clusterbootstraptemplate_types.go
+++ b/apis/run/v1alpha3/clusterbootstraptemplate_types.go
@@ -15,7 +15,6 @@ type ClusterBootstrapTemplateSpec struct {
 	// +kubebuilder:default:=false
 	Paused bool `json:"paused,omitempty"`
 
-	// TODO these are optional for temp testing, change when TKR v1alpha3 is available
 	// +optional
 	CNI *ClusterBootstrapPackage `json:"cni,omitempty"`
 	// +optional

--- a/apis/run/v1alpha3/kappcontrollerconfig_types.go
+++ b/apis/run/v1alpha3/kappcontrollerconfig_types.go
@@ -13,24 +13,28 @@ import (
 type KappControllerConfigSpec struct {
 	// The namespace in which kapp-controller is deployed
 	//+kubebuilder:validation:Optional
-	//+kubebuilder:default:=kube-system
+	//+kubebuilder:default:=tkg-system
 	Namespace string `json:"namespace,omitempty"`
 
-	KappController KappController `json:"kappController,omitempty"`
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:default:={deployment:{hostNetwork:true}}
+	KappController KappController `json:"kappController,omitempty"` // object default needs at least one param so that CRD generation is not null, issue https://github.com/kubernetes-sigs/controller-tools/issues/631
 }
 
 type KappController struct {
 	// Whether to create namespace specified for kapp-controller
 	//+kubebuilder:validation:Optional
-	//+kubebuilder:default:=true
+	//+kubebuilder:default:=false
 	CreateNamespace bool `json:"createNamespace,omitempty"`
 
 	// The namespace value used for global packaging resources. Any Package and PackageMetadata CRs within that namespace will be included in all other namespaces on the cluster, without duplicating them
 	//+kubebuilder:validation:Optional
-	//+kubebuilder:default:=tanzu-package-repo-global
+	//+kubebuilder:default:=tkg-system
 	GlobalNamespace string `json:"globalNamespace,omitempty"`
 
-	Deployment KappDeployment `json:"deployment,omitempty"`
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:default:={hostNetwork:true}
+	Deployment KappDeployment `json:"deployment,omitempty"` // object default needs at least one param so that CRD generation is not null, issue https://github.com/kubernetes-sigs/controller-tools/issues/631
 
 	Config KappConfig `json:"config,omitempty"`
 }
@@ -58,7 +62,7 @@ type KappDeployment struct {
 
 	// Bind port for kapp-controller API
 	//+kubebuilder:validation:Optional
-	//+kubebuilder:default:=10350
+	//+kubebuilder:default:=10100
 	APIPort int `json:"apiPort,omitempty"`
 
 	// Address for metrics server

--- a/config/crd/bases/run.tanzu.vmware.com_clusterbootstraps.yaml
+++ b/config/crd/bases/run.tanzu.vmware.com_clusterbootstraps.yaml
@@ -103,8 +103,6 @@ spec:
                   type: object
                 type: array
               cni:
-                description: TODO these are optional for temp testing, change when
-                  TKR v1alpha3 is available
                 properties:
                   refName:
                     type: string

--- a/config/crd/bases/run.tanzu.vmware.com_clusterbootstraptemplates.yaml
+++ b/config/crd/bases/run.tanzu.vmware.com_clusterbootstraptemplates.yaml
@@ -100,8 +100,6 @@ spec:
                   type: object
                 type: array
               cni:
-                description: TODO these are optional for temp testing, change when
-                  TKR v1alpha3 is available
                 properties:
                   refName:
                     type: string

--- a/config/crd/bases/run.tanzu.vmware.com_kappcontrollerconfigs.yaml
+++ b/config/crd/bases/run.tanzu.vmware.com_kappcontrollerconfigs.yaml
@@ -55,6 +55,9 @@ spec:
             description: KappControllerConfigSpec defines the desired state of KappControllerConfig
             properties:
               kappController:
+                default:
+                  deployment:
+                    hostNetwork: true
                 properties:
                   config:
                     properties:
@@ -85,13 +88,15 @@ spec:
                         type: string
                     type: object
                   createNamespace:
-                    default: true
+                    default: false
                     description: Whether to create namespace specified for kapp-controller
                     type: boolean
                   deployment:
+                    default:
+                      hostNetwork: true
                     properties:
                       apiPort:
-                        default: 10350
+                        default: 10100
                         description: Bind port for kapp-controller API
                         type: integer
                       concurrency:
@@ -131,7 +136,7 @@ spec:
                         type: array
                     type: object
                   globalNamespace:
-                    default: tanzu-package-repo-global
+                    default: tkg-system
                     description: The namespace value used for global packaging resources.
                       Any Package and PackageMetadata CRs within that namespace will
                       be included in all other namespaces on the cluster, without
@@ -139,7 +144,7 @@ spec:
                     type: string
                 type: object
               namespace:
-                default: kube-system
+                default: tkg-system
                 description: The namespace in which kapp-controller is deployed
                 type: string
             type: object


### PR DESCRIPTION
Adds defaults for KappController CRD

Signed-off-by: Vijay Katam <vkatam@vmware.com>

### What this PR does / why we need it
Add defaults for KappController CRD. Without the defaults a PackageInstall with the corresponding kapp-controller deployment on TKG will not succeed. 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1887

### Describe testing done for PR
Created a config and verified that all defaults are filled in.
Create
```
apiVersion: run.tanzu.vmware.com/v1alpha3
kind: KappControllerConfig
metadata:
  name: foo
  namespace: default
spec:
  namespace: default
```
Result 
```
apiVersion: run.tanzu.vmware.com/v1alpha3
kind: KappControllerConfig
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"run.tanzu.vmware.com/v1alpha3","kind":"KappControllerConfig","metadata":{"annotations":{},"name":"foo","namespace":"default"},"spec":{"namespace":"default"}}
  creationTimestamp: "2022-03-26T01:10:13Z"
  generation: 1
  name: foo
  namespace: default
  resourceVersion: "3560284"
  uid: 607f0e38-21df-4928-9f08-cf1b42f61016
spec:
  kappController:
    createNamespace: false
    deployment:
      apiPort: 10350
      concurrency: 4
      hostNetwork: true
      metricsBindAddress: "0"
      priorityClassName: system-cluster-critical
      tolerations:
      - key: CriticalAddonsOnly
        operator: Exists
      - effect: NoSchedule
        key: node-role.kubernetes.io/master
      - effect: NoSchedule
        key: node.kubernetes.io/not-ready
      - effect: NoSchedule
        key: node.cloudprovider.kubernetes.io/uninitialized
        value: "true"
    globalNamespace: tkg-system
  namespace: default
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
