### PR TITLE
Configure etcd `extraArgs` from TKR during cluster creation/upgrade

### DIFF
--- a/.github/workflows/plugin_tests.yaml
+++ b/.github/workflows/plugin_tests.yaml
@@ -19,8 +19,11 @@ jobs:
     name: Plugin Tests
     runs-on: tkg
     steps:
-      - name: Free disk space on runner
-        run: sudo rm -rf /usr/share/dotnet
+      - name: Free disk space and clean up installed plugins on runner
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /home/tanzu/.local/share/tanzu-cli/*
+          mkdir -p /home/tanzu/.local/share/tanzu-cli/test
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
@@ -85,7 +88,7 @@ jobs:
         run: make install-cli-plugins ENABLE_CONTEXT_AWARE_PLUGIN_DISCOVERY=false
 
       - name: Cleanup
-        run: rm -rf ~/.tanzu ~/.tkg ~/.config; docker kill $(docker ps -q) | true; docker system prune -a --volumes -f
+        run: rm -rf ~/.tanzu ~/.tkg ~/.config ~/.cache/tanzu; docker kill $(docker ps -q) | true; docker system prune -a --volumes -f
 
       - name: Run cluster test plugin
         run: tanzu test plugin cluster

--- a/.github/workflows/tkg_integration_tests.yaml
+++ b/.github/workflows/tkg_integration_tests.yaml
@@ -20,8 +20,10 @@ jobs:
     name: TKG Integration Tests CAPD
     runs-on: tkg
     steps:
-    - name: Free disk space on runner
-      run: sudo rm -rf /usr/share/dotnet
+    - name: Free disk space and clean up installed plugins on runner
+      run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /home/tanzu/.local/share/tanzu-cli/*
 
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
@@ -85,8 +87,10 @@ jobs:
     env:
       azure_client_id: ${{secrets.AZURE_CLIENT_ID_SAIB}}
     steps:
-    - name: Free disk space on runner
-      run: sudo rm -rf /usr/share/dotnet
+    - name: Free disk space and clean up installed plugins on runner
+      run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /home/tanzu/.local/share/tanzu-cli/*
 
     - name: Set up Go 1.x
       uses: actions/setup-go@v2

--- a/.github/workflows/tkgpackage_integration_test.yaml
+++ b/.github/workflows/tkgpackage_integration_test.yaml
@@ -21,8 +21,10 @@ jobs:
     name: Package Plugin Tests CAPD
     runs-on: tkg
     steps:
-      - name: Free disk space on runner
-        run: sudo rm -rf /usr/share/dotnet
+      - name: Free disk space and clean up installed plugins on runner
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /home/tanzu/.local/share/tanzu-cli/*
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v2

--- a/pkg/v1/providers/infrastructure-aws/v1.2.0/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-aws/v1.2.0/ytt/overlay.yaml
@@ -113,6 +113,15 @@ spec:
         local:
           imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageRepository)
           imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageTag
+          #@ if getattr(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local, "extraArgs", None) != None:
+          #@overlay/match missing_ok=True
+          extraArgs:
+            #@ for key in bomDataForK8sVersion.kubeadmConfigSpec.etcd.local["extraArgs"]:
+            #@overlay/match missing_ok=True
+            #@yaml/text-templated-strings
+            (@= key @): #@ "{}".format(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local["extraArgs"][key]).lower()
+            #@ end
+          #@ end
       dns:
         imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.dns.imageRepository)
         imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag

--- a/pkg/v1/providers/infrastructure-azure/v1.0.1/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.0.1/ytt/overlay.yaml
@@ -189,6 +189,15 @@ spec:
         local:
           imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageRepository)
           imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageTag
+          #@ if getattr(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local, "extraArgs", None) != None:
+          #@overlay/match missing_ok=True
+          extraArgs:
+            #@ for key in bomDataForK8sVersion.kubeadmConfigSpec.etcd.local["extraArgs"]:
+            #@overlay/match missing_ok=True
+            #@yaml/text-templated-strings
+            (@= key @): #@ "{}".format(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local["extraArgs"][key]).lower()
+            #@ end
+          #@ end
       dns:
         imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.dns.imageRepository)
         imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag

--- a/pkg/v1/providers/infrastructure-docker/v1.1.3/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-docker/v1.1.3/ytt/overlay.yaml
@@ -82,6 +82,15 @@ spec:
         local:
           imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageRepository)
           imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageTag
+          #@ if getattr(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local, "extraArgs", None) != None:
+          #@overlay/match missing_ok=True
+          extraArgs:
+            #@ for key in bomDataForK8sVersion.kubeadmConfigSpec.etcd.local["extraArgs"]:
+            #@overlay/match missing_ok=True
+            #@yaml/text-templated-strings
+            (@= key @): #@ "{}".format(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local["extraArgs"][key]).lower()
+            #@ end
+          #@ end
       dns:
         imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.dns.imageRepository)
         imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag

--- a/pkg/v1/providers/infrastructure-vsphere/v1.1.0/ytt/overlay-windows.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.1.0/ytt/overlay-windows.yaml
@@ -249,6 +249,15 @@ spec:
         local:
           imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageRepository)
           imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageTag
+          #@ if getattr(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local, "extraArgs", None) != None:
+          #@overlay/match missing_ok=True
+          extraArgs:
+            #@ for key in bomDataForK8sVersion.kubeadmConfigSpec.etcd.local["extraArgs"]:
+            #@overlay/match missing_ok=True
+            #@yaml/text-templated-strings
+            (@= key @): #@ "{}".format(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local["extraArgs"][key]).lower()
+            #@ end
+          #@ end
       dns:
         imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.dns.imageRepository)
         imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag

--- a/pkg/v1/providers/infrastructure-vsphere/v1.1.0/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.1.0/ytt/overlay.yaml
@@ -265,6 +265,15 @@ spec:
         local:
           imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageRepository)
           imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageTag
+          #@ if getattr(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local, "extraArgs", None) != None:
+          #@overlay/match missing_ok=True
+          extraArgs:
+            #@ for key in bomDataForK8sVersion.kubeadmConfigSpec.etcd.local["extraArgs"]:
+            #@overlay/match missing_ok=True
+            #@yaml/text-templated-strings
+            (@= key @): #@ "{}".format(bomDataForK8sVersion.kubeadmConfigSpec.etcd.local["extraArgs"][key]).lower()
+            #@ end
+          #@ end
       dns:
         imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.dns.imageRepository)
         imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag

--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_aws.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_aws.model
@@ -1,7 +1,7 @@
 --CONTROLPLANE-MACHINE-COUNT: "NOTPROVIDED", "1","3","5"
 --WORKER-MACHINE-COUNT:       "NOTPROVIDED", "3"
 --CONTROLPLANE-SIZE:          "NOTPROVIDED", "i3.xlarge"
---TKR:                        "NOTPROVIDED", "v1.22.3+vmware.1-tkg.2-zshippable"
+--TKR:                        "NOTPROVIDED", "v1.22.5+vmware.1-tkg.2-zshippable"
 --NAMESPACE:                  "NOTPROVIDED", "default", "test"
 --SIZE:                       "NOTPROVIDED", "t3.medium"
 --WORKER-SIZE:                "NOTPROVIDED", "m5.xlarge"

--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_azure.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_azure.model
@@ -1,7 +1,7 @@
 --CONTROLPLANE-MACHINE-COUNT: "NOTPROVIDED", "1","3","5"
 --WORKER-MACHINE-COUNT:       "NOTPROVIDED", "3"
 --CONTROLPLANE-SIZE:          "NOTPROVIDED", "i3.xlarge"
---TKR:                        "NOTPROVIDED", "v1.22.3+vmware.1-tkg.2-zshippable", "v0.0.0+no-azure-image", "v0.0.0+marketplace-image", "v0.0.0+marketplace-image-no-thirdpartyimage", "v0.0.0+shared-gallery-image"
+--TKR:                        "NOTPROVIDED", "v1.22.5+vmware.1-tkg.2-zshippable", "v0.0.0+no-azure-image", "v0.0.0+marketplace-image", "v0.0.0+marketplace-image-no-thirdpartyimage", "v0.0.0+shared-gallery-image"
 --NAMESPACE:                  "NOTPROVIDED", "default", "test"
 --SIZE:                       "NOTPROVIDED", "t3.medium"
 --WORKER-SIZE:                "NOTPROVIDED", "m5.xlarge"

--- a/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
+++ b/pkg/v1/providers/tests/clustergen/param_models/cluster_optional.model
@@ -1,7 +1,7 @@
 --CONTROLPLANE-MACHINE-COUNT: "NOTPROVIDED"
 --WORKER-MACHINE-COUNT:       "NOTPROVIDED"
 --CONTROLPLANE-SIZE:          "NOTPROVIDED"
---TKR:                        "NOTPROVIDED", "v1.22.3+vmware.1-tkg.2-zshippable"
+--TKR:                        "NOTPROVIDED", "v1.22.5+vmware.1-tkg.2-zshippable"
 --NAMESPACE:                  "NOTPROVIDED"
 --SIZE:                       "NOTPROVIDED"
 --WORKER-SIZE:                "NOTPROVIDED"

--- a/pkg/v1/tkg/client/upgrade_cluster.go
+++ b/pkg/v1/tkg/client/upgrade_cluster.go
@@ -58,7 +58,8 @@ type mdInfastructureTemplateInfo struct {
 	MDInfrastructureTemplateNamespace string
 }
 
-type componentInfo struct {
+// ComponentInfo defines cluster component related metadata used for upgrade
+type ComponentInfo struct {
 	TkrVersion                         string
 	KubernetesVersion                  string
 	ImageRepository                    string
@@ -67,6 +68,7 @@ type componentInfo struct {
 	EtcdDataDir                        string
 	EtcdImageRepository                string
 	EtcdImageTag                       string
+	EtcdExtraArgs                      map[string]string
 	KCPInfrastructureTemplateName      string
 	KCPInfrastructureTemplateNamespace string
 	MDInfastructureTemplates           map[string]mdInfastructureTemplateInfo
@@ -90,9 +92,10 @@ const (
 	upgradeStateSuccess               = "Success"
 )
 
-type clusterUpgradeInfo struct {
-	UpgradeComponentInfo componentInfo
-	ActualComponentInfo  componentInfo
+// ClusterUpgradeInfo defines cluster upgrade metadata used during upgrade process
+type ClusterUpgradeInfo struct {
+	UpgradeComponentInfo ComponentInfo
+	ActualComponentInfo  ComponentInfo
 
 	KCPObjectName      string
 	KCPObjectNamespace string
@@ -398,7 +401,7 @@ func (c *TkgClient) upgradeAddonPostNodeUpgrade(regionalClusterClient clustercli
 	return nil
 }
 
-func (c *TkgClient) applyPatchAndWait(regionalClusterClient, currentClusterClient clusterclient.Client, upgradeClusterConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) applyPatchAndWait(regionalClusterClient, currentClusterClient clusterclient.Client, upgradeClusterConfig *ClusterUpgradeInfo) error {
 	var err error
 	kubernetesVersion := upgradeClusterConfig.UpgradeComponentInfo.KubernetesVersion
 
@@ -441,7 +444,7 @@ func (c *TkgClient) applyPatchAndWait(regionalClusterClient, currentClusterClien
 
 	log.Info("Upgrading control plane nodes...")
 	log.Infof("Patching KubeadmControlPlane with the kubernetes version %s...", kubernetesVersion)
-	err = c.patchKubernetesVersionToKubeadmControlPlane(regionalClusterClient, upgradeClusterConfig)
+	err = c.PatchKubernetesVersionToKubeadmControlPlane(regionalClusterClient, upgradeClusterConfig)
 	if err != nil {
 		return errors.Wrap(err, "unable to patch kubernetes version to kubeadm control plane")
 	}
@@ -488,7 +491,7 @@ func (c *TkgClient) applyPatchAndWait(regionalClusterClient, currentClusterClien
 	return nil
 }
 
-func (c *TkgClient) getUpgradeClusterConfig(options *UpgradeClusterOptions) (*clusterUpgradeInfo, error) {
+func (c *TkgClient) getUpgradeClusterConfig(options *UpgradeClusterOptions) (*ClusterUpgradeInfo, error) {
 	bomConfiguration, err := c.tkgBomClient.GetBOMConfigurationFromTkrVersion(options.TkrVersion)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to read in configuration from BOM file")
@@ -498,12 +501,13 @@ func (c *TkgClient) getUpgradeClusterConfig(options *UpgradeClusterOptions) (*cl
 		log.Infof("Using custom image repository: %s", bomConfiguration.ImageConfig.ImageRepository)
 	}
 
-	upgradeInfo := &clusterUpgradeInfo{}
+	upgradeInfo := &ClusterUpgradeInfo{}
 	upgradeInfo.UpgradeComponentInfo.TkrVersion = bomConfiguration.Release.Version
 	upgradeInfo.UpgradeComponentInfo.KubernetesVersion = bomConfiguration.KubeadmConfigSpec.KubernetesVersion
 	upgradeInfo.UpgradeComponentInfo.CoreDNSImageTag = bomConfiguration.KubeadmConfigSpec.DNS.ImageTag
 	upgradeInfo.UpgradeComponentInfo.EtcdDataDir = bomConfiguration.KubeadmConfigSpec.Etcd.Local.DataDir
 	upgradeInfo.UpgradeComponentInfo.EtcdImageTag = bomConfiguration.KubeadmConfigSpec.Etcd.Local.ImageTag
+	upgradeInfo.UpgradeComponentInfo.EtcdExtraArgs = bomConfiguration.KubeadmConfigSpec.Etcd.Local.ExtraArgs
 
 	upgradeInfo.ClusterName = options.ClusterName
 	upgradeInfo.ClusterNamespace = options.Namespace
@@ -541,7 +545,7 @@ func (c *TkgClient) getUpgradeClusterConfig(options *UpgradeClusterOptions) (*cl
 // Updating VM_TEMPLATE/AWS_AMI_ID in existing template will not help as it is passed as reference and controllers will not get reconciled unless the name
 // of the InfrastructureMachineTemplate is changed under KCP.Spec.InfrastructureTemplate and MD.Spec.Template.Spec.infrastructureRef
 // Because of the above reason we need to create new InfrastructureTemplates and update the reference in KCP and MD object of existing cluster
-func (c *TkgClient) createInfrastructureTemplateForUpgrade(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) createInfrastructureTemplateForUpgrade(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	var err error
 
 	kcp, err := regionalClusterClient.GetKCPObjectForCluster(clusterUpgradeConfig.ClusterName, clusterUpgradeConfig.ClusterNamespace)
@@ -564,6 +568,8 @@ func (c *TkgClient) createInfrastructureTemplateForUpgrade(regionalClusterClient
 	clusterUpgradeConfig.ActualComponentInfo.EtcdDataDir = kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.DataDir
 	clusterUpgradeConfig.ActualComponentInfo.EtcdImageRepository = kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ImageRepository
 	clusterUpgradeConfig.ActualComponentInfo.EtcdImageTag = kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ImageTag
+	clusterUpgradeConfig.ActualComponentInfo.EtcdExtraArgs = kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ExtraArgs
+
 	clusterUpgradeConfig.ActualComponentInfo.KCPInfrastructureTemplateName = kcp.Spec.MachineTemplate.InfrastructureRef.Name
 	clusterUpgradeConfig.ActualComponentInfo.KCPInfrastructureTemplateNamespace = kcp.Spec.MachineTemplate.InfrastructureRef.Namespace
 
@@ -593,7 +599,7 @@ func (c *TkgClient) createInfrastructureTemplateForUpgrade(regionalClusterClient
 	}
 }
 
-func isNewAWSTemplateRequired(machineTemplate *capav1beta1.AWSMachineTemplate, clusterUpgradeConfig *clusterUpgradeInfo, actualK8sVersion *string) bool {
+func isNewAWSTemplateRequired(machineTemplate *capav1beta1.AWSMachineTemplate, clusterUpgradeConfig *ClusterUpgradeInfo, actualK8sVersion *string) bool {
 	if actualK8sVersion == nil || *actualK8sVersion != clusterUpgradeConfig.UpgradeComponentInfo.KubernetesVersion {
 		return true
 	}
@@ -606,7 +612,7 @@ func isNewAWSTemplateRequired(machineTemplate *capav1beta1.AWSMachineTemplate, c
 	return false
 }
 
-func isNewDockerTemplateRequired(machineTemplate *capdv1beta1.DockerMachineTemplate, clusterUpgradeConfig *clusterUpgradeInfo, actualK8sVersion *string) bool {
+func isNewDockerTemplateRequired(machineTemplate *capdv1beta1.DockerMachineTemplate, clusterUpgradeConfig *ClusterUpgradeInfo, actualK8sVersion *string) bool {
 	if actualK8sVersion == nil || *actualK8sVersion != clusterUpgradeConfig.UpgradeComponentInfo.KubernetesVersion {
 		return true
 	}
@@ -618,7 +624,7 @@ func isNewDockerTemplateRequired(machineTemplate *capdv1beta1.DockerMachineTempl
 	return false
 }
 
-func (c *TkgClient) createAWSControlPlaneMachineTemplate(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) createAWSControlPlaneMachineTemplate(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	var err error
 	awsMachineTemplate := &capav1beta1.AWSMachineTemplate{}
 	err = regionalClusterClient.GetResource(awsMachineTemplate, kcp.Spec.MachineTemplate.InfrastructureRef.Name, kcp.Spec.MachineTemplate.InfrastructureRef.Namespace, nil, nil)
@@ -650,7 +656,7 @@ func (c *TkgClient) createAWSControlPlaneMachineTemplate(regionalClusterClient c
 	return nil
 }
 
-func (c *TkgClient) createAWSMachineDeploymentMachineTemplateForWorkers(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) createAWSMachineDeploymentMachineTemplateForWorkers(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	var err error
 
 	for i := range clusterUpgradeConfig.MDObjects {
@@ -693,7 +699,7 @@ func (c *TkgClient) createAWSMachineDeploymentMachineTemplateForWorkers(regional
 	return nil
 }
 
-func (c *TkgClient) createCAPDInfrastructureTemplateForUpgrade(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) createCAPDInfrastructureTemplateForUpgrade(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	err := c.getCAPDImageForK8sVersion(clusterUpgradeConfig)
 	if err != nil {
 		return errors.Wrap(err, "unable to get docker image for CAPD template")
@@ -708,7 +714,7 @@ func (c *TkgClient) createCAPDInfrastructureTemplateForUpgrade(regionalClusterCl
 	return nil
 }
 
-func (c *TkgClient) createAWSInfrastructureTemplateForUpgrade(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) createAWSInfrastructureTemplateForUpgrade(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	err := c.getAWSAMIIDForK8sVersion(regionalClusterClient, clusterUpgradeConfig)
 	if err != nil {
 		return errors.Wrap(err, "unable to get AMIID for aws template")
@@ -722,7 +728,7 @@ func (c *TkgClient) createAWSInfrastructureTemplateForUpgrade(regionalClusterCli
 	return nil
 }
 
-func isNewAzureTemplateRequired(machineTemplate *capzv1beta1.AzureMachineTemplate, clusterUpgradeConfig *clusterUpgradeInfo, actualK8sVersion *string) bool { // nolint:gocyclo
+func isNewAzureTemplateRequired(machineTemplate *capzv1beta1.AzureMachineTemplate, clusterUpgradeConfig *ClusterUpgradeInfo, actualK8sVersion *string) bool { // nolint:gocyclo
 	if actualK8sVersion == nil || *actualK8sVersion != clusterUpgradeConfig.UpgradeComponentInfo.KubernetesVersion {
 		return true
 	}
@@ -790,7 +796,7 @@ func getAzureImage(azureImage *tkgconfigbom.AzureInfo) *capzv1beta1.Image {
 	return nil
 }
 
-func (c *TkgClient) createAzureControlPlaneMachineTemplate(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) createAzureControlPlaneMachineTemplate(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	var err error
 	azureMachineTemplate := &capzv1beta1.AzureMachineTemplate{}
 	err = regionalClusterClient.GetResource(azureMachineTemplate, kcp.Spec.MachineTemplate.InfrastructureRef.Name, kcp.Spec.MachineTemplate.InfrastructureRef.Namespace, nil, nil)
@@ -822,7 +828,7 @@ func (c *TkgClient) createAzureControlPlaneMachineTemplate(regionalClusterClient
 	return nil
 }
 
-func (c *TkgClient) createCAPDControlPlaneMachineTemplate(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) createCAPDControlPlaneMachineTemplate(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	var err error
 	dockerMachineTemplate := &capdv1beta1.DockerMachineTemplate{}
 	err = regionalClusterClient.GetResource(dockerMachineTemplate, kcp.Spec.MachineTemplate.InfrastructureRef.Name, kcp.Spec.MachineTemplate.InfrastructureRef.Namespace, nil, nil)
@@ -854,7 +860,7 @@ func (c *TkgClient) createCAPDControlPlaneMachineTemplate(regionalClusterClient 
 	return nil
 }
 
-func (c *TkgClient) createCAPDMachineDeploymentMachineTemplateForWorkers(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) createCAPDMachineDeploymentMachineTemplateForWorkers(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	var err error
 	for i := range clusterUpgradeConfig.MDObjects {
 		dockerMachineTemplateForMD := &capdv1beta1.DockerMachineTemplate{}
@@ -893,7 +899,7 @@ func (c *TkgClient) createCAPDMachineDeploymentMachineTemplateForWorkers(regiona
 	return nil
 }
 
-func (c *TkgClient) createAzureMachineDeploymentMachineTemplateForWorkers(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) createAzureMachineDeploymentMachineTemplateForWorkers(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	var err error
 
 	for i := range clusterUpgradeConfig.MDObjects {
@@ -933,7 +939,7 @@ func (c *TkgClient) createAzureMachineDeploymentMachineTemplateForWorkers(region
 	return nil
 }
 
-func (c *TkgClient) createAzureInfrastructureTemplateForUpgrade(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) createAzureInfrastructureTemplateForUpgrade(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	if !isSharedGalleryImage(&clusterUpgradeConfig.UpgradeComponentInfo.AzureImage) && !isMarketplaceImage(&clusterUpgradeConfig.UpgradeComponentInfo.AzureImage) {
 		return errors.New("unable to proceed with the upgrade due to invalid azure image information")
 	}
@@ -946,7 +952,7 @@ func (c *TkgClient) createAzureInfrastructureTemplateForUpgrade(regionalClusterC
 	return nil
 }
 
-func isNewVSphereTemplateRequired(machineTemplate *capvv1beta1.VSphereMachineTemplate, clusterUpgradeConfig *clusterUpgradeInfo, actualK8sVersion *string) bool {
+func isNewVSphereTemplateRequired(machineTemplate *capvv1beta1.VSphereMachineTemplate, clusterUpgradeConfig *ClusterUpgradeInfo, actualK8sVersion *string) bool {
 	if actualK8sVersion == nil || *actualK8sVersion != clusterUpgradeConfig.UpgradeComponentInfo.KubernetesVersion {
 		return true
 	}
@@ -957,7 +963,7 @@ func isNewVSphereTemplateRequired(machineTemplate *capvv1beta1.VSphereMachineTem
 	return false
 }
 
-func (c *TkgClient) createVSphereControlPlaneMachineTemplate(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) createVSphereControlPlaneMachineTemplate(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	// Get the actual MachineTemplate object associated with actual KCP object
 	actualVsphereMachineTemplate := &capvv1beta1.VSphereMachineTemplate{}
 	err := regionalClusterClient.GetResource(actualVsphereMachineTemplate, kcp.Spec.MachineTemplate.InfrastructureRef.Name, kcp.Spec.MachineTemplate.InfrastructureRef.Namespace, nil, nil)
@@ -991,7 +997,7 @@ func (c *TkgClient) createVSphereControlPlaneMachineTemplate(regionalClusterClie
 	return nil
 }
 
-func (c *TkgClient) createVSphereMachineDeploymentMachineTemplateForWorkers(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) createVSphereMachineDeploymentMachineTemplateForWorkers(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	var err error
 
 	for i := range clusterUpgradeConfig.MDObjects {
@@ -1034,7 +1040,7 @@ func (c *TkgClient) createVSphereMachineDeploymentMachineTemplateForWorkers(regi
 	return nil
 }
 
-func (c *TkgClient) createVsphereInfrastructureTemplateForUpgrade(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) createVsphereInfrastructureTemplateForUpgrade(regionalClusterClient clusterclient.Client, kcp *capikubeadmv1beta1.KubeadmControlPlane, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	var err error
 
 	vcClient, dcName, err := regionalClusterClient.GetVCClientAndDataCenter(
@@ -1071,7 +1077,7 @@ func (c *TkgClient) createVsphereInfrastructureTemplateForUpgrade(regionalCluste
 	return nil
 }
 
-func (c *TkgClient) patchKubernetesVersionToKubeadmControlPlane(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) PatchKubernetesVersionToKubeadmControlPlane(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	log.V(6).Infof("Cluster Name: %s, Cluster Namespace %s", clusterUpgradeConfig.ClusterName, clusterUpgradeConfig.ClusterNamespace)
 	currentKCP, err := regionalClusterClient.GetKCPObjectForCluster(clusterUpgradeConfig.ClusterName, clusterUpgradeConfig.ClusterNamespace)
 	if err != nil {
@@ -1107,6 +1113,12 @@ func (c *TkgClient) patchKubernetesVersionToKubeadmControlPlane(regionalClusterC
 		currentKCP.Spec.KubeadmConfigSpec.ClusterConfiguration.DNS.ImageTag = clusterUpgradeConfig.UpgradeComponentInfo.CoreDNSImageTag
 		currentKCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ImageRepository = clusterUpgradeConfig.UpgradeComponentInfo.EtcdImageRepository
 		currentKCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ImageTag = clusterUpgradeConfig.UpgradeComponentInfo.EtcdImageTag
+		if currentKCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ExtraArgs == nil {
+			currentKCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ExtraArgs = map[string]string{}
+		}
+		for k, v := range clusterUpgradeConfig.UpgradeComponentInfo.EtcdExtraArgs {
+			currentKCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ExtraArgs[k] = v
+		}
 	}
 
 	pollOptions := &clusterclient.PollOptions{Interval: upgradePatchInterval, Timeout: upgradePatchTimeout}
@@ -1124,7 +1136,7 @@ func (c *TkgClient) patchKubernetesVersionToKubeadmControlPlane(regionalClusterC
 	return nil
 }
 
-func (c *TkgClient) patchKubernetesVersionToMachineDeployment(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) patchKubernetesVersionToMachineDeployment(regionalClusterClient clusterclient.Client, clusterUpgradeConfig *ClusterUpgradeInfo) error {
 	var err error
 	for i := range clusterUpgradeConfig.MDObjects {
 		if clusterUpgradeConfig.MDObjects[i].Spec.Template.Spec.Version != nil &&
@@ -1166,7 +1178,7 @@ func (c *TkgClient) patchKubernetesVersionToMachineDeployment(regionalClusterCli
 }
 
 // handleKappControllerUpgrade contains upgrade logic required for kapp-controller.
-func (c *TkgClient) handleKappControllerUpgrade(regionalClusterClient, currentClusterClient clusterclient.Client, upgradeClusterConfig *clusterUpgradeInfo) error {
+func (c *TkgClient) handleKappControllerUpgrade(regionalClusterClient, currentClusterClient clusterclient.Client, upgradeClusterConfig *ClusterUpgradeInfo) error {
 	// In TKG version prior to v1.3, kapp-controller could have been deployed by user as part of tkg-extensions deployment.
 	// We need to delete the existing kapp-controller since a new kapp-controller will be installed from TKG v1.3 for addons management.
 	if err := currentClusterClient.DeleteExistingKappController(); err != nil {
@@ -1275,7 +1287,7 @@ func (c *TkgClient) getRegionalClusterNameAndNamespace(clusterClient clusterclie
 	return clusterName, clusterNamespace, nil
 }
 
-func (c *TkgClient) getAWSAMIIDForK8sVersion(regionalClusterClient clusterclient.Client, upgradeInfo *clusterUpgradeInfo) error {
+func (c *TkgClient) getAWSAMIIDForK8sVersion(regionalClusterClient clusterclient.Client, upgradeInfo *ClusterUpgradeInfo) error {
 	awsClusterObject := &capav1beta1.AWSCluster{}
 	if err := regionalClusterClient.GetResource(awsClusterObject, upgradeInfo.ClusterName, upgradeInfo.ClusterNamespace, nil, nil); err != nil {
 		return errors.Wrap(err, "unable to retrieve aws cluster object to retrieve AMI settings")
@@ -1296,7 +1308,7 @@ func (c *TkgClient) getAWSAMIIDForK8sVersion(regionalClusterClient clusterclient
 	return nil
 }
 
-func (c *TkgClient) getCAPDImageForK8sVersion(upgradeInfo *clusterUpgradeInfo) error {
+func (c *TkgClient) getCAPDImageForK8sVersion(upgradeInfo *ClusterUpgradeInfo) error {
 	if upgradeInfo.UpgradeComponentInfo.CAPDImageName == "" {
 		bomConfiguration, err := c.tkgBomClient.GetDefaultTkgBOMConfiguration()
 		if err != nil {

--- a/pkg/v1/tkg/client/upgrade_cluster_test.go
+++ b/pkg/v1/tkg/client/upgrade_cluster_test.go
@@ -774,6 +774,54 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 		})
 	})
 
+	var _ = Describe("Test PatchKubernetesVersionToKubeadmControlPlane", func() {
+		Context("Testing EtcdExtraArgs parameter configuration", func() {
+			It("when EtcdExtraArgs is defined", func() {
+				clusterUpgradeConfig := &ClusterUpgradeInfo{
+					ClusterName:      "cluster-1",
+					ClusterNamespace: constants.DefaultNamespace,
+					UpgradeComponentInfo: ComponentInfo{
+						EtcdExtraArgs:     map[string]string{"fake-arg": "fake-arg-value"},
+						KubernetesVersion: "v1.18.0+vmware.2",
+					},
+					ActualComponentInfo: ComponentInfo{
+						KubernetesVersion: "v1.18.0+vmware.1",
+					},
+				}
+
+				err = tkgClient.PatchKubernetesVersionToKubeadmControlPlane(regionalClusterClient, clusterUpgradeConfig)
+				Expect(err).To(BeNil())
+
+				updatedKCP, err := regionalClusterClient.GetKCPObjectForCluster(clusterUpgradeConfig.ClusterName, clusterUpgradeConfig.ClusterNamespace)
+				Expect(err).To(BeNil())
+				Expect(updatedKCP.ObjectMeta.Name).To(Equal("kcp-cluster-1"))
+				Expect(updatedKCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ExtraArgs["fake-arg"]).To(Equal("fake-arg-value"))
+			})
+
+			It("when EtcdExtraArgs is empty", func() {
+				clusterUpgradeConfig := &ClusterUpgradeInfo{
+					ClusterName:      "cluster-1",
+					ClusterNamespace: constants.DefaultNamespace,
+					UpgradeComponentInfo: ComponentInfo{
+						EtcdExtraArgs:     map[string]string{},
+						KubernetesVersion: "v1.18.0+vmware.2",
+					},
+					ActualComponentInfo: ComponentInfo{
+						KubernetesVersion: "v1.18.0+vmware.1",
+					},
+				}
+
+				err = tkgClient.PatchKubernetesVersionToKubeadmControlPlane(regionalClusterClient, clusterUpgradeConfig)
+				Expect(err).To(BeNil())
+
+				updatedKCP, err := regionalClusterClient.GetKCPObjectForCluster(clusterUpgradeConfig.ClusterName, clusterUpgradeConfig.ClusterNamespace)
+				Expect(err).To(BeNil())
+				Expect(updatedKCP.ObjectMeta.Name).To(Equal("kcp-cluster-1"))
+				Expect(len(updatedKCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ExtraArgs)).To(Equal(0))
+			})
+		})
+	})
+
 	var _ = Describe("Test helper functions", func() {
 		Context("Testing the kube-vip modifier helper function", func() {
 			It("modifies the kube-vip parameters", func() {

--- a/pkg/v1/tkg/fakes/config/bom/tkr-bom-v1.18.0+vmware.1-tkg.2.yaml
+++ b/pkg/v1/tkg/fakes/config/bom/tkr-bom-v1.18.0+vmware.1-tkg.2.yaml
@@ -25,6 +25,8 @@ kubeadmConfigSpec:
       dataDir: /var/lib/etcd
       imageRepository: registry.tkg.vmware.run
       imageTag: v3.4.13_vmware.4
+      extraArgs:
+        fake-arg: fake-arg-value
   dns:
     type: CoreDNS
     imageRepository: registry.tkg.vmware.run

--- a/pkg/v1/tkg/tkgconfigbom/bom_test.go
+++ b/pkg/v1/tkg/tkgconfigbom/bom_test.go
@@ -231,7 +231,7 @@ var (
 					Expect(err).To(MatchError("No BOM file found with TKr version "))
 				})
 			})
-			Context("When tkr version is found", func() {
+			Context("When tkr version(v1.18.0+vmware.1-tkg.2) is found", func() {
 				BeforeEach(func() {
 					createTempDirectory()
 					tkgConfigDir = testingDir
@@ -245,6 +245,34 @@ var (
 				It("Should return the BOMConfiguration", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(bomConfiguration).ToNot(BeNil())
+				})
+				It("Should return the correct etcd configuration", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bomConfiguration.KubeadmConfigSpec.Etcd.Local.DataDir).To(Equal("/var/lib/etcd"))
+					Expect(bomConfiguration.KubeadmConfigSpec.Etcd.Local.ImageRepository).To(Equal("registry.tkg.vmware.run"))
+					Expect(bomConfiguration.KubeadmConfigSpec.Etcd.Local.ImageTag).To(Equal("v3.4.13_vmware.4"))
+					Expect(len(bomConfiguration.KubeadmConfigSpec.Etcd.Local.ExtraArgs)).To(Equal(1))
+					Expect(bomConfiguration.KubeadmConfigSpec.Etcd.Local.ExtraArgs["fake-arg"]).To(Equal("fake-arg-value"))
+				})
+			})
+			Context("When tkr version(v1.19.3+vmware.1-tkg.1) is found", func() {
+				BeforeEach(func() {
+					createTempDirectory()
+					tkgConfigDir = testingDir
+					setupBomFile("../fakes/config/bom/tkr-bom-v1.18.0+vmware.1-tkg.2.yaml", tkgConfigDir)
+					setupBomFile("../fakes/config/bom/tkr-bom-v1.19.3+vmware.1-tkg.1.yaml", tkgConfigDir)
+					tkrVersion = "v1.19.3+vmware.1-tkg.1"
+				})
+				AfterEach(func() {
+					deleteTempDirectory()
+				})
+				It("Should return the BOMConfiguration with valid etcd data when extraArgs not defined in KubeadmConfigSpec.Etcd.Local", func() {
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bomConfiguration).ToNot(BeNil())
+					Expect(bomConfiguration.KubeadmConfigSpec.Etcd.Local.DataDir).To(Equal("/var/lib/etcd"))
+					Expect(bomConfiguration.KubeadmConfigSpec.Etcd.Local.ImageRepository).To(Equal("registry.tkg.vmware.run"))
+					Expect(bomConfiguration.KubeadmConfigSpec.Etcd.Local.ImageTag).To(Equal("v3.4.13_vmware.4"))
+					Expect(len(bomConfiguration.KubeadmConfigSpec.Etcd.Local.ExtraArgs)).To(Equal(0))
 				})
 			})
 		})

--- a/pkg/v1/tkg/tkgconfigbom/bom_types.go
+++ b/pkg/v1/tkg/tkgconfigbom/bom_types.go
@@ -85,9 +85,10 @@ type etcd struct {
 }
 
 type localEtcd struct {
-	DataDir         string `yaml:"dataDir"`
-	ImageRepository string `yaml:"imageRepository"`
-	ImageTag        string `yaml:"imageTag"`
+	DataDir         string            `yaml:"dataDir"`
+	ImageRepository string            `yaml:"imageRepository"`
+	ImageTag        string            `yaml:"imageTag"`
+	ExtraArgs       map[string]string `yaml:"extraArgs,omitempty"`
 }
 
 type dns struct {


### PR DESCRIPTION
### What this PR does / why we need it
- As per https://groups.google.com/a/kubernetes.io/g/dev/c/B7gJs88XtQc/m/rSgNOzV2BwAJ?utm_medium=email&utm_source=footer
  there is a data corruption bug in the etcd 3.5 series.
- As part of mitigation, we need to add `experimental-initial-corrupt-check` when configuring etcd
  in the extraArgs.
- This change configures extraArgs for etcd by reading the values from TKR

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1959

### Describe testing done for PR
1. Create vsphere management cluster. 
   - `tanzu management-cluster create -f cluster-config/vsphere/mc-1/mc-1.yaml -v 6`
1. Once the management cluster gets created successfully verify the KCP resource with etcd configuration.
   - As the management-cluster deployed is using etcd v3.5.x verify the `experimental-initial-corrupt-check` is set to `true`
   - `kubectl get kcp aws-mc-1-control-plane -n tkg-system -ojson | jq '.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.extraArgs."experimental-initial-corrupt-check"'` returns `"true"`
1. Create workload cluster with v1.21 tkr which uses etcd v3.4
   - This should not include `experimental-initial-corrupt-check` configuration as part of KCP as etcd v3.4 is used
1. (pending) Upgrade the workload cluster to v1.22 tkg which uses etcd v3.5
   - After the upgrade `experimental-initial-corrupt-check: true` should be set as part of KCP configuration


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Configure etcd extraArgs from TKR during cluster creation/upgrade
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
