### PR TITLE
Add cluster pause webhook

### DIFF
--- a/addons/controllers/cluster_pause_webhook_test.go
+++ b/addons/controllers/cluster_pause_webhook_test.go
@@ -1,0 +1,98 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware-tanzu/tanzu-framework/addons/testutil"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+)
+
+const (
+	clusterpPauseWebhookManifestFile = "testdata/webhooks/cluster-pause-webhook-manifests.yaml"
+	clusterPauseWebhookScrtName      = "cluster-pause-webhook-tls"
+	clusterPauseWebhookServiceName   = "cluster-pause-webhook-service"
+	clusterPauseWebhookLabel         = "cluster-pause-webhook"
+)
+
+var _ = Describe("when cluster paused state is managed by webhook", func() {
+	JustBeforeEach(func() {
+		// Create the webhook configurations
+		f, err := os.Open(clusterpPauseWebhookManifestFile)
+		Expect(err).ToNot(HaveOccurred())
+		err = testutil.CreateResources(f, cfg, dynamicClient)
+		Expect(err).ToNot(HaveOccurred())
+		f.Close()
+
+		// set up the certificates and webhook before creating any objects
+		By("Creating and installing new certificates for ClusterBootstrap Admission Webhooks")
+		webhookCertDetails := testutil.WebhookCertificatesDetails{
+			CertPath:           certPath,
+			KeyPath:            keyPath,
+			WebhookScrtName:    clusterPauseWebhookScrtName,
+			AddonNamespace:     addonNamespace,
+			WebhookServiceName: clusterPauseWebhookServiceName,
+			LabelSelector:      clusterPauseWebhookLabel,
+		}
+		err = testutil.SetupWebhookCertificates(ctx, k8sClient, k8sConfig, &webhookCertDetails)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		By("Deleting pause webhook")
+		// Create the webhooks
+		f, err := os.Open(clusterpPauseWebhookManifestFile)
+		Expect(err).ToNot(HaveOccurred())
+		err = testutil.DeleteResources(f, cfg, dynamicClient, true)
+		Expect(err).ToNot(HaveOccurred())
+		f.Close()
+	})
+
+	Context("if cluster topology version changes", func() {
+		It("webhook should set pause state in cluster object", func() {
+			// Create a cluster object
+			cluster := &clusterapiv1beta1.Cluster{}
+			cluster.Name = "pause-test-cluster"
+			cluster.Namespace = addonNamespace
+			cluster.Spec.Topology = &clusterapiv1beta1.Topology{
+				Version: "v1.19.3---vmware.1",
+			}
+			err := k8sClient.Create(ctx, cluster)
+			Expect(err).ToNot(HaveOccurred())
+
+			// It shouldn't be paused
+			key := client.ObjectKey{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name,
+			}
+			err = k8sClient.Get(ctx, key, cluster)
+			cluster = cluster.DeepCopy()
+			Expect(err).ToNot(HaveOccurred())
+			if cluster.Annotations != nil {
+				_, ok := cluster.Annotations[constants.ClusterPauseLabel]
+				Expect(ok).ToNot(BeTrue())
+			}
+			Expect(cluster.Spec.Paused).ToNot(BeTrue())
+
+			// Update cluster version
+			cluster.Spec.Topology = &clusterapiv1beta1.Topology{
+				Version: "v1.20.5---vmware.1",
+			}
+			err = k8sClient.Update(ctx, cluster)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Cluster should be paused
+			Expect(cluster.Annotations).ToNot(BeNil())
+			Expect(cluster.Annotations[constants.ClusterPauseLabel]).To(Equal(cluster.Spec.Topology.Version))
+			Expect(cluster.Spec.Paused).To(BeTrue())
+		})
+	})
+})

