### PR TITLE
TKR Resolver: Use cluster variables

### DIFF
--- a/apis/run/v1alpha3/tanzukubernetesrelease_types.go
+++ b/apis/run/v1alpha3/tanzukubernetesrelease_types.go
@@ -21,9 +21,8 @@ const (
 	AnnotationResolveOSImage = "run.tanzu.vmware.com/resolve-os-image"
 	AnnotationOSImageRef     = "run.tanzu.vmware.com/os-image-ref"
 
-	LabelTKR               = "run.tanzu.vmware.com/tkr"
-	LabelKubernetesVersion = "run.tanzu.vmware.com/kubernetesVersion"
-	LabelOSImage           = "run.tanzu.vmware.com/os-image"
+	LabelTKR     = "run.tanzu.vmware.com/tkr"
+	LabelOSImage = "run.tanzu.vmware.com/os-image"
 )
 
 // TanzuKubernetesReleaseSpec defines the desired state of TanzuKubernetesRelease

--- a/pkg/v2/tkr/util/topology/cluster.go
+++ b/pkg/v2/tkr/util/topology/cluster.go
@@ -5,6 +5,7 @@ package topology
 
 import (
 	"encoding/json"
+	"reflect"
 
 	"github.com/pkg/errors"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -19,15 +20,53 @@ func SetVariable(cluster *clusterv1.Cluster, name string, value interface{}) err
 		return err
 	}
 
-	cVar := clusterVariableForName(cluster, name)
+	cVar := ensureClusterVariableForName(cluster, name)
 	cVar.Value = *jsonValue
 	return nil
 }
 
 // GetVariable gets the value of the cluster variable.
+// Pre-reqs: cluster.Spec.Topology != nil
 func GetVariable(cluster *clusterv1.Cluster, name string, value interface{}) error {
-	cVar := clusterVariableForName(cluster, name)
-	data, _ := json.Marshal(cVar.Value) // apiextensionsv1.JSON never returns errors when (un)marshaling JSON
+	var jsonValue apiextensionsv1.JSON
+	if cVar := clusterVariableForName(cluster, name); cVar != nil {
+		jsonValue = cVar.Value
+	}
+	data, _ := json.Marshal(jsonValue) // apiextensionsv1.JSON never returns errors when (un)marshaling JSON
+	err := json.Unmarshal(data, value)
+	return errors.Wrap(err, "unmarshalling from JSON into value")
+}
+
+// SetMDVariable sets the cluster variable, to the given value.
+// Pre-reqs: cluster.Spec.Topology != nil
+func SetMDVariable(cluster *clusterv1.Cluster, mdIndex int, name string, value interface{}) error {
+	jsonValue, err := jsonValue(value)
+	if err != nil {
+		return err
+	}
+
+	cVar := ensureClusterVariableForName(cluster, name)
+	if reflect.DeepEqual(*jsonValue, cVar.Value) {
+		return nil
+	}
+
+	mdVar := ensureMachineDeploymentVariableForName(cluster, mdIndex, name)
+	mdVar.Value = *jsonValue
+	return nil
+}
+
+// GetMDVariable gets the value of the cluster variable.
+// Pre-reqs: cluster.Spec.Topology != nil
+func GetMDVariable(cluster *clusterv1.Cluster, mdIndex int, name string, value interface{}) error {
+	var jsonValue apiextensionsv1.JSON
+
+	if mdVar := machineDeploymentVariableForName(cluster, mdIndex, name); mdVar != nil {
+		jsonValue = mdVar.Value
+	} else if cVar := clusterVariableForName(cluster, name); cVar != nil {
+		jsonValue = cVar.Value
+	}
+
+	data, _ := json.Marshal(jsonValue) // apiextensionsv1.JSON never returns errors when (un)marshaling JSON
 	err := json.Unmarshal(data, value)
 	return errors.Wrap(err, "unmarshalling from JSON into value")
 }
