### PR TITLE
Fix post-merge tests involving get_pr_num

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,8 +38,11 @@ jobs:
       with:
         # when event is a pull request, obtaining the PR number is obvious
         filter_pull_request: '.number'
-        # when event is a push (merge of PR), obtains original PR number from the merge commit message
-        filter_push: '.head_commit.message | capture("Merge pull request #(?<pr>[[:digit:]]+)").pr | tonumber'
+        # when event is a push (merge of PR), since we require linear history,
+        # we are not even generating a merge commit that can help identify the
+        # PR number, so don't even try. Instead we just hard-code to a dummy
+        # value.
+        filter_push: 1009
 
     - name: Find Comment
       uses: peter-evans/find-comment@v1

--- a/.github/workflows/plugin_tests.yaml
+++ b/.github/workflows/plugin_tests.yaml
@@ -50,8 +50,11 @@ jobs:
         with:
           # when event is a pull request, obtaining the PR number is obvious
           filter_pull_request: '.number'
-          # when event is a push (merge of PR), obtains original PR number from the merge commit message
-          filter_push: '.head_commit.message | capture("Merge pull request #(?<pr>[[:digit:]]+)").pr | tonumber'
+          # when event is a push (merge of PR), since we require linear history,
+          # we are not even generating a merge commit that can help identify the
+          # PR number, so don't even try. Instead we just hard-code to a dummy
+          # value.
+          filter_push: 1009
 
       - name: Find Comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/tkg_integration_tests.yaml
+++ b/.github/workflows/tkg_integration_tests.yaml
@@ -2,7 +2,7 @@ name: TKG Integration Tests
 
 on:
   pull_request:
-    branches: [ main, release-*, package-based-lcm ]
+    branches: [ main, release-*, package-based-lcm* ]
     paths:
     - 'pkg/v1/tkg/**'
     - '!pkg/v1/tkg/tkgpackage*/*'
@@ -12,7 +12,7 @@ on:
     - '.github/workflows/tkg_integration_tests.yaml'
 
   push:
-    branches: [ package-based-lcm ]
+    branches: [ package-based-lcm* ]
     paths:
     - 'pkg/v1/tkg/**'
     - '!pkg/v1/tkg/tkgpackage*/*'
@@ -63,8 +63,11 @@ jobs:
       with:
         # when event is a pull request, obtaining the PR number is obvious
         filter_pull_request: '.number'
-        # when event is a push (merge of PR), obtains original PR number from the merge commit message
-        filter_push: '.head_commit.message | capture("Merge pull request #(?<pr>[[:digit:]]+)").pr | tonumber'
+        # when event is a push (merge of PR), since we require linear history,
+        # we are not even generating a merge commit that can help identify the
+        # PR number, so don't even try. Instead we just hard-code to a dummy
+        # value.
+        filter_push: 1009
 
     - name: Find Comment
       uses: peter-evans/find-comment@v1
@@ -131,8 +134,11 @@ jobs:
       with:
         # when event is a pull request, obtaining the PR number is obvious
         filter_pull_request: '.number'
-        # when event is a push (merge of PR), obtains original PR number from the merge commit message
-        filter_push: '.head_commit.message | capture("Merge pull request #(?<pr>[[:digit:]]+)").pr | tonumber'
+        # when event is a push (merge of PR), since we require linear history,
+        # we are not even generating a merge commit that can help identify the
+        # PR number, so don't even try. Instead we just hard-code to a dummy
+        # value.
+        filter_push: 1009
 
     - name: Find Comment
       uses: peter-evans/find-comment@v1
@@ -231,8 +237,11 @@ jobs:
         with:
           # when event is a pull request, obtaining the PR number is obvious
           filter_pull_request: '.number'
-          # when event is a push (merge of PR), obtains original PR number from the merge commit message
-          filter_push: '.head_commit.message | capture("Merge pull request #(?<pr>[[:digit:]]+)").pr | tonumber'
+          # when event is a push (merge of PR), since we require linear history,
+          # we are not even generating a merge commit that can help identify the
+          # PR number, so don't even try. Instead we just hard-code to a dummy
+          # value.
+          filter_push: 1009
 
       - name: Find Comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/tkgpackage_integration_test.yaml
+++ b/.github/workflows/tkgpackage_integration_test.yaml
@@ -54,8 +54,11 @@ jobs:
         with:
           # when event is a pull request, obtaining the PR number is obvious
           filter_pull_request: '.number'
-          # when event is a push (merge of PR), obtains original PR number from the merge commit message
-          filter_push: '.head_commit.message | capture("Merge pull request #(?<pr>[[:digit:]]+)").pr | tonumber'
+          # when event is a push (merge of PR), since we require linear history,
+          # we are not even generating a merge commit that can help identify the
+          # PR number, so don't even try. Instead we just hard-code to a dummy
+          # value.
+          filter_push: 1009
 
       - name: Find Comment
         uses: peter-evans/find-comment@v1


### PR DESCRIPTION
### What this PR does / why we need it

    Any tests that uses Dovyski/payload-info-action to extract PR number
    post merge needs to rely on PR number found in the merge commit,
    something which we do not have anymore now that we have moved to
    linearized history.

    This means no post-merge test should ever rely on parsing any PR metadata
    to work.

    Related-to: #246
    (to close once merged to main)

    Signed-off-by: Vui Lam <vui@vmware.com>

### Which issue(s) this PR fixes

Related-to: #246

### Describe testing done for PR

Verified on branch that triggers the test  on push (package-based-lcm-stage) works as expected

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- x Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- x Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- x Ensure PR contains terms all contributors can understand and links all contributors can access

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
