### PR TITLE
Show TKR name in cluster list and cluster get commands

### DIFF
--- a/cmd/cli/plugin/cluster/get.go
+++ b/cmd/cli/plugin/cluster/get.go
@@ -131,14 +131,14 @@ func getCluster(server *v1alpha1.Server, clusterName string) error {
 		return err
 	}
 
-	t := component.NewOutputWriter(cmdOutput, "table", "NAME", "NAMESPACE", "STATUS", "CONTROLPLANE", "WORKERS", "KUBERNETES", "ROLES")
+	t := component.NewOutputWriter(cmdOutput, "table", "NAME", "NAMESPACE", "STATUS", "CONTROLPLANE", "WORKERS", "KUBERNETES", "ROLES", "TKR")
 
 	cl := results.ClusterInfo
 	clusterRoles := noneTag
 	if len(cl.Roles) != 0 {
 		clusterRoles = strings.Join(cl.Roles, ",")
 	}
-	t.AddRow(cl.Name, cl.Namespace, cl.Status, cl.ControlPlaneCount, cl.WorkerCount, cl.K8sVersion, clusterRoles)
+	t.AddRow(cl.Name, cl.Namespace, cl.Status, cl.ControlPlaneCount, cl.WorkerCount, cl.K8sVersion, clusterRoles, cl.TKR)
 
 	t.Render()
 

