### PR TITLE
Switch from strings.Title to cases.Title

### DIFF
--- a/addons/controllers/packageinstallstatus_controller.go
+++ b/addons/controllers/packageinstallstatus_controller.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -294,8 +296,9 @@ func (r *PackageInstallStatusReconciler) reconcileClusterBootstrapStatus(
 	}
 
 	// we populate 'Message' with Carvel's PackageInstall 'UsefulErrorMessage' field as it contains more detailed information in case of an error
+	title := cases.Title(language.Und)
 	condition := clusterapiv1beta1.Condition{
-		Type: clusterapiv1beta1.ConditionType(strings.Title(pkgShortname)) + "-" +
+		Type: clusterapiv1beta1.ConditionType(title.String(pkgShortname)) + "-" +
 			clusterapiv1beta1.ConditionType(pkgiCondition.Type),
 		Status:             pkgiCondition.Status,
 		Message:            util.GetKappUsefulErrorMessage(pkgi.Status.UsefulErrorMessage),
@@ -309,7 +312,7 @@ func (r *PackageInstallStatusReconciler) reconcileClusterBootstrapStatus(
 	// to only consider condition types' prefix (pkgi name) rather than the full condition type for condition's equality check and custom comparison logic is net implemented in CAPI's condition util Set() as of now
 	var conditionExists bool
 	for i, existingCond := range clusterBootstrap.Status.Conditions {
-		if !strings.Contains(string(existingCond.Type), strings.Title(pkgShortname)) {
+		if !strings.Contains(string(existingCond.Type), title.String(pkgShortname)) {
 			continue
 		}
 		conditionExists = true
@@ -328,7 +331,7 @@ func (r *PackageInstallStatusReconciler) reconcileClusterBootstrapStatus(
 func (r *PackageInstallStatusReconciler) removeConditionIfExistsForPkgName(clusterBootstrap *runtanzuv1alpha3.ClusterBootstrap, pkgRefName string) {
 	for i, existingCond := range clusterBootstrap.Status.Conditions {
 		pkgShortname := strings.Split(pkgRefName, ".")[0]
-		if strings.Contains(string(existingCond.Type), strings.Title(pkgShortname)) {
+		if strings.Contains(string(existingCond.Type), cases.Title(language.Und).String(pkgShortname)) {
 			clusterBootstrap.Status.Conditions = append(clusterBootstrap.Status.Conditions[:i], clusterBootstrap.Status.Conditions[i+1:]...)
 		}
 	}


### PR DESCRIPTION
### What this PR does / why we need it

`strings.Title` has been deprecated starting in go 1.18. We haven't
moved to this version yet, but we will need to at some point in the near
future. To avoid issues when that time comes, this updates the few
instances we had of this to start using the recommended replacement of
`cases.Title`.

https://github.com/golang/go/issues/48367
https://tip.golang.org/doc/go1.18#minor_library_changes

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2217 

### Describe testing done for PR

Ran `make lint` and observed the failure with current source. Updated the three instances of `strings.Title` to use the recommended replacement. Ran `make lint` again and verified the errors went away.

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access