### PR TITLE
Update clusterclasses to use TKR_DATA variable values to populate image data

### DIFF
--- a/pkg/v1/providers/infrastructure-aws/v1.2.0/cconly/base.yaml
+++ b/pkg/v1/providers/infrastructure-aws/v1.2.0/cconly/base.yaml
@@ -307,10 +307,11 @@ spec:
       openAPIV3Schema:
         type: boolean
         default: false
-  - name: TKR_KUBERNETES_SPEC
+  - name: TKR_DATA
     schema:
       openAPIV3Schema:
         type: object
+        properties: {}
   patches:
   - name: AWSCT_main
     definitions:
@@ -482,6 +483,34 @@ spec:
               {{if .AWS_SECURITY_GROUP_NODE }}  node: {{.AWS_SECURITY_GROUP_NODE}} {{end}}
               {{if .AWS_SECURITY_GROUP_LB }}  lb: {{.AWS_SECURITY_GROUP_LB}} {{end}}
 
+  - name: AWS_KCPT
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/imageRepository
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}'
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd/local/imageRepository
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}'
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd/local/imageTag
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.etcd.imageTag}}'
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/dns/imageRepository
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}'
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/dns/imageTag
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.coredns.imageTag}}'
   - name: AWS_MT_controlplane
     definitions:
     - selector:
@@ -502,6 +531,10 @@ spec:
         path: "/spec/template/spec/rootVolume/size"
         valueFrom:
           variable: AWS_CONTROL_PLANE_OS_DISK_SIZE_GIB
+      - op: replace
+        path: /spec/template/spec/ami/id
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).osImageRef.id}}'
 
   - name: AWS_MT_worker
     definitions:
@@ -525,6 +558,53 @@ spec:
         path: "/spec/template/spec/rootVolume/size"
         valueFrom:
           variable: AWS_NODE_OS_DISK_SIZE_GIB
+      - op: replace
+        path: /spec/template/spec/ami/id
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.machineDeployment.version).osImageRef.id}}'
+
+  - name: nodeLabels
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            node-labels: {{$first := true}}
+              {{- range $key, $val := (index .TKR_DATA .builtin.controlPlane.version).labels}}
+              {{- if $first }}
+                {{- $first = false }}
+              {{- else -}}
+                ,
+              {{- end }}
+              {{- $key }}={{- $val }}
+              {{- end}}
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - "tkg-worker"
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            node-labels: {{$first := true}}
+              {{- range $key, $val := (index .TKR_DATA .builtin.machineDeployment.version).labels}}
+              {{- if $first }}
+                {{- $first = false }}
+              {{- else -}}
+                ,
+              {{- end }}
+              {{- $key }}={{- $val }}
+              {{- end}}
   - name: httpProxy
     enabledIf: '{{not (not .proxy)}}'
     definitions:
@@ -987,16 +1067,16 @@ spec:
               cloud-provider: aws
               tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
           dns:
-            imageRepository: projects-stg.registry.vmware.com/tkg #! TODO '${_TKG_COREDNS_IMAGE_REPOSITORY}' May be a variable for package level
-            imageTag: v1.8.4_vmware.5 #! TODO '${_TKG_COREDNS_IMAGE_TAG}' May be a variable for package level
+            imageRepository: #! e.g. projects-stg.registry.vmware.com/tkg
+            imageTag: #! e.g. 1.8.4_vmware.5
           etcd:
             local:
               dataDir: /var/lib/etcd
-              imageRepository: projects-stg.registry.vmware.com/tkg #! TODO '${_TKG_ETCD_IMAGE_REPOSITORY}' May be a variable for package level
-              imageTag: v3.5.0_vmware.5 #! TODO '${_TKG_ETCD_IMAGE_TAG}' May be a variable for package level
+              imageRepository: #! e.g. projects-stg.registry.vmware.com/tkg
+              imageTag: #! e.g. v3.5.0_vmware.5
               extraArgs:
                 cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-          imageRepository: projects-stg.registry.vmware.com/tkg #! TODO '${_TKG_COREDNS_IMAGE_REPOSITORY}' May be a variable for package level
+          imageRepository: #! e.g. projects-stg.registry.vmware.com/tkg
           scheduler:
             extraArgs:
               tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384

--- a/pkg/v1/providers/infrastructure-aws/v1.2.0/yttcc/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-aws/v1.2.0/yttcc/overlay.yaml
@@ -100,3 +100,23 @@ spec:
       value: #@ vars[configVariable]
     #@ end
     #@ end
