### PR TITLE
Add edition to `tkg-metadata` configmap

### DIFF
--- a/pkg/v1/providers/ytt/02_addons/metadata/add_cluster_metadata.yaml
+++ b/pkg/v1/providers/ytt/02_addons/metadata/add_cluster_metadata.yaml
@@ -39,6 +39,7 @@ cluster:
  plan: #@ data.values.CLUSTER_PLAN
  kubernetesProvider: #@ get_kubernetes_provider()
  tkgVersion: #@ data.values.TKG_VERSION
+ edition: #@ data.values.BUILD_EDITION
  infrastructure:
   provider: #@ get_provider()
 bom:


### PR DESCRIPTION
### What this PR does / why we need it

This propogates the edition (tce vs tkg) to the tkg-metadata confimap.
This requirement came from a need for Tanzu Mission Control (TMC) to
be able to detect the type of workload cluster. However, this field
should propogate in both workload and management clusters.

### Which issue(s) this PR fixes

* Fixes: https://github.com/vmware-tanzu/community-edition/issues/3593

### Describe testing done for PR

1. Created a docker-based cluster with the edition set to `tce`.

    snapshot of `config.yaml`:

    ```yaml
    $ grep edition ~/.config/tanzu/config.yaml
        edition: tce
    ```

1. Query edition in configmap:

    ```yaml
    $ docker exec -it 634 kubectl --kubeconfig=/etc/kubernetes/admin.conf get cm -n tkg-system-public tkg-metadata -oyaml | grep -i edition
          edition: tce
    ```

### Release note

```release-note
tanzu edition now exposed in `tkg-metadata` configmap
```