### PR TITLE
addons/pinniped/config-controller: update secret when wlc is created or updated

### DIFF
--- a/addons/pinniped/config-controller/controllers/constants.go
+++ b/addons/pinniped/config-controller/controllers/constants.go
@@ -3,12 +3,6 @@
 
 package controllers
 
-import (
-	"reflect"
-
-	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
-)
-
 const (
 	//TODO: I kinda don't like that we're copying a lot of these from addons/pkg/constants
 
@@ -102,6 +96,3 @@ const (
 ---
 `
 )
-
-// clusterKind is the Kind for cluster-api Cluster object
-var clusterKind = reflect.TypeOf(clusterapiv1beta1.Cluster{}).Name()

--- a/addons/pinniped/config-controller/controllers/utils.go
+++ b/addons/pinniped/config-controller/controllers/utils.go
@@ -9,11 +9,8 @@ import (
 	"reflect"
 	"strings"
 
-	"gopkg.in/yaml.v3"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
 	"github.com/go-logr/logr"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -167,47 +164,6 @@ func getClusterFromSecret(ctx context.Context, c client.Client, secret *corev1.S
 	}
 
 	return cluster, nil
-}
-
-// clusterHasLabel checks if the cluster has the given label... copy from predicates/tkr.go.... could we use that directly?
-func clusterHasLabel(label string, logger logr.Logger) predicate.Funcs {
-	return predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return processIfClusterHasLabel(label, e.ObjectNew, logger.WithValues("predicate", "updateEvent"))
-		},
-		CreateFunc: func(e event.CreateEvent) bool {
-			return processIfClusterHasLabel(label, e.Object, logger.WithValues("predicate", "createEvent"))
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return processIfClusterHasLabel(label, e.Object, logger.WithValues("predicate", "deleteEvent"))
-		},
-		GenericFunc: func(e event.GenericEvent) bool {
-			return processIfClusterHasLabel(label, e.Object, logger.WithValues("predicate", "genericEvent"))
-		},
-	}
-}
-
-// processIfClusterHasLabel determines if the input object is a cluster with a non-empty
-// value for the specified label. For other input object types, it returns true
-func processIfClusterHasLabel(label string, obj client.Object, log logr.Logger) bool {
-	kind := obj.GetObjectKind().GroupVersionKind().Kind
-
-	if kind != clusterKind {
-		return true
-	}
-
-	labels := obj.GetLabels()
-	if labels != nil {
-		if l, ok := labels[label]; ok && l != "" {
-			return true
-		}
-	}
-
-	log.V(1).Info("Cluster resource does not have label",
-		"label", label,
-		clusterNamespaceLogKey, obj.GetNamespace(),
-		clusterNameLogKey, obj.GetName())
-	return false
 }
 
 // getMutateFn returns a function that updates the "values.yaml" section of the given secret

--- a/addons/pinniped/config-controller/controllers/utils_test.go
+++ b/addons/pinniped/config-controller/controllers/utils_test.go
@@ -53,6 +53,24 @@ func updateObject(ctx context.Context, o client.Object) {
 	}).Should(Succeed())
 }
 
+func verifyNoSecretFunc(ctx context.Context, cluster *clusterapiv1beta1.Cluster, isV1 bool) func(Gomega) {
+	return func(g Gomega) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cluster.Namespace,
+				Name:      fmt.Sprintf("%s-pinniped.tanzu.vmware.com-package", cluster.Name),
+			},
+		}
+
+		if isV1 {
+			secret.Name = fmt.Sprintf("%s-pinniped-addon", cluster.Name)
+		}
+
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)
+		g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+	}
+}
+
 func verifySecretFunc(ctx context.Context, cluster *clusterapiv1beta1.Cluster, configMap *corev1.ConfigMap, isV1 bool) func(Gomega) {
 	return func(g Gomega) {
 		clusterCopy := cluster.DeepCopy()

--- a/addons/pinniped/config-controller/controllers/v3_controller_test.go
+++ b/addons/pinniped/config-controller/controllers/v3_controller_test.go
@@ -294,15 +294,32 @@ var _ = Describe("Controller", func() {
 				deleteObject(ctx, s)
 			}
 		})
-		When("the configmap gets created", func() {
-			BeforeEach(func() {
-				createObject(ctx, configMap)
+		Context("the configmap gets created", func() {
+			When("there are no ClusterBootstrap secrets", func() {
+				BeforeEach(func() {
+					for _, s := range secrets {
+						deleteObject(ctx, s)
+					}
+					createObject(ctx, configMap)
+				})
+
+				It("does not create any secrets", func() {
+					for _, c := range clusters {
+						Eventually(verifyNoSecretFunc(ctx, c, false)).Should(Succeed())
+					}
+				})
 			})
 
-			It("updates all the ClusterBootstrap secrets", func() {
-				for _, c := range clusters {
-					Eventually(verifySecretFunc(ctx, c, configMap, false)).Should(Succeed())
-				}
+			When("there are ClusterBootstrap secrets", func() {
+				BeforeEach(func() {
+					createObject(ctx, configMap)
+				})
+
+				It("updates all the ClusterBootstrap secrets", func() {
+					for _, c := range clusters {
+						Eventually(verifySecretFunc(ctx, c, configMap, false)).Should(Succeed())
+					}
+				})
 			})
 		})
 


### PR DESCRIPTION
### What this PR does / why we need it
Update Pinniped addon secret (v1alpha1) if configmap present and workload cluster is created or updated.

### Which issue(s) this PR fixes

Fixes #

### Describe testing done for PR
Added unit tests, tested v1alpha1 and v1alpha3 on TKG cluster in vSphere

### Release note
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
