### PR TITLE
fix deleting management cluster clean up avi resource error in long latency condition

### DIFF
--- a/pkg/v1/tkg/client/delete_region.go
+++ b/pkg/v1/tkg/client/delete_region.go
@@ -470,15 +470,12 @@ func (c *TkgClient) waitForAVIResourceCleanup(regionalClusterClient clusterclien
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return errors.Wrapf(err, "unable to get ako statefulset")
+		log.Warning("unable to get ako statefulset")
 	}
 	if err := regionalClusterClient.WaitForAVIResourceCleanUp(constants.AkoStatefulSetName, constants.AkoNamespace); err != nil {
-		// losing connection should be consider as AVI resources clean up finished.
-		// TODO: (xudongl) Any ideas how to make this line cleaner? Thanks.
-		if strings.Contains(err.Error(), "dial tcp") {
-			return nil
+		if !strings.Contains(err.Error(), "dial tcp") {
+			log.Error(err, "clean up AVI resources error")
 		}
-		return err
 	}
 	return nil
 }

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -634,7 +634,12 @@ func (c *client) WaitForAutoscalerDeployment(deploymentName, namespace string) e
 }
 
 func (c *client) WaitForAVIResourceCleanUp(statefulSetName, namespace string) error {
-	return c.GetResource(&appsv1.StatefulSet{}, statefulSetName, namespace, VerifyAVIResourceCleanupFinished, &PollOptions{Interval: CheckResourceInterval, Timeout: AVIResourceCleanupTimeout})
+	err := c.GetResource(&appsv1.StatefulSet{}, statefulSetName, namespace, VerifyAVIResourceCleanupFinished, &PollOptions{Interval: CheckResourceInterval, Timeout: AVIResourceCleanupTimeout})
+	// retry once when network condition is poor
+	if apierrors.IsServiceUnavailable(err) {
+		return c.GetResource(&appsv1.StatefulSet{}, statefulSetName, namespace, VerifyAVIResourceCleanupFinished, &PollOptions{Interval: CheckResourceInterval, Timeout: AVIResourceCleanupTimeout})
+	}
+	return err
 }
 
 func (c *client) WaitForPackageInstall(packageName, namespace string, packageInstallTimeout time.Duration) error {


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

### What this PR does / why we need it

Fix when the network condition is poor, clean up avi resources could cause the management cluster deletion failed error.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2330

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

- launched vSphere testbed, create and delete management cluster several times to verify this change, and test passed. 

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
deleting management cluster can run successfully even in high latency network env.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
