### PR TITLE
Conditonally set --node-ip on kubelet for TKR 1.22+ IPv6 workload clusters

### DIFF
--- a/pkg/v1/providers/infrastructure-vsphere/v1.1.0/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.1.0/ytt/overlay.yaml
@@ -1,15 +1,34 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
+#@ load("@ytt:regexp", "regexp")
 
 
-#@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "get_default_tkg_bom_data", "kubeadm_image_repo", "get_image_repo_for_component", "get_vsphere_thumbprint")
+#@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "get_default_tkg_bom_data", "kubeadm_image_repo", "get_image_repo_for_component", "get_vsphere_thumbprint", "get_tkr_version_from_tkr_name")
 
 #@ load("lib/validate.star", "validate_configuration")
 #@ load("@ytt:yaml", "yaml")
 #@ validate_configuration("vsphere")
 
+#! The compare_semver_versions function compares the major, minor, patch
+#! numbers of two versions. It returns 1 if a > b, 0 if a == b, -1 if a < b.
+#! Anything after the patch number is ignored. a and b must be in the
+#! form of v<X>.<Y>.<Z>[+build-info]
+#@ def compare_semver_versions(a, b):
+#@   a_array = regexp.replace("v?(\d+\.\d+\.\d+).*", a, "$1").split(".")
+#@   b_array = regexp.replace("v?(\d+\.\d+\.\d+).*", b, "$1").split(".")
+#@   for i in range(len(a_array)):
+#@     if int(a_array[i]) > int(b_array[i]):
+#@       return 1
+#@     elif int(a_array[i]) < int(b_array[i]):
+#@       return -1
+#@     end
+#@   end
+#@   return 0
+#@ end
+
 #@ bomDataForK8sVersion = get_bom_data_for_tkr_name()
 #@ bomData = get_default_tkg_bom_data()
+#@ tkrVersion = get_tkr_version_from_tkr_name(data.values.KUBERNETES_RELEASE)
 
 #@ if not data.values.IS_WINDOWS_WORKLOAD_CLUSTER:
 
@@ -290,7 +309,7 @@ spec:
     #@overlay/remove
     - content:
     #@ end
-    #@ if data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"]:
+    #@ if data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"] and compare_semver_versions(tkrVersion, "v1.22.8") >= 0:
     #@overlay/append
     - content: ""
       owner: root:root
@@ -315,7 +334,7 @@ spec:
     #! the primary IP family, set --node-ip on kubelet so that host network pods
     #! do not get the kube-vip address as their pod IP.
     #! See: https://github.com/vmware-tanzu/tanzu-framework/issues/2098
-    #@ if not data.values.AVI_CONTROL_PLANE_HA_PROVIDER and data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"]:
+    #@ if not data.values.AVI_CONTROL_PLANE_HA_PROVIDER and data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"] and compare_semver_versions(tkrVersion, "v1.22.8") >= 0:
     preKubeadmCommands:
     #@overlay/append
     - echo "KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)" >> /etc/sysconfig/kubelet

