### PR TITLE
derive all service and pod cidrs from cluster config

### DIFF
--- a/pkg/v1/tkg/client/upgrade_addon.go
+++ b/pkg/v1/tkg/client/upgrade_addon.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -381,10 +382,10 @@ func (c *TkgClient) setNetworkingConfiguration(regionalClusterClient clusterclie
 
 	if cluster.Spec.ClusterNetwork != nil {
 		if cluster.Spec.ClusterNetwork.Pods != nil && len(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks) > 0 {
-			c.TKGConfigReaderWriter().Set(constants.ConfigVariableClusterCIDR, cluster.Spec.ClusterNetwork.Pods.CIDRBlocks[0])
+			c.TKGConfigReaderWriter().Set(constants.ConfigVariableClusterCIDR, strings.Join(cluster.Spec.ClusterNetwork.Pods.CIDRBlocks, ","))
 		}
 		if cluster.Spec.ClusterNetwork.Services != nil && len(cluster.Spec.ClusterNetwork.Services.CIDRBlocks) > 0 {
-			c.TKGConfigReaderWriter().Set(constants.ConfigVariableServiceCIDR, cluster.Spec.ClusterNetwork.Services.CIDRBlocks[0])
+			c.TKGConfigReaderWriter().Set(constants.ConfigVariableServiceCIDR, strings.Join(cluster.Spec.ClusterNetwork.Services.CIDRBlocks, ","))
 		}
 		ipFamily, err := GetIPFamily(cluster)
 		if err != nil {

--- a/pkg/v1/tkg/client/upgrade_addon_test.go
+++ b/pkg/v1/tkg/client/upgrade_addon_test.go
@@ -207,21 +207,21 @@ var _ = Describe("Unit tests for addons upgrade", func() {
 			BeforeEach(func() {
 				addonsToBeUpgraded = []string{"tkr/tkr-controller"}
 			})
-			It("sets the cluster CIDR in the TKGConfig", func() {
-				clusterCIDR, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterCIDR)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(clusterCIDR).To(Equal("2.3.4.5/16"))
-			})
-			It("sets the service CIDR in the TKGConfig", func() {
-				serviceCIDR, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableServiceCIDR)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(serviceCIDR).To(Equal("1.2.3.4/16"))
-			})
 			When("the cidrs are unset", func() {
 				It("sets the IPFamily to ipv4", func() {
 					ipFamily, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableIPFamily)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(ipFamily).To(Equal("ipv4"))
+				})
+				It("sets the cluster CIDR in the TKGConfig", func() {
+					clusterCIDR, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterCIDR)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(clusterCIDR).To(Equal("2.3.4.5/16"))
+				})
+				It("sets the service CIDR in the TKGConfig", func() {
+					serviceCIDR, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableServiceCIDR)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(serviceCIDR).To(Equal("1.2.3.4/16"))
 				})
 			})
 			When("the cluster is ipv4", func() {
@@ -234,6 +234,16 @@ var _ = Describe("Unit tests for addons upgrade", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(ipFamily).To(Equal("ipv4"))
 				})
+				It("sets the serviceCIDRs to be ipv4", func() {
+					serviceCIDRs, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableServiceCIDR)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(serviceCIDRs).To(Equal("2.3.4.5/16"))
+				})
+				It("sets the podCIDRs to be ipv4", func() {
+					podCIDRs, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterCIDR)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(podCIDRs).To(Equal("1.2.3.4/16"))
+				})
 			})
 			When("the cluster is ipv6", func() {
 				BeforeEach(func() {
@@ -244,6 +254,16 @@ var _ = Describe("Unit tests for addons upgrade", func() {
 					ipFamily, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableIPFamily)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(ipFamily).To(Equal("ipv6"))
+				})
+				It("sets the serviceCIDRs to be ipv6", func() {
+					serviceCIDRs, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableServiceCIDR)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(serviceCIDRs).To(Equal("fd00::/32"))
+				})
+				It("sets the podCIDRs to be ipv6", func() {
+					podCIDRs, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterCIDR)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(podCIDRs).To(Equal("fd01::/32"))
 				})
 			})
 			When("the cluster is dualstack and primary ipv4", func() {
@@ -256,6 +276,16 @@ var _ = Describe("Unit tests for addons upgrade", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(ipFamily).To(Equal("ipv4,ipv6"))
 				})
+				It("sets the serviceCIDRs to be ipv4,ipv6", func() {
+					serviceCIDRs, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableServiceCIDR)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(serviceCIDRs).To(Equal("1.2.3.4/16,fd00::/32"))
+				})
+				It("sets the podCIDRs to be ipv4,ipv6", func() {
+					podCIDRs, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterCIDR)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(podCIDRs).To(Equal("2.3.4.5/16,fd01::/32"))
+				})
 			})
 			When("the cluster is dualstack and primary ipv6", func() {
 				BeforeEach(func() {
@@ -266,6 +296,16 @@ var _ = Describe("Unit tests for addons upgrade", func() {
 					ipFamily, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableIPFamily)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(ipFamily).To(Equal("ipv6,ipv4"))
+				})
+				It("sets the serviceCIDRs to be ipv6,ipv4", func() {
+					serviceCIDRs, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableServiceCIDR)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(serviceCIDRs).To(Equal("fd00::/32,1.2.3.4/16"))
+				})
+				It("sets the podCIDRs to be ipv6,ipv4", func() {
+					podCIDRs, err := tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterCIDR)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(podCIDRs).To(Equal("fd01::/32,2.3.4.5/16"))
 				})
 			})
 		})


### PR DESCRIPTION
### What this PR does / why we need it
This fixes an error encountered when trying to delete an IPv6 primary
dualstack cluster.

KinD clusters provisioned when upgrading or deleting dualstack IPv6 primary
clusters expect pod cidrs and service cidrs from both IP families to be
present.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Deployed an IPv6-primary dualstack management cluster and was able to successfully delete it.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support deletion of IPv6 primary dualstack management clusters with automatically provisioned cleanup clusters.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