@@ -51,6 +90,51 @@ func clusterVariableForName(cluster *clusterv1.Cluster, name string) *clusterv1.
 			return v
 		}
 	}
+	return nil
+}
+
+// ensureClusterVariableForName finds or creates in the cluster the *ClusterVariable for the given name.
+// Pre-reqs: cluster.Spec.Topology != nil
+func ensureClusterVariableForName(cluster *clusterv1.Cluster, name string) *clusterv1.ClusterVariable {
+	for i := range cluster.Spec.Topology.Variables {
+		v := &cluster.Spec.Topology.Variables[i]
+		if v.Name == name {
+			return v
+		}
+	}
 	cluster.Spec.Topology.Variables = append(cluster.Spec.Topology.Variables, clusterv1.ClusterVariable{Name: name})
 	return &cluster.Spec.Topology.Variables[len(cluster.Spec.Topology.Variables)-1]
+}
+
+// clusterVariableOverrideForName finds or creates in the cluster the *ClusterVariable for the given name.
+// Pre-reqs: cluster.Spec.Topology != nil && cluster.Spec.Topology.Workers != nil
+func machineDeploymentVariableForName(cluster *clusterv1.Cluster, mdIndex int, name string) *clusterv1.ClusterVariable {
+	md := &cluster.Spec.Topology.Workers.MachineDeployments[mdIndex]
+	if md.Variables == nil {
+		return nil
+	}
+	for i := range md.Variables.Overrides {
+		v := &md.Variables.Overrides[i]
+		if v.Name == name {
+			return v
+		}
+	}
+	return nil
+}
+
+// ensureMachineDeploymentVariableForName finds or creates in the cluster the *ClusterVariable for the given name.
+// Pre-reqs: cluster.Spec.Topology != nil && cluster.Spec.Topology.Workers != nil
+func ensureMachineDeploymentVariableForName(cluster *clusterv1.Cluster, mdIndex int, name string) *clusterv1.ClusterVariable {
+	md := &cluster.Spec.Topology.Workers.MachineDeployments[mdIndex]
+	if md.Variables == nil {
+		md.Variables = &clusterv1.MachineDeploymentVariables{}
+	}
+	for i := range md.Variables.Overrides {
+		v := &md.Variables.Overrides[i]
+		if v.Name == name {
+			return v
+		}
+	}
+	md.Variables.Overrides = append(md.Variables.Overrides, clusterv1.ClusterVariable{Name: name})
+	return &md.Variables.Overrides[len(md.Variables.Overrides)-1]
 }

