### PR TITLE
Removes superfluous logging of machine-controller

### DIFF
--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -1233,21 +1233,21 @@ func (r *ClusterBootstrapReconciler) makeClusterIsReadyForDeletion(cluster *clus
 		log.Error(err, "failed to lookup clusterbootstrap")
 		return false, err
 	}
-	if apierrors.IsNotFound(err) {
-		log.Info("ClusterBootstrap not found")
-	} else if hasPackageInstalls(r.context, remoteClient, cluster, r.Config.SystemNamespace, clusterBootstrap.Spec.AdditionalPackages, log) {
+	if apierrors.IsNotFound(err) { // if there is no clusterbootstrap then the cluster is ready for deletion
+		return true, nil
+	}
+
+	if hasPackageInstalls(r.context, remoteClient, cluster, r.Config.SystemNamespace, clusterBootstrap.Spec.AdditionalPackages, log) {
 		err = r.removeAdditionalPackageInstalls(remoteClient, cluster, clusterBootstrap, log)
 		if err != nil {
 			return false, err
 		}
 		return false, nil
 	}
-	log.Info("cluster is ready for deletion")
 	return true, nil
 }
 
 func (r *ClusterBootstrapReconciler) removeFinalizersFromClusterResources(cluster *clusterapiv1beta1.Cluster, log logr.Logger) error {
-	log.Info("removing finalizer from clusterbootstrap if present")
 	clusterBootstrap := &runtanzuv1alpha3.ClusterBootstrap{}
 	err := r.Client.Get(r.context, client.ObjectKeyFromObject(cluster), clusterBootstrap)
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -1261,7 +1261,6 @@ func (r *ClusterBootstrapReconciler) removeFinalizersFromClusterResources(cluste
 		}
 	}
 
-	log.Info("removing finalizer from cluster kubeconfig secret if present")
 	clusterKubeConfigSecret := &corev1.Secret{}
 	key := client.ObjectKey{Namespace: cluster.Namespace, Name: secretutil.Name(cluster.Name, secretutil.Kubeconfig)}
 	err = r.Client.Get(r.context, key, clusterKubeConfigSecret)
@@ -1271,17 +1270,14 @@ func (r *ClusterBootstrapReconciler) removeFinalizersFromClusterResources(cluste
 			return err
 		}
 	} else if !apierrors.IsNotFound(err) {
-		log.Error(err, "unable to fetch cluster kubeconfig secret")
 		return err
 	}
 
-	log.Info("removing finalizer from cluster if present")
 	err = r.removeFinalizer(cluster)
 	if err != nil {
 		return err
 	}
 
-	log.Info("all finalizers have been removed from cluster resources")
 	return nil
 }
 
@@ -1366,7 +1362,6 @@ func (r *ClusterBootstrapReconciler) removeAdditionalPackageInstalls(remoteClien
 				Namespace: r.Config.SystemNamespace,
 			},
 		}
-		log.Info(fmt.Sprintf("deleteting package install %s/%s", additionalPkgInstall.Namespace, additionalPkgInstall.Name))
 		err = remoteClient.Delete(r.context, additionalPkgInstall)
 		if err != nil && !apierrors.IsNotFound(err) {
 			log.Error(err, fmt.Sprintf("unable to delete package install for %s/%s",


### PR DESCRIPTION
Enough information can be obtain from error loging,
making log.info unecessary

### What this PR does / why we need it
Log.infos on are making the machine-controller very  noisy. 
There is enough information on error logs to monitor any problem. 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Removes superfluous logging of machine-controller
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