+    #! TODO: make this data only available while testing.
+    #@overlay/append
+    - name: TKR_DATA
+      value:
+        v1.23.5+vmware.1: #! this comes from the clusterclt for testing
+          kubernetesSpec:
+            version: v1.23.5+vmware.1
+            imageRepository: #@ bomDataForK8sVersion.kubeadmConfigSpec.imageRepository
+            etcd:
+              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageTag
+            coredns:
+              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag
+          labels:
+            os-name: ubuntu
+            os-type: linux
+            os-arch: amd64
+          osImageRef:
+            id: dummy-ami-id
+            region: dummy-region
+

--- a/pkg/v1/providers/infrastructure-azure/v1.0.1/cconly/base.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.0.1/cconly/base.yaml
@@ -265,10 +265,11 @@ spec:
       openAPIV3Schema:
         type: string
         default: ""
-  - name: TKR_KUBERNETES_SPEC
+  - name: TKR_DATA
     schema:
       openAPIV3Schema:
         type: object
+        properties: {}
   patches:
   - name: AzureClusterCustomTags
     enabledIf: '{{if .AZURE_CUSTOM_TAGS}}true{{end}}'
@@ -398,6 +399,40 @@ spec:
             diskSizeGB: {{.AZURE_CONTROL_PLANE_OS_DISK_SIZE_GIB}}
             managedDisk:
               storageAccountType: {{.AZURE_CONTROL_PLANE_OS_DISK_STORAGE_ACCOUNT_TYPE}}
+      - op: replace
+        path: /spec/template/spec/image/marketplace
+        valueFrom:
+          template: |
+            {{ range $k, $v := (index .TKR_DATA .builtin.controlPlane.version).osImageRef }}{{$k}}: {{$v}}
+            {{end}}
+  - name: KCPT_ControlPlane_Main
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/imageRepository
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}'
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd/local/imageRepository
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}'
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd/local/imageTag
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.etcd.imageTag}}'
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/dns/imageRepository
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}'
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/dns/imageTag
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.coredns.imageTag}}'
   - name: AMT_MachineDeployment_Main
     definitions:
     - selector:
@@ -428,6 +463,12 @@ spec:
             diskSizeGB: {{ .AZURE_NODE_OS_DISK_SIZE_GIB }}
             managedDisk:
               storageAccountType: {{ .AZURE_NODE_OS_DISK_STORAGE_ACCOUNT_TYPE }}
+      - op: replace
+        path: /spec/template/spec/image/marketplace
+        valueFrom:
+          template: |
+            {{ range $k, $v := (index .TKR_DATA .builtin.machineDeployment.version).osImageRef }}{{$k}}: {{$v}}
+            {{end}}
   - name: AMT_EnableNodeDataDisk
     enabledIf: '{{if .AZURE_ENABLE_NODE_DATA_DISK}}true{{end}}'
     definitions:
@@ -544,6 +585,48 @@ spec:
           template: |
             frontendIPsCount: {{ .AZURE_NODE_OUTBOUND_LB_FRONTEND_IP_COUNT }}
             idleTimeoutInMinutes: {{ .AZURE_NODE_OUTBOUND_LB_IDLE_TIMEOUT_IN_MINUTES }}
+  - name: nodeLabels
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            node-labels: {{$first := true}}
+              {{- range $key, $val := (index .TKR_DATA .builtin.controlPlane.version).labels}}
+              {{- if $first }}
+                {{- $first = false }}
+              {{- else -}}
+                ,
+              {{- end }}
+              {{- $key }}={{- $val }}
+              {{- end}}
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - "tkg-worker"
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            node-labels: {{$first := true}}
+              {{- range $key, $val := (index .TKR_DATA .builtin.machineDeployment.version).labels}}
+              {{- if $first }}
+                {{- $first = false }}
+              {{- else -}}
+                ,
+              {{- end }}
+              {{- $key }}={{- $val }}
+              {{- end}}
   - name: httpProxy
     enabledIf: '{{not (not .proxy)}}'
     definitions:
@@ -1019,17 +1102,17 @@ spec:
               name: cloud-config
               readOnly: true
           dns:
-            imageRepository: registry.tkg.vmware.run
-            imageTag: v1.6.5_vmware.4
+            imageRepository: #! e.g. registry.tkg.vmware.run
+            imageTag: #! e.g. v1.6.5_vmware.4
           etcd:
             local:
               dataDir: /var/lib/etcddisk/etcd
               extraArgs:
                 cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
                 quota-backend-bytes: "8589934592"
-              imageRepository: registry.tkg.vmware.run
-              imageTag: v3.4.3_vmware.4
-          imageRepository: registry.tkg.vmware.run
+              imageRepository: #! e.g. registry.tkg.vmware.run
+              imageTag: #! e.g v3.4.3_vmware.4
+          imageRepository: #! e.g. registry.tkg.vmware.run
         diskSetup:
           filesystems:
           - device: /dev/disk/azure/scsi1/lun0
