### PR TITLE
addons/pinniped/config-controller: delete secret when wlc deleted

### DIFF
--- a/addons/pinniped/config-controller/controllers/utils.go
+++ b/addons/pinniped/config-controller/controllers/utils.go
@@ -225,6 +225,13 @@ func getMutateFn(secret *corev1.Secret, pinnipedInfoCM *corev1.ConfigMap, cluste
 	}
 }
 
+func secretNameFromClusterName(clusterName types.NamespacedName) types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: clusterName.Namespace,
+		Name:      fmt.Sprintf("%s-pinniped-addon", clusterName.Name),
+	}
+}
+
 type pinnipedDataValues struct {
 	IdentityManagementType string   `yaml:"identity_management_type,omitempty"`
 	Infrastructure         string   `yaml:"infrastructure_provider,omitempty"`

--- a/addons/pinniped/config-controller/controllers/v1_controller_test.go
+++ b/addons/pinniped/config-controller/controllers/v1_controller_test.go
@@ -134,6 +134,34 @@ var _ = Describe("Controller", func() {
 				})
 			})
 		})
+
+		Context("cluster is deleted", func() {
+			When("there is no pinniped-info configmap", func() {
+				BeforeEach(func() {
+					deleteObject(ctx, cluster)
+				})
+
+				It("does not create a secret", func() {
+					Eventually(verifyNoSecretFunc(ctx, cluster, true)).Should(Succeed())
+				})
+			})
+
+			When("there is a pinniped-info configmap", func() {
+				BeforeEach(func() {
+					createObject(ctx, configMap)
+					Eventually(verifySecretFunc(ctx, cluster, configMap, true)).Should(Succeed())
+					deleteObject(ctx, cluster)
+				})
+
+				AfterEach(func() {
+					deleteObject(ctx, configMap)
+				})
+
+				It("deletes the secret", func() {
+					Eventually(verifyNoSecretFunc(ctx, cluster, true)).Should(Succeed())
+				})
+			})
+		})
 	})
 
 	Context("pinniped-info configmap", func() {

--- a/addons/pinniped/config-controller/controllers/v3_controller.go
+++ b/addons/pinniped/config-controller/controllers/v3_controller.go
@@ -105,6 +105,7 @@ func (c *PinnipedV3Controller) Reconcile(ctx context.Context, req ctrl.Request) 
 
 func (c *PinnipedV3Controller) reconcileSecret(ctx context.Context, secret *corev1.Secret, pinnipedInfoCM *corev1.ConfigMap, log logr.Logger) error {
 	// check if secret is scheduled for deletion, if so, skip reconcile
+	log = log.WithValues(secretNamespaceLogKey, secret.Namespace, secretNameLogKey, secret.Name)
 	if !secret.GetDeletionTimestamp().IsZero() {
 		log.V(1).Info("secret is getting deleted, skipping reconcile")
 		return nil
@@ -152,7 +153,7 @@ func (c *PinnipedV3Controller) reconcileDataValues(ctx context.Context, secret *
 		return err
 	}
 
-	log.Info("finished creating/patching", "result", result)
+	log.Info("finished reconciling secret", "result", result)
 
 	return nil
 }

--- a/addons/pinniped/config-controller/manifests/role.yaml
+++ b/addons/pinniped/config-controller/manifests/role.yaml
@@ -19,6 +19,7 @@ rules:
   - secrets
   verbs:
   - create
+  - delete
   - get
   - list
   - patch


### PR DESCRIPTION
### What this PR does / why we need it
Delete Pinniped addon secret (v1alpha1) if secret exists and workload cluster is deleted.

### Which issue(s) this PR fixes

Fixes #

### Describe testing done for PR
Added unit tests, tested v1alpha1 and v1alpha3 on TKG cluster in vSphere

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
