### PR TITLE
[v0.11.x cherry-pick]: Use log.Infof for formatted log string

### DIFF
--- a/pkg/v1/tkg/client/utils.go
+++ b/pkg/v1/tkg/client/utils.go
@@ -350,15 +350,15 @@ func (c *TkgClient) getMachineCountForMC(plan string) (int, int) {
 		if cpc%2 == 1 {
 			controlPlaneMachineCount = cpc
 		} else {
-			log.Info("Using default value for CONTROL_PLANE_MACHINE_COUNT= %d. Reason: Provided value is an even number", controlPlaneMachineCount)
+			log.Infof("Using default value for CONTROL_PLANE_MACHINE_COUNT = %d. Reason: Provided value is an even number", controlPlaneMachineCount)
 		}
 	} else {
-		log.Info("Using default value for CONTROL_PLANE_MACHINE_COUNT= %d. Reason: %s", controlPlaneMachineCount, err.Error())
+		log.Infof("Using default value for CONTROL_PLANE_MACHINE_COUNT = %d. Reason: %s", controlPlaneMachineCount, err.Error())
 	}
 	if wc, err := tkgconfighelper.GetIntegerVariableFromConfig(constants.ConfigVariableWorkerMachineCount, c.TKGConfigReaderWriter()); err == nil {
 		workerMachineCount = wc
 	} else {
-		log.Info("Using default value for WORKER_MACHINE_COUNT= %d. Reason: %s", workerMachineCount, err.Error())
+		log.Infof("Using default value for WORKER_MACHINE_COUNT = %d. Reason: %s", workerMachineCount, err.Error())
 	}
 
 	return controlPlaneMachineCount, workerMachineCount


### PR DESCRIPTION
There were a few cases where log.Info() was being used, while the
intention was to use log.Infof(). The Info() call can take a variable
number of arguments, but they are expected to be a set of key/value
pairs that will be formatted and printed. If the number of formatting
arguments is odd, or if the expected key is not a string type, this
would case a somewhat confusing error to be emitted stating "key is not
a string".

This updates the few found cases so they get the expected formatting of
output.

Signed-off-by: Sean McGinnis <smcginnis@vmware.com>
(cherry picked from commit 1bc62469ecdd4114c14b64b8ed2addc8904bb69d)
Signed-off-by: joshrosso <rossoj@vmware.com>