### PR TITLE
addons/pinniped/post-deploy: create pinniped-info from package

### DIFF
--- a/addons/pinniped/post-deploy/pkg/configure/configure.go
+++ b/addons/pinniped/post-deploy/pkg/configure/configure.go
@@ -328,13 +328,6 @@ func Pinniped(ctx context.Context, c Clients, inspector inspect.Inspector, p *Pa
 			zap.S().Error(err)
 			return err
 		}
-
-		// create configmap for Pinniped info
-		if err := createOrUpdatePinnipedInfo(ctx, supervisor.PinnipedInfo{
-			ConciergeIsClusterScoped: p.ConciergeIsClusterScoped,
-		}, c.K8SClientset); err != nil {
-			return err
-		}
 	} else {
 		return fmt.Errorf("unknown cluster type %s", p.ClusterType)
 	}

--- a/addons/pinniped/post-deploy/pkg/configure/configure_test.go
+++ b/addons/pinniped/post-deploy/pkg/configure/configure_test.go
@@ -83,16 +83,6 @@ func TestPinniped(t *testing.T) {
 		},
 	}
 
-	pinnipedInfoConfigMapWorkloadCluster := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "kube-public",
-			Name:      "pinniped-info",
-		},
-		Data: map[string]string{
-			"concierge_is_cluster_scoped": "true",
-		},
-	}
-
 	certificateGVR := certmanagerv1.SchemeGroupVersion.WithResource("certificates")
 	supervisorCertificate := &certmanagerv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
@@ -328,10 +318,7 @@ func TestPinniped(t *testing.T) {
 				ConciergeIsClusterScoped: true,
 			},
 			wantKubeClientActions: []kubetesting.Action{
-				// 2. Create the Pinniped info configmap
-				kubetesting.NewGetAction(configMapGVR, pinnipedInfoConfigMapWorkloadCluster.Namespace, pinnipedInfoConfigMapWorkloadCluster.Name),
-				kubetesting.NewCreateAction(configMapGVR, pinnipedInfoConfigMapWorkloadCluster.Namespace, pinnipedInfoConfigMapWorkloadCluster),
-				// 3. Look for any supervisor pods to recreate (we do this on both management and workload clusters)
+				// 2. Look for any supervisor pods to recreate (we do this on both management and workload clusters)
 				kubetesting.NewListAction(podGVR, podGVK, supervisorNamespace, metav1.ListOptions{}),
 			},
 			wantCertManagerClientActions: []kubetesting.Action{},
@@ -372,10 +359,7 @@ func TestPinniped(t *testing.T) {
 				ConciergeIsClusterScoped: true,
 			},
 			wantKubeClientActions: []kubetesting.Action{
-				// 2. Create the Pinniped info configmap
-				kubetesting.NewGetAction(configMapGVR, pinnipedInfoConfigMapWorkloadCluster.Namespace, pinnipedInfoConfigMapWorkloadCluster.Name),
-				kubetesting.NewCreateAction(configMapGVR, pinnipedInfoConfigMapWorkloadCluster.Namespace, pinnipedInfoConfigMapWorkloadCluster),
-				// 3. Look for any supervisor pods to recreate (we do this on both management and workload clusters)
+				// 2. Look for any supervisor pods to recreate (we do this on both management and workload clusters)
 				kubetesting.NewListAction(podGVR, podGVK, supervisorNamespace, metav1.ListOptions{}),
 			},
 			wantCertManagerClientActions: []kubetesting.Action{},


### PR DESCRIPTION
...instead of post-deploy job. We are trying to get rid of the post-deploy
job on the workload cluster. This is one step.

Signed-off-by: Andrew Keesler <akeesler@vmware.com>

### What this PR does / why we need it
```
    addons/pinniped/post-deploy: create pinniped-info from package

    ...instead of post-deploy job. We are trying to get rid of the post-deploy
    job on the workload cluster. This is one step.
```

### Which issue(s) this PR fixes

None

### Describe testing done for PR

* Created workload cluster to test fresh install of package
* Upgraded existing workload cluster to test upgrade of package

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

None

#### Special notes for your reviewer
 
None