### PR TITLE
[release-0.11] Prevent host net pods from getting kube-vip addr

### DIFF
--- a/pkg/v1/providers/infrastructure-vsphere/v1.0.3/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.0.3/ytt/overlay.yaml
@@ -240,7 +240,7 @@ spec:
           advertiseAddress: '0.0.0.0'
           #@ end
           bindPort: #@ data.values.CLUSTER_API_SERVER_PORT
-      #@ end      
+      #@ end
     clusterConfiguration:
       imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.imageRepository)
       etcd:
@@ -268,6 +268,13 @@ spec:
     #@overlay/remove
     - content:
     #@ end
+    #@ if data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"]:
+    #@overlay/append
+    - content: ""
+      owner: root:root
+      path: /etc/sysconfig/kubelet
+      permissions: "0640"
+    #@ end
     users:
     #@overlay/match by=overlay.index(0)
     #@overlay/replace
@@ -281,6 +288,15 @@ spec:
     postKubeadmCommands:
     #@overlay/append
     - sed -i '/listen-client-urls/ s/$/,https:\/\/127.0.0.1:2379/' /etc/kubernetes/manifests/etcd.yaml
+    #@ end
+    #! When using kube-vip as the control plane endpoint provider with IPv6 as
+    #! the primary IP family, set --node-ip on kubelet so that host network pods
+    #! do not get the kube-vip address as their pod IP.
+    #! See: https://github.com/vmware-tanzu/tanzu-framework/issues/2098
+    #@ if not data.values.AVI_CONTROL_PLANE_HA_PROVIDER and data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"]:
+    preKubeadmCommands:
+    #@overlay/append
+    - echo "KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)" >> /etc/sysconfig/kubelet
     #@ end
   replicas: #@ data.values.CONTROL_PLANE_MACHINE_COUNT
   version: #@ data.values.KUBERNETES_VERSION


### PR DESCRIPTION
### What this PR does / why we need it

Backport of main branch PR: #2103 

On IPv6 only clusters or dual stack clusters with IPv6 as the primary IP
family, configure `--node-ip` for kubelet on the control plane nodes to
the first detected IP address prior to launching kube-vip.

Otherwise, prior to cloud-provider-vsphere taking over, kubelet will use
the kube-vip address as the node IP and host network pods that start up
early will get this address set as their pod IP.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2098

### Describe testing done for PR

1. Ran unit tests 
2. Automated end to end tests pass for IPv6 (see [this comment](https://github.com/vmware-tanzu/tanzu-framework/pull/2234#issuecomment-1112694945))
3. Manually validated the following:

check `/etc/sysconfig/kubelet` on a control plane node:
```
capv@tkg-mgmt-vc-control-plane-vft2s:~$ sudo cat /etc/sysconfig/kubelet
KUBELET_EXTRA_ARGS=--node-ip=fd01:1:2:2916:0:a:0:d72
```

check that kubelet process has `--node-ip` set:
```
capv@tkg-mgmt-vc-control-plane-vft2s:~$ ps -ef | grep /usr/bin/kubelet | grep -v grep
root        1963       1  5 21:39 ?        00:00:50 /usr/bin/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf --config=/var/lib/kubelet/config.yaml --cloud-provider=external --container-runtime=remote --container-runtime-endpoint=/var/run/containerd/containerd.sock --pod-infra-container-image=projects.registry.vmware.com/tkg/pause:3.5 --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 --node-ip=fd01:1:2:2916:0:a:0:d72

capv@tkg-mgmt-vc-control-plane-vft2s:~$ ps -ef | grep /usr/bin/kubelet | grep -v grep | awk '{print $17}'
--node-ip=fd01:1:2:2916:0:a:0:d72
```

check that network device has the kube-vip address (addr w/ `cccc` in it):
```
capv@tkg-mgmt-vc-control-plane-vft2s:~$ ip addr show dev eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 00:50:56:b7:d2:ff brd ff:ff:ff:ff:ff:ff
    inet6 fd01:1:2:2916:0:a:cccc:20d7/128 scope global
       valid_lft forever preferred_lft forever
    inet6 fd01:1:2:2916:0:a:0:d72/128 scope global dynamic noprefixroute
       valid_lft 42038sec preferred_lft 25838sec
    inet6 fd01:1:2:2916:250:56ff:feb7:d2ff/64 scope global dynamic mngtmpaddr noprefixroute
       valid_lft 2591714sec preferred_lft 604514sec
    inet6 fe80::250:56ff:feb7:d2ff/64 scope link
       valid_lft forever preferred_lft forever
```

verify that no pods have kube-vip address:
```
kubo@ubuntu-2004:~$ kubectl get po -A -o json | jq -r .items[].status.podIPs[].ip | sort | uniq
2620:124:6020:c202:0:a:0:1c9b
2620:124:6020:c202:0:a:0:cbc
fd00:100:64:1::2
fd00:100:64:1::3
fd00:100:64:1::4
fd00:100:64:1::5
fd00:100:64::2
fd00:100:64::3
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixed issue where some host network pods get pod IP set to kube-vip control plane endpoint address on clusters with IPv6 as the primary IP family
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