--- a/pkg/v1/providers/tests/unit/custom_nameservers_test.go
+++ b/pkg/v1/providers/tests/unit/custom_nameservers_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Control Plane/Workload Node Nameserver Ytt Templating", func()
 		BeforeEach(func() {
 			values = createDataValues(map[string]string{
 				"CLUSTER_NAME":                   "foo",
+				"KUBERNETES_RELEASE":             "v1.22.11---vmware.1-tkg.1",
 				"TKG_CLUSTER_ROLE":               "workload",
 				"TKG_IP_FAMILY":                  "ipv4",
 				"CONTROL_PLANE_NODE_NAMESERVERS": "1.1.1.1,2.2.2.2",
@@ -75,6 +76,7 @@ var _ = Describe("Control Plane/Workload Node Nameserver Ytt Templating", func()
 		BeforeEach(func() {
 			values = createDataValues(map[string]string{
 				"CLUSTER_NAME":                   "foo",
+				"KUBERNETES_RELEASE":             "v1.22.11---vmware.1-tkg.1",
 				"TKG_CLUSTER_ROLE":               "workload",
 				"TKG_IP_FAMILY":                  "ipv6",
 				"CONTROL_PLANE_NODE_NAMESERVERS": "fd00::1,fd00::2",
@@ -120,6 +122,7 @@ var _ = Describe("Control Plane/Workload Node Nameserver Ytt Templating", func()
 		BeforeEach(func() {
 			values = createDataValues(map[string]string{
 				"CLUSTER_NAME":                   "foo",
+				"KUBERNETES_RELEASE":             "v1.22.11---vmware.1-tkg.1",
 				"TKG_CLUSTER_ROLE":               "workload",
 				"TKG_IP_FAMILY":                  "ipv4,ipv6",
 				"CONTROL_PLANE_NODE_NAMESERVERS": "1.1.1.1,fd00::2",

--- a/pkg/v1/providers/tests/unit/fixtures/yttmocks/lib/helpers.star
+++ b/pkg/v1/providers/tests/unit/fixtures/yttmocks/lib/helpers.star
@@ -69,3 +69,8 @@ end
 def get_no_proxy():
     return "fake-no-proxy"
 end
+
+def get_tkr_version_from_tkr_name(tkr_name):
+   strs = tkr_name.split("---")
+   return strs[0] + "+" + strs[1]
+end

--- a/pkg/v1/providers/tests/unit/ip_family_test.go
+++ b/pkg/v1/providers/tests/unit/ip_family_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 
 	. "github.com/vmware-tanzu/tanzu-framework/test/pkg/matchers"
@@ -261,11 +262,12 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 			When("cluster cidr and service cidr have multiple values", func() {
 				BeforeEach(func() {
 					values = createDataValues(map[string]string{
-						"CLUSTER_NAME":     "foo",
-						"TKG_CLUSTER_ROLE": "workload",
-						"TKG_IP_FAMILY":    "ipv4,ipv6",
-						"CLUSTER_CIDR":     "100.96.0.0/11,fd00:100:96::/48",
-						"SERVICE_CIDR":     "100.64.0.0/18,fd00:100:64::/108",
+						"CLUSTER_NAME":       "foo",
+						"KUBERNETES_RELEASE": "v1.22.11---vmware.1-tkg.1",
+						"TKG_CLUSTER_ROLE":   "workload",
+						"TKG_IP_FAMILY":      "ipv4,ipv6",
+						"CLUSTER_CIDR":       "100.96.0.0/11,fd00:100:96::/48",
+						"SERVICE_CIDR":       "100.64.0.0/18,fd00:100:64::/108",
 					})
 				})
 
@@ -287,11 +289,12 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 			When("cluster cidr and service cidr have a single value", func() {
 				BeforeEach(func() {
 					values = createDataValues(map[string]string{
-						"CLUSTER_NAME":     "foo",
-						"TKG_CLUSTER_ROLE": "workload",
-						"TKG_IP_FAMILY":    "ipv4",
-						"CLUSTER_CIDR":     "100.96.0.0/11",
-						"SERVICE_CIDR":     "100.64.0.0/18",
+						"CLUSTER_NAME":       "foo",
+						"KUBERNETES_RELEASE": "v1.22.11---vmware.1-tkg.1",
+						"TKG_CLUSTER_ROLE":   "workload",
+						"TKG_IP_FAMILY":      "ipv4",
+						"CLUSTER_CIDR":       "100.96.0.0/11",
+						"SERVICE_CIDR":       "100.64.0.0/18",
 					})
 				})
 
@@ -318,6 +321,7 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 				BeforeEach(func() {
 					values = createDataValues(map[string]string{
 						"CLUSTER_NAME":            "foo",
+						"KUBERNETES_RELEASE":      "v1.22.11---vmware.1-tkg.1",
 						"TKG_CLUSTER_ROLE":        "workload",
 						"TKG_IP_FAMILY":           "ipv4",
 						"CLUSTER_CIDR":            "100.96.0.0/11",
@@ -376,6 +380,7 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 				BeforeEach(func() {
 					values = createDataValues(map[string]string{
 						"CLUSTER_NAME":            "foo",
+						"KUBERNETES_RELEASE":      "v1.22.11---vmware.1-tkg.1",
 						"TKG_CLUSTER_ROLE":        "workload",
 						"TKG_IP_FAMILY":           "ipv6",
 						"CLUSTER_CIDR":            "fd00:100:96::/48",
@@ -415,7 +420,16 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.advertiseAddress", "::/0"))
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.joinConfiguration.controlPlane.localAPIEndpoint.bindPort", "443"))
 				})
-				It("configures node-ip on the control plane nodes by echoing the detected node ip into KUBELET_EXTRA_ARGS in /etc/sysconfig/kubelet", func() {
+				DescribeTable("configures node-ip on the control plane nodes by echoing the detected node ip into KUBELET_EXTRA_ARGS in /etc/sysconfig/kubelet when the tkr is >= 1.22.8", func(kubernetesRelease string) {
+					values = createDataValues(map[string]string{
+						"CLUSTER_NAME":            "foo",
+						"KUBERNETES_RELEASE":      kubernetesRelease,
+						"TKG_CLUSTER_ROLE":        "workload",
+						"TKG_IP_FAMILY":           "ipv6",
+						"CLUSTER_CIDR":            "fd00:100:96::/48",
+						"SERVICE_CIDR":            "fd00:100:64::/108",
+						"CLUSTER_API_SERVER_PORT": "443",
+					})
 					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
 					Expect(err).NotTo(HaveOccurred())
 
@@ -430,13 +444,50 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].path", "/etc/sysconfig/kubelet"))
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].permissions", "0640"))
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.preKubeadmCommands[5]", "echo \"KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)\" >> /etc/sysconfig/kubelet"))
-				})
+				},
+					Entry("when the tkr is 1.22.8", "v1.22.8---vmware.1-tkg.1"),
+					Entry("when the tkr is 1.22.11", "v1.22.11---vmware.1-tkg.1"),
+					Entry("when the tkr is 1.22.12", "v1.22.12---vmware.1-tkg.1"),
+					Entry("when the tkr is 1.22.40", "v1.22.40---vmware.1-tkg.1"),
+					Entry("when the tkr is 1.23.7", "v1.23.7---vmware.1-tkg.1"),
+					Entry("when the tkr is 1.23.10", "v1.23.10---vmware.1-tkg.1"),
+				)
+				DescribeTable("does not configure node-ip on the control plane into KUBELET_EXTRA_ARGS in /etc/sysconfig/kubelet when the tkr is < 1.22.8", func(kubernetesRelease string) {
+					values = createDataValues(map[string]string{
+						"CLUSTER_NAME":            "foo",
+						"KUBERNETES_RELEASE":      kubernetesRelease,
+						"TKG_CLUSTER_ROLE":        "workload",
+						"TKG_IP_FAMILY":           "ipv6",
+						"CLUSTER_CIDR":            "fd00:100:96::/48",
+						"SERVICE_CIDR":            "fd00:100:64::/108",
+						"CLUSTER_API_SERVER_PORT": "443",
+					})
+					output, err := ytt.RenderYTTTemplate(ytt.CommandOptions{}, paths, strings.NewReader(values))
+					Expect(err).NotTo(HaveOccurred())
+
+					kubeadmControlPlaneDocs, err := FindDocsMatchingYAMLPath(output, map[string]string{
+						"$.kind": "KubeadmControlPlane",
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(kubeadmControlPlaneDocs).To(HaveLen(1))
+					Expect(kubeadmControlPlaneDocs[0]).NotTo(HaveYAMLPath("$.spec.kubeadmConfigSpec.files[1]"))
+					Expect(kubeadmControlPlaneDocs[0]).NotTo(ContainSubstring("KUBELET_EXTRA_ARGS=--node-ip="))
+				},
+					Entry("when the tkr is 1.22.7", "v1.22.7---vmware.1-tkg.1"),
+					Entry("when the tkr is 1.21.20", "v1.21.20---vmware.1-tkg.1"),
+					Entry("when the tkr is 1.21.8", "v1.21.8---vmware.1-tkg.1"),
+					Entry("when the tkr is 1.20.15", "v1.20.15---vmware.1-tkg.1"),
+					Entry("when the tkr is 1.20.3", "v1.20.3---vmware.1-tkg.1"),
+					Entry("when the tkr is 1.6.0", "v1.6.0---vmware.1-tkg.1"),
+				)
 			})
 
 			When("data values are set to ipv4,ipv6 dual stack settings", func() {
 				BeforeEach(func() {
 					values = createDataValues(map[string]string{
 						"CLUSTER_NAME":            "foo",
+						"KUBERNETES_RELEASE":      "v1.22.11---vmware.1-tkg.1",
 						"TKG_CLUSTER_ROLE":        "workload",
 						"TKG_IP_FAMILY":           "ipv4,ipv6",
 						"CLUSTER_CIDR":            "100.96.0.0/11,fd00:100:96::/48",
@@ -542,6 +593,7 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 				BeforeEach(func() {
 					values = createDataValues(map[string]string{
 						"CLUSTER_NAME":                   "foo",
+						"KUBERNETES_RELEASE":             "v1.22.11---vmware.1-tkg.1",
 						"TKG_CLUSTER_ROLE":               "workload",
 						"TKG_IP_FAMILY":                  "ipv6,ipv4",
 						"CLUSTER_CIDR":                   "fd00:100:96::/48,100.96.0.0/11",


### PR DESCRIPTION
### What this PR does / why we need it

This PR will conditonally set --node-ip on kubelet for tkr 1.22.8+. This is a follow up fix to PR #2103.

Setting the `--node-ip` requires a change in the vsphere-cpi to allow excluding the `VSPHERE_CONTROL_PLANE_ENDPOINT` IP from being assigned to the node (#1480). That change only exists in vsphere-cpi 1.22 release (https://github.com/kubernetes/cloud-provider-vsphere/pull/556), which is only used in tkr 1.22.x. Therefore we want to avoid setting the `--node-ip` on the kubelet in tkr versions below 1.22.8, otherwise cluster creation will fail.

Deploying IPv6 workload clusters below TKR 1.22.8 will deploy successfully, but will continue to contain the bugs where the `VSPHERE_CONTROL_PLANE_ENDPOINT` ip is assigned to the node and host network pods. This bug may cause other issues and it is recommended that IPv6 workload cluster be deployed with 1.22+.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Deployed IPv6 management cluster
  - noted nodes and pods did not contain kube-vip ip
  - noted --node-ip was set on kubelet process

Deployed IPv6 TKR 1.23 workload cluster
  - noted nodes and pods did not contain kube-vip ip
  - noted --node-ip was set on kubelet process

Deployed IPv6 TKR 1.22 workload cluster
  - noted nodes and pods did not contain kube-vip ip
  - noted --node-ip was set on kubelet process

Deployed IPv6 TKR 1.21 workload cluster
  - noted nodes and pods *DO* contain kube-vip ip
  - noted --node-ip was *NOT* set on kubelet process

Added unit tests to test ytt templating for `--node-ip` in vsphere provider templates.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

Note: Not adding a release note because the real release note for the fix is in https://github.com/vmware-tanzu/tanzu-framework/pull/1480 and we fixed a regression caused by that PR before release.

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