@@ -1097,7 +1180,7 @@ spec:
         lun: 0
         nameSuffix: etcddisk
       image:
-        id: image_id
+        marketplace:
       osDisk:
         diskSizeGB: 128
         managedDisk:
@@ -1148,7 +1231,7 @@ spec:
           storageAccountType: Premium_LRS
         osType: Linux
       image:
-        id: image_id
+        marketplace:
       sshPublicKey: ${AZURE_SSH_PUBLIC_KEY_B64:=""}
       vmSize: ${AZURE_NODE_MACHINE_TYPE}
 

--- a/pkg/v1/providers/infrastructure-azure/v1.0.1/yttcc/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.0.1/yttcc/overlay.yaml
@@ -110,7 +110,28 @@ spec:
       value: #@ vars[configVariable]
     #@ end
     #@ end
-
+    #! TODO: make this data only applied while testing
+    #@overlay/append
+    - name: TKR_DATA
+      value:
+        v1.23.5+vmware.1: #! value comes from clusterctl
+          kubernetesSpec:
+            version: v1.23.5+vmware.1
+            imageRepository: #@ bomDataForK8sVersion.kubeadmConfigSpec.imageRepository
+            etcd:
+              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageTag
+            coredns:
+              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag
+          labels:
+            os-name: ubuntu
+            os-type: linux
+            os-arch: amd64
+          osImageRef:
+            sku: dummy-sku
+            publisher: dummy-publisher
+            offer: dummy-offer
+            version: dummy-version
+            thirdPartyImage: dummy-third-party-image
 
 #@ if data.values.TKG_CLUSTER_ROLE == "management":
 ---

--- a/pkg/v1/providers/infrastructure-vsphere/v1.1.0/cconly/base.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.1.0/cconly/base.yaml
@@ -413,23 +413,16 @@ spec:
       openAPIV3Schema:
         type: boolean
         default: false
-  - name: TKR_KUBERNETES_SPEC
-    schema:
-      openAPIV3Schema:
-        type: object
-        properties:
-          KubeVIP:
-            type: object
-            properties:
-              ImageRepository:
-                type: string
-              ImageTag:
-                type: string
   - name: CLUSTER_NAME
     required: true
     schema:
       openAPIV3Schema:
         type: string
+  - name: TKR_DATA
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties: {}
   patches:
   - name: vsphereClusterTemplate
     definitions:
@@ -589,6 +582,26 @@ spec:
         path: /spec/template/spec/replicas
         valueFrom:
           variable: CONTROL_PLANE_MACHINE_COUNT
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/imageRepository
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}'
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd/local/imageRepository
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}'
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd/local/imageTag
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.etcd.imageTag}}'
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/dns/imageRepository
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}'
+      - op: replace
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/dns/imageTag
+        valueFrom:
+          template: '{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.coredns.imageTag}}'
   - name: KubeadmConfigTemplate
     definitions:
     - selector:
@@ -619,7 +632,6 @@ spec:
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
-          # TODO fix the image path
           template: |
             owner: root:root
             path: /etc/kubernetes/manifests/kube-vip.yaml
@@ -656,7 +668,7 @@ spec:
                     value: "20"
                   - name: vip_retryperiod
                     value: "4"
