### PR TITLE
Pick new key for golangci-lint cache

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -93,7 +93,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ${{ runner.temp }}/lint_cache
-        key: ${{ runner.os }}-lint-cache
+        key: ${{ runner.os }}-lint-cache-2
 
     - name: Run lint checks
       env:


### PR DESCRIPTION
### What this PR does / why we need it

It appears the linter cache saved atm is causing linter errors for some
reason. Picking a new key to force a regen.


### Which issue(s) this PR fixes


Closes: #2135

### Describe testing done for PR

Monitoring current lint check.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- x Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- x Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- x Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