--- a/cmd/cli/plugin/cluster/list.go
+++ b/cmd/cli/plugin/cluster/list.go
@@ -70,13 +70,13 @@ func listClusters(cmd *cobra.Command, server *v1alpha1.Server) error {
 	if lc.outputFormat == string(component.JSONOutputType) || lc.outputFormat == string(component.YAMLOutputType) {
 		t = component.NewObjectWriter(cmd.OutOrStdout(), lc.outputFormat, clusters)
 	} else {
-		t = component.NewOutputWriter(cmd.OutOrStdout(), lc.outputFormat, "NAME", "NAMESPACE", "STATUS", "CONTROLPLANE", "WORKERS", "KUBERNETES", "ROLES", "PLAN")
+		t = component.NewOutputWriter(cmd.OutOrStdout(), lc.outputFormat, "NAME", "NAMESPACE", "STATUS", "CONTROLPLANE", "WORKERS", "KUBERNETES", "ROLES", "PLAN", "TKR")
 		for _, cl := range clusters {
 			clusterRoles := "<none>"
 			if len(cl.Roles) != 0 {
 				clusterRoles = strings.Join(cl.Roles, ",")
 			}
-			t.AddRow(cl.Name, cl.Namespace, cl.Status, cl.ControlPlaneCount, cl.WorkerCount, cl.K8sVersion, clusterRoles, cl.Plan)
+			t.AddRow(cl.Name, cl.Namespace, cl.Status, cl.ControlPlaneCount, cl.WorkerCount, cl.K8sVersion, clusterRoles, cl.Plan, cl.TKR)
 		}
 	}
 	t.Render()

--- a/cmd/cli/plugin/managementcluster/get.go
+++ b/cmd/cli/plugin/managementcluster/get.go
@@ -132,13 +132,13 @@ func getClusterDetails(currServ *v1alpha1.Server) error {
 		return err
 	}
 
-	t := component.NewOutputWriter(cmdOutput, "table", "NAME", "NAMESPACE", "STATUS", "CONTROLPLANE", "WORKERS", "KUBERNETES", "ROLES", "PLAN")
+	t := component.NewOutputWriter(cmdOutput, "table", "NAME", "NAMESPACE", "STATUS", "CONTROLPLANE", "WORKERS", "KUBERNETES", "ROLES", "PLAN", "TKR")
 	cl := results.ClusterInfo
 	clusterRoles := "<none>"
 	if len(cl.Roles) != 0 {
 		clusterRoles = strings.Join(cl.Roles, ",")
 	}
-	t.AddRow(cl.Name, cl.Namespace, cl.Status, cl.ControlPlaneCount, cl.WorkerCount, cl.K8sVersion, clusterRoles, cl.Plan)
+	t.AddRow(cl.Name, cl.Namespace, cl.Status, cl.ControlPlaneCount, cl.WorkerCount, cl.K8sVersion, clusterRoles, cl.Plan, cl.TKR)
 
 	t.Render()
 	log.Infof("\n\nDetails:\n\n")

--- a/pkg/v1/tkg/client/get_cluster.go
+++ b/pkg/v1/tkg/client/get_cluster.go
@@ -28,6 +28,7 @@ type ClusterInfo struct {
 	WorkerCount       string            `json:"workers" yaml:"workers"`
 	K8sVersion        string            `json:"kubernetes" yaml:"kubernetes"`
 	Roles             []string          `json:"roles" yaml:"roles"`
+	TKR               string            `json:"tkr" yaml:"tkr"`
 	Labels            map[string]string `json:"labels" yaml:"labels"`
 }
 
@@ -92,6 +93,7 @@ func (c *TkgClient) GetClusterObjects(clusterClient clusterclient.Client, listOp
 		cluster.K8sVersion = getClusterK8sVersion(clusterInfo)
 		cluster.Roles = getClusterRoles(clusterInfo.cluster.Labels)
 		cluster.Labels = clusterInfo.cluster.Labels
+		cluster.TKR = getClusterTKR(clusterInfo.cluster.Labels)
 		clusters = append(clusters, cluster)
 	}
 
@@ -122,6 +124,7 @@ func (c *TkgClient) GetClusterObjectsForPacific(clusterClient clusterclient.Clie
 		cluster.WorkerCount = getClusterWorkerCountForPacific(clusterInfo)
 		cluster.K8sVersion = clusterInfo.cluster.Spec.Distribution.Version
 		cluster.Labels = clusterInfo.cluster.Labels
+		cluster.TKR = getClusterTKR(clusterInfo.cluster.Labels)
 		clusters = append(clusters, cluster)
 	}
 

--- a/pkg/v1/tkg/client/get_cluster_helper.go
+++ b/pkg/v1/tkg/client/get_cluster_helper.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	runv1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+
 	"github.com/pkg/errors"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -23,7 +25,8 @@ import (
 
 const (
 	// TKGPlanAnnotation plan annotation
-	TKGPlanAnnotation = "tkg/plan"
+	TKGPlanAnnotation     = "tkg/plan"
+	LegacyClusterTKRLabel = "tanzuKubernetesRelease"
 )
 
 type clusterObjects struct {
@@ -278,6 +281,17 @@ func getClusterRoles(clusterLabels map[string]string) []string {
 	}
 
 	return clusterRoles
+}
+
+func getClusterTKR(clusterLabels map[string]string) string {
+	var clusterTKR string
+	if tkrName, exists := clusterLabels[LegacyClusterTKRLabel]; exists {
+		clusterTKR = tkrName
+	}
+	if tkrName, exists := clusterLabels[runv1.LabelTKR]; exists {
+		clusterTKR = tkrName
+	}
+	return clusterTKR
 }
 
 // ################### Helpers for determining Cluster Status ##################

--- a/pkg/v1/tkg/client/get_cluster_test.go
+++ b/pkg/v1/tkg/client/get_cluster_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"time"
 
+	runv1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -22,6 +24,7 @@ import (
 )
 
 var fakeManagementClusterName = "fake-mgmt-cluster"
+var fakeTKRName = "v1.1.1---faketkr.1-tkg1"
 
 var _ = Describe("Unit tests for get clusters", func() {
 	var (
@@ -76,6 +79,7 @@ var _ = Describe("Unit tests for get clusters", func() {
 					Namespace:   constants.DefaultNamespace,
 					Labels: map[string]string{
 						TkgLabelClusterRolePrefix + TkgLabelClusterRoleWorkload: "",
+						LegacyClusterTKRLabel: fakeTKRName,
 					},
 					ClusterOptions: fakehelper.TestClusterOptions{
 						Phase:                   "deleting",
@@ -112,6 +116,7 @@ var _ = Describe("Unit tests for get clusters", func() {
 				Expect(clusterInfo[0].K8sVersion).To(Equal(createClusterOptions.CPOptions.K8sVersion))
 				Expect(clusterInfo[0].Roles).To(Equal([]string{TkgLabelClusterRoleWorkload}))
 				Expect(clusterInfo[0].Status).To(Equal(string(TKGClusterPhaseDeleting)))
+				Expect(clusterInfo[0].TKR).To(Equal(fakeTKRName))
 			})
 		})
 
@@ -122,6 +127,7 @@ var _ = Describe("Unit tests for get clusters", func() {
 					Namespace:   constants.DefaultNamespace,
 					Labels: map[string]string{
 						TkgLabelClusterRolePrefix + TkgLabelClusterRoleWorkload: "",
+						runv1.LabelTKR: fakeTKRName,
 					},
 					ClusterOptions: fakehelper.TestClusterOptions{
 						Phase:                   "provisioning",
@@ -155,6 +161,7 @@ var _ = Describe("Unit tests for get clusters", func() {
 				Expect(clusterInfo[0].K8sVersion).To(Equal(createClusterOptions.CPOptions.K8sVersion))
 				Expect(clusterInfo[0].Roles).To(Equal([]string{TkgLabelClusterRoleWorkload}))
 				Expect(clusterInfo[0].Status).To(Equal(string(TKGClusterPhaseCreating)))
+				Expect(clusterInfo[0].TKR).To(Equal(fakeTKRName))
 			})
 		})
 
@@ -198,6 +205,7 @@ var _ = Describe("Unit tests for get clusters", func() {
 				Expect(clusterInfo[0].K8sVersion).To(Equal(createClusterOptions.CPOptions.K8sVersion))
 				Expect(clusterInfo[0].Roles).To(Equal([]string{TkgLabelClusterRoleWorkload}))
 				Expect(clusterInfo[0].Status).To(Equal(string(TKGClusterPhaseCreating)))
+				Expect(clusterInfo[0].TKR).To(Equal(""))
 			})
 		})
 
@@ -901,6 +909,7 @@ var _ = Describe("Unit tests for get clusters", func() {
 					Namespace:   constants.DefaultNamespace,
 					Labels: map[string]string{
 						TkgLabelClusterRolePrefix + TkgLabelClusterRoleWorkload: "",
+						runv1.LabelTKR: fakeTKRName,
 					},
 					ClusterOptions: fakehelper.TestClusterOptions{
 						Phase: "running",
@@ -930,6 +939,7 @@ var _ = Describe("Unit tests for get clusters", func() {
 				Expect(clusterInfo[0].K8sVersion).To(Equal(createClusterOptions.CPOptions.K8sVersion))
 				Expect(clusterInfo[0].Status).To(Equal(string(TKGClusterPhaseRunning)))
 				Expect(clusterInfo[0].Labels).Should(Equal(createClusterOptions.Labels))
+				Expect(clusterInfo[0].TKR).To(Equal(fakeTKRName))
 			})
 		})
 
@@ -965,6 +975,7 @@ var _ = Describe("Unit tests for get clusters", func() {
 				Expect(clusterInfo[0].WorkerCount).To(Equal(fmt.Sprintf("%v/%v", createClusterOptions.ListMDOptions[0].ReadyReplicas, createClusterOptions.ListMDOptions[0].SpecReplicas)))
 				Expect(clusterInfo[0].K8sVersion).To(Equal(createClusterOptions.CPOptions.K8sVersion))
 				Expect(clusterInfo[0].Status).To(Equal(string(TKGClusterPhaseCreating)))
+				Expect(clusterInfo[0].TKR).To(Equal(""))
 			})
 		})
 	})


### PR DESCRIPTION
Signed-off-by: PremKumar Kalle <pkalle@vmware.com>

### What this PR does / why we need it
This PR adds support to show the TKR name in the output for `tanzu cluster list` ,`tanzu cluster get` and `tanzu mc get` command
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2390 

### Describe testing done for PR
- Unit tested
- Tested with cluster list
- Tested with mc get
```
❯ tanzu cluster list --include-management-cluster
  NAME                      NAMESPACE   STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES       PLAN  TKR
  test-aws-prem-pkgtest-mc  tkg-system  running  1/1           1/1      v1.23.5+vmware.1  management  dev   v1.23.5---vmware.1-tkg.1-zshippable
❯ tanzu mc get
  NAME                      NAMESPACE   STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES       PLAN  TKR                                  
  test-aws-prem-pkgtest-mc  tkg-system  running  1/1           1/1      v1.23.5+vmware.1  management  dev   v1.23.5---vmware.1-tkg.1-zshippable  


Details:

NAME                                                                         READY  SEVERITY  REASON  SINCE  MESSAGE
/test-aws-prem-pkgtest-mc                                                    True                     10d           
├─ClusterInfrastructure - AWSCluster/test-aws-prem-pkgtest-mc                True                     10d           
├─ControlPlane - KubeadmControlPlane/test-aws-prem-pkgtest-mc-control-plane  True                     13d           
│ └─Machine/test-aws-prem-pkgtest-mc-control-plane-sb7x9                     True                     13d           
└─Workers                                                                                                           
  └─MachineDeployment/test-aws-prem-pkgtest-mc-md-0                          True                     13d           
    └─Machine/test-aws-prem-pkgtest-mc-md-0-dfdb8bbf5-ck52w                  True                     13d           


Providers:

  NAMESPACE                          NAME                   TYPE                    PROVIDERNAME  VERSION  WATCHNAMESPACE  
  capa-system                        infrastructure-aws     InfrastructureProvider  aws           v1.2.0                   
  capi-kubeadm-bootstrap-system      bootstrap-kubeadm      BootstrapProvider       kubeadm       v1.1.3                   
  capi-kubeadm-control-plane-system  control-plane-kubeadm  ControlPlaneProvider    kubeadm       v1.1.3                   
  capi-system                        cluster-api            CoreProvider            cluster-api   v1.1.3   
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Show TKR name in cluster list and cluster get commands
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
