### PR TITLE
Update the KR plugin to implement the new TKR API v1alpha3

### DIFF
--- a/cmd/cli/plugin/tkr/utils/helpers.go
+++ b/cmd/cli/plugin/tkr/utils/helpers.go
@@ -1,0 +1,33 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package utils provides common utility functions
+package utils
+
+import (
+	"path/filepath"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgctl"
+)
+
+func getConfigDir() (string, error) {
+	tanzuConfigDir, err := config.LocalDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(tanzuConfigDir, "tkg"), nil
+}
+
+func CreateTKGClient(kubeconfig, kubecontext, logFile string, logLevel int32) (tkgctl.TKGClient, error) {
+	configDir, err := getConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	return tkgctl.New(tkgctl.Options{
+		ConfigDir:   configDir,
+		KubeConfig:  kubeconfig,
+		KubeContext: kubecontext,
+		LogOptions:  tkgctl.LoggingOptions{Verbosity: logLevel, File: logFile},
+	})
+}

--- a/cmd/cli/plugin/tkr/v1alpha1/activate_deactivate.go
+++ b/cmd/cli/plugin/tkr/v1alpha1/activate_deactivate.go
@@ -1,16 +1,18 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package main
+// Package v1alpha1 provides the command definitions for TKR API v1alpha1
+package v1alpha1
 
 import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/vmware-tanzu/tanzu-framework/cmd/cli/plugin/tkr/utils"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 )
 