-                  image: {{.TKR_KUBERNETES_SPEC.KubeVIP.ImageRepository}}/kube-vip:{{.TKR_KUBERNETES_SPEC.KubeVIP.ImageTag}}
+                  image: {{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}/kube-vip:{{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageTag}}
                   imagePullPolicy: IfNotPresent
                   name: kube-vip
                   resources: {}
@@ -809,6 +821,48 @@ spec:
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/postKubeadmCommands/-
         value: sed -i '/listen-client-urls/ s/$/,https:\/\/127.0.0.1:2379/' /etc/kubernetes/manifests/etcd.yaml
+  - name: nodeLabels
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            node-labels: {{$first := true}}
+              {{- range $key, $val := (index .TKR_DATA .builtin.controlPlane.version).labels}}
+              {{- if $first }}
+                {{- $first = false }}
+              {{- else -}}
+                ,
+              {{- end }}
+              {{- $key }}={{- $val }}
+              {{- end}}
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - "tkg-worker"
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            node-labels: {{$first := true}}
+              {{- range $key, $val := (index .TKR_DATA .builtin.machineDeployment.version).labels}}
+              {{- if $first }}
+                {{- $first = false }}
+              {{- else -}}
+                ,
+              {{- end }}
+              {{- $key }}={{- $val }}
+              {{- end}}
   - name: httpProxy
     enabledIf: '{{not (not .proxy)}}'
     definitions:

--- a/pkg/v1/providers/infrastructure-vsphere/v1.1.0/yttcc/base-template.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.1.0/yttcc/base-template.yaml
@@ -22,5 +22,3 @@ spec:
         name: tkg-worker-pool
         replicas: ${WORKER_MACHINE_COUNT}
     variables:
-    - name: VSPHERE_CONTROL_PLANE_ENDPOINT
-      value: "${VSPHERE_CONTROL_PLANE_ENDPOINT}"

--- a/pkg/v1/providers/infrastructure-vsphere/v1.1.0/yttcc/overlay-windows.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.1.0/yttcc/overlay-windows.yaml
@@ -101,8 +101,25 @@ spec:
       machineDeployments:
       #@overlay/match by=overlay.index(0)
       - replicas: #@ data.values.WORKER_MACHINE_COUNT
+    #! TODO: this should only be available during testing
     #@overlay/match missing_ok=True
     variables:
+    - name: TKR_DATA
+      value:
+        v1.21.2: #! comes from clusterctl during testing
+          kubernetesSpec:
+            version: v1.21.2
+            imageRepository: #@ bomDataForK8sVersion.kubeadmConfigSpec.imageRepository
+            etcd:
+              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageTag
+            coredns:
+              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag
+            kube-vip:
+              imageTag: dummy-kube-vip-image-tag
+          labels:
+            os-name: ubuntu
+            os-type: linux
+            os-arch: amd64
     #@ vars = get_cluster_variables()
     #@ if vars["TKG_CUSTOM_IMAGE_REPOSITORY"] == "":
     #@  vars["TKG_CUSTOM_IMAGE_REPOSITORY"] = bomData.imageConfig.imageRepository

--- a/pkg/v1/providers/infrastructure-vsphere/v1.1.0/yttcc/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.1.0/yttcc/overlay.yaml
@@ -73,8 +73,25 @@ spec:
         failureDomain: #@ data.values.VSPHERE_AZ_2
         #@ end
       #@ end
+    #! TODO: this should only be available during testing
     #@overlay/match missing_ok=True
     variables:
+    - name: TKR_DATA
+      value:
+        v1.21.2: #! comes from clusterctl during testing
+          kubernetesSpec:
+            version: v1.21.2
+            imageRepository: #@ bomDataForK8sVersion.kubeadmConfigSpec.imageRepository
+            etcd:
+              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageTag
+            coredns:
+              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag
+            kube-vip:
+              imageTag: dummy-kube-vip-image-tag
+          labels:
+            os-name: ubuntu
+            os-type: linux
+            os-arch: amd64
     #@ vars = get_cluster_variables()
     #@ for configVariable in vars:
     #@  if vars[configVariable] != None and configVariable in ["CLUSTER_API_SERVER_PORT", "CLUSTER_NAME", "CONTROL_PLANE_MACHINE_COUNT", "VSPHERE_CONTROL_PLANE_NUM_CPUS", "VSPHERE_CONTROL_PLANE_DISK_GIB", "VSPHERE_CONTROL_PLANE_MEM_MIB", "VSPHERE_WORKER_NUM_CPUS", "VSPHERE_WORKER_DISK_GIB", "VSPHERE_WORKER_MEM_MIB", "VSPHERE_CLONE_MODE", "VSPHERE_NETWORK", "VSPHERE_DATACENTER", "VSPHERE_DATASTORE", "VSPHERE_FOLDER", "VSPHERE_RESOURCE_POOL", "VSPHERE_STORAGE_POLICY_ID", "VSPHERE_SERVER", "VSPHERE_TLS_THUMBPRINT", "VSPHERE_SSH_AUTHORIZED_KEY", "VSPHERE_TEMPLATE", "VSPHERE_WINDOWS_TEMPLATE", "VSPHERE_CONTROL_PLANE_ENDPOINT", "proxy", "TKG_PROXY_CA_CERT", "TKG_CUSTOM_IMAGE_REPOSITORY", "TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY", "TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE", "SERVICE_CIDR", "CLUSTER_CIDR", "ENABLE_AUDIT_LOGGING", "AVI_CONTROL_PLANE_HA_PROVIDER"]:


### PR DESCRIPTION
This change updates the kubeletExtraArgs to set node-labels based on tkrData. Also updates the KubeadmControlPlaneTemplate to populate etcd and coredns image data from the tkr variable.

### What this PR does / why we need it
Updates clusterclass definitions to consume tkrData to set image repository and tag data.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2171  

### Describe testing done for PR

Tested all template changes with a template evaluator tool. Confirmed that the generated templates have the desired values set.
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
