### PR TITLE
Fixes vSphere network name issue

### DIFF
--- a/pkg/v1/tkg/web/node-server/src/routes/api/mockService.js
+++ b/pkg/v1/tkg/web/node-server/src/routes/api/mockService.js
@@ -229,32 +229,32 @@ router.get(`${ENDPOINT}/providers/vsphere/networks`, (req, res) => {
     let vcNetworksResponse = [
         {
             name: 'Network 1',
-            id: 'network-1',
+            moid: 'network-1',
             displayName: 'Network 1'
         },
         {
             name: 'Network 2',
-            id: 'network-2',
+            moid: 'network-2',
             displayName: 'Network 2'
         },
         {
             name: 'Network 3',
-            id: 'network-3',
+            moid: 'network-3',
             displayName: 'Network 3'
         },
         {
             name: 'Network 4',
-            id: 'network-4',
+            moid: 'network-4',
             displayName: 'Network 4'
         },
         {
             name: 'Network 5',
-            id: 'network-5',
+            moid: 'network-5',
             displayName: 'Network 5'
         },
         {
             name: 'Network 6',
-            id: 'network-6',
+            moid: 'network-6',
             displayName: 'Network 6'
         }
     ];

--- a/pkg/v1/tkg/web/src/app/views/landing/docker-wizard/docker-wizard.component.ts
+++ b/pkg/v1/tkg/web/src/app/views/landing/docker-wizard/docker-wizard.component.ts
@@ -71,7 +71,6 @@ export class DockerWizardComponent extends WizardBaseDirective implements OnInit
     }
 
     setFromPayload(payload: DockerRegionalClusterParams) {
-        this.setFieldValue(WizardForm.NETWORK, NetworkField.NETWORK_NAME, payload.networking.networkName);
         this.setFieldValue(WizardForm.NETWORK, NetworkField.CLUSTER_SERVICE_CIDR,  payload.networking.clusterServiceCIDR);
         this.setFieldValue(WizardForm.NETWORK, NetworkField.CLUSTER_POD_CIDR,  payload.networking.clusterPodCIDR);
         this.setFieldValue(WizardForm.NETWORK, NetworkField.CNI_TYPE,  payload.networking.cniType);
@@ -87,7 +86,6 @@ export class DockerWizardComponent extends WizardBaseDirective implements OnInit
         const payload: DockerRegionalClusterParams = {}
 
         payload.networking = {
-            networkName: this.getFieldValue(WizardForm.NETWORK, NetworkField.NETWORK_NAME),
             clusterDNSName: '',
             clusterNodeCIDR: '',
             clusterServiceCIDR: this.getFieldValue(WizardForm.NETWORK, NetworkField.CLUSTER_SERVICE_CIDR),

--- a/pkg/v1/tkg/web/src/app/views/landing/wizard/shared/wizard-base/wizard-base.ts
+++ b/pkg/v1/tkg/web/src/app/views/landing/wizard/shared/wizard-base/wizard-base.ts
@@ -365,8 +365,12 @@ export abstract class WizardBaseDirective extends BasicSubscriber implements Wiz
      * @param payload
      */
     initPayloadWithCommons(payload: any) {
+        // The network name field is only used by vSphere. If it is populated, the value of the field is an OBJECT, whose name field
+        // should be considered the network name.
+        // TODO: refactor to move vSphere-specific assignment to vSphere wizard (or to vSphere network step, if steps fill out the payload)
+        const selectedNetwork = this.getFieldValue(WizardForm.NETWORK, NetworkField.NETWORK_NAME);
         payload.networking = {
-            networkName: this.getFieldValue(WizardForm.NETWORK, NetworkField.NETWORK_NAME),
+            networkName: selectedNetwork ? selectedNetwork.name : '',
             clusterDNSName: '',
             clusterNodeCIDR: '',
             clusterServiceCIDR: this.getFieldValue(WizardForm.NETWORK, NetworkField.CLUSTER_SERVICE_CIDR),


### PR DESCRIPTION
### Which issue(s) this PR fixes
Fixes issue (no GitHub issue created) where vSphere network name (in create payload) is currently set to an object instead of a string (field from within object)

### Describe testing done for PR
Local testing