### PR TITLE
[release-0.11] Fix context-scoped plugins not getting installed after creating management-cluster from UI

### DIFF
--- a/pkg/v1/tkg/web/server/handlers/init.go
+++ b/pkg/v1/tkg/web/server/handlers/init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/pkg/errors"
 
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/pluginmanager"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clientcreator"
@@ -92,6 +93,10 @@ func (app *App) CreateVSphereRegionalCluster(params vsphere.CreateVSphereRegiona
 			log.Infof("\nManagement cluster created!\n\n")
 			log.Info("\nYou can now create your first workload cluster by running the following:\n\n")
 			log.Info("  tanzu cluster create [name] -f [file]\n\n")
+			err = pluginmanager.SyncPlugins(app.InitOptions.ClusterName)
+			if err != nil {
+				log.Warningf("unable to sync plugins after management cluster create. Please run `tanzu plugin sync` command manually to install/update plugins")
+			}
 			// wait for the logs to be dispatched to UI before exit
 			time.Sleep(sleepTimeForLogsPropogation)
 			// exit the BE server on success
@@ -173,6 +178,10 @@ func (app *App) CreateAWSRegionalCluster(params aws.CreateAWSRegionalClusterPara
 			log.Infof("\nManagement cluster created!\n\n")
 			log.Info("\nYou can now create your first workload cluster by running the following:\n\n")
 			log.Info("  tanzu cluster create [name] -f [file]\n\n")
+			err = pluginmanager.SyncPlugins(app.InitOptions.ClusterName)
+			if err != nil {
+				log.Warningf("unable to sync plugins after management cluster create. Please run `tanzu plugin sync` command manually to install/update plugins")
+			}
 			// wait for the logs to be dispatched to UI before exit
 			time.Sleep(sleepTimeForLogsPropogation)
 			// exit the BE server on success
@@ -273,6 +282,10 @@ func (app *App) CreateAzureRegionalCluster(params azure.CreateAzureRegionalClust
 			log.Infof("\nManagement cluster created!\n\n")
 			log.Info("\nYou can now create your first workload cluster by running the following:\n\n")
 			log.Info("  tanzu cluster create [name] -f [file]\n\n")
+			err = pluginmanager.SyncPlugins(app.InitOptions.ClusterName)
+			if err != nil {
+				log.Warningf("unable to sync plugins after management cluster create. Please run `tanzu plugin sync` command manually to install/update plugins")
+			}
 			// wait for the logs to be dispatched to UI before exit
 			time.Sleep(sleepTimeForLogsPropogation)
 			// exit the BE server on success
@@ -338,6 +351,10 @@ func (app *App) CreateDockerRegionalCluster(params docker.CreateDockerRegionalCl
 			log.Infof("\nManagement cluster created!\n\n")
 			log.Info("\nYou can now create your first workload cluster by running the following:\n\n")
 			log.Info("  tanzu cluster create [name] -f [file]\n\n")
+			err = pluginmanager.SyncPlugins(app.InitOptions.ClusterName)
+			if err != nil {
+				log.Warningf("unable to sync plugins after management cluster create. Please run `tanzu plugin sync` command manually to install/update plugins")
+			}
 			// wait for the logs to be dispatched to UI before exit
 			time.Sleep(sleepTimeForLogsPropogation)
 			// exit the BE server on success


### PR DESCRIPTION
### What this PR does / why we need it
- Fix plugins not getting installed after creating management-cluster from UI

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/2293

### Describe testing done for PR
Create management-cluster using UI and make sure context-scoped plugins gets installed
<img width="1335" alt="Screen Shot 2022-05-03 at 1 55 22 PM" src="https://user-images.githubusercontent.com/7102902/166605539-4122b5a1-8e00-4ef5-bd59-64ca9e852c1d.png">



<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix context-scoped plugins not getting installed after creating management-cluster through Kickstart UI
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
