### PR TITLE
Run integration test on push

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,11 +13,13 @@ Example: Created vSphere workload cluster to verify change.
 
 **Special notes for your reviewer**:
 
-**Does this PR introduce a [user-facing](https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note) change?**:
+**Release note**:
 <!--
-If no, just write "NONE" in the release-note block below.
-If yes, a release note is required:
-Enter your extended release note in the block below.
+See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
+for more details.
+
+Please add a short text in the release-note block below (or "NONE" if not applicable)
+if there is anything in this PR that is worthy of mention in the next release.
 -->
 ```release-note
 


### PR DESCRIPTION
### What this PR does / why we need it

Testing enabling running the integration tests on push to target branch (package-based-lcm)
This is required since PRs from forks do not have access to the secrets required to run these tests with (and effectively skips them)

### Which issue(s) this PR fixes

Fixes # (n/a)

### Describe testing done for PR

monitor action history after this pr is pushed

### Release note

```release-note
None
```

### PR Checklist

### Additional information

#### Special notes for your reviewer

