### PR TITLE
adding vspherecsiconfig crd & running 'vendir sync'

### DIFF
--- a/packages/management/addons-manager-v2/bundle/config/upstream/csi.tanzu.vmware.com_vspherecsiconfigs.yaml
+++ b/packages/management/addons-manager-v2/bundle/config/upstream/csi.tanzu.vmware.com_vspherecsiconfigs.yaml
@@ -1,0 +1,117 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: vspherecsiconfigs.csi.tanzu.vmware.com
+spec:
+  group: csi.tanzu.vmware.com
+  names:
+    kind: VSphereCSIConfig
+    listKind: VSphereCSIConfigList
+    plural: vspherecsiconfigs
+    singular: vspherecsiconfig
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VSphereCSIConfig is the Schema for the vspherecsiconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereCSIConfigSpec defines the desired state of VSphereCSIConfig
+            properties:
+              vsphereCSI:
+                properties:
+                  config:
+                    properties:
+                      attachTimeout:
+                        type: string
+                      clusterName:
+                        type: string
+                      datacenter:
+                        type: string
+                      deploymentReplicas:
+                        format: int32
+                        type: integer
+                      httpProxy:
+                        type: string
+                      httpsProxy:
+                        type: string
+                      insecureFlag:
+                        type: boolean
+                      namespace:
+                        description: The namespace csi components are to be deployed
+                          in
+                        type: string
+                      noProxy:
+                        type: string
+                      password:
+                        type: string
+                      provisionTimeout:
+                        type: string
+                      publicNetwork:
+                        type: string
+                      region:
+                        type: string
+                      resizerTimeout:
+                        type: string
+                      server:
+                        type: string
+                      tlsThumbprint:
+                        type: string
+                      useTopologyCategories:
+                        type: boolean
+                      username:
+                        type: string
+                      vSphereVersion:
+                        type: string
+                      windowsSupport:
+                        type: boolean
+                      zone:
+                        type: string
+                    type: object
+                  mode:
+                    description: The vSphere mode. Either `vsphereCSI` or `vsphereParavirtualCSI`.
+                    enum:
+                    - vsphereCSI
+                    - vsphereParavirtualCSI
+                    type: string
+                required:
+                - mode
+                type: object
+            required:
+            - vsphereCSI
+            type: object
+          status:
+            description: VSphereCSIConfigStatus defines the observed state of VSphereCSIConfig
+            properties:
+              secretRef:
+                description: Name of the secret created by csi controller
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/packages/management/addons-manager-v2/vendir.lock.yml
+++ b/packages/management/addons-manager-v2/vendir.lock.yml
@@ -39,6 +39,14 @@ directories:
       tags:
       - v0.19.0-dev-33-ga0788c22
     path: cpi.tanzu.vmware.com_vspherecpiconfigs.yaml
+  - git:
+      commitTitle: adding vspherecsiconfig api and controller (#2046)
+      sha: 9d1b2568aee9fee17b12e85a8ca3fe29c391473a
+      tags:
+      - v0.21.0-dev-50-g9d1b2568
+    path: csi.tanzu.vmware.com_vspherecsiconfigs.yaml
+  - manual: {}
+    path: cni-webhook-manifests.lib.yaml
   path: bundle/config/upstream
 - contents:
   - manual: {}

--- a/packages/management/addons-manager-v2/vendir.yml
+++ b/packages/management/addons-manager-v2/vendir.yml
@@ -48,6 +48,15 @@ directories:
         newRootPath: config/crd/bases/cpi.tanzu.vmware.com_vspherecpiconfigs.yaml
         includePaths:
           - config/crd/bases/cpi.tanzu.vmware.com_vspherecpiconfigs.yaml
+      - path: csi.tanzu.vmware.com_vspherecsiconfigs.yaml
+        git:
+          url: git@github.com:vmware-tanzu/tanzu-framework.git
+          ref: 9d1b2568aee9fee17b12e85a8ca3fe29c391473a
+        newRootPath: config/crd/bases/csi.tanzu.vmware.com_vspherecsiconfigs.yaml
+        includePaths:
+          - config/crd/bases/csi.tanzu.vmware.com_vspherecsiconfigs.yaml
+      - path: cni-webhook-manifests.lib.yaml
+        manual: {}
   - path: bundle/config/overlays
     contents:
       - path: feature-gate-clusterbootstrap.yaml


### PR DESCRIPTION
### What this PR does / why we need it
follow up to : https://github.com/vmware-tanzu/tanzu-framework/pull/2046

- We are adding 'csi.tanzu.vmware.com_vspherecsiconfigs.yaml' to vendir.yml for addons-manager-v2
- Ran 'vendir sync' with updated the contents of 'packages/management/addons-manager-v2/bundle/config/upstream/'

### Which issue(s) this PR fixes
Fixes #1579

### Describe testing done for PR
Built the package and deployed on a kind cluster and ensure vsphere csi CRD is up and running

### Release note
```
package-based-lcm: Add VSphereCSIConfig CRD to addons-manager package
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