--- a/pkg/v2/tkr/util/topology/cluster_test.go
+++ b/pkg/v2/tkr/util/topology/cluster_test.go
@@ -1,0 +1,130 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package topology
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestClusterVariables(t *testing.T) {
+	RegisterFailHandler(Fail)
+	suiteConfig, _ := GinkgoConfiguration()
+	suiteConfig.FailFast = true
+	RunSpecs(t, "util/topology helpers", suiteConfig)
+}
+
+const (
+	varA = "A"
+	varB = "B"
+)
+
+type AData struct {
+	Foo *string `json:"foo,omitempty"`
+	Bar *int    `json:"bar,omitempty"`
+}
+
+var _ = Describe("Cluster variable getters and setters", func() {
+	var (
+		clusterClass *clusterv1.ClusterClass
+		cluster      *clusterv1.Cluster
+	)
+
+	BeforeEach(func() {
+		clusterClass = &clusterv1.ClusterClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cc-0",
+				Namespace: "test-ns",
+			},
+		}
+		clusterClass.Spec.Variables = []clusterv1.ClusterClassVariable{
+			{Name: varA},
+			{Name: varB},
+		}
+		cluster = &clusterv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-c-0",
+				Namespace: clusterClass.Namespace,
+			},
+			Spec: clusterv1.ClusterSpec{
+				Topology: &clusterv1.Topology{
+					Class: clusterClass.Name,
+					Workers: &clusterv1.WorkersTopology{
+						MachineDeployments: []clusterv1.MachineDeploymentTopology{
+							{
+								Variables: &clusterv1.MachineDeploymentVariables{
+									Overrides: []clusterv1.ClusterVariable{
+										{
+											Name:  varA,
+											Value: apiextensionsv1.JSON{Raw: []byte(`{"foo":"something"}`)},
+										},
+									},
+								},
+							},
+						},
+					},
+					Variables: []clusterv1.ClusterVariable{
+						{
+							Name:  varA,
+							Value: apiextensionsv1.JSON{Raw: []byte(`{"foo":"bar"}`)},
+						},
+						{
+							Name:  varB,
+							Value: apiextensionsv1.JSON{Raw: []byte(`{"bar":"foo"}`)},
+						},
+					},
+				},
+			},
+		}
+	})
+
+	Describe("SetMDVariable()", func() {
+		When("the Cluster variable has a different value", func() {
+			It("should set the MD override", func() {
+				aData1 := &AData{Foo: pointer.String("Not the same!")}
+				var aData *AData
+
+				Expect(GetVariable(cluster, varA, &aData)).To(Succeed())
+				Expect(aData).ToNot(Equal(aData1), "Cluster var is supposed to be different")
+
+				Expect(GetMDVariable(cluster, 0, varA, &aData)).To(Succeed())
+				Expect(aData).ToNot(Equal(aData1), "MD var is supposed to be different")
+
+				Expect(SetMDVariable(cluster, 0, varA, aData1)).To(Succeed(), "setting the MD var")
+
+				Expect(GetMDVariable(cluster, 0, varA, &aData)).To(Succeed())
+				Expect(aData).To(Equal(aData1), "MD var should be equal to the set value")
+
+				Expect(GetVariable(cluster, varA, &aData)).To(Succeed())
+				Expect(aData).ToNot(Equal(aData1), "Cluster var should still be different")
+			})
+		})
+		When("the Cluster variable has the same value as being set", func() {
+			It("should delete the MD override if it is set", func() {
+				aData1 := &AData{Foo: pointer.String("bar")}
+				var aData *AData
+
+				Expect(GetVariable(cluster, varA, &aData)).To(Succeed())
+				Expect(aData).To(Equal(aData1), "Cluster var is supposed to be the same")
+
+				Expect(GetMDVariable(cluster, 0, varA, &aData)).To(Succeed())
+				Expect(aData).ToNot(Equal(aData1), "MD var is supposed to be different")
+
+				Expect(SetMDVariable(cluster, 0, varA, aData1)).To(Succeed(), "setting the MD var")
+
+				Expect(GetMDVariable(cluster, 0, varA, &aData)).To(Succeed())
+				Expect(aData).To(Equal(aData1), "MD var should now be equal to the set value")
+
+				Expect(GetVariable(cluster, varA, &aData)).To(Succeed())
+				Expect(aData).To(Equal(aData1), "Cluster var should still be the same")
+			})
+		})
+	})
+})

--- a/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster.go
+++ b/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster.go
@@ -132,7 +132,7 @@ func (cw *Webhook) constructQuery(cluster *clusterv1.Cluster, clusterClass *clus
 		return &data.Query{ControlPlane: cpQuery}, nil
 	}
 
