### PR TITLE
Create workload cluster with Cluster class input file for TKGS

### DIFF
--- a/pkg/v1/tkg/client/cluster.go
+++ b/pkg/v1/tkg/client/cluster.go
@@ -431,10 +431,18 @@ func (c *TkgClient) createPacificCluster(options *CreateClusterOptions, waitForC
 		return errors.New("creating Tanzu Kubernetes Cluster is not compatible with the node size options: --size, --controlplane-size, and --worker-size")
 	}
 
-	configYaml, err = c.getPacificClusterConfiguration(options)
-	if err != nil {
-		return errors.Wrap(err, "failed to create Tanzu Kubernetes Cluster service for vSphere workload cluster")
+	if options.IsInputFileClusterClassBased {
+		configYaml, err = getContentFromInputFile(options.ClusterConfigFile)
+		if err != nil {
+			return errors.Wrap(err, "unable to get cluster configuration")
+		}
+	} else {
+		configYaml, err = c.getPacificClusterConfiguration(options)
+		if err != nil {
+			return errors.Wrap(err, "failed to create Tanzu Kubernetes Cluster service for vSphere workload cluster")
+		}
 	}
+
 	clusterName, namespace, err = c.getClusterNameAndNameSpace()
 	if err != nil {
 		return errors.Wrap(err, "failed to get cluster name and namespace")

--- a/pkg/v1/tkg/tkgctl/helpers.go
+++ b/pkg/v1/tkg/tkgctl/helpers.go
@@ -188,6 +188,7 @@ func (t *tkgctl) checkIfInputFileIsClusterClassBased(clusterConfigFile string) (
 func (t *tkgctl) processCClusterObjectForConfigurationVariables(cclusterObj unstructured.Unstructured) {
 	variablesMap := make(map[string]string)
 	variablesMap[constants.ConfigVariableClusterName] = cclusterObj.GetName()
+	variablesMap[constants.ConfigVariableNamespace] = cclusterObj.GetNamespace()
 	spec := cclusterObj.Object["spec"].(map[string]interface{})
 	if spec != nil {
 		topology := spec["topology"].(map[string]interface{})
@@ -218,6 +219,7 @@ func (t *tkgctl) processCClusterObjectForConfigurationVariables(cclusterObj unst
 func (t *tkgctl) overrideClusterOptionsWithCClusterConfigurationValues(cc *CreateClusterOptions) {
 	cc.ClusterName, _ = t.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterName)
 	cc.Plan, _ = t.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterPlan)
+	cc.Namespace, _ = t.TKGConfigReaderWriter().Get(constants.ConfigVariableNamespace)
 	cc.InfrastructureProvider, _ = t.TKGConfigReaderWriter().Get(constants.ConfigVariableInfraProvider)
 	cc.ControlPlaneMachineCount, _ = tkgconfighelper.GetIntegerVariableFromConfig(constants.ConfigVariableControlPlaneMachineCount, t.TKGConfigReaderWriter())
 	cc.WorkerMachineCount, _ = tkgconfighelper.GetIntegerVariableFromConfig(constants.ConfigVariableWorkerMachineCount, t.TKGConfigReaderWriter())
@@ -232,6 +234,7 @@ func (t *tkgctl) overrideClusterOptionsWithCClusterConfigurationValues(cc *Creat
 // overrideManagementClusterOptionsWithCClusterConfigurationValues overrides InitRegion attributes with latest values from the environment.
 func (t *tkgctl) overrideManagementClusterOptionsWithCClusterConfigurationValues(ir *InitRegionOptions) {
 	ir.ClusterName, _ = t.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterName)
+	ir.Namespace, _ = t.TKGConfigReaderWriter().Get(constants.ConfigVariableNamespace)
 	ir.Plan, _ = t.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterPlan)
 	ir.InfrastructureProvider, _ = t.TKGConfigReaderWriter().Get(constants.ConfigVariableInfraProvider)
 	ir.Size, _ = t.TKGConfigReaderWriter().Get(constants.ConfigVariableSize)


### PR DESCRIPTION
### What this PR does / why we need it

- Supports creating workload cluster in TKGS cluster using cluster class input file (instead of the legacy input configuration file)
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2203

### Describe testing done for PR

1. Creating the Workload cluster with Cluster Class input file in the TKGS environment.
       - With command `tanzu cluster create -f ccluster.yaml`
       - Check cluster is being create with command `tanzu cluster list` or `kubectl cluster -A` (make sure you login to vSphere with kubectl)
3. Creating the Workload cluster with the legacy configuration file in the TKGS environment.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: `tanzu cluster create --file clusterclass.yaml` supports to create workload cluster in the TKGS environment with cluster class YAML input file.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
