### PR TITLE
Prevent host network pods from getting kube-vip address on clusters with IPv6 as the primary IP family

### DIFF
--- a/pkg/v1/providers/infrastructure-vsphere/v1.1.0/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.1.0/ytt/overlay.yaml
@@ -235,12 +235,6 @@ spec:
         #@ end
         bindPort: #@ data.values.CLUSTER_API_SERVER_PORT
       #@ end
-      #@ if data.values.TKG_IP_FAMILY == "ipv6,ipv4":
-      nodeRegistration:
-        kubeletExtraArgs:
-          #@overlay/match missing_ok=True
-          node-ip: "::"
-      #@ end
     joinConfiguration:
       #@ if (not data.values.AVI_CONTROL_PLANE_HA_PROVIDER) and data.values.CLUSTER_API_SERVER_PORT:
       #@overlay/match missing_ok=True
@@ -252,12 +246,6 @@ spec:
           advertiseAddress: '0.0.0.0'
           #@ end
           bindPort: #@ data.values.CLUSTER_API_SERVER_PORT
-      #@ end
-      #@ if data.values.TKG_IP_FAMILY == "ipv6,ipv4":
-      nodeRegistration:
-        kubeletExtraArgs:
-          #@overlay/match missing_ok=True
-          node-ip: "::"
       #@ end
     clusterConfiguration:
       imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.imageRepository)
@@ -302,6 +290,13 @@ spec:
     #@overlay/remove
     - content:
     #@ end
+    #@ if data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"]:
+    #@overlay/append
+    - content: ""
+      owner: root:root
+      path: /etc/sysconfig/kubelet
+      permissions: "0640"
+    #@ end
     users:
     #@overlay/match by=overlay.index(0)
     #@overlay/replace
@@ -315,6 +310,15 @@ spec:
     postKubeadmCommands:
     #@overlay/append
     - sed -i '/listen-client-urls/ s/$/,https:\/\/127.0.0.1:2379/' /etc/kubernetes/manifests/etcd.yaml
+    #@ end
+    #! When using kube-vip as the control plane endpoint provider with IPv6 as
+    #! the primary IP family, set --node-ip on kubelet so that host network pods
+    #! do not get the kube-vip address as their pod IP.
+    #! See: https://github.com/vmware-tanzu/tanzu-framework/issues/2098
+    #@ if not data.values.AVI_CONTROL_PLANE_HA_PROVIDER and data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"]:
+    preKubeadmCommands:
+    #@overlay/append
+    - echo "KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)" >> /etc/sysconfig/kubelet
     #@ end
   replicas: #@ data.values.CONTROL_PLANE_MACHINE_COUNT
   version: #@ data.values.KUBERNETES_VERSION

--- a/pkg/v1/providers/tests/unit/ip_family_test.go
+++ b/pkg/v1/providers/tests/unit/ip_family_test.go
@@ -357,7 +357,19 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.advertiseAddress", "0.0.0.0"))
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.bindPort", "443"))
 				})
+				It("does not configure node ip in KUBELET_EXTRA_ARGS in /etc/sysconfig/kubelet", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
 
+					kubeadmControlPlaneDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "KubeadmControlPlane",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(kubeadmControlPlaneDocs).To(HaveLen(1))
+					Expect(kubeadmControlPlaneDocs[0]).NotTo(HaveYAMLPath("$.spec.kubeadmConfigSpec.files[1]"))
+					Expect(kubeadmControlPlaneDocs[0]).NotTo(HaveYAMLPath("$.spec.kubeadmConfigSpec.preKubeadmCommands[5]"))
+				})
 			})
 
 			When("data values are set to single stack IPv6 settings", func() {
@@ -402,6 +414,22 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.initConfiguration.localAPIEndpoint.bindPort", "443"))
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.advertiseAddress", "::/0"))
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.bindPort", "443"))
+				})
+				It("configures node-ip on the control plane nodes by echoing the detected node ip into KUBELET_EXTRA_ARGS in /etc/sysconfig/kubelet", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					kubeadmControlPlaneDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "KubeadmControlPlane",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(kubeadmControlPlaneDocs).To(HaveLen(1))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].content", ""))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].owner", "root:root"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].path", "/etc/sysconfig/kubelet"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].permissions", "0640"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.preKubeadmCommands[5]", "echo \"KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)\" >> /etc/sysconfig/kubelet"))
 				})
 			})
 
