### PR TITLE
[release-0.11] Use go 1.16 during linter checks

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -94,12 +94,21 @@ jobs:
           - addons/pinniped/post-deploy
           - pkg/v1/providers/tests
     steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.16'
+      id: go
+
     - uses: actions/checkout@v2
 
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
         version: v1.39.0
+        # not in action.yaml! : go-version: 1.16.15
+        # skips go installation and rely on earlier setup-go step to fix go to 1.16
+        skip-go-installation: true
         args: --timeout=10m -v
         working-directory: ${{matrix.working-directory}}
 


### PR DESCRIPTION
Configure golangci-lint action to use golang 1.16 for PRs targetting release-0.11 branch

### What this PR does / why we need it
golangci-lint-action defaults to go 1.18 and gives a bunch of false negatives when linting the source on release-0.11 branch

### Which issue(s) this PR fixes

Fixes #1986

### Describe testing done for PR

Push PR and verify that linter checks now passes without any source modification.
Also see checks in test PR: https://github.com/vmware-tanzu/tanzu-framework/pull/1983

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
```release-note
None
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
