### PR TITLE
Add signal library, simpler context handling in plugins, and orderly shutdown of Tanzu CLI

### DIFF
--- a/cmd/cli/plugin/feature/activate.go
+++ b/cmd/cli/plugin/feature/activate.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -34,10 +33,7 @@ func featureActivate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("couldn't get featureGateRunner: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
-	defer cancel()
-
-	if err := featureGateClient.ActivateFeature(ctx, featureName, featuregate); err != nil {
+	if err := featureGateClient.ActivateFeature(cmd.Context(), featureName, featuregate); err != nil {
 		return fmt.Errorf("couldn't activate feature %s: %w", featureName, err)
 	}
 	cmd.Printf("Feature %s Activated", featureName)

--- a/cmd/cli/plugin/feature/deactivate.go
+++ b/cmd/cli/plugin/feature/deactivate.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -27,10 +26,7 @@ var FeatureDeactivateCmd = &cobra.Command{
 			return fmt.Errorf("couldn't get a featureGateRunner: %w", err)
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
-		defer cancel()
-
-		if err := featureGateClient.DeactivateFeature(ctx, featureName, featuregate); err != nil {
+		if err := featureGateClient.DeactivateFeature(cmd.Context(), featureName, featuregate); err != nil {
 			return fmt.Errorf("couldn't deactivate feature %s: %w", featureName, err)
 		}
 		cmd.Printf("Feature %s Deactivated", featureName)

--- a/cmd/cli/plugin/feature/list.go
+++ b/cmd/cli/plugin/feature/list.go
@@ -57,8 +57,7 @@ func featureList(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("couldn't get featureGateRunner: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
-	defer cancel()
+	ctx := cmd.Context()
 
 	gate, err := featureGateClient.GetFeatureGate(ctx, featuregate)
 	if crClient.IgnoreNotFound(err) != nil {

--- a/cmd/cli/plugin/feature/main.go
+++ b/cmd/cli/plugin/feature/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/aunum/log"
@@ -38,11 +39,11 @@ func main() {
 
 	ctx := signals.SetupSignalHandler()
 	ctx, cancel := context.WithTimeout(ctx, contextTimeout)
-	defer cancel()
 	p.AddContext(ctx)
 
 	if err := p.Execute(); err != nil {
-		log.Errorf("executing plugin: %w", err)
-		return
+		cancel()
+		os.Exit(1)
 	}
+	cancel()
 }

--- a/cmd/cli/plugin/feature/main.go
+++ b/cmd/cli/plugin/feature/main.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"os"
+	"context"
 	"time"
 
 	"github.com/aunum/log"
@@ -12,6 +12,7 @@ import (
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/command/plugin"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/signals"
 )
 
 var descriptor = cliv1alpha1.PluginDescriptor{
@@ -35,7 +36,13 @@ func main() {
 		FeatureDeactivateCmd,
 	)
 
+	ctx := signals.SetupSignalHandler()
+	ctx, cancel := context.WithTimeout(ctx, contextTimeout)
+	defer cancel()
+	p.AddContext(ctx)
+
 	if err := p.Execute(); err != nil {
-		os.Exit(1)
+		log.Errorf("executing plugin: %w", err)
+		return
 	}
 }

--- a/pkg/v1/cli/cmd.go
+++ b/pkg/v1/cli/cmd.go
@@ -30,13 +30,12 @@ func NewTestFor(pluginName string) *cliv1alpha1.PluginDescriptor {
 }
 
 // GetCmd returns a cobra command for the plugin.
-func GetCmd(p *cliv1alpha1.PluginDescriptor) *cobra.Command {
+func GetCmd(ctx context.Context, p *cliv1alpha1.PluginDescriptor) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   p.Name,
 		Short: p.Description,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			runner := NewRunner(p.Name, p.InstallationPath, args)
-			ctx := context.Background()
 			return runner.Run(ctx)
 		},
 		DisableFlagParsing: true,
@@ -59,7 +58,6 @@ func GetCmd(p *cliv1alpha1.PluginDescriptor) *cobra.Command {
 			completion = append(completion, toComplete)
 
 			runner := NewRunner(p.Name, p.InstallationPath, completion)
-			ctx := context.Background()
 			output, _, err := runner.RunOutput(ctx)
 			if err != nil {
 				return nil, cobra.ShellCompDirectiveError
@@ -92,7 +90,6 @@ func GetCmd(p *cliv1alpha1.PluginDescriptor) *cobra.Command {
 			completion = append(completion, toComplete)
 
 			runner := NewRunner(p.Name, p.InstallationPath, completion)
-			ctx := context.Background()
 			output, stderr, err := runner.RunOutput(ctx)
 			if err != nil || stderr != "" {
 				return nil, cobra.ShellCompDirectiveError
@@ -117,7 +114,6 @@ func GetCmd(p *cliv1alpha1.PluginDescriptor) *cobra.Command {
 
 		// Pass this new command in to our plugin to have it handle help output
 		runner := NewRunner(p.Name, p.InstallationPath, helpArgs)
-		ctx := context.Background()
 		err := runner.Run(ctx)
 		if err != nil {
 			log.Error("Help output for '%s' is not available.", c.Name())

--- a/pkg/v1/cli/command/core/root.go
+++ b/pkg/v1/cli/command/core/root.go
@@ -17,8 +17,13 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/pluginmanager"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/signals"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 )
+
+// interruptTimeout determines how long the Tanzu CLI will wait after a SIGTERM
+// or SIGINT system signal before killing plugins.
+const interruptTimeout = 30 * time.Second
 
 // RootCmd is the core root Tanzu command
 var RootCmd = &cobra.Command{
@@ -81,8 +86,9 @@ func NewRootCmd() (*cobra.Command, error) {
 		}
 	}
 
+	ctx := signals.SetupSignalHandlerWithTimeout(interruptTimeout)
 	for _, plugin := range plugins {
-		RootCmd.AddCommand(cli.GetCmd(plugin))
+		RootCmd.AddCommand(cli.GetCmd(ctx, plugin))
 	}
 
 	duplicateAliasWarning()

--- a/pkg/v1/cli/command/plugin/plugin.go
+++ b/pkg/v1/cli/command/plugin/plugin.go
@@ -4,6 +4,8 @@
 package plugin
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
@@ -13,6 +15,7 @@ import (
 // Plugin is a Tanzu CLI plugin.
 type Plugin struct {
 	Cmd *cobra.Command
+	Ctx context.Context
 }
 
 // NewPlugin creates an instance of Plugin.
@@ -29,6 +32,11 @@ func NewPlugin(descriptor *cliv1alpha1.PluginDescriptor) (*Plugin, error) {
 	p.Cmd.AddCommand(genDocsCmd)
 	p.Cmd.AddCommand(newPostInstallCmd(descriptor))
 	return p, nil
+}
+
+// AddContext allows plugins to be executed with a context.
+func (p *Plugin) AddContext(ctx context.Context) {
+	p.Ctx = ctx
 }
 
 // NewPluginFromFile create a new instance of Plugin from a file descriptor.
@@ -51,5 +59,9 @@ func (p *Plugin) AddCommands(commands ...*cobra.Command) {
 
 // Execute executes the plugin.
 func (p *Plugin) Execute() error {
+	if p.Ctx != nil {
+		return p.Cmd.ExecuteContext(p.Ctx)
+	}
+
 	return p.Cmd.Execute()
 }

--- a/pkg/v1/cli/signals/signals.go
+++ b/pkg/v1/cli/signals/signals.go
@@ -1,0 +1,57 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package signals intercepts system signals and returns a context.
+package signals
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/aunum/log"
+)
+
+// SetupSignalHandler will return a context that will be canceled if the system
+// sends either a SIGINT or SIGTERM signal.
+func SetupSignalHandler() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig, ok := <-sigCh
+		if !ok {
+			return
+		}
+
+		log.Infof("%s: shutting down", sig)
+		cancel()
+	}()
+
+	return ctx
+}
+
+// SetupSignalHandlerWithTimeout will return a context that will be canceled
+// after a specified amount of time after the system sends either a SIGINT or
+// SIGTERM signal.
+func SetupSignalHandlerWithTimeout(timeout time.Duration) context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig, ok := <-sigCh
+		if !ok {
+			return
+		}
+
+		log.Infof("%s signal: waiting %v before forcing shut down", sig, timeout)
+		<-time.After(timeout)
+		cancel()
+	}()
+
+	return ctx
+}

--- a/pkg/v1/cli/signals/signals_test.go
+++ b/pkg/v1/cli/signals/signals_test.go
@@ -1,0 +1,115 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package signals
+
+import (
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestSetupSignalHandler ensures that when a signal is sent, context channel
+// done is sent right away.
+func TestSetupSignalHandler(t *testing.T) {
+	tests := []struct {
+		desc      string
+		tolerance time.Duration
+		signal    syscall.Signal
+	}{
+		{
+			"Signal interrupt gets caught and sends context done",
+			time.Millisecond * 100,
+			syscall.SIGINT,
+		},
+		{
+			"Signal terminate gets caught and sends context done",
+			time.Millisecond * 100,
+			syscall.SIGTERM,
+		},
+	}
+
+	for _, tc := range tests {
+		ctx := SetupSignalHandler()
+
+		startTime := time.Now()
+		var wg sync.WaitGroup
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					if time.Since(startTime) > tc.tolerance {
+						t.Errorf("%s: want: immediate interrupt signal, got: no signal after %v", tc.desc, tc.tolerance)
+						return
+					}
+				}
+			}
+		}()
+
+		// Send system signal.
+		if err := syscall.Kill(syscall.Getpid(), tc.signal); err != nil {
+			t.Errorf("want: no error, got: %v", err)
+		}
+		wg.Wait()
+	}
+}
+
+func TestSetupSignalHandlerWithTimeout(t *testing.T) {
+	tests := []struct {
+		desc      string
+		waitTime  time.Duration
+		tolerance time.Duration
+		signal    syscall.Signal
+	}{
+		{
+			"Signal interrupt gets caught and sends context done after specified timeout",
+			time.Second * 1,
+			time.Millisecond * 100,
+			syscall.SIGINT,
+		},
+		{
+			"Signal terminate gets caught and sends context done after specified timeout",
+			time.Second * 1,
+			time.Millisecond * 100,
+			syscall.SIGTERM,
+		},
+	}
+
+	for _, tc := range tests {
+		ctx := SetupSignalHandlerWithTimeout(tc.waitTime)
+
+		startTime := time.Now()
+		var wg sync.WaitGroup
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					if time.Since(startTime) < tc.waitTime {
+						t.Errorf("%s: want: interrupt signal after %v, got: signal prematurely, after %v", tc.desc, tc.waitTime, time.Since(startTime))
+					}
+					return
+				default:
+					if time.Since(startTime) > (tc.waitTime + tc.tolerance) {
+						t.Errorf("%s: want: interrupt signal after %v, got: no signal after %v", tc.desc, tc.waitTime, tc.waitTime+tc.tolerance)
+						return
+					}
+				}
+			}
+		}()
+
+		// Send system signal.
+		if err := syscall.Kill(syscall.Getpid(), tc.signal); err != nil {
+			t.Errorf("want: no error, got: %v", err)
+		}
+		wg.Wait()
+	}
+}


### PR DESCRIPTION
Signed-off-by: F. Gold <fgold@vmware.com>

### What this PR does / why we need it

This PR provides a signal handling library within Tanzu Framework that plugin developers may and are encouraged to use (but not required to) to capture SIGINT and SIGTERM system signals. It updates [Plugin Developer documentation](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/cli/plugin_implementation_guide.md) explaining what the library does. This PR provides an example of how to use the library by updating the [featuregate plugin](https://github.com/vmware-tanzu/tanzu-framework/tree/main/cmd/cli/plugin/feature).

This PR also provides an easier way to pass context to all the Cobra commands a plugin executes. Context facilitates graceful shutdown of plugins by providing information as to when a program should begin to exit.

Tanzu CLI will use the new signals library to update the context that was passed while executing plugins (child processes). When a SIGTERM or SIGINT is detected, Tanzu CLI will wait a predetermined amount of time to give plugins a chance to gracefully exit. The CLI will shut down when all plugins exit or when the time runs out, whichever happens sooner.

There are a few reasons why this PR is beneficial:

- By providing a signals library, documentation, and an example, it will be easier for plugin developers to implement graceful shutdown of plugins when SIGTERM or SIGINT are sent. Currently, there is no consistency or guidance in signal handling and may lead to unnecessarily confusing user experience.
- By allowing for context to be sent during plugin execution, it will be easier for plugin developers to use a single context for all the commands in a plugin. Currently, separate contexts must be created for each command in a plugin.
- Tanzu CLI will now wait for plugins to shutdown when a SIGINT or SIGTERM is sent instead of shutting down immediately (default and current behavior). This behavior is more orderly and allows for final logging (and potentially other actions in the future) before plugins exit.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #201

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Created unit tests to ensure signals library intercepts system SIGINT and SIGTERM signals and responds in the expected amount of time.

Created a very simple plugin in my [personal repository](https://github.com/codegold79/tanzu-playground/tree/main/plugin-play) to demonstrate the signal handling and graceful shutdown works as intended when installed and run via Tanzu CLI.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Provide signals library for signal handling as well as the ability for each plugin to pass context to all its commonds upon execution. Tanzu CLI now waits for all plugins to exit or a timeout (whichever happens first) when SIGTERM or SIGINT is captured instead of attempting to shutdown immediately.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
