### PR TITLE
Remove namespace in CalicoConfig and change the output format of vethMTU to string

### DIFF
--- a/addons/controllers/calico/calicoconfig_utils.go
+++ b/addons/controllers/calico/calicoconfig_utils.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -17,7 +18,6 @@ import (
 
 // calicoConfigSpec defines the desired state of CalicoConfig
 type calicoConfigSpec struct {
-	Namespace     string `yaml:"namespace,omitempty"`
 	InfraProvider string `yaml:"infraProvider"`
 	IPFamily      string `yaml:"ipFamily,omitempty"`
 	Calico        calico `yaml:"calico,omitempty"`
@@ -28,7 +28,7 @@ type calico struct {
 }
 
 type config struct {
-	VethMTU     int64  `yaml:"vethMTU,omitempty"`
+	VethMTU     string `yaml:"vethMTU,omitempty"`
 	ClusterCIDR string `yaml:"clusterCIDR"`
 }
 
@@ -36,8 +36,7 @@ func mapCalicoConfigSpec(cluster *clusterapiv1beta1.Cluster, config *cniv1alpha1
 	var err error
 
 	configSpec := &calicoConfigSpec{}
-	configSpec.Namespace = config.Spec.Namespace
-	configSpec.Calico.Config.VethMTU = config.Spec.Calico.Config.VethMTU
+	configSpec.Calico.Config.VethMTU = strconv.FormatInt(config.Spec.Calico.Config.VethMTU, 10)
 
 	// Derive InfraProvider from the cluster
 	configSpec.InfraProvider, err = util.GetInfraProvider(cluster)

--- a/addons/controllers/testdata/test-calico.yaml
+++ b/addons/controllers/testdata/test-calico.yaml
@@ -17,7 +17,6 @@ metadata:
   name: test-cluster-calico
   namespace: default
 spec:
-  namespace: "kube-system"
   infraProvider: vsphere
   ipFamily: ipv4
   clusterCIDR: ""

--- a/apis/cni/v1alpha1/calicoconfig_types.go
+++ b/apis/cni/v1alpha1/calicoconfig_types.go
@@ -9,12 +9,6 @@ import (
 
 // CalicoConfigSpec defines the desired state of CalicoConfig
 type CalicoConfigSpec struct {
-
-	// The namespace in which calico is deployed
-	//+ kubebuilder:validation:Optional
-	//+kubebuilder:default:=kube-system
-	Namespace string `json:"namespace,omitempty"`
-
 	Calico Calico `json:"calico,omitempty"`
 }
 

--- a/apis/cni/v1alpha1/calicoconfig_webhook.go
+++ b/apis/cni/v1alpha1/calicoconfig_webhook.go
@@ -4,20 +4,10 @@
 package v1alpha1
 
 import (
-	"fmt"
-	"reflect"
-
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
-
-// log is for logging in this package.
-var calicoconfiglog = logf.Log.WithName("calicoconfig-resource")
 
 func (r *CalicoConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
@@ -31,32 +21,14 @@ var _ webhook.Validator = &CalicoConfig{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *CalicoConfig) ValidateCreate() error {
+	// No validation required for CalicoConfig creation
 	return nil
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *CalicoConfig) ValidateUpdate(old runtime.Object) error {
-	calicoconfiglog.Info("validate update", "name", r.Name)
-
-	oldObj, ok := old.(*CalicoConfig)
-	if !ok {
-		return apierrors.NewBadRequest(fmt.Sprintf("Expected an CalicoConfig but got a %T", oldObj))
-	}
-
-	var allErrs field.ErrorList
-
-	// Check for changes to immutable fields and return errors
-	if !reflect.DeepEqual(r.Spec.Namespace, oldObj.Spec.Namespace) {
-		allErrs = append(allErrs,
-			field.Invalid(field.NewPath("spec", "namespace"),
-				r.Spec.Namespace, "field is immutable"),
-		)
-	}
-	if len(allErrs) == 0 {
-		return nil
-	}
-	return apierrors.NewInvalid(
-		schema.GroupKind{Group: "cni.tanzu.vmware.com", Kind: "CalicoConfig"}, r.Name, allErrs)
+	// No validation required for CalicoConfig update
+	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/config/crd/bases/cni.tanzu.vmware.com_calicoconfigs.yaml
+++ b/config/crd/bases/cni.tanzu.vmware.com_calicoconfigs.yaml
@@ -64,10 +64,6 @@ spec:
                         type: integer
                     type: object
                 type: object
-              namespace:
-                default: kube-system
-                description: The namespace in which calico is deployed
-                type: string
             type: object
           status:
             description: CalicoConfigStatus defines the observed state of CalicoConfig


### PR DESCRIPTION
### What this PR does / why we need it
* In converted data values yaml, `vethMTU` should be string instead of int64
* Remove `namespace` in CalicoConfig because it is an invalid field in calico packages which never took effect before and about to be deprecated

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Update CalicoConfig `vethMTU` to string and remove `namespace`
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
Seems the `make test` in addon is broken.