### PR TITLE
addons/pinniped/config-controller: restore wlc secret when modified or deleted

### DIFF
--- a/addons/pinniped/config-controller/README.md
+++ b/addons/pinniped/config-controller/README.md
@@ -36,3 +36,30 @@ ytt -f ./hack/ytt -v tkr=v1.23.3---vmware.1-tkg.1 -v infrastructure_provider=vsp
 # arguments are ytt args passed as: -v <arg> for example, something like:
 ./hack/generate-package-secret.sh -v tkr=v1.23.3---vmware.1-tkg.1 -v infrastructure_provider=vsphere
 ```
+
+To change the log level, add the `--v=LOG_LEVEL` arg to the controller deployment.  LOG_LEVEL should
+be a number.  Default log level is 0. Example:
+
+```yaml
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: pinniped-config-controller-manager
+  namespace: pinniped
+spec:
+  selector:
+    matchLabels:
+      app: pinniped-config-controller-manager
+  template:
+    metadata:
+      labels:
+        app: pinniped-config-controller-manager
+    spec:
+      serviceAccountName: pinniped-config-controller-manager
+      containers:
+      - args:
+        - --v=1
+        image: #@ data.values.image
+        name: pinniped-config-controller-manager
+```

--- a/addons/pinniped/config-controller/controllers/v3_controller.go
+++ b/addons/pinniped/config-controller/controllers/v3_controller.go
@@ -149,6 +149,7 @@ func (c *PinnipedV3Controller) reconcileDataValues(ctx context.Context, secret *
 	// TODO: Create or Patch here vs. just patch since it should already be there?
 	result, err := controllerutil.CreateOrPatch(ctx, c.client, pinnipedSecret, getMutateFn(pinnipedSecret, pinnipedInfoCM, cluster, log, false))
 	if err != nil {
+		// TODO: Return err if not found here or nah?  (maybe depends on contract w/CB controller)
 		log.Error(err, "error creating or patching data values")
 		return err
 	}


### PR DESCRIPTION
### What this PR does / why we need it
Restore WLC secret if modified/deleted for v1alpha1, restore if modified for v1alpha3 (currently deferring to clusterbootstrap controller to handle delete case for v1alpha3 secret)

### Which issue(s) this PR fixes

Fixes #

### Describe testing done for PR
Added unit tests, tested v1alpha1 and v1alpha3 on TKG cluster in vSphere

### Release note
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