@@ -495,6 +523,19 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 					Expect(kubeadmConfigTemplateDocs).To(HaveLen(1))
 					Expect(kubeadmConfigTemplateDocs[0]).NotTo(HaveYAMLPath("$.spec.template.spec.joinConfiguration.nodeRegistration.kubeletExtraArgs.node-ip"))
 				})
+				It("does not configure node ip in KUBELET_EXTRA_ARGS in /etc/sysconfig/kubelet", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					kubeadmControlPlaneDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "KubeadmControlPlane",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(kubeadmControlPlaneDocs).To(HaveLen(1))
+					Expect(kubeadmControlPlaneDocs[0]).NotTo(HaveYAMLPath("$.spec.kubeadmConfigSpec.files[1]"))
+					Expect(kubeadmControlPlaneDocs[0]).NotTo(HaveYAMLPath("$.spec.kubeadmConfigSpec.preKubeadmCommands[5]"))
+				})
 			})
 
 			When("data values are set to ipv6,ipv4 dual stack settings", func() {
@@ -567,7 +608,7 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 					Expect(kubeadmControlPlaneDocs).To(HaveLen(1))
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.clusterConfiguration.apiServer.extraArgs.advertise-address", "2001:db8::2"))
 				})
-				It("renders control plane template to configure kubelet with '::' as the node IP", func() {
+				It("does not render node-ip field for control plane nodes", func() {
 					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
 					Expect(err).NotTo(HaveOccurred())
 
@@ -577,8 +618,12 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(kubeadmControlPlaneDocs).To(HaveLen(1))
-					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.initConfiguration.nodeRegistration.kubeletExtraArgs.node-ip", "::"))
-					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.nodeRegistration.kubeletExtraArgs.node-ip", "::"))
+					Expect(kubeadmControlPlaneDocs[0]).NotTo(HaveYAMLPath("$.spec.kubeadmConfigSpec.initConfiguration.nodeRegistration.kubeletExtraArgs.node-ip"))
+					Expect(kubeadmControlPlaneDocs[0]).NotTo(HaveYAMLPath("$.spec.kubeadmConfigSpec.joinConfiguration.nodeRegistration.kubeletExtraArgs.node-ip"))
+				})
+				It("configures kubelet on the worker nodes with '::' as the node IP", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
 
 					kubeadmConfigTemplateDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
 						"$.kind": "KubeadmConfigTemplate",
@@ -587,6 +632,22 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 
 					Expect(kubeadmConfigTemplateDocs).To(HaveLen(1))
 					Expect(kubeadmConfigTemplateDocs[0]).To(HaveYAMLPathWithValue("$.spec.template.spec.joinConfiguration.nodeRegistration.kubeletExtraArgs.node-ip", "::"))
+				})
+				It("configures node-ip on the control plane nodes by echoing the detected node ip into KUBELET_EXTRA_ARGS in /etc/sysconfig/kubelet", func() {
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					kubeadmControlPlaneDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "KubeadmControlPlane",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(kubeadmControlPlaneDocs).To(HaveLen(1))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].content", ""))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].owner", "root:root"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].path", "/etc/sysconfig/kubelet"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].permissions", "0640"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.preKubeadmCommands[5]", "echo \"KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)\" >> /etc/sysconfig/kubelet"))
 				})
 			})
 		})


