### PR TITLE
Hide TKR_DATA when not running yaml tests

### DIFF
--- a/pkg/v1/providers/config_default.yaml
+++ b/pkg/v1/providers/config_default.yaml
@@ -631,6 +631,8 @@ VSPHERE_VERSION:
 CORE_DNS_IP:
 #! This defines feature flag package-based-lcm is enabled or not
 FEATURE_FLAG_PACKAGE_BASED_LCM:
+#! Used for testing clusterclasses only
+TKR_DATA:
 
 #! ---------------------------------------------------------------------
 #! BoM file processing, internal use only

--- a/pkg/v1/providers/infrastructure-aws/v1.2.0/yttcc/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-aws/v1.2.0/yttcc/overlay.yaml
@@ -97,28 +97,9 @@ spec:
     variables:
     #@ vars = get_aws_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["region", "sshKeyName", "bastion", "network", "controlPlane", "worker", "loadBalancerSchemeInternal", "identityRef", "imageRepository", "trust", "auditLogging", "cni"]:
+    #@  if vars[configVariable] != None and configVariable in ["region", "sshKeyName", "bastion", "network", "controlPlane", "worker", "loadBalancerSchemeInternal", "identityRef", "imageRepository", "trust", "auditLogging", "cni", "TKR_DATA"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end
     #@ end
-    #! TODO: make this data only available while testing.
-    #@overlay/append
-    - name: TKR_DATA
-      value:
-        v1.23.5+vmware.1: #! this comes from the clusterclt for testing
-          kubernetesSpec:
-            version: v1.23.5+vmware.1
-            imageRepository: projects-stg.registry.vmware.com
-            etcd:
-              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageTag
-            coredns:
-              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag
-          labels:
-            os-name: ubuntu
-            os-type: linux
-            os-arch: amd64
-          osImageRef:
-            id: dummy-ami-id
-            region: dummy-region
 

--- a/pkg/v1/providers/infrastructure-azure/v1.0.1/yttcc/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.0.1/yttcc/overlay.yaml
@@ -119,33 +119,11 @@ spec:
     variables:
     #@ vars = get_azure_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["location", "network", "controlPlane", "worker", "resourceGroup", "subscriptionID", "identityRef", "clusterRole", "environment", "sshPublicKey", "acceleratedNetworking", "privateCluster", "frontendPrivateIP", "imageRepository", "auditLogging", "customTags", "apiServerPort", "trust"]:
+    #@  if vars[configVariable] != None and configVariable in ["location", "network", "controlPlane", "worker", "resourceGroup", "subscriptionID", "identityRef", "clusterRole", "environment", "sshPublicKey", "acceleratedNetworking", "privateCluster", "frontendPrivateIP", "imageRepository", "auditLogging", "customTags", "apiServerPort", "trust", "TKR_DATA"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end
     #@ end
-    #! TODO: make this data only applied while testing
-    #@overlay/append
-    - name: TKR_DATA
-      value:
-        v1.23.5+vmware.1: #! value comes from clusterctl
-          kubernetesSpec:
-            version: v1.23.5+vmware.1
-            imageRepository: projects-stg.registry.vmware.com
-            etcd:
-              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageTag
-            coredns:
-              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag
-          labels:
-            os-name: ubuntu
-            os-type: linux
-            os-arch: amd64
-          osImageRef:
-            sku: dummy-sku
-            publisher: dummy-publisher
-            offer: dummy-offer
-            version: dummy-version
-            thirdPartyImage: dummy-third-party-image
 
 #@ if data.values.TKG_CLUSTER_ROLE == "management":
 ---

--- a/pkg/v1/providers/infrastructure-vsphere/v1.1.0/yttcc/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.1.0/yttcc/overlay.yaml
@@ -73,28 +73,11 @@ spec:
         failureDomain: #@ data.values.VSPHERE_AZ_2
         #@ end
       #@ end
-    #! TODO: this should only be available during testing
     #@overlay/match missing_ok=True
     variables:
-    - name: TKR_DATA
-      value:
-        v1.21.2: #! comes from clusterctl during testing
-          kubernetesSpec:
-            version: v1.21.2
-            imageRepository: projects-stg.registry.vmware.com
-            etcd:
-              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.etcd.local.imageTag
-            coredns:
-              imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag
-            kube-vip:
-              imageTag: dummy-kube-vip-image-tag
-          labels:
-            os-name: ubuntu
-            os-type: linux
-            os-arch: amd64
     #@ vars = get_vsphere_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider"]:
+    #@  if vars[configVariable] != None and configVariable in ["apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "TKR_DATA"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/pkg/v1/providers/yttcc/lib/config_variable_association.star
+++ b/pkg/v1/providers/yttcc/lib/config_variable_association.star
@@ -371,7 +371,11 @@ def get_cluster_variables():
     if data.values["CLUSTER_API_SERVER_PORT"] != None:
         vars["apiServerPort"] = data.values["CLUSTER_API_SERVER_PORT"]
     end
-    
+
+    if data.values["TKR_DATA"] != "":
+        vars["TKR_DATA"] = data.values["TKR_DATA"]
+    end
+
     return vars
 end
 


### PR DESCRIPTION
This change adds TKR_DATA to the ccluster.yml when testing in clustergen

### What this PR does / why we need it
This PR updates the clustergen test runner to append fake TKR_DATA to the config file. This data is necessary for the dry run process to generate the expected output classes. We don't want this fake data leak to customer scenarios, so the test runner directly updates the config file with the TKR_DATA

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
