### PR TITLE
Fix a potential TKR Resolver index corruption

### DIFF
--- a/pkg/v2/tkr/resolver/data/types.go
+++ b/pkg/v2/tkr/resolver/data/types.go
@@ -93,6 +93,9 @@ type OSImages map[string]*runv1.OSImage
 
 // Filter returns a subset of TKRs satisfying the predicate f.
 func (tkrs TKRs) Filter(f func(tkr *runv1.TanzuKubernetesRelease) bool) TKRs {
+	if tkrs == nil {
+		return nil
+	}
 	result := make(TKRs, len(tkrs))
 	for name, tkr := range tkrs {
 		if f(tkr) {
@@ -110,6 +113,9 @@ func (tkrs TKRs) Intersect(other TKRs) TKRs {
 
 // Filter returns a subset of OSImages satisfying the predicate f.
 func (osImages OSImages) Filter(f func(osImage *runv1.OSImage) bool) OSImages {
+	if osImages == nil {
+		return nil
+	}
 	result := make(OSImages, len(osImages))
 	for name, osImage := range osImages {
 		if f(osImage) {


### PR DESCRIPTION
### What this PR does / why we need it

The issue fixed here would manifest itself if an OSImage was deleted and then re-added. In such case, the osImageToTKRs internal index would not be restored to its original state.

Also, cleanup: make `tkrs` the first argument of `filterOSImagesByTKRForTKRs()` for consistency with similar functions named `filter...ForTKRs()`.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

None (yet)

### Describe testing done for PR

Added unit tests illustrating the issue and guarding against it.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
