### PR TITLE
Prevent finalizer from being added to management cluster

### DIFF
--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -279,10 +279,13 @@ func (r *ClusterBootstrapReconciler) createOrPatchResourcesForAdditionalPackages
 			}
 		}
 	}
-	if len(clusterBootstrap.Spec.AdditionalPackages) > 0 { // If we reach this and there are at least one additional package, we need to add finalizer
-		err := r.addFinalizersToClusterResources(cluster, log)
-		if err != nil {
-			return ctrl.Result{}, err
+	if len(clusterBootstrap.Spec.AdditionalPackages) > 0 { // If we reach this and there are at least one additional package, we need to add finalizer unless it is a management cluster
+		_, isManagmentCluster := cluster.Labels[tkrconstants.ManagementClusterRoleLabel]
+		if !isManagmentCluster {
+			err := r.addFinalizersToClusterResources(cluster, log)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
 		}
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it
Management clusters should not have addons finalizers adde to them. 
If the finalizers is present, it will cause problems for the cluster lifecycle. 
For example, when kind clean up clusters is used to delete the management cluster, the clean up cluster does not 
have kapp controller running (or addons-manager) so there is nothing to remove the finalizer from it. 

This pr prevents finalizers from being added to clusters which are labeled as management clusters.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2426

### Describe testing done for PR

make test. 



### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
addons finalizers will not be added to clusters labeled as management clusters
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
