### PR TITLE
[release-0.11] Fix provider version mismatch when talking with old management cluster using TKG client library

### DIFF
--- a/pkg/v1/providers/infrastructure-azure/v1.0.1/cluster-template-definition-dev.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.0.1/cluster-template-definition-dev.yaml
@@ -1,0 +1,10 @@
+apiVersion: providers.tanzu.vmware.com/v1alpha1
+kind: TemplateDefinition
+spec:
+  paths:
+    - path: providers/infrastructure-azure/v1.0.2/ytt
+    - path: providers/infrastructure-azure/ytt
+    - path: providers/ytt
+    - path: bom
+      filemark: text-plain
+    - path: providers/config_default.yaml

--- a/pkg/v1/providers/infrastructure-azure/v1.0.1/cluster-template-definition-dev.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.0.1/cluster-template-definition-dev.yaml
@@ -1,3 +1,6 @@
+#! This is dummy cluster template file that enables the client library 
+#! to create/upgrade when connecting older patch versions of the management cluster. 
+#! Not relevant when operations is invoked directly via the CLI.
 apiVersion: providers.tanzu.vmware.com/v1alpha1
 kind: TemplateDefinition
 spec:

--- a/pkg/v1/providers/infrastructure-azure/v1.0.1/cluster-template-definition-prod.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.0.1/cluster-template-definition-prod.yaml
@@ -1,0 +1,10 @@
+apiVersion: providers.tanzu.vmware.com/v1alpha1
+kind: TemplateDefinition
+spec:
+  paths:
+    - path: providers/infrastructure-azure/v1.0.2/ytt
+    - path: providers/infrastructure-azure/ytt
+    - path: providers/ytt
+    - path: bom
+      filemark: text-plain
+    - path: providers/config_default.yaml

--- a/pkg/v1/providers/infrastructure-azure/v1.0.1/cluster-template-definition-prod.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.0.1/cluster-template-definition-prod.yaml
@@ -1,3 +1,6 @@
+#! This is dummy cluster template file that enables the client library 
+#! to create/upgrade when connecting older patch versions of the management cluster. 
+#! Not relevant when operations is invoked directly via the CLI.
 apiVersion: providers.tanzu.vmware.com/v1alpha1
 kind: TemplateDefinition
 spec:

--- a/pkg/v1/providers/infrastructure-vsphere/v1.0.2/cluster-template-definition-dev-windows.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.0.2/cluster-template-definition-dev-windows.yaml
@@ -1,0 +1,10 @@
+apiVersion: providers.tanzu.vmware.com/v1alpha1
+kind: TemplateDefinition
+spec:
+  paths:
+    - path: providers/infrastructure-vsphere/v1.0.3/ytt
+    - path: providers/infrastructure-vsphere/ytt
+    - path: providers/ytt
+    - path: bom
+      filemark: text-plain
+    - path: providers/config_default.yaml

--- a/pkg/v1/providers/infrastructure-vsphere/v1.0.2/cluster-template-definition-dev-windows.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.0.2/cluster-template-definition-dev-windows.yaml
@@ -1,3 +1,6 @@
+#! This is dummy cluster template file that enables the client library 
+#! to create/upgrade when connecting older patch versions of the management cluster. 
+#! Not relevant when operations is invoked directly via the CLI.
 apiVersion: providers.tanzu.vmware.com/v1alpha1
 kind: TemplateDefinition
 spec:

--- a/pkg/v1/providers/infrastructure-vsphere/v1.0.2/cluster-template-definition-dev.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.0.2/cluster-template-definition-dev.yaml
@@ -1,0 +1,10 @@
+apiVersion: providers.tanzu.vmware.com/v1alpha1
+kind: TemplateDefinition
+spec:
+  paths:
+    - path: providers/infrastructure-vsphere/v1.0.3/ytt
+    - path: providers/infrastructure-vsphere/ytt
+    - path: providers/ytt
+    - path: bom
+      filemark: text-plain
+    - path: providers/config_default.yaml

--- a/pkg/v1/providers/infrastructure-vsphere/v1.0.2/cluster-template-definition-dev.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.0.2/cluster-template-definition-dev.yaml
@@ -1,3 +1,6 @@
+#! This is dummy cluster template file that enables the client library 
+#! to create/upgrade when connecting older patch versions of the management cluster. 
+#! Not relevant when operations is invoked directly via the CLI.
 apiVersion: providers.tanzu.vmware.com/v1alpha1
 kind: TemplateDefinition
 spec:

--- a/pkg/v1/providers/infrastructure-vsphere/v1.0.2/cluster-template-definition-prod.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.0.2/cluster-template-definition-prod.yaml
@@ -1,0 +1,10 @@
+apiVersion: providers.tanzu.vmware.com/v1alpha1
+kind: TemplateDefinition
+spec:
+  paths:
+    - path: providers/infrastructure-vsphere/v1.0.3/ytt
+    - path: providers/infrastructure-vsphere/ytt
+    - path: providers/ytt
+    - path: bom
+      filemark: text-plain
+    - path: providers/config_default.yaml

--- a/pkg/v1/providers/infrastructure-vsphere/v1.0.2/cluster-template-definition-prod.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.0.2/cluster-template-definition-prod.yaml
@@ -1,3 +1,6 @@
+#! This is dummy cluster template file that enables the client library 
+#! to create/upgrade when connecting older patch versions of the management cluster. 
+#! Not relevant when operations is invoked directly via the CLI.
 apiVersion: providers.tanzu.vmware.com/v1alpha1
 kind: TemplateDefinition
 spec:


### PR DESCRIPTION
### What this PR does / why we need it

- The current issue is version of the provider template to use is determined by the provider installed on the management-cluster that library/cli is talking with. 
- As we are talking to old management-cluster, library is expecting to find the old provider template that we are not bundling with the new CLI which causes this bug.
- This is happening across v1.5.x patch releases where latest TKG release is not able to create/upgrade workload cluster when talking to older patch version of management-cluster.

**NOTE:** The added files are dummy cluster template files that enables the client library to create/upgrade when connecting older patch versions of the management cluster. Not relevant when operations is invoked directly via the CLI.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2332

### Describe testing done for PR
1. Create azure management-cluster using Tanzu CLI v0.11.1 (TKGm v1.5.1)
2. Use latest Tanzu CLI with this fix
3. Create workload cluster when talking with (TKGm v1.5.1) management-cluster
4. Upgrade workload cluster when talking with (TKGm v1.5.1) management-cluster

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix provider version mismatch when talking with old management cluster using `tkgctl` library
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