### PR DESCRIPTION
On IPv6 only clusters or dual stack clusters with IPv6 as the primary IP
family, configure `--node-ip` for kubelet on the control plane nodes to
the first detected IP address prior to launching kube-vip.

Otherwise, prior to cloud-provider vsphere taking over, kubelet will use
the kube-vip address as the node IP and host network pods that start up
early will get this address set as their pod IP.

See: https://github.com/vmware-tanzu/tanzu-framework/issues/2098

### What this PR does / why we need it

### Which issue(s) this PR fixes

Fixes #2098

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Created vSphere workload cluster to verify change. 

Some details:

Contents of `/etc/sysconfig/kubelet` on the control plane node:
```
root@grapefruit-control-plane-6wgj7:~# cat /etc/sysconfig/kubelet
KUBELET_EXTRA_ARGS=--node-ip=fd01:1:2:2915:0:a:0:1eb2
```

kubelet process args:
```
root@grapefruit-control-plane-6wgj7:~# ps -ef | grep /usr/bin/kubelet | grep -v grep
root        1993       1  4 18:59 ?        00:00:26 /usr/bin/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --config=/var/lib/kubelet/config.yaml --cloud-provider=external --container-runtime=remote --container-runtime-endpoint=/var/run/containerd/containerd.sock --pod-infra-container-image=projects-stg.registry.vmware.com/tkg/pause:3.5 --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 --node-ip=fd01:1:2:2915:0:a:0:1eb2
```

...just that arg:
```
root@grapefruit-control-plane-6wgj7:~# ps -ef | grep /usr/bin/kubelet | grep -v grep | awk '{print $17}'
--node-ip=fd01:1:2:2915:0:a:0:1eb2
```

IP addresses on device after kube-vip is up with control plane endpoint IP `fd01:1:2:2915:0:a:cccc:81b7`:
```
root@grapefruit-control-plane-6wgj7:~# ip addr show dev eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 00:50:56:bd:6d:7d brd ff:ff:ff:ff:ff:ff
    inet6 fd01:1:2:2915:0:a:cccc:81b7/128 scope global
       valid_lft forever preferred_lft forever
    inet6 fd01:1:2:2915:0:a:0:1eb2/128 scope global dynamic noprefixroute
       valid_lft 42769sec preferred_lft 26569sec
    inet6 fd01:1:2:2915:250:56ff:febd:6d7d/64 scope global dynamic mngtmpaddr noprefixroute
       valid_lft 2591961sec preferred_lft 604761sec
    inet6 fe80::250:56ff:febd:6d7d/64 scope link
       valid_lft forever preferred_lft forever
```

