### PR TITLE
[release-0.11] Conditonally set --node-ip on kubelet for TKR 1.22+ IPv6 workload clusters

### DIFF
--- a/pkg/v1/providers/infrastructure-vsphere/v1.0.3/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.0.3/ytt/overlay.yaml
@@ -1,15 +1,34 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
+#@ load("@ytt:regexp", "regexp")
 
 
-#@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "get_default_tkg_bom_data", "kubeadm_image_repo", "get_image_repo_for_component", "get_vsphere_thumbprint")
+#@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "get_default_tkg_bom_data", "kubeadm_image_repo", "get_image_repo_for_component", "get_vsphere_thumbprint", "get_tkr_version_from_tkr_name")
 
 #@ load("lib/validate.star", "validate_configuration")
 #@ load("@ytt:yaml", "yaml")
 #@ validate_configuration("vsphere")
 
+#! The compare_semver_versions function compares the major, minor, patch
+#! numbers of two versions. It returns 1 if a > b, 0 if a == b, -1 if a < b.
+#! Anything after the patch number is ignored. a and b must be in the
+#! form of v<X>.<Y>.<Z>[+build-info]
+#@ def compare_semver_versions(a, b):
+#@   a_array = regexp.replace("v?(\d+\.\d+\.\d+).*", a, "$1").split(".")
+#@   b_array = regexp.replace("v?(\d+\.\d+\.\d+).*", b, "$1").split(".")
+#@   for i in range(len(a_array)):
+#@     if int(a_array[i]) > int(b_array[i]):
+#@       return 1
+#@     elif int(a_array[i]) < int(b_array[i]):
+#@       return -1
+#@     end
+#@   end
+#@   return 0
+#@ end
+
 #@ bomDataForK8sVersion = get_bom_data_for_tkr_name()
 #@ bomData = get_default_tkg_bom_data()
+#@ tkrVersion = get_tkr_version_from_tkr_name(data.values.KUBERNETES_RELEASE)
 
 #@ if not data.values.IS_WINDOWS_WORKLOAD_CLUSTER:
 
@@ -268,7 +287,7 @@ spec:
     #@overlay/remove
     - content:
     #@ end
-    #@ if data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"]:
+    #@ if data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"] and compare_semver_versions(tkrVersion, "v1.22.8") >= 0:
     #@overlay/append
     - content: ""
       owner: root:root
@@ -293,7 +312,7 @@ spec:
     #! the primary IP family, set --node-ip on kubelet so that host network pods
     #! do not get the kube-vip address as their pod IP.
     #! See: https://github.com/vmware-tanzu/tanzu-framework/issues/2098
-    #@ if not data.values.AVI_CONTROL_PLANE_HA_PROVIDER and data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"]:
+    #@ if not data.values.AVI_CONTROL_PLANE_HA_PROVIDER and data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"] and compare_semver_versions(tkrVersion, "v1.22.8") >= 0:
     preKubeadmCommands:
     #@overlay/append
     - echo "KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)" >> /etc/sysconfig/kubelet