--- a/addons/controllers/suite_test.go
+++ b/addons/controllers/suite_test.go
@@ -279,7 +279,7 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	err = (&cniv1alpha1.CalicoConfig{}).SetupWebhookWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
-	err = (&webhooks.Cluster{Client: k8sClient}).SetupWebhookWithManager(mgr)
+	err = (&webhooks.ClusterPause{Client: k8sClient}).SetupWebhookWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {

--- a/addons/controllers/suite_test.go
+++ b/addons/controllers/suite_test.go
@@ -279,6 +279,8 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(err).ToNot(HaveOccurred())
 	err = (&cniv1alpha1.CalicoConfig{}).SetupWebhookWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
+	err = (&webhooks.Cluster{Client: k8sClient}).SetupWebhookWithManager(mgr)
+	Expect(err).ToNot(HaveOccurred())
 
 	go func() {
 		defer GinkgoRecover()

--- a/addons/controllers/testdata/webhooks/cluster-pause-webhook-manifests.yaml
+++ b/addons/controllers/testdata/webhooks/cluster-pause-webhook-manifests.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-pause-webhook-service
+  namespace: tkg-system
+spec:
+  type: ExternalName
+  externalName: 127.0.0.1
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    webhook-cert: cluster-pause-webhook
+  name: cluster-pause-mutating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      #placeholder for cabundle. To be modifed by patch or programatically.
+      caBundle: Cg==
+      service:
+        name: cluster-pause-webhook-service
+        namespace: tkg-system
+        path: /mutate-cluster-x-k8s-io-v1beta1-cluster
+        port: 9443
+    failurePolicy: Fail
+    name: cluster.pause.mutating.vmware.com
+    rules:
+      - apiGroups:
+          - cluster.x-k8s.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - UPDATE
+        resources:
+          - clusters
+    sideEffects: None
+    timeoutSeconds: 10

--- a/addons/testutil/test_helpers.go
+++ b/addons/testutil/test_helpers.go
@@ -283,9 +283,6 @@ func SetupWebhookCertificates(ctx context.Context, k8sClient client.Client, k8sC
 	if err != nil {
 		return err
 	}
-	if len(vwcfgs.Items) == 0 {
-		return fmt.Errorf("validating Webhook Configuration List is empty")
-	}
 	for i := range vwcfgs.Items {
 		wcfg := vwcfgs.Items[i]
 		for j := range wcfg.Webhooks {
@@ -300,9 +297,6 @@ func SetupWebhookCertificates(ctx context.Context, k8sClient client.Client, k8sC
 	err = k8sClient.List(ctx, mwcfgs, &client.ListOptions{LabelSelector: labelSelector})
 	if err != nil {
 		return err
-	}
-	if len(vwcfgs.Items) == 0 {
-		return fmt.Errorf("mutating Webhook Configuration List is empty")
 	}
 	for i := range mwcfgs.Items {
 		wcfg := mwcfgs.Items[i]

--- a/pkg/v1/tkg/constants/cluster_internal.go
+++ b/pkg/v1/tkg/constants/cluster_internal.go
@@ -117,6 +117,8 @@ const (
 	AddonNameLabel = "tkg.tanzu.vmware.com/addon-name"
 	// ClusterNameLabel is the label on the Secret to indicate the cluster on which addon is to be installed
 	ClusterNameLabel = "tkg.tanzu.vmware.com/cluster-name"
+	// ClusterPauseLabel is the label on the Cluster Object to indicate the cluster is paused by TKG
+	ClusterPauseLabel = "tkg.tanzu.vmware.com/paused"
 )
 
 // TKG management package related constants

--- a/pkg/v1/webhooks/cluster_pause_webhook.go
+++ b/pkg/v1/webhooks/cluster_pause_webhook.go
@@ -17,34 +17,34 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 )
 
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-cluster-x-k8s-io-v1beta1-cluster,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=clusters,versions=v1beta1,name=default.cluster.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+// ClusterPause implements a validating and defaulting webhook for Cluster.
+type ClusterPause struct {
+	Client client.Reader
+}
+
 // SetupWebhookWithManager sets up Cluster webhooks.
-func (wh *Cluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+func (wh *ClusterPause) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(&clusterv1.Cluster{}).
 		WithDefaulter(wh).
 		Complete()
 }
 
-// +kubebuilder:webhook:verbs=create;update,path=/mutate-cluster-x-k8s-io-v1beta1-cluster,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=clusters,versions=v1beta1,name=default.cluster.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
-
-// Cluster implements a validating and defaulting webhook for Cluster.
-type Cluster struct {
-	Client client.Reader
-}
-
-var _ webhook.CustomDefaulter = &Cluster{}
+var _ webhook.CustomDefaulter = &ClusterPause{}
 
 // Default satisfies the defaulting webhook interface.
-func (wh *Cluster) Default(ctx context.Context, obj runtime.Object) error {
+func (wh *ClusterPause) Default(ctx context.Context, obj runtime.Object) error {
 	cluster, ok := obj.(*clusterv1.Cluster)
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", obj))
 	}
 
 	// Try to get the current cluster CR so we can compare the version
-	oldCluster := &clusterv1.Cluster{}
+	currentCluster := &clusterv1.Cluster{}
 	key := client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}
-	err := wh.Client.Get(ctx, key, oldCluster)
+	err := wh.Client.Get(ctx, key, currentCluster)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
@@ -55,7 +55,7 @@ func (wh *Cluster) Default(ctx context.Context, obj runtime.Object) error {
 	if cluster.Spec.Topology != nil {
 		// Add pause to cluster if the topology.version changes
 		// The cluster pause state will be unset by ClusterBootstrap controller after it rolls out package updates
-		if oldCluster.Spec.Topology == nil || cluster.Spec.Topology.Version != oldCluster.Spec.Topology.Version {
+		if currentCluster.Spec.Topology == nil || cluster.Spec.Topology.Version != currentCluster.Spec.Topology.Version {
 			cluster.Spec.Paused = true
 			if cluster.Annotations == nil {
 				cluster.Annotations = map[string]string{}

--- a/pkg/v1/webhooks/cluster_pause_webhook.go
+++ b/pkg/v1/webhooks/cluster_pause_webhook.go
@@ -1,0 +1,69 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+)
+
+// SetupWebhookWithManager sets up Cluster webhooks.
+func (wh *Cluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&clusterv1.Cluster{}).
+		WithDefaulter(wh).
+		Complete()
+}
+
+// +kubebuilder:webhook:verbs=create;update,path=/mutate-cluster-x-k8s-io-v1beta1-cluster,mutating=true,failurePolicy=fail,matchPolicy=Equivalent,groups=cluster.x-k8s.io,resources=clusters,versions=v1beta1,name=default.cluster.cluster.x-k8s.io,sideEffects=None,admissionReviewVersions=v1;v1beta1
+
+// Cluster implements a validating and defaulting webhook for Cluster.
+type Cluster struct {
+	Client client.Reader
+}
+
+var _ webhook.CustomDefaulter = &Cluster{}
+
+// Default satisfies the defaulting webhook interface.
+func (wh *Cluster) Default(ctx context.Context, obj runtime.Object) error {
+	cluster, ok := obj.(*clusterv1.Cluster)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("expected a Cluster but got a %T", obj))
+	}
+
+	// Try to get the current cluster CR so we can compare the version
+	oldCluster := &clusterv1.Cluster{}
+	key := client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}
+	err := wh.Client.Get(ctx, key, oldCluster)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if cluster.Spec.Topology != nil {
+		// Add pause to cluster if the topology.version changes
+		// The cluster pause state will be unset by ClusterBootstrap controller after it rolls out package updates
+		if oldCluster.Spec.Topology == nil || cluster.Spec.Topology.Version != oldCluster.Spec.Topology.Version {
+			cluster.Spec.Paused = true
+			if cluster.Annotations == nil {
+				cluster.Annotations = map[string]string{}
+			}
+			// Use the desired TKR version as label value, ClusterBootstrap will unset
+			cluster.Annotations[constants.ClusterPauseLabel] = cluster.Spec.Topology.Version
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Lucheng Bao <luchengb@vmware.com>

### What this PR does / why we need it
Add cluster pause webhook

This webhook will set the cluster to pause state and add TKG pause annotation when topology.version is bumped.
Later, ClusterBootstrap controller will unset the pause after it rolls out the package upgrades.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1850 

### Describe testing done for PR
Added testcase in env test

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Add cluster pause webhook
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