no pods using that address:
```
kubo@ubuntu-2004:~$ kubectl get po -A -o wide
NAMESPACE      NAME                                                     READY   STATUS    RESTARTS        AGE     IP                         NODE                               NOMINATED NODE   READINESS GATES
kube-system    antrea-agent-8sw87                                       2/2     Running   0               8m42s   fd01:1:2:2915:0:a:0:1eb2   grapefruit-control-plane-6wgj7     <none>           <none>
kube-system    antrea-agent-xsvvb                                       2/2     Running   0               8m42s   fd01:1:2:2915:0:a:0:2ff    grapefruit-md-0-6b58fff55f-54r76   <none>           <none>
kube-system    antrea-controller-6787fc968f-s8l5q                       1/1     Running   0               8m42s   fd01:1:2:2915:0:a:0:2ff    grapefruit-md-0-6b58fff55f-54r76   <none>           <none>
kube-system    coredns-67cdb6d6ff-6hjxk                                 1/1     Running   0               11m     fd00:100:64::3             grapefruit-control-plane-6wgj7     <none>           <none>
kube-system    coredns-67cdb6d6ff-hz4kg                                 1/1     Running   0               11m     fd00:100:64:1::5           grapefruit-md-0-6b58fff55f-54r76   <none>           <none>
kube-system    etcd-grapefruit-control-plane-6wgj7                      1/1     Running   1 (13m ago)     13m     fd01:1:2:2915:0:a:0:1eb2   grapefruit-control-plane-6wgj7     <none>           <none>
kube-system    kube-apiserver-grapefruit-control-plane-6wgj7            1/1     Running   0               13m     fd01:1:2:2915:0:a:0:1eb2   grapefruit-control-plane-6wgj7     <none>           <none>
kube-system    kube-controller-manager-grapefruit-control-plane-6wgj7   1/1     Running   1 (12m ago)     13m     fd01:1:2:2915:0:a:0:1eb2   grapefruit-control-plane-6wgj7     <none>           <none>
kube-system    kube-proxy-k2d7j                                         1/1     Running   0               11m     fd01:1:2:2915:0:a:0:1eb2   grapefruit-control-plane-6wgj7     <none>           <none>
kube-system    kube-proxy-rqzlw                                         1/1     Running   0               10m     fd01:1:2:2915:0:a:0:2ff    grapefruit-md-0-6b58fff55f-54r76   <none>           <none>
kube-system    kube-scheduler-grapefruit-control-plane-6wgj7            1/1     Running   1 (12m ago)     13m     fd01:1:2:2915:0:a:0:1eb2   grapefruit-control-plane-6wgj7     <none>           <none>
kube-system    kube-vip-grapefruit-control-plane-6wgj7                  1/1     Running   1 (12m ago)     13m     fd01:1:2:2915:0:a:0:1eb2   grapefruit-control-plane-6wgj7     <none>           <none>
kube-system    metrics-server-7487f985b6-qsfjd                          1/1     Running   0               8m56s   fd00:100:64:1::3           grapefruit-md-0-6b58fff55f-54r76   <none>           <none>
kube-system    vsphere-cloud-controller-manager-lsxnk                   1/1     Running   0               7m50s   fd01:1:2:2915:0:a:0:1eb2   grapefruit-control-plane-6wgj7     <none>           <none>
kube-system    vsphere-csi-controller-778b56445d-lv8ht                  6/6     Running   0               8m55s   fd00:100:64::2             grapefruit-control-plane-6wgj7     <none>           <none>
kube-system    vsphere-csi-node-cjgc4                                   3/3     Running   3 (7m39s ago)   8m55s   fd01:1:2:2915:0:a:0:1eb2   grapefruit-control-plane-6wgj7     <none>           <none>
kube-system    vsphere-csi-node-z7kx6                                   3/3     Running   3 (7m50s ago)   8m55s   fd01:1:2:2915:0:a:0:2ff    grapefruit-md-0-6b58fff55f-54r76   <none>           <none>
tanzu-system   secretgen-controller-589bd78769-vvwrz                    1/1     Running   0               8m54s   fd00:100:64:1::4           grapefruit-md-0-6b58fff55f-54r76   <none>           <none>
tkg-system     kapp-controller-5f794bcd7f-cfw82                         1/1     Running   0               11m     fd01:1:2:2915:0:a:0:1eb2   grapefruit-control-plane-6wgj7     <none>           <none>
tkg-system     tanzu-capabilities-controller-manager-54c564c7c6-242hh   1/1     Running   0               11m     fd00:100:64:1::2           grapefruit-md-0-6b58fff55f-54r76   <none>           <none>
```

these are all the pod IPs used:
```
kubo@ubuntu-2004:~$ kubectl get po -A -o json | jq -r .items[].status.podIPs[].ip | sort | uniq
fd00:100:64:1::2
fd00:100:64:1::3
fd00:100:64:1::4
fd00:100:64:1::5
fd00:100:64::2
fd00:100:64::3
fd01:1:2:2915:0:a:0:1eb2
fd01:1:2:2915:0:a:0:2ff
```


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixed issue where some host network pods get pod IP set to kube-vip control plane endpoint address on clusters with IPv6 as the primary IP family
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