-	mdQueries, err := cw.constructMDQueries(tkr, cluster, clusterClass, tkrSelector)
+	mdQueries, err := cw.constructMDOSImageQueries(tkr, cluster, clusterClass, tkrSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (cw *Webhook) filterOSImageQuery(tkr *runv1.TanzuKubernetesRelease, tkrData
 	return osImageQuery
 }
 
-func (cw *Webhook) constructMDQueries(tkr *runv1.TanzuKubernetesRelease, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass, tkrSelector labels.Selector) ([]*data.OSImageQuery, error) {
+func (cw *Webhook) constructMDOSImageQueries(tkr *runv1.TanzuKubernetesRelease, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass, tkrSelector labels.Selector) ([]*data.OSImageQuery, error) {
 	mdOSImageQueries := make([]*data.OSImageQuery, len(cluster.Spec.Topology.Workers.MachineDeployments))
 
 	for i := range cluster.Spec.Topology.Workers.MachineDeployments {

--- a/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster.go
+++ b/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster.go
@@ -13,10 +13,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -28,6 +26,8 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/util/topology"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/util/version"
 )
+
+const VarTKRData = "TKR_DATA"
 
 type Webhook struct {
 	TKRResolver resolver.CachingResolver
@@ -91,15 +91,8 @@ func (cw *Webhook) ResolveAndSetMetadata(cluster *clusterv1.Cluster, clusterClas
 		}
 	}
 
-	setMetadata(result, cluster)
-
-	tkr := cw.getTKR(cluster)
-	if tkr == nil {
-		return errors.Errorf("resolved TKR not available: cluster '%s/%s', TKR '%s'", cluster.Namespace, cluster.Name, cluster.Labels[runv1.LabelTKR])
-	}
-
-	cw.adjustClusterKubernetesSpec(tkr, clusterClass, cluster)
-	return nil
+	err = cw.setTKRData(result, cluster)
+	return errors.Wrapf(err, "failed to set TKR_DATA: cluster '%s/%s', TKR '%s'", cluster.Namespace, cluster.Name, cluster.Labels[runv1.LabelTKR])
 }
 
 // constructQuery creates TKR resolution query from cluster and clusterClass metadata.
@@ -122,13 +115,24 @@ func (cw *Webhook) constructQuery(cluster *clusterv1.Cluster, clusterClass *clus
 		osImageSelector = labels.Everything() // default to empty selector (matches all) for OSImages
 	}
 
-	cpQuery := cw.constructOSImageQuery(cluster.Spec.Topology.Version, tkrSelector, osImageSelector, labels.Merge(cluster.Labels, cluster.Spec.Topology.ControlPlane.Metadata.Labels))
+	tkr := cw.getTKR(cluster)
+
+	var tkrData TKRData
+	if err := topology.GetVariable(cluster, VarTKRData, &tkrData); err != nil {
+		return nil, err
+	}
+
+	cpQuery := cw.filterOSImageQuery(tkr, tkrData, &data.OSImageQuery{
+		K8sVersionPrefix: cluster.Spec.Topology.Version,
+		TKRSelector:      tkrSelector,
+		OSImageSelector:  osImageSelector,
+	})
 
 	if cluster.Spec.Topology.Workers == nil {
 		return &data.Query{ControlPlane: cpQuery}, nil
 	}
 
-	mdQueries, err := cw.constructMDQueries(cluster, clusterClass, tkrSelector)
+	mdQueries, err := cw.constructMDQueries(tkr, cluster, clusterClass, tkrSelector)
 	if err != nil {
 		return nil, err
 	}
@@ -161,33 +165,28 @@ func getAnnotation(annotations map[string]string, name string) *string {
 	return &value
 }
 
-// constructOSImageQuery determines if resolution of TKR/OSImage is needed, and creates the *OSImageQuery that
+// filterOSImageQuery determines if resolution of TKR/OSImage is needed. It returns the passed *OSImageQuery that
 // instructs the resolver to perform the resolution. If not, nil is returned, indicating that no resolution is necessary
 // for this particular part of the cluster topology (either controlPlane or a machineDeployment).
-func (cw *Webhook) constructOSImageQuery(v string, tkrSelector, osImageSelector labels.Selector, labelSet labels.Set) *data.OSImageQuery {
-	if tkrName, ok := labelSet[runv1.LabelTKR]; ok {
-		if tkr := cw.TKRResolver.Get(tkrName, &runv1.TanzuKubernetesRelease{}).(*runv1.TanzuKubernetesRelease); tkr != nil {
-			if osImageName, ok := labelSet[runv1.LabelOSImage]; ok {
+func (cw *Webhook) filterOSImageQuery(tkr *runv1.TanzuKubernetesRelease, tkrData TKRData, osImageQuery *data.OSImageQuery) *data.OSImageQuery {
+	if tkr != nil && tkrData != nil {
+		if tkrDataValue := tkrData[tkr.Spec.Kubernetes.Version]; tkrDataValue != nil && tkrDataValue.Labels[runv1.LabelTKR] == tkr.Name {
+			if osImageName, ok := tkrDataValue.Labels[runv1.LabelOSImage]; ok {
 				if osImage := cw.TKRResolver.Get(osImageName, &runv1.OSImage{}).(*runv1.OSImage); osImage != nil {
 					// Found TKR and OSImage. Now, see if they match the provided version and selectors.
-					req, _ := labels.NewRequirement(version.Label(v), selection.Exists, nil)
-					tkrSelectorWithVersion := tkrSelector.Add(*req)
-					osImageSelectorWithVersion := osImageSelector.Add(*req)
-					if tkrSelectorWithVersion.Matches(labels.Set(tkr.Labels)) && osImageSelectorWithVersion.Matches(labels.Set(osImage.Labels)) {
+					if version.Prefixes(tkr.Spec.Version).Has(osImageQuery.K8sVersionPrefix) &&
+						osImageQuery.TKRSelector.Matches(labels.Set(tkr.Labels)) &&
+						osImageQuery.OSImageSelector.Matches(labels.Set(osImage.Labels)) {
 						return nil // indicating we don't need to resolve: already have matching TKR and OSImage
 					}
 				}
 			}
 		}
 	}
-	return &data.OSImageQuery{
-		K8sVersionPrefix: v,
-		TKRSelector:      tkrSelector,
-		OSImageSelector:  osImageSelector,
-	}
+	return osImageQuery
 }
 
-func (cw *Webhook) constructMDQueries(cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass, tkrSelector labels.Selector) ([]*data.OSImageQuery, error) {
+func (cw *Webhook) constructMDQueries(tkr *runv1.TanzuKubernetesRelease, cluster *clusterv1.Cluster, clusterClass *clusterv1.ClusterClass, tkrSelector labels.Selector) ([]*data.OSImageQuery, error) {
 	mdOSImageQueries := make([]*data.OSImageQuery, len(cluster.Spec.Topology.Workers.MachineDeployments))
 
 	for i := range cluster.Spec.Topology.Workers.MachineDeployments {
@@ -207,7 +206,15 @@ func (cw *Webhook) constructMDQueries(cluster *clusterv1.Cluster, clusterClass *
 			osImageSelector = labels.Everything() // default to empty selector (matches all)
 		}
 
-		mdOSImageQueries[i] = cw.constructOSImageQuery(cluster.Spec.Topology.Version, tkrSelector, osImageSelector, labels.Merge(cluster.Labels, md.Metadata.Labels))
+		var tkrData TKRData
+		if err := topology.GetMDVariable(cluster, i, VarTKRData, &tkrData); err != nil {
+			return nil, err
+		}
+		mdOSImageQueries[i] = cw.filterOSImageQuery(tkr, tkrData, &data.OSImageQuery{
+			K8sVersionPrefix: cluster.Spec.Topology.Version,
+			TKRSelector:      tkrSelector,
+			OSImageSelector:  osImageSelector,
+		})
 	}
 	return mdOSImageQueries, nil
 }
@@ -261,43 +268,98 @@ func (e *errUnresolved) Error() string {
 	return sb.String()
 }
 
-// setMetadata sets cluster TKR resolution metadata based on result.
+// setTKRData sets cluster TKR resolution metadata based on result.
 // It also ensures OSImage labels and os-image-ref annotation are set on controlPlane and machineDeployment
 // if TKR resolution took place.
-func setMetadata(result data.Result, cluster *clusterv1.Cluster) {
+func (cw *Webhook) setTKRData(result data.Result, cluster *clusterv1.Cluster) error {
 	if result.ControlPlane != nil {
-		getMap(&cluster.Labels)[runv1.LabelTKR] = result.ControlPlane.TKRName
-		getMap(&cluster.Labels)[runv1.LabelKubernetesVersion] = version.Label(result.ControlPlane.K8sVersion)
+		tkrData, err := ensureTKRData(cluster)
+		if err != nil {
+			return err
+		}
 
-		setMetadataFromOSImageResult(result.ControlPlane,
-			getMap(&cluster.Spec.Topology.ControlPlane.Metadata.Labels),
-			getMap(&cluster.Spec.Topology.ControlPlane.Metadata.Annotations))
+		getMap(&cluster.Labels)[runv1.LabelTKR] = result.ControlPlane.TKRName
+		cluster.Spec.Topology.Version = result.ControlPlane.K8sVersion
+
+		tkrData[result.ControlPlane.K8sVersion] = tkrDataValueForResult(result.ControlPlane)
+
+		if err := topology.SetVariable(cluster, VarTKRData, tkrData); err != nil {
+			return err
+		}
 	}
 
 	for i, osImageResult := range result.MachineDeployments {
 		if osImageResult != nil {
-			setMetadataFromOSImageResult(osImageResult,
-				getMap(&cluster.Spec.Topology.Workers.MachineDeployments[i].Metadata.Labels),
-				getMap(&cluster.Spec.Topology.Workers.MachineDeployments[i].Metadata.Annotations))
+			tkrDataMD, err := ensureTKRDataMD(cluster, i)
+			if err != nil {
+				return err
+			}
+
+			tkrDataMD[osImageResult.K8sVersion] = tkrDataValueForResult(osImageResult)
+
+			if err := topology.SetMDVariable(cluster, i, VarTKRData, tkrDataMD); err != nil {
+				return err
+			}
 		}
 	}
+
+	return nil
 }
 
-func setMetadataFromOSImageResult(osImageResult *data.OSImageResult, ls, annots map[string]string) {
-	for osImageName, osImage := range osImageResult.OSImagesByTKR[osImageResult.TKRName] { // only one such OSImage
-		ls[runv1.LabelTKR] = osImageResult.TKRName
-		ls[runv1.LabelOSImage] = osImageName
+func ensureTKRData(cluster *clusterv1.Cluster) (TKRData, error) {
+	var tkrData TKRData
+	if err := topology.GetVariable(cluster, VarTKRData, &tkrData); err != nil {
+		return nil, err
+	}
+	if tkrData == nil {
+		tkrData = TKRData{}
+		if err := topology.SetVariable(cluster, VarTKRData, &tkrData); err != nil {
+			return nil, err
+		}
+	}
+	return tkrData, nil
+}
 
-		ls[runv1.LabelOSType] = osImage.Spec.OS.Type
-		ls[runv1.LabelOSName] = osImage.Spec.OS.Name
-		ls[runv1.LabelOSVersion] = osImage.Spec.OS.Version
-		ls[runv1.LabelOSArch] = osImage.Spec.OS.Arch
+func ensureTKRDataMD(cluster *clusterv1.Cluster, i int) (TKRData, error) {
+	_, err := ensureTKRData(cluster)
+	if err != nil {
+		return nil, err
+	}
 
-		bytes, _ := yaml.Marshal(osImage.Spec.Image.Ref) // error always nil: data from the API Server is safe
-		annots[runv1.AnnotationOSImageRef] = string(bytes)
+	var tkrDataMD TKRData
+	if err := topology.GetMDVariable(cluster, i, VarTKRData, &tkrDataMD); err != nil {
+		return nil, err
+	}
 
-		ls[runv1.LabelImageType] = osImage.Spec.Image.Type
-		osimage.SetRefLabels(ls, osImage.Spec.Image.Type, osImage.Spec.Image.Ref)
+	return tkrDataMD, nil
+}
+
+func tkrDataValueForResult(osImageResult *data.OSImageResult) *TKRDataValue {
+	for _, osImage := range osImageResult.OSImagesByTKR[osImageResult.TKRName] { // only one such OSImage
+		tkr := osImageResult.TKRsByK8sVersion[osImageResult.K8sVersion][osImageResult.TKRName]
+		return tkrDataValue(tkr, osImage)
+	}
+	return nil // this should never happen
+}
+
+func tkrDataValue(tkr *runv1.TanzuKubernetesRelease, osImage *runv1.OSImage) *TKRDataValue {
+	ls := labels.Set{
+		runv1.LabelTKR:     tkr.Name,
+		runv1.LabelOSImage: osImage.Name,
+
+		runv1.LabelOSType:    osImage.Spec.OS.Type,
+		runv1.LabelOSName:    osImage.Spec.OS.Name,
+		runv1.LabelOSVersion: osImage.Spec.OS.Version,
+		runv1.LabelOSArch:    osImage.Spec.OS.Arch,
+
+		runv1.LabelImageType: osImage.Spec.Image.Type,
+	}
+	osimage.SetRefLabels(ls, osImage.Spec.Image.Type, osImage.Spec.Image.Ref)
+
+	return &TKRDataValue{
+		KubernetesSpec: tkr.Spec.Kubernetes,
+		OSImageRef:     osImage.Spec.Image.Ref,
+		Labels:         ls,
 	}
 }
 
@@ -345,16 +407,4 @@ func (cw *Webhook) getTKR(cluster *clusterv1.Cluster) *runv1.TanzuKubernetesRele
 		return nil
 	}
 	return cw.TKRResolver.Get(tkrName, &runv1.TanzuKubernetesRelease{}).(*runv1.TanzuKubernetesRelease)
-}
-
-const VarTKRKubernetesSpec = "TKR_KUBERNETES_SPEC"
-
-func (cw *Webhook) adjustClusterKubernetesSpec(tkr *runv1.TanzuKubernetesRelease, clusterClass *clusterv1.ClusterClass, cluster *clusterv1.Cluster) {
-	cluster.Spec.Topology.Version = tkr.Spec.Kubernetes.Version
-
-	if topology.ClusterClassVariable(clusterClass, VarTKRKubernetesSpec) == nil {
-		cw.Log.Info("Skipping setting the variable: not defined in ClusterClass", "variable", VarTKRKubernetesSpec, "ClusterClass", fmt.Sprintf("%s/%s", clusterClass.Namespace, clusterClass.Name))
-		return
-	}
-	_ = topology.SetVariable(cluster, VarTKRKubernetesSpec, &tkr.Spec.Kubernetes) // ignoring error: tkr.Spec.Kubernetes always marshals to/from JSON cleanly
 }

--- a/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/tkrdata.go
+++ b/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/tkrdata.go
@@ -1,0 +1,18 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"k8s.io/apimachinery/pkg/labels"
+
+	runv1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+)
+
+type TKRData map[string]*TKRDataValue
+
+type TKRDataValue struct {
+	KubernetesSpec runv1.KubernetesSpec   `json:"kubernetesSpec"`
+	OSImageRef     map[string]interface{} `json:"osImageRef"`
+	Labels         labels.Set             `json:"labels"`
+}


### PR DESCRIPTION
### What this PR does / why we need it

Storing TKR resolution data in CP and MD metadata sections causes a double rollout of the controlPlane and machineDeployments because both the version change and the metadata change are detected and applied by the Cluster API topology controller independently (even if they happen to be made in the same update to the Cluster).

To work around that, we need to avoid updating the CP and MD metadata by storing TKR resolution information in a cluster variable.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1993

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Updated unit tests to reflect storing TKR resolution data in the TKR_DATA variable.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
TKR Resolver Cluster webhook now stores the TKR/OSImage data in the TKR_DATA cluster variable.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
