### PR TITLE
Load proxy CA to TKG Management cluster and Workload cluster's node's CA trust store

### DIFF
--- a/pkg/v1/providers/ytt/03_customizations/http_proxy_ca_cert.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/http_proxy_ca_cert.yaml
@@ -1,0 +1,62 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+#@ load("/lib/helpers.star", "tkg_image_repo_customized", "tkg_image_repo_hostname", "tkg_image_repo_ca_cert", "tkg_image_repo_skip_tls_verify")
+
+#! This ytt overlay adds proxy certificate on TKG cluster nodes, so containerd and other tools trust these CA certificates.
+#! It works when using Photon or Ubuntu or Amazon linux 2 as the TKG node template on all TKG infrastructure providers.
+
+#@ if data.values.TKG_PROXY_CA_CERT != "":
+#@overlay/match by=overlay.subset({"kind":"KubeadmControlPlane"})
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+spec:
+  kubeadmConfigSpec:
+    #@overlay/match missing_ok=True
+    preKubeadmCommands:
+      #! For Photon OS
+      #@overlay/append
+      - ! which rehash_ca_certificates.sh 2>/dev/null || rehash_ca_certificates.sh
+      #! For Ubuntu
+      #@overlay/append
+      - ! which update-ca-certificates 2>/dev/null || (mv /etc/ssl/certs/tkg-custom-ca.pem /usr/local/share/ca-certificates/tkg-custom-ca.crt && update-ca-certificates)
+      #! For Amazon
+      #@overlay/append
+      - ! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)
+      #@overlay/append
+      - systemctl restart containerd
+    #@overlay/match missing_ok=True
+    files:
+      #@overlay/append
+      - path: /etc/ssl/certs/tkg-custom-ca.pem
+        content: #@ tkg_image_repo_ca_cert()
+        encoding: "base64"
+        permissions: "0444"
+#@overlay/match by=overlay.subset({"kind":"KubeadmConfigTemplate"}),expects="1+"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+spec:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      preKubeadmCommands:
+        #! For Photon OS
+        #@overlay/append
+        - ! which rehash_ca_certificates.sh 2>/dev/null || rehash_ca_certificates.sh
+        #! For Ubuntu
+        #@overlay/append
+        - ! which update-ca-certificates 2>/dev/null || (mv /etc/ssl/certs/tkg-custom-ca.pem /usr/local/share/ca-certificates/tkg-custom-ca.crt && update-ca-certificates)
+        #! For Amazon
+        #@overlay/append
+        - ! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)
+        #@overlay/append
+        - systemctl restart containerd
+      #@overlay/match missing_ok=True
+      files:
+        #@overlay/append
+        - path: /etc/ssl/certs/tkg-custom-ca.pem
+          content: #@ tkg_image_repo_ca_cert()
+          encoding: "base64"
+          permissions: "0444"
+#@ end


### PR DESCRIPTION
### What this PR does / why we need it
Currently, when using proxy with ssl termination, deploying workload that image is in docker/gcr, the workload would fail.
This is because containerd's config has the proxy ca cert mapped to projects.registry.vmware.com. It can't validate other registry with that cert.

This PR make the node VM (Management cluster and Workload cluster, not kind) trust the CA cert of proxy, so that when pulling images, containerd will trust the CA of proxy.
Kind case is kind of tricky since it can't be covered by a simple overlay and customer's are supposed to deploy workload with image from third party registry.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #https://github.com/vmware-tanzu/tanzu-framework/issues/1966

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Load proxy CA passed in `TKG_PROXY_CA_CERT ` to TKG cluster's CA trust store
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
