### PR TITLE
[release-0.11] Consider additional metadata as part of kubernetes build version during version comparison

### DIFF
--- a/pkg/v1/tkg/utils/common.go
+++ b/pkg/v1/tkg/utils/common.go
@@ -114,8 +114,11 @@ func CompareVMwareVersionStrings(v1, v2 string) (int, error) {
 		return compareResult, nil
 	}
 
-	v1VmwareBuildVersion, err1 := strconv.Atoi(v1s[1])
-	v2VmwareBuildVersion, err2 := strconv.Atoi(v2s[1])
+	buildVersionV1 := strings.Split(v1s[1], "-")
+	buildVersionV2 := strings.Split(v2s[1], "-")
+
+	v1VmwareBuildVersion, err1 := strconv.Atoi(buildVersionV1[0])
+	v2VmwareBuildVersion, err2 := strconv.Atoi(buildVersionV2[0])
 	if err1 != nil || err2 != nil {
 		return 0, errors.New("invalid version string")
 	}

--- a/pkg/v1/tkg/utils/common_test.go
+++ b/pkg/v1/tkg/utils/common_test.go
@@ -16,6 +16,8 @@ var (
 	k8sv1174           = "v1.17.4+vmware.2"
 	k8sv1182           = "v1.18.2+vmware.2"
 	k8sv1191           = "v1.19.1+vmware.2"
+	k8sv11731Fips1     = "v1.17.3+vmware.1-fips.1"
+	k8sv11732Fips1     = "v1.17.3+vmware.2-fips.1"
 	vABC               = "vA.B.C"
 	fakePathABC        = "gcr.io/fakepath/tkg/kind/node:vA.B.C"
 	tkrNameSample      = "tkr---version"
@@ -411,6 +413,61 @@ var _ = Describe("CompareVMwareVersionStrings", func() {
 			Expect(compareResult).To(Equal(0))
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError("invalid version string"))
+		})
+	})
+
+	Context("When buildVersion includes -suffix and", func() {
+		BeforeEach(func() {
+			fromVersion = k8sv11731Fips1
+			toVersion = "v1.17.4+vmware.1-fips.1"
+		})
+		It("expect compareResult < 0", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(compareResult < 0).To(Equal(true))
+		})
+	})
+
+	Context("When buildVersion includes -suffix and buildVersion is different", func() {
+		BeforeEach(func() {
+			fromVersion = k8sv11731Fips1
+			toVersion = k8sv11732Fips1
+		})
+		It("expect compareResult < 0", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(compareResult < 0).To(Equal(true))
+		})
+	})
+
+	Context("When buildVersion includes -suffix and buildVersion is different", func() {
+		BeforeEach(func() {
+			fromVersion = k8sv11732Fips1
+			toVersion = k8sv11731Fips1
+		})
+		It("expect compareResult > 0", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(compareResult > 0).To(Equal(true))
+		})
+	})
+
+	Context("When buildVersion includes -suffix and buildVersion are same", func() {
+		BeforeEach(func() {
+			fromVersion = k8sv11731Fips1
+			toVersion = k8sv11731Fips1
+		})
+		It("expect compareResult = 0", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(compareResult == 0).To(Equal(true))
+		})
+	})
+
+	Context("When buildVersion includes -suffix and version are different", func() {
+		BeforeEach(func() {
+			fromVersion = k8sv11731Fips1
+			toVersion = "v1.17.3+vmware.1-fips.2"
+		})
+		It("expect compareResult = 0", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(compareResult == 0).To(Equal(true))
 		})
 	})
 })


### PR DESCRIPTION
### What this PR does / why we need it
- Consider additional metadata as part of kubernetes build version during version comparison
- Example: Consider v1.17.3+vmware.1-fips.1 and v1.17.3+vmware.2-fips.1 comparison

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/2292

### Describe testing done for PR
- Added unit tests

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Consider additional metadata as part of kubernetes build version during version comparison
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