-var activeCmd = &cobra.Command{
+var ActivateCmd = &cobra.Command{
 	Use:   "activate TKR_NAME",
 	Short: "Activate Tanzu Kubernetes Releases",
 	Long:  "Activate Tanzu Kubernetes Releases",
@@ -18,7 +20,7 @@ var activeCmd = &cobra.Command{
 	RunE:  activateKubernetesReleasesCmd,
 }
 
-var deactiveCmd = &cobra.Command{
+var DeactivateCmd = &cobra.Command{
 	Use:   "deactivate TKR_NAME",
 	Short: "Deactivate Tanzu Kubernetes Releases",
 	Long:  "Deactivate Tanzu Kubernetes Releases",
@@ -36,7 +38,7 @@ func activateKubernetesReleasesCmd(cmd *cobra.Command, args []string) error {
 		return errors.New("activating TanzuKubernetesRelease with a global server is not implemented yet")
 	}
 
-	tkgctlClient, err := createTKGClient(server.ManagementClusterOpts.Path, server.ManagementClusterOpts.Context)
+	tkgctlClient, err := utils.CreateTKGClient(server.ManagementClusterOpts.Path, server.ManagementClusterOpts.Context, LogFile, LogLevel)
 	if err != nil {
 		return err
 	}
@@ -59,7 +61,7 @@ func deactivateKubernetesReleasesCmd(cmd *cobra.Command, args []string) error {
 		return errors.New("deactivating TanzuKubernetesRelease with a global server is not implemented yet")
 	}
 
-	tkgctlClient, err := createTKGClient(server.ManagementClusterOpts.Path, server.ManagementClusterOpts.Context)
+	tkgctlClient, err := utils.CreateTKGClient(server.ManagementClusterOpts.Path, server.ManagementClusterOpts.Context, LogFile, LogLevel)
 	if err != nil {
 		return err
 	}

--- a/cmd/cli/plugin/tkr/v1alpha1/available_upgrade.go
+++ b/cmd/cli/plugin/tkr/v1alpha1/available_upgrade.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package main
+package v1alpha1
 
 import (
 	"fmt"
@@ -21,7 +21,7 @@ import (
 
 const lenMsg = 2
 
-var availableUpgradesCmd = &cobra.Command{
+var AvailableUpgradesCmd = &cobra.Command{
 	Use:     "available-upgrades",
 	Short:   "Get upgrade information for a Tanzu Kubernetes Release",
 	Long:    `Get upgrade information for a Tanzu Kubernetes Release`,
@@ -37,8 +37,8 @@ var getAvailableUpgradesCmd = &cobra.Command{
 }
 
 func init() {
-	availableUpgradesCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
-	availableUpgradesCmd.AddCommand(getAvailableUpgradesCmd)
+	AvailableUpgradesCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
+	AvailableUpgradesCmd.AddCommand(getAvailableUpgradesCmd)
 }
 
 func getAvailableUpgrades(cmd *cobra.Command, args []string) error {
@@ -58,7 +58,7 @@ func getAvailableUpgrades(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	t := component.NewOutputWriter(availableUpgradesCmd.OutOrStdout(), outputFormat, "NAME", "VERSION")
+	t := component.NewOutputWriter(AvailableUpgradesCmd.OutOrStdout(), outputFormat, "NAME", "VERSION")
 	for i := range results {
 		t.AddRow(results[i].Name, results[i].Spec.Version)
 	}

--- a/cmd/cli/plugin/tkr/v1alpha1/available_upgrade_test.go
+++ b/cmd/cli/plugin/tkr/v1alpha1/available_upgrade_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package main
+package v1alpha1
 
 import (
 	"strings"

--- a/cmd/cli/plugin/tkr/v1alpha1/doc.go
+++ b/cmd/cli/plugin/tkr/v1alpha1/doc.go
@@ -1,6 +1,8 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+package v1alpha1
+
 /*
 Kubernetes release operations.
 
@@ -57,4 +59,3 @@ Sample command and output:
     NAME    VERSION   ARCH
     photonos 1.1       amd64
 */
-package main

--- a/cmd/cli/plugin/tkr/v1alpha1/get_tkr.go
+++ b/cmd/cli/plugin/tkr/v1alpha1/get_tkr.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package main
+package v1alpha1
 
 import (
 	"io"
@@ -18,6 +18,12 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/utils"
 )
 
+var (
+	LogLevel     int32
+	LogFile      string
+	outputFormat string
+)
+
 type getTKROptions struct {
 	listAll bool
 	output  io.Writer
@@ -25,7 +31,7 @@ type getTKROptions struct {
 
 var gtkr = &getTKROptions{}
 
-var getTanzuKubernetesRleasesCmd = &cobra.Command{
+var GetTanzuKubernetesRleasesCmd = &cobra.Command{
 	Use:   "get TKR_NAME",
 	Short: "Get available Tanzu Kubernetes releases",
 	Long:  "Get available Tanzu Kubernetes releases",
@@ -33,8 +39,8 @@ var getTanzuKubernetesRleasesCmd = &cobra.Command{
 }
 
 func init() {
-	getTanzuKubernetesRleasesCmd.Flags().BoolVarP(&gtkr.listAll, "all", "a", false, "List all the available Tanzu Kubernetes releases including Incompatible and deactivated")
-	getTanzuKubernetesRleasesCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
+	GetTanzuKubernetesRleasesCmd.Flags().BoolVarP(&gtkr.listAll, "all", "a", false, "List all the available Tanzu Kubernetes releases including Incompatible and deactivated")
+	GetTanzuKubernetesRleasesCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
 }
 
 func getKubernetesReleases(cmd *cobra.Command, args []string) error {

--- a/cmd/cli/plugin/tkr/v1alpha1/get_tkr_test.go
+++ b/cmd/cli/plugin/tkr/v1alpha1/get_tkr_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package main
+package v1alpha1
 
 import (
 	"bytes"

--- a/cmd/cli/plugin/tkr/v1alpha1/os.go
+++ b/cmd/cli/plugin/tkr/v1alpha1/os.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package main
+package v1alpha1
 
 import (
 	"time"
@@ -17,7 +17,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/types"
 )
 
-var osCmd = &cobra.Command{
+var OsCmd = &cobra.Command{
 	Use:   "os",
 	Short: "Get the OS information for a Tanzu Kubernetes Release",
 	Long:  `Get the OS information for a Tanzu Kubernetes Release`,
@@ -40,7 +40,7 @@ var getOSCmd = &cobra.Command{
 func init() {
 	getOSCmd.Flags().StringVarP(&goo.region, "region", "", "", "The AWS region where AMIs are available")
 	getOSCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
-	osCmd.AddCommand(getOSCmd)
+	OsCmd.AddCommand(getOSCmd)
 }
 
 //nolint:gocyclo,funlen

--- a/cmd/cli/plugin/tkr/v1alpha3/activate_deactivate.go
+++ b/cmd/cli/plugin/tkr/v1alpha3/activate_deactivate.go
@@ -1,0 +1,104 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package v1alpha3 provides the command definitions for TKR API v1alpha3
+package v1alpha3
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/types"
+
+	runv1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
+)
+
+var ActivateCmd = &cobra.Command{
+	Use:   "activate TKR_NAME",
+	Short: "Activate Tanzu Kubernetes Releases",
+	Long:  "Activate Tanzu Kubernetes Releases",
+	Args:  cobra.ExactArgs(1),
+	RunE:  activateKubernetesReleasesCmd,
+}
+
+var DeactivateCmd = &cobra.Command{
+	Use:   "deactivate TKR_NAME",
+	Short: "Deactivate Tanzu Kubernetes Releases",
+	Long:  "Deactivate Tanzu Kubernetes Releases",
+	Args:  cobra.ExactArgs(1),
+	RunE:  deactivateKubernetesReleasesCmd,
+}
+
+func activateKubernetesReleasesCmd(cmd *cobra.Command, args []string) error {
+	clusterClient, err := getClusterClient()
+	if err != nil {
+		return err
+	}
+
+	err = activateKubernetesReleases(clusterClient, args[0])
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deactivateKubernetesReleasesCmd(cmd *cobra.Command, args []string) error {
+	clusterClient, err := getClusterClient()
+	if err != nil {
+		return err
+	}
+
+	err = deactivateKubernetesReleases(clusterClient, args[0])
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func activateKubernetesReleases(clusterClient clusterclient.Client, tkrName string) error {
+	var tkr runv1alpha3.TanzuKubernetesRelease
+	patchFormat := `
+	{
+		"metadata": {
+		    "labels": {
+			    %q: null
+		    }
+	    }
+	}`
+	activateTKRTimeout := 10 * time.Second
+	checkResourceInterval := 5 * time.Second
+	patchStr := fmt.Sprintf(patchFormat, runv1alpha3.LabelDeactivated)
+	pollOptions := &clusterclient.PollOptions{Interval: checkResourceInterval, Timeout: activateTKRTimeout}
+	err := clusterClient.PatchResource(&tkr, tkrName, "", patchStr, types.MergePatchType, pollOptions)
+	if err != nil {
+		return errors.Wrap(err, "unable to patch the TKr object to remove the inactive label")
+	}
+
+	return nil
+}
+func deactivateKubernetesReleases(clusterClient clusterclient.Client, tkrName string) error {
+	var tkr runv1alpha3.TanzuKubernetesRelease
+	patchFormat := `
+	{
+		"metadata": {
+		    "labels": {
+			    %q: ""
+		    }
+	    }
+	}`
+	deactivateTKRTimeout := 10 * time.Second
+	checkResourceInterval := 5 * time.Second
+	patchStr := fmt.Sprintf(patchFormat, runv1alpha3.LabelDeactivated)
+	pollOptions := &clusterclient.PollOptions{Interval: checkResourceInterval, Timeout: deactivateTKRTimeout}
+	err := clusterClient.PatchResource(&tkr, tkrName, "", patchStr, types.MergePatchType, pollOptions)
+	if err != nil {
+		return errors.Wrap(err, "unable to patch the TKr object with inactive label")
+	}
+
+	return nil
+}

--- a/cmd/cli/plugin/tkr/v1alpha3/activate_deactivate_test.go
+++ b/cmd/cli/plugin/tkr/v1alpha3/activate_deactivate_test.go
@@ -1,0 +1,83 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha3
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+)
+
+var _ = Describe("deactivate/activate TKR", func() {
+	var (
+		tkrName       string
+		err           error
+		clusterClient *fakes.ClusterClient
+	)
+
+	BeforeEach(func() {
+		clusterClient = &fakes.ClusterClient{}
+		tkrName = "fakeTKRName"
+	})
+
+	Context("deactivating TKR", func() {
+		JustBeforeEach(func() {
+			err = deactivateKubernetesReleases(clusterClient, tkrName)
+		})
+		Context("When the patching TKR return error", func() {
+			BeforeEach(func() {
+				clusterClient.PatchResourceReturns(errors.New("fake TKR patch error"))
+			})
+			It("should return error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("fake TKR patch error"))
+			})
+		})
+		Context("When the patching TKR return success", func() {
+			BeforeEach(func() {
+				clusterClient.PatchResourceReturns(nil)
+			})
+			It("should not return error", func() {
+				Expect(err).ToNot(HaveOccurred())
+				_, getTKRName, _, gotPatch, gotPatchType, _ := clusterClient.PatchResourceArgsForCall(0)
+				Expect(getTKRName).To(Equal("fakeTKRName"))
+				Expect(gotPatchType).To(Equal(types.MergePatchType))
+				expectedPatchLabel := `"deactivated": ""`
+				Expect(gotPatch).To(ContainSubstring(expectedPatchLabel))
+			})
+		})
+	})
+
+	Context("activating TKR", func() {
+		JustBeforeEach(func() {
+			err = activateKubernetesReleases(clusterClient, tkrName)
+		})
+		Context("When the patching TKR return error", func() {
+			BeforeEach(func() {
+				clusterClient.PatchResourceReturns(errors.New("fake TKR patch error"))
+			})
+			It("should return error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("fake TKR patch error"))
+			})
+		})
+		Context("When the patching TKR return success", func() {
+			BeforeEach(func() {
+				clusterClient.PatchResourceReturns(nil)
+			})
+			It("should not return error", func() {
+				Expect(err).ToNot(HaveOccurred())
+				_, getTKRName, _, gotPatch, gotPatchType, _ := clusterClient.PatchResourceArgsForCall(0)
+				Expect(getTKRName).To(Equal("fakeTKRName"))
+				Expect(gotPatchType).To(Equal(types.MergePatchType))
+				expectedPatchLabel := `"deactivated": null`
+				Expect(gotPatch).To(ContainSubstring(expectedPatchLabel))
+			})
+		})
+	})
+
+})

--- a/cmd/cli/plugin/tkr/v1alpha3/doc.go
+++ b/cmd/cli/plugin/tkr/v1alpha3/doc.go
@@ -1,0 +1,45 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha3
+
+/*
+Kubernetes release operations.
+
+
+Get available Tanzu Kubernetes Releases
+
+Usage:
+  tanzu kubernetes-release get TKR_NAME [flags]
+
+Flags:
+  -h, --help   help for get
+
+Sample command and output:
+
+  tanzu kubernetes-release get
+    NAME                VERSION                         COMPATIBLE     		Active
+    v1.16.3---vmware.2  v1.16.3+vmware.2-tkg.1            False             True
+    v1.17.13---vmware.1 v1.17.13+vmware.1-tkg.1           True              True
+    v1.18.2---vmware.1  v1.18.2+vmware.1-tkg.1            True              True
+    v1.18.6---vmware.1  v1.18.6+vmware.1-tkg.1            True              True
+    v1.19.3---vmware.1  v1.19.3+vmware.1-tkg.1            True              True
+    v1.19.3---vmware.2  v1.19.3+vmware.2-tkg.1            True              False
+
+
+
+Get supported OS info of a Tanzu Kubernetes Release
+
+Usage:
+  tanzu kubernetes-release os get TKR_NAME [flags]
+
+Flags:
+  -h, --help help for get
+  --region string The AWS region where AMIs are available
+
+Sample command and output:
+
+  tanzu kubernetes-release os get v1.18.6---vmware.1
+    NAME    VERSION   ARCH
+    photonos 1.1       amd64
+*/

--- a/cmd/cli/plugin/tkr/v1alpha3/get_tkr.go
+++ b/cmd/cli/plugin/tkr/v1alpha3/get_tkr.go
@@ -1,0 +1,118 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha3
+
+import (
+	"io"
+	"strings"
+	"time"
+
+	runv1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
+)
+
+var (
+	LogLevel     int32
+	LogFile      string
+	outputFormat string
+)
+
+type getTKROptions struct {
+	listAll bool
+	output  io.Writer
+}
+
+var gtkr = &getTKROptions{}
+
+var GetTanzuKubernetesRleasesCmd = &cobra.Command{
+	Use:   "get TKR_NAME",
+	Short: "Get available Tanzu Kubernetes releases",
+	Long:  "Get available Tanzu Kubernetes releases",
+	RunE:  getKubernetesReleases,
+}
+
+func init() {
+	GetTanzuKubernetesRleasesCmd.Flags().BoolVarP(&gtkr.listAll, "all", "a", false, "List all the available Tanzu Kubernetes releases including Incompatible and deactivated")
+	GetTanzuKubernetesRleasesCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
+}
+
+func getKubernetesReleases(cmd *cobra.Command, args []string) error {
+	server, err := config.GetCurrentServer()
+	if err != nil {
+		return err
+	}
+
+	if server.IsGlobal() {
+		return errors.New("getting Tanzu Kubernetes release with a global server is not implemented yet")
+	}
+
+	clusterClientOptions := clusterclient.Options{GetClientInterval: 2 * time.Second, GetClientTimeout: 5 * time.Second}
+	clusterClient, err := clusterclient.NewClient(server.ManagementClusterOpts.Path, server.ManagementClusterOpts.Context, clusterClientOptions)
+	if err != nil {
+		return err
+	}
+	tkrName := ""
+	if len(args) != 0 {
+		tkrName = args[0]
+	}
+	gtkr.output = cmd.OutOrStdout()
+	return runGetKubernetesReleases(clusterClient, tkrName)
+}
+
+func runGetKubernetesReleases(clusterClient clusterclient.Client, tkrName string) error {
+	tkrs, err := getTKRs(clusterClient, tkrName)
+	if err != nil {
+		return err
+	}
+
+	t := component.NewOutputWriter(gtkr.output, outputFormat, "NAME", "VERSION", "COMPATIBLE", "ACTIVE")
+	for i := range tkrs {
+		compatible := ""
+		for _, condition := range tkrs[i].Status.Conditions {
+			if condition.Type == runv1alpha3.ConditionCompatible {
+				compatible = string(condition.Status)
+			}
+		}
+		labels := tkrs[i].Labels
+		activeStatus := "True"
+		if labels != nil {
+			if _, exists := labels[runv1alpha3.LabelDeactivated]; exists {
+				activeStatus = "False"
+			}
+		}
+
+		if !gtkr.listAll && (!strings.EqualFold(compatible, "true") || !strings.EqualFold(activeStatus, "true")) {
+			continue
+		}
+		t.AddRow(tkrs[i].Name, tkrs[i].Spec.Version, compatible, activeStatus)
+	}
+	t.Render()
+	return nil
+}
+
+func getTKRs(clusterClient clusterclient.Client, tkrName string) ([]runv1alpha3.TanzuKubernetesRelease, error) {
+	var tkrList runv1alpha3.TanzuKubernetesReleaseList
+
+	err := clusterClient.ListResources(&tkrList)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list TKr's")
+	}
+	if tkrName == "" {
+		return tkrList.Items, nil
+	}
+
+	result := []runv1alpha3.TanzuKubernetesRelease{}
+	for i := range tkrList.Items {
+		if strings.HasPrefix(tkrList.Items[i].Name, tkrName) {
+			result = append(result, tkrList.Items[i])
+		}
+	}
+	return result, nil
+}

--- a/cmd/cli/plugin/tkr/v1alpha3/get_tkr_test.go
+++ b/cmd/cli/plugin/tkr/v1alpha3/get_tkr_test.go
@@ -1,0 +1,159 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha3
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	crtclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	runv1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+)
+
+const tkr1_17 = "v1.17"
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "TKR test")
+}
+
+var _ = Describe("runGetKubernetesReleases", func() {
+	var (
+		tkrName       string
+		err           error
+		clusterClient *fakes.ClusterClient
+		tkrs          []runv1alpha3.TanzuKubernetesRelease
+		stdOutput     string
+	)
+
+	BeforeEach(func() {
+		clusterClient = &fakes.ClusterClient{}
+		tkrName = ""
+	})
+
+	JustBeforeEach(func() {
+		reader, writer, perr := os.Pipe()
+		if perr != nil {
+			panic(perr)
+		}
+		stdout := os.Stdout
+		stderr := os.Stderr
+		defer func() {
+			os.Stdout = stdout
+			os.Stderr = stderr
+		}()
+		os.Stdout = writer
+		os.Stderr = writer
+		gtkr.output = writer
+		out := make(chan string)
+		wg := new(sync.WaitGroup)
+		wg.Add(1)
+		go func() {
+			var buf bytes.Buffer
+			wg.Done()
+			_, copyErr := io.Copy(&buf, reader)
+			Expect(copyErr).ToNot(HaveOccurred())
+			out <- buf.String()
+		}()
+		wg.Wait()
+		err = runGetKubernetesReleases(clusterClient, tkrName)
+		writer.Close()
+		stdOutput = <-out
+
+	})
+
+	Context("When the GetTanzuKubernetesReleases return error", func() {
+		BeforeEach(func() {
+			clusterClient.ListResourcesReturns(errors.New("fake TKR error"))
+		})
+		It("should return error", func() {
+			Expect(err).To(HaveOccurred())
+		})
+	})
+	Context("When the GetTanzuKubernetesReleases returns the TKRs successfully", func() {
+		BeforeEach(func() {
+			tkr1 := getFakeTKR("v1.17.17---vmware.1-tkg.2", "v1.17.17+vmware.1", corev1.ConditionFalse)
+			tkr2 := getFakeTKR("v1.17.18---vmware.1-tkg.1", "v1.17.18+vmware.1", corev1.ConditionTrue)
+
+			tkrs = []runv1alpha3.TanzuKubernetesRelease{tkr1, tkr2}
+			clusterClient.ListResourcesCalls(func(tkrl interface{}, option ...crtclient.ListOption) error {
+				tkrList := tkrl.(*runv1alpha3.TanzuKubernetesReleaseList)
+				tkrList.Items = append(tkrList.Items, tkrs...)
+				return nil
+			})
+		})
+		It("should not return error", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdOutput).To(ContainSubstring("v1.17.18---vmware.1-tkg.1"))
+			Expect(stdOutput).ToNot(ContainSubstring("v1.17.17---vmware.1-tkg.2"))
+		})
+	})
+	Context("When the TKR name prefix is given and listing TKRs returns the TKRs successfully", func() {
+		BeforeEach(func() {
+			tkrName = tkr1_17
+			tkr1 := getFakeTKR("v1.17.17---vmware.1-tkg.2", "v1.17.17+vmware.1", corev1.ConditionFalse)
+			tkr2 := getFakeTKR("v1.17.18---vmware.1-tkg.1", "v1.17.18+vmware.1", corev1.ConditionTrue)
+
+			tkrs = []runv1alpha3.TanzuKubernetesRelease{tkr1, tkr2}
+			clusterClient.ListResourcesCalls(func(tkrl interface{}, option ...crtclient.ListOption) error {
+				tkrList := tkrl.(*runv1alpha3.TanzuKubernetesReleaseList)
+				tkrList.Items = append(tkrList.Items, tkrs...)
+				return nil
+			})
+		})
+		It("should not return error", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdOutput).To(ContainSubstring("v1.17.18---vmware.1-tkg.1"))
+			Expect(stdOutput).ToNot(ContainSubstring("v1.17.17---vmware.1-tkg.2"))
+		})
+	})
+	Context("When the TKRs are deactivated", func() {
+		BeforeEach(func() {
+			tkrName = tkr1_17
+			tkr1 := getFakeTKR("v1.17.17---vmware.1-tkg.2", "v1.17.17+vmware.1", corev1.ConditionFalse)
+			tkr2 := getFakeTKR("v1.17.18---vmware.1-tkg.1", "v1.17.18+vmware.1", corev1.ConditionTrue)
+			tkr1.Labels[runv1alpha3.LabelDeactivated] = ""
+			tkr2.Labels[runv1alpha3.LabelDeactivated] = ""
+			tkrs = []runv1alpha3.TanzuKubernetesRelease{tkr1, tkr2}
+			clusterClient.ListResourcesCalls(func(tkrl interface{}, option ...crtclient.ListOption) error {
+				tkrList := tkrl.(*runv1alpha3.TanzuKubernetesReleaseList)
+				tkrList.Items = append(tkrList.Items, tkrs...)
+				return nil
+			})
+		})
+		It("should not return error and the output should not show any TKR", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdOutput).ToNot(ContainSubstring("v1.17.18---vmware.1-tkg.1"))
+			Expect(stdOutput).ToNot(ContainSubstring("v1.17.17---vmware.1-tkg.2"))
+		})
+	})
+
+})
+
+func getFakeTKR(tkrName, k8sversion string, compatibleStatus corev1.ConditionStatus) runv1alpha3.TanzuKubernetesRelease {
+	tkr := runv1alpha3.TanzuKubernetesRelease{}
+	tkr.Name = tkrName
+	tkr.Labels = make(map[string]string)
+	tkr.Spec.Version = strings.ReplaceAll(tkrName, "---", "+")
+	tkr.Spec.Kubernetes.Version = k8sversion
+	tkr.Status.Conditions = []clusterv1.Condition{
+		{
+			Type:   runv1alpha3.ConditionCompatible,
+			Status: compatibleStatus,
+		},
+	}
+	return tkr
+}

--- a/cmd/cli/plugin/tkr/v1alpha3/os.go
+++ b/cmd/cli/plugin/tkr/v1alpha3/os.go
@@ -1,0 +1,192 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha3
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	runv1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+)
+
+var OsCmd = &cobra.Command{
+	Use:   "os",
+	Short: "Get the OS information for a Tanzu Kubernetes Release",
+	Long:  `Get the OS information for a Tanzu Kubernetes Release`,
+}
+
+type getOSOptions struct {
+	region string
+}
+
+var goo = &getOSOptions{}
+
+var getOSCmd = &cobra.Command{
+	Use:   "get TKR_NAME",
+	Short: "Get the OSes that are available for a Tanzu Kubernetes Release",
+	Long:  `Get the OSes that are available for a Tanzu Kubernetes Release`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  getOS,
+}
+var awsOsImageRefRegionKey = "region"
+
+func init() {
+	getOSCmd.Flags().StringVarP(&goo.region, "region", "", "", "The AWS region where AMIs are available")
+	getOSCmd.Flags().StringVarP(&outputFormat, "output", "o", "", "Output format (yaml|json|table)")
+	OsCmd.AddCommand(getOSCmd)
+}
+
+func getOS(cmd *cobra.Command, args []string) error {
+	clusterClient, err := getClusterClient()
+	if err != nil {
+		return err
+	}
+
+	tkrName := args[0]
+	osInfoMap, err := osInfoByTKR(clusterClient, tkrName, goo)
+	if err != nil {
+		return nil
+	}
+	t := component.NewOutputWriter(cmd.OutOrStdout(), outputFormat, "NAME", "VERSION", "ARCH")
+	for _, os := range osInfoMap {
+		t.AddRow(os.Name, os.Version, os.Arch)
+	}
+	t.Render()
+	return nil
+}
+
+func osInfoByTKR(clusterClient clusterclient.Client, tkrName string, options *getOSOptions) (map[string]runv1alpha3.OSInfo, error) {
+	osImages, err := osImagesByTKR(clusterClient, tkrName)
+	if err != nil {
+		return nil, err
+	}
+	resultOSImages, err := filterOSImagesWithInfraSpecificOptions(clusterClient, options, osImages)
+	if err != nil {
+		return nil, err
+	}
+	return osInfoOfImages(resultOSImages), nil
+}
+
+type stringSet map[string]struct{}
+
+func (set stringSet) Add(ss ...string) stringSet {
+	for _, s := range ss {
+		set[s] = struct{}{}
+	}
+	return set
+}
+
+func (set stringSet) Has(s string) bool {
+	_, exists := set[s]
+	return exists
+}
+
+func osImagesByTKR(clusterClient clusterclient.Client, tkrName string) ([]runv1alpha3.OSImage, error) {
+	osImages, err := getOSImages(clusterClient)
+	if err != nil {
+		return nil, err
+	}
+	osImageNamesInTKR, err := getOSImageNamesInTKR(clusterClient, tkrName)
+	if err != nil {
+		return nil, err
+	}
+	candidates := stringSet{}.Add(osImageNamesInTKR...)
+	result := filterOsImages(osImages, func(image *runv1alpha3.OSImage) bool {
+		return candidates.Has(image.Name)
+	})
+	return result, nil
+}
+
+func osInfoOfImages(osImages []runv1alpha3.OSImage) map[string]runv1alpha3.OSInfo {
+	results := map[string]runv1alpha3.OSInfo{}
+	for i := range osImages {
+		osInfo := osImages[i].Spec.OS
+		results[OsInfoString(osInfo)] = osInfo
+	}
+	return results
+}
+func filterOSImagesWithInfraSpecificOptions(clusterClient clusterclient.Client,
+	options *getOSOptions, osImages []runv1alpha3.OSImage) ([]runv1alpha3.OSImage, error) {
+
+	infra, err := clusterClient.GetClusterInfrastructure()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get current management cluster infrastructure")
+	}
+	if infra == constants.InfrastructureRefAWS && options.region != "" {
+		osImages = filterOsImages(osImages, func(osImage *runv1alpha3.OSImage) bool {
+			if regionName, exists := osImage.Spec.Image.Ref[awsOsImageRefRegionKey]; exists && regionName == options.region {
+				return true
+			}
+			return false
+		})
+	}
+	return osImages, nil
+}
+func getOSImages(clusterClient clusterclient.Client) ([]runv1alpha3.OSImage, error) {
+	var osImageList runv1alpha3.OSImageList
+	err := clusterClient.ListResources(&osImageList)
+	if err != nil {
+		return nil, err
+	}
+	var osImages []runv1alpha3.OSImage
+	for i := range osImageList.Items {
+		osImages = append(osImages, osImageList.Items[i])
+	}
+	return osImages, nil
+}
+
+func getOSImageNamesInTKR(clusterClient clusterclient.Client, tkrName string) ([]string, error) {
+	var tkr runv1alpha3.TanzuKubernetesRelease
+	err := clusterClient.GetResource(&tkr, tkrName, "", nil, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get TKR ")
+	}
+
+	osImageNamesInTKR := make([]string, len(tkr.Spec.OSImages))
+	for i := range tkr.Spec.OSImages {
+		osImageNamesInTKR[i] = tkr.Spec.OSImages[i].Name
+	}
+	return osImageNamesInTKR, nil
+}
+
+type osImagePredicate func(osImage *runv1alpha3.OSImage) bool
+
+func filterOsImages(osImages []runv1alpha3.OSImage, p osImagePredicate) []runv1alpha3.OSImage {
+	result := make([]runv1alpha3.OSImage, 0, len(osImages))
+	for i := range osImages {
+		if p(&osImages[i]) {
+			result = append(result, osImages[i])
+		}
+	}
+	return result
+}
+
+func OsInfoString(os runv1alpha3.OSInfo) string {
+	return fmt.Sprintf("%s-%s-%s", os.Name, os.Version, os.Arch)
+}
+
+func getClusterClient() (clusterclient.Client, error) {
+	server, err := config.GetCurrentServer()
+	if err != nil {
+		return nil, err
+	}
+
+	if server.IsGlobal() {
+		return nil, errors.New("getting TanzuKubernetesRelease with a global server is not implemented yet")
+	}
+
+	clusterClientOptions := clusterclient.Options{GetClientInterval: 2 * time.Second, GetClientTimeout: 5 * time.Second}
+	clusterClient, err := clusterclient.NewClient(server.ManagementClusterOpts.Path, server.ManagementClusterOpts.Context, clusterClientOptions)
+	if err != nil {
+		return nil, err
+	}
+	return clusterClient, nil
+}

--- a/cmd/cli/plugin/tkr/v1alpha3/os_test.go
+++ b/cmd/cli/plugin/tkr/v1alpha3/os_test.go
@@ -1,0 +1,183 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha3
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	runv1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/resolver/data"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/util/testdata"
+)
+
+const (
+	k8s1_20_1 = "v1.20.1+vmware.1"
+	k8s1_20_2 = "v1.20.2+vmware.1"
+	k8s1_21_1 = "v1.21.1+vmware.1"
+	k8s1_21_3 = "v1.21.3+vmware.1"
+	k8s1_22_0 = "v1.22.0+vmware.1"
+)
+
+var k8sVersions = []string{k8s1_20_1, k8s1_20_2, k8s1_21_1, k8s1_21_3, k8s1_22_0}
+
+var _ = Describe("os get", func() {
+	var (
+		tkrName       string
+		err           error
+		clusterClient *fakes.ClusterClient
+		tkr           *runv1alpha3.TanzuKubernetesRelease
+		osImages      data.OSImages
+		tkrs          data.TKRs
+		cmdOptions    *getOSOptions
+		gotOSInfoMap  map[string]runv1alpha3.OSInfo
+	)
+
+	BeforeEach(func() {
+		clusterClient = &fakes.ClusterClient{}
+		tkrName = ""
+		cmdOptions = &getOSOptions{}
+		osImages = testdata.GenOSImages(k8sVersions, 3)
+		tkrs = testdata.GenTKRs(2, testdata.SortOSImagesByK8sVersion(osImages))
+		tkr = testdata.ChooseTKR(tkrs)
+	})
+
+	JustBeforeEach(func() {
+		gotOSInfoMap, err = osInfoByTKR(clusterClient, tkrName, cmdOptions)
+	})
+
+	Context("When the get OSImages return error", func() {
+		BeforeEach(func() {
+			clusterClient.ListResourcesReturns(errors.New("fake get OSImages error"))
+		})
+		It("should return error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("fake get OSImages error"))
+			Expect(gotOSInfoMap).To(BeNil())
+		})
+	})
+	Context("When the get TKR return error", func() {
+		BeforeEach(func() {
+			clusterClient.ListResourcesCalls(func(o interface{}, option ...client.ListOption) error {
+				imgl := o.(*runv1alpha3.OSImageList)
+				imgl.Items = append(imgl.Items, getOSImagesList(osImages)...)
+				return nil
+			})
+			clusterClient.GetResourceReturns(errors.New("fake get TKR error"))
+		})
+		It("should return error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("fake get TKR error"))
+			Expect(gotOSInfoMap).To(BeNil())
+		})
+	})
+	Context("When the OSImages and TKR are available", func() {
+		BeforeEach(func() {
+			clusterClient.ListResourcesCalls(func(o interface{}, option ...client.ListOption) error {
+				osImagelist := o.(*runv1alpha3.OSImageList)
+				osImagelist.Items = append(osImagelist.Items, getOSImagesList(osImages)...)
+				return nil
+			})
+			clusterClient.GetResourceCalls(func(o interface{}, tkrName, ns string, pv clusterclient.PostVerifyrFunc, poll *clusterclient.PollOptions) error {
+				*o.(*runv1alpha3.TanzuKubernetesRelease) = *tkr
+				return nil
+			})
+
+		})
+		It("should not return error", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(gotOSInfoMap).ToNot(BeNil())
+			Expect(len(gotOSInfoMap)).ToNot(BeZero())
+			Expect(validateOSInfoResults(gotOSInfoMap, tkr, osImages, "")).To(BeNil())
+		})
+	})
+	Context("When the OSImages and TKR are available and get cluster infrastructure returns error", func() {
+		BeforeEach(func() {
+			clusterClient.ListResourcesCalls(func(o interface{}, option ...client.ListOption) error {
+				osImagelist := o.(*runv1alpha3.OSImageList)
+				osImagelist.Items = append(osImagelist.Items, getOSImagesList(osImages)...)
+				return nil
+			})
+			clusterClient.GetResourceCalls(func(o interface{}, tkrName, ns string, pv clusterclient.PostVerifyrFunc, poll *clusterclient.PollOptions) error {
+				*o.(*runv1alpha3.TanzuKubernetesRelease) = *tkr
+				return nil
+			})
+			clusterClient.GetClusterInfrastructureReturns("", errors.New("fake getclusterInfrastructure error"))
+
+		})
+		It("should return error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("fake getclusterInfrastructure error"))
+			Expect(gotOSInfoMap).To(BeNil())
+		})
+	})
+	Context("When user provides region and the OSImages and TKR are available and get cluster infrastructure returns success", func() {
+		BeforeEach(func() {
+			clusterClient.ListResourcesCalls(func(o interface{}, option ...client.ListOption) error {
+				osImagelist := o.(*runv1alpha3.OSImageList)
+				osImagelist.Items = append(osImagelist.Items, getOSImagesList(osImages)...)
+				return nil
+			})
+			clusterClient.GetResourceCalls(func(o interface{}, tkrName, ns string, pv clusterclient.PostVerifyrFunc, poll *clusterclient.PollOptions) error {
+				*o.(*runv1alpha3.TanzuKubernetesRelease) = *tkr
+				return nil
+			})
+			cmdOptions = &getOSOptions{region: chooseRegionFromTKR(tkr, osImages)}
+			clusterClient.GetClusterInfrastructureReturns(constants.InfrastructureRefAWS, nil)
+
+		})
+		It("should not return error", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(gotOSInfoMap).ToNot(BeNil())
+			Expect(validateOSInfoResults(gotOSInfoMap, tkr, osImages, cmdOptions.region)).To(BeNil())
+		})
+	})
+})
+
+func getOSImagesList(osImages data.OSImages) []runv1alpha3.OSImage {
+	var result []runv1alpha3.OSImage
+	for _, image := range osImages {
+		result = append(result, *image)
+	}
+	return result
+}
+
+func chooseRegionFromTKR(tkr *runv1alpha3.TanzuKubernetesRelease, osImages data.OSImages) string {
+	osImageName := tkr.Spec.OSImages[0].Name
+	return osImages[osImageName].Spec.Image.Ref["region"].(string)
+}
+
+func validateOSInfoResults(gotOSInfoMap map[string]runv1alpha3.OSInfo,
+	tkr *runv1alpha3.TanzuKubernetesRelease, osImages data.OSImages, region string) error {
+
+	osImageNamesInTKR := []string{}
+	for _, o := range tkr.Spec.OSImages {
+		osImageNamesInTKR = append(osImageNamesInTKR, o.Name)
+	}
+	for _, name := range osImageNamesInTKR {
+		osImage, exists := osImages[name]
+		if !exists {
+			return errors.Errorf("unable to find the TKR's osImage '%s' in the given osImages", name)
+		}
+		if region != "" && osImage.Spec.Image.Ref["region"] != region {
+			continue
+		}
+		osInfo := osImage.Spec.OS
+		osInfoInString := OsInfoString(osInfo)
+		oi, exists := gotOSInfoMap[osInfoInString]
+		if !exists {
+			return errors.Errorf("unable to find the osInfo of OsImage '%s'", name)
+		}
+		if oi != osInfo {
+			return errors.Errorf("osInfo of OsImage '%s' doesn't match with osInfo returned ", name)
+		}
+	}
+
+	return nil
+}