--- a/pkg/v1/providers/tests/unit/custom_nameservers_test.go
+++ b/pkg/v1/providers/tests/unit/custom_nameservers_test.go
@@ -30,6 +30,7 @@ var _ = Describe("Control Plane/Workload Node Nameserver Ytt Templating", func()
 		BeforeEach(func() {
 			values = createDataValues(map[string]string{
 				"CLUSTER_NAME":                   "foo",
+				"KUBERNETES_RELEASE":             "v1.22.11---vmware.1-tkg.1",
 				"TKG_CLUSTER_ROLE":               "workload",
 				"TKG_IP_FAMILY":                  "ipv4",
 				"CONTROL_PLANE_NODE_NAMESERVERS": "1.1.1.1,2.2.2.2",
@@ -75,6 +76,7 @@ var _ = Describe("Control Plane/Workload Node Nameserver Ytt Templating", func()
 		BeforeEach(func() {
 			values = createDataValues(map[string]string{
 				"CLUSTER_NAME":                   "foo",
+				"KUBERNETES_RELEASE":             "v1.22.11---vmware.1-tkg.1",
 				"TKG_CLUSTER_ROLE":               "workload",
 				"TKG_IP_FAMILY":                  "ipv6",
 				"CONTROL_PLANE_NODE_NAMESERVERS": "fd00::1,fd00::2",
@@ -120,6 +122,7 @@ var _ = Describe("Control Plane/Workload Node Nameserver Ytt Templating", func()
 		BeforeEach(func() {
 			values = createDataValues(map[string]string{
 				"CLUSTER_NAME":                   "foo",
+				"KUBERNETES_RELEASE":             "v1.22.11---vmware.1-tkg.1",
 				"TKG_CLUSTER_ROLE":               "workload",
 				"TKG_IP_FAMILY":                  "ipv4,ipv6",
 				"CONTROL_PLANE_NODE_NAMESERVERS": "1.1.1.1,fd00::2",

--- a/pkg/v1/providers/tests/unit/fixtures/yttmocks/lib/helpers.star
+++ b/pkg/v1/providers/tests/unit/fixtures/yttmocks/lib/helpers.star
@@ -69,3 +69,8 @@ end
 def get_no_proxy():
     return "fake-no-proxy"
 end
+
+def get_tkr_version_from_tkr_name(tkr_name):
+   strs = tkr_name.split("---")
+   return strs[0] + "+" + strs[1]
+end

--- a/pkg/v1/providers/tests/unit/matchers/yaml_path_matchers.go
+++ b/pkg/v1/providers/tests/unit/matchers/yaml_path_matchers.go
@@ -7,7 +7,7 @@ package matchers
 import (
 	"fmt"
 	"reflect"
-	"strings"
+	"regexp"
 
 	"github.com/vmware-labs/yaml-jsonpath/pkg/yamlpath"
 	"gopkg.in/yaml.v3"
@@ -24,7 +24,8 @@ type pathWithValue struct {
 
 // FindDocsMatchingYAMLPath finds yaml documents that match all paths with values provided.
 func FindDocsMatchingYAMLPath(yamlString string, pathsWithValues map[string]string) ([]string, error) {
-	docStrings := strings.Split(yamlString, "---")
+	re := regexp.MustCompile("(?m)^---$")
+	docStrings := re.Split(yamlString, -1)
 
 	var yamlPathWithValues []pathWithValue
 	for path, value := range pathsWithValues {


### PR DESCRIPTION
### What this PR does / why we need it

This PR backports #2380 to release-0.11.

This PR will conditonally set --node-ip on kubelet for tkr 1.22.8+. This is a follow up fix to PR https://github.com/vmware-tanzu/tanzu-framework/pull/2103.

Setting the --node-ip requires a change in the vsphere-cpi to allow excluding the VSPHERE_CONTROL_PLANE_ENDPOINT IP from being assigned to the node (https://github.com/vmware-tanzu/tanzu-framework/pull/2234). That change only exists in vsphere-cpi 1.22 release (https://github.com/kubernetes/cloud-provider-vsphere/pull/556), which is only used in tkr 1.22.x. Therefore we want to avoid setting the --node-ip on the kubelet in tkr versions below 1.22.8, otherwise cluster creation will fail.

Deploying IPv6 workload clusters below TKR 1.22.8 will deploy successfully, but will continue to contain the bugs where the VSPHERE_CONTROL_PLANE_ENDPOINT ip is assigned to the node and host network pods. This bug may cause other issues and it is recommended that IPv6 workload cluster be deployed with 1.22+.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Deployed IPv6 management cluster
* noted nodes and pods did not contain kube-vip ip
* noted --node-ip was set on kubelet process

Deployed IPv6 TKR 1.22 workload cluster
* noted nodes and pods did not contain kube-vip ip
* noted --node-ip was set on kubelet process

Deployed IPv6 TKR 1.21 workload cluster
* noted nodes and pods DO contain kube-vip ip
* noted --node-ip was NOT set on kubelet process

Deployed IPv6 TKR 1.20 workload cluster
* noted nodes and pods DO contain kube-vip ip
* noted --node-ip was NOT set on kubelet process

Added unit tests to test ytt templating for `--node-ip` in vsphere provider templates.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Conditonally set --node-ip on kubelet for TKR 1.22+ IPv6 workload clusters
```

Note: Not adding a release note because the real release note for the fix is in https://github.com/vmware-tanzu/tanzu-framework/pull/2234 and we fixed a regression caused by that PR before release.

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
