### PR TITLE
ensure TKG_NO_PROXY value is stored in sorted order

### DIFF
--- a/pkg/v1/providers/ytt/09_miscellaneous/08_store_data_values.yaml
+++ b/pkg/v1/providers/ytt/09_miscellaneous/08_store_data_values.yaml
@@ -20,9 +20,16 @@
 
 #@ for configVariable in kvs:
 
+
 #@ if configVariable not in list_skip_variable_from_storing and data.values.PROVIDER_TYPE in kvs[configVariable]:
+#@ value = data.values[configVariable]
+#@ if configVariable == "TKG_NO_PROXY":
+#@   no_proxy_list = data.values.TKG_NO_PROXY.split(",")
+#@   value = ",".join(sorted(list(set(no_proxy_list))))
+#@ end
+
 #@yaml/text-templated-strings
-(@= configVariable @): #@ data.values[configVariable]
+(@= configVariable @): #@ value
 #@ end
 
 #@ end


### PR DESCRIPTION
### What this PR does / why we need it

Fixes the remaining case of #1877 where the config-values Secret is still
storing the no proxy value in arbitrary order, causing some unnecessary
noise in clustergen tests.


### Which issue(s) this PR fixes

Fixes: #1877

### Describe testing done for PR
```
make clustergen
```
verified that remaining no_proxy diffs are gone

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note

```release-note
None
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- x Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- x Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- x Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