--- a/pkg/v1/config/clientconfig.go
+++ b/pkg/v1/config/clientconfig.go
@@ -54,6 +54,9 @@ const (
 	// or legacy way of managing management components. This is also used for clusterclass based management and workload
 	// cluster provisioning
 	FeatureFlagPackageBasedLCM = "features.global.package-based-lcm-beta"
+	// TKR version v1alpha3 feature flag determines whether to use Tanzu Kubernetes Release API version v1alpha3. Setting
+	// feature flag to true will allow to use the TKR version v1alpha3; false allows to use legacy TKR version v1alpha1
+	FeatureFlagTKRVersionV1Alpha3 = "features.global.tkr-version-v1alpha3-beta"
 )
 
 // DefaultCliFeatureFlags is used to populate an initially empty config file with default values for feature flags.
@@ -83,6 +86,7 @@ var (
 		FeatureFlagManagementClusterNetworkSeparation:         false,
 		FeatureFlagAwsInstanceTypesExcludeArm:                 true,
 		FeatureFlagPackageBasedLCM:                            false,
+		FeatureFlagTKRVersionV1Alpha3:                         false,
 	}
 )
 

--- a/pkg/v1/tkg/client/client.go
+++ b/pkg/v1/tkg/client/client.go
@@ -199,10 +199,16 @@ type Client interface {
 	// IsManagementClusterAKindCluster determines if the creation of management cluster is successful
 	IsManagementClusterAKindCluster(clusterName string) (bool, error)
 	// GetTanzuKubernetesReleases returns the available TanzuKubernetesReleases
+	// Deprecated: This would not be supported from TKR API version v1alpha3,
+	// user can use go client to get TKR
 	GetTanzuKubernetesReleases(tkrName string) ([]runv1alpha1.TanzuKubernetesRelease, error)
 	// ActivateTanzuKubernetesReleases activates TanzuKubernetesRelease
+	// Deprecated: This would not be supported from TKR API version v1alpha3,
+	// user can use go client to set the labels to activate/deactivate the TKR
 	ActivateTanzuKubernetesReleases(tkrName string) error
 	// DeactivateTanzuKubernetesReleases deactivates TanzuKubernetesRelease
+	// Deprecated: This would not be supported from TKR API version v1alpha3,
+	// user can use go client to set the labels to activate/deactivate the TKR
 	DeactivateTanzuKubernetesReleases(tkrName string) error
 	// IsPacificRegionalCluster checks if the cluster pointed to by kubeconfig  is Pacific management cluster(supervisor)
 	IsPacificRegionalCluster() (bool, error)

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -60,6 +60,7 @@ import (
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
 	runv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
+	runv1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo"
 	capdiscovery "github.com/vmware-tanzu/tanzu-framework/pkg/v1/sdk/capabilities/discovery"
 	tmcv1alpha1 "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/api/tmc/v1alpha1"
@@ -306,8 +307,12 @@ type Client interface {
 	// GetClusterInfrastructure gets cluster infrastructure name like VSphereCluster, AWSCluster, AzureCluster
 	GetClusterInfrastructure() (string, error)
 	// ActivateTanzuKubernetesReleases activates TanzuKubernetesRelease
+	// Deprecated: This would not be supported from TKR API version v1alpha3,
+	// user can use go client to set the labels to activate/deactivate the TKR
 	ActivateTanzuKubernetesReleases(tkrName string) error
 	// DeactivateTanzuKubernetesReleases deactivates TanzuKubernetesRelease
+	// Deprecated: This would not be supported from TKR API version v1alpha3,
+	// user can use go client to set the labels to activate/deactivate the TKR
 	DeactivateTanzuKubernetesReleases(tkrName string) error
 	// IsClusterRegisteredToTMC returns true if cluster is registered to Tanzu Mission Control
 	IsClusterRegisteredToTMC() (bool, error)
@@ -416,7 +421,7 @@ func init() {
 	_ = extensionsV1.AddToScheme(scheme)
 	_ = rbacv1.AddToScheme(scheme)
 	_ = addonsv1.AddToScheme(scheme)
-	_ = runv1alpha1.AddToScheme(scheme)
+	_ = runv1alpha3.AddToScheme(scheme)
 	_ = kappipkg.AddToScheme(scheme)
 	_ = cliv1alpha1.AddToScheme(scheme)
 }

--- a/pkg/v1/tkg/tkgctl/interface.go
+++ b/pkg/v1/tkg/tkgctl/interface.go
@@ -75,10 +75,16 @@ type TKGClient interface {
 	// GetClusterPinnipedInfo returns the cluster and pinniped info
 	GetClusterPinnipedInfo(options GetClusterPinnipedInfoOptions) (*client.ClusterPinnipedInfo, error)
 	// GetTanzuKubernetesReleases returns the available TanzuKubernetesReleases
+	// Deprecated: This would not be supported from TKR API version v1alpha3,
+	// user can use go client to get TKR
 	GetTanzuKubernetesReleases(tkrName string) ([]runv1alpha1.TanzuKubernetesRelease, error)
 	// ActivateTanzuKubernetesReleases activates TanzuKubernetesRelease
+	// Deprecated: This would not be supported from TKR API version v1alpha3,
+	// user can use go client to set the labels to activate/deactivate the TKR
 	ActivateTanzuKubernetesReleases(tkrName string) error
 	// DeactivateTanzuKubernetesReleases deactivates TanzuKubernetesRelease
+	// Deprecated: This would not be supported from TKR API version v1alpha3,
+	// user can use go client to set the labels to activate/deactivate the TKR
 	DeactivateTanzuKubernetesReleases(tkrName string) error
 	// IsPacificRegionalCluster checks if the cluster pointed to by kubeconfig  is Pacific management cluster(supervisor)
 	IsPacificRegionalCluster() (bool, error)


### PR DESCRIPTION
-  Added a feature flag "features.global.tkr-version-v1alpha3-beta" (with default set to disabled) to enable KR plugin for new TKR API v1alpha3.
- "available-upgrades" subcommand would not be available for TKR API version v1alpha3 as UpdatesAvailable condition will be removed in v1alpha3
- Deprecated the below methods from tkgctl interface,user can use go-client to perform these operations
   i)GetTanzuKubernetesReleases
   ii)ActivateTanzuKubernetesReleases
   iii)DeactivateTanzuKubernetesReleases

Signed-off-by: PremKumar Kalle <pkalle@vmware.com>

### What this PR does / why we need it
Update the `kubernetes release` plugin to implement the new TKR API v1alpha3
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1924 

### Describe testing done for PR
set the feature flag using `tanzu config set features.global.tkr-version-v1alpha3-beta true`
Later performed 
1) tanzu kr get  and it successfully displayed the v1alpha3 TKRs
```
❯ tanzu kr get -a
  NAME                               VERSION                 COMPATIBLE  ACTIVE  
  v1.22.5---vmware.1-tkg.2  v1.22.5+vmware.1-tkg.2              True    
  v1.23.3---vmware.1-tkg.1  v1.23.3+vmware.1-tkg.1              True    
  v1.23.5---vmware.1-tkg.1  v1.23.5+vmware.1-tkg.1              True    

```
2) tanzu kr deactivate <tkr-name> -- it shows the TKR as deactivated by using tanzu kr get command
```
❯ tanzu kr get -a
  NAME                      VERSION                 COMPATIBLE  ACTIVE  
  v1.22.5---vmware.1-tkg.2  v1.22.5+vmware.1-tkg.2              True    
  v1.23.3---vmware.1-tkg.1  v1.23.3+vmware.1-tkg.1              True    
  v1.23.5---vmware.1-tkg.1  v1.23.5+vmware.1-tkg.1              True    
❯ tanzu kr deactivate v1.22.5---vmware.1-tkg.2
Applying patch to resource v1.22.5---vmware.1-tkg.2 of type *v1alpha3.TanzuKubernetesRelease ...
❯ tanzu kr get -a
  NAME                      VERSION                 COMPATIBLE  ACTIVE  
  v1.23.3---vmware.1-tkg.1  v1.23.3+vmware.1-tkg.1              True    
  v1.23.5---vmware.1-tkg.1  v1.23.5+vmware.1-tkg.1              True    

```
3) tanzu kr activate <tkr-name> -- it shows the TKR as activated by using tanzu kr get command
```
❯ tanzu kr activate v1.22.5---vmware.1-tkg.2
Applying patch to resource v1.22.5---vmware.1-tkg.2 of type *v1alpha3.TanzuKubernetesRelease ...
❯ tanzu kr get -a
  NAME                      VERSION                 COMPATIBLE  ACTIVE  
  v1.22.5---vmware.1-tkg.2  v1.22.5+vmware.1-tkg.2              True    
  v1.23.3---vmware.1-tkg.1  v1.23.3+vmware.1-tkg.1              True    
  v1.23.5---vmware.1-tkg.1  v1.23.5+vmware.1-tkg.1              True    


```
4) tanzu kr os <tkr-name> -- it shows the os information for all the supported os images
```
❯ tanzu kr os get v1.22.5---vmware.1-tkg.2 --region us-west-2
  NAME    VERSION  ARCH   
  ubuntu  20.04    amd64  
  amazon  2        amd64  
❯ tanzu kr os get v1.22.5---vmware.1-tkg.2 --region us-west-1
  NAME  VERSION  ARCH  

```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Update the KR plugin to implement the new TKR API v1alpha3
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
