### PR TITLE
Opted out of CEIP when ENABLE_CEIP_PARTICIPATION is set to false

### DIFF
--- a/cmd/cli/plugin/managementcluster/common.go
+++ b/cmd/cli/plugin/managementcluster/common.go
@@ -15,16 +15,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 )
 
-const (
-	// DefaultCEIPSetting is the CEIP setting for created management-clusters
-	DefaultCEIPSetting = "true"
-	// DefaultCEIPTCESetting is the CEIP setting for TCE management-clusters
-	DefaultCEIPTCESetting = "false"
-	// TCEBuildEditionName is the name expected to represent a TCE build of the management-cluster plugin
-	// This value comes from the TCE build process (see the project's Makefile)
-	TCEBuildEditionName = "tce"
-)
-
 func newTKGCtlClient(forceUpdateTKGCompatibilityImage bool) (tkgctl.TKGClient, error) {
 	tkgConfigDir, err := getTKGConfigDir()
 	if err != nil {

--- a/cmd/cli/plugin/managementcluster/create.go
+++ b/cmd/cli/plugin/managementcluster/create.go
@@ -106,12 +106,7 @@ func init() {
 	// commercial Tanzu editions turn CEIP on by default.
 	// community edition turns it off
 
-	edition, _ := config.GetEdition()
-	defaultCeip := DefaultCEIPSetting
-	if edition == TCEBuildEditionName {
-		defaultCeip = DefaultCEIPTCESetting
-	}
-	createCmd.Flags().StringVarP(&iro.ceipOptIn, "ceip-participation", "", defaultCeip, "Specify if this management cluster should participate in VMware CEIP. (See [*])")
+	createCmd.Flags().StringVarP(&iro.ceipOptIn, "ceip-participation", "", "", "Specify if this management cluster should participate in VMware CEIP. (See [*])")
 	createCmd.Flags().MarkHidden("ceip-participation") //nolint
 
 	createCmd.Flags().BoolVarP(&iro.deployTKGonVsphere7, "deploy-tkg-on-vSphere7", "", false, "Deploy TKG Management cluster on vSphere 7.0 without prompt")

--- a/pkg/v1/tkg/test/config/azure.yaml
+++ b/pkg/v1/tkg/test/config/azure.yaml
@@ -2,6 +2,7 @@
 infrastructure_name: azure
 cluster_prefix: ""
 tkg_config_variables:
+  ENABLE_CEIP_PARTICIPATION: "false"
   AZURE_SUBSCRIPTION_ID: ""
   AZURE_TENANT_ID: ""
   AZURE_CLIENT_ID: ""

--- a/pkg/v1/tkg/test/config/docker.yaml
+++ b/pkg/v1/tkg/test/config/docker.yaml
@@ -1,5 +1,7 @@
 ---
 infrastructure_name: docker
 management_cluster_name: tkg-mc
+tkg_config_variables:
+  ENABLE_CEIP_PARTICIPATION: "false"
 management_cluster_options:
   plan: dev

--- a/pkg/v1/tkg/test/tkgctl/azure/azure_suite_test.go
+++ b/pkg/v1/tkg/test/tkgctl/azure/azure_suite_test.go
@@ -126,6 +126,10 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	optOutStatus, err := tkgCtlClient.GetCEIP()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(optOutStatus.CeipStatus).To(Equal("Opt-out"))
+
 	err = tkgCtlClient.ConfigCluster(tkgctl.CreateClusterOptions{
 		ClusterConfigFile: clusterConfigFile,
 		Edition:           "tkg",

--- a/pkg/v1/tkg/test/tkgctl/docker/docker_suite_test.go
+++ b/pkg/v1/tkg/test/tkgctl/docker/docker_suite_test.go
@@ -124,6 +124,10 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	optOutStatus, err := tkgCtlClient.GetCEIP()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(optOutStatus.CeipStatus).To(Equal("Opt-out"))
+
 	By(fmt.Sprintf("Creating initial workload cluster %q", clusterName))
 
 	defer os.Remove(clusterConfigFile)

--- a/pkg/v1/tkg/tkgctl/helper_constants.go
+++ b/pkg/v1/tkg/tkgctl/helper_constants.go
@@ -6,3 +6,4 @@ package tkgctl
 
 // True string constant for the value "true"
 var True = "true"
+var False = "false"

--- a/pkg/v1/tkg/tkgctl/init.go
+++ b/pkg/v1/tkg/tkgctl/init.go
@@ -69,7 +69,7 @@ func (t *tkgctl) Init(options InitRegionOptions) error {
 
 	ceipOptIn, err := strconv.ParseBool(options.CeipOptIn)
 	if err != nil {
-		ceipOptIn = false
+		ceipOptIn = true
 	}
 
 	if logPath, err := t.getAuditLogPath(options.ClusterName); err == nil {
@@ -317,6 +317,8 @@ func (t *tkgctl) configureInitManagementClusterOptionsFromConfigFile(iro *InitRe
 		ceipOptIn, err := t.TKGConfigReaderWriter().Get(constants.ConfigVariableEnableCEIPParticipation)
 		if err == nil {
 			iro.CeipOptIn = ceipOptIn
+		} else if iro.Edition == "tce" {
+			iro.CeipOptIn = False
 		} else {
 			iro.CeipOptIn = True
 		}

--- a/pkg/v1/tkg/tkgctl/utils.go
+++ b/pkg/v1/tkg/tkgctl/utils.go
@@ -1,0 +1,19 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgctl
+
+import "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+
+func (t *tkgctl) setCEIPOptinBasedOnConfigAndBuildEdition(edition string) string {
+	ceipOptIn, err := t.TKGConfigReaderWriter().Get(constants.ConfigVariableEnableCEIPParticipation)
+	if err == nil {
+		return ceipOptIn
+	}
+
+	if edition == TCEBuildEdition {
+		return False
+	}
+
+	return True
+}

--- a/pkg/v1/tkg/tkgctl/utils_test.go
+++ b/pkg/v1/tkg/tkgctl/utils_test.go
@@ -1,0 +1,84 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgctl
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgconfigreaderwriter"
+
+	"os"
+)
+
+var _ = Describe("Unit tests for ceip", func() {
+	var (
+		tkgctlClient *tkgctl
+	)
+
+	BeforeEach(func() {
+		tkgConfigReaderWriter, err := tkgconfigreaderwriter.NewReaderWriterFromConfigFile("../fakes/config/config.yaml", "../fakes/config/config.yaml")
+		Expect(err).ToNot(HaveOccurred())
+		tkgctlClient = &tkgctl{
+			tkgConfigReaderWriter: tkgConfigReaderWriter,
+		}
+	})
+
+	Context("CEIP value is set to true in the config file", func() {
+		BeforeEach(func() {
+			tkgctlClient.tkgConfigReaderWriter.Set(constants.ConfigVariableEnableCEIPParticipation, "true")
+		})
+
+		It("When build edition is tce", func() {
+			ceipOptinStatus := tkgctlClient.setCEIPOptinBasedOnConfigAndBuildEdition("tce")
+			Expect(ceipOptinStatus).To(Equal("true"))
+		})
+		It("When build edition is tkg", func() {
+			ceipOptinStatus := tkgctlClient.setCEIPOptinBasedOnConfigAndBuildEdition("tkg")
+			Expect(ceipOptinStatus).To(Equal("true"))
+		})
+
+		AfterEach(func() {
+			err := os.Unsetenv(constants.ConfigVariableEnableCEIPParticipation)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("CEIP value is set to false in the config file", func() {
+		BeforeEach(func() {
+			tkgctlClient.tkgConfigReaderWriter.Set(constants.ConfigVariableEnableCEIPParticipation, "false")
+		})
+
+		It("When build edition is tce", func() {
+			ceipOptinStatus := tkgctlClient.setCEIPOptinBasedOnConfigAndBuildEdition("tce")
+			Expect(ceipOptinStatus).To(Equal("false"))
+		})
+		It("When build edition is tkg", func() {
+			ceipOptinStatus := tkgctlClient.setCEIPOptinBasedOnConfigAndBuildEdition("tkg")
+			Expect(ceipOptinStatus).To(Equal("false"))
+		})
+
+		AfterEach(func() {
+			err := os.Unsetenv(constants.ConfigVariableEnableCEIPParticipation)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("CEIP value is not set in the config file", func() {
+		BeforeEach(func() {
+			err := os.Unsetenv(constants.ConfigVariableEnableCEIPParticipation)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("When build edition is tce", func() {
+			ceipOptinStatus := tkgctlClient.setCEIPOptinBasedOnConfigAndBuildEdition("tce")
+			Expect(ceipOptinStatus).To(Equal("false"))
+		})
+		It("When build edition is tkg", func() {
+			ceipOptinStatus := tkgctlClient.setCEIPOptinBasedOnConfigAndBuildEdition("tkg")
+			Expect(ceipOptinStatus).To(Equal("true"))
+		})
+	})
+})


### PR DESCRIPTION
### What this PR does / why we need it
CEIP should be false for TCE by default, and true for other editions. 
If ENABLE_CEIP_PARTICIPATION is set to false, then CEIP participation must be disabled. This PR is ensure that functionality.

### Which issue(s) this PR fixes

Fixes #https://github.com/vmware-tanzu/tanzu-framework/issues/2197

### Describe testing done for PR
Manual Testing
Before making the fix
1. Created a management cluster on AWS by setting `ENABLE_CEIP_PARTICIPATION: false`
2. Console output showed CEIP Status: Opt In
3. Noticed that the tkg-telemetry cronjob was running on the cluster
```
$ kubectl get pods -A
NAMESPACE                           NAME                                                                READY   STATUS      RESTARTS   AGE
...
tkg-system-telemetry                tkg-telemetry-27525600-thmkg                                        0/1     Completed   0          16h
tkg-system-telemetry                tkg-telemetry-27525960-wtxfr                                        0/1     Completed   0          10h
tkg-system-telemetry                tkg-telemetry-27526320-rbflp                                        0/1     Completed   0          4h53m
...

$ kubectl get cronjob -A
NAMESPACE              NAME            SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
tkg-system-telemetry   tkg-telemetry   0 */6 * * *   False     0        4h53m           4d22h
```

After making the fix
1. Created a management cluster on AWS by setting `ENABLE_CEIP_PARTICIPATION: false`
2. Console output showed CEIP Optin: false
```
ENABLE_CEIP_PARTICIPATION=false ./artifacts/darwin/amd64/cli/management-cluster/v0.22.0-dev/tanzu-management-cluster-darwin_amd64 create -f ~/sample-aws-20220502.yaml -v 6
...
CEIP Opt-in status: false
```
3. Verified that the tkg-telemetry cronjob is not running
```
$ kubectl get cronjob -A
No resources found
```
4. Verified the opt-in status using the ceip-plugin
```
$ ./artifacts/darwin/amd64/cli/management-cluster/v0.22.0-dev/tanzu-management-cluster-darwin_amd64 ceip-participation get
  MANAGEMENT-CLUSTER-NAME      CEIP-STATUS
  tkg-mgmt-aws-20220503102629  Opt-out
```

Automated testing:
* Set `ENABLE_CEIP_PARTICIPATION: false` while running the Integration tests that run as part of the Github CI, and added a step to verify that the CEIP Status is Opt-out

## Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
* Fixed bug where ENABLE_CEIP_PARTICIPATION config variable was not being heeded
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
