### PR TITLE
Fix cluster template generation issue when current context is not bootstrap cluster context

### DIFF
--- a/pkg/v1/tkg/client/init.go
+++ b/pkg/v1/tkg/client/init.go
@@ -179,6 +179,9 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 		return errors.Wrap(err, "unable to create bootstrap cluster")
 	}
 
+	// Configure kubeconfig as part of options as bootstrap cluster kubeconfig
+	options.Kubeconfig = bootstrapClusterKubeconfigPath
+
 	isBootstrapClusterCreated = true
 	log.Infof("Bootstrapper created. Kubeconfig: %s", bootstrapClusterKubeconfigPath)
 	bootStrapClusterClient, err := clusterclient.NewClient(bootstrapClusterKubeconfigPath, "", clusterclient.Options{OperationTimeout: c.timeout})


### PR DESCRIPTION
### What this PR does / why we need it
- Fix cluster template generation issue when current context is not bootstrap cluster context
- Issue: 
    - When creating the cluster template clusterctl was using incorrect kubeconfig (default pointing to the default kubeconfig).
    - Because of this when bootstrap cluster's kubeconfig is not the default kubeconfig it doesn't find the clusterclass and it will add the clusterclass related information along with the CCluster yaml
    - By configuring kubeconfig to the bootstrap cluster config we are able to fix this issue

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Related-to #2419

### Describe testing done for PR
- Create management-cluster using `package-based-lcm` featureflag enabled. 

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Fix cluster template generation issue when current context is not bootstrap cluster context
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
