### PR TITLE
Upload coverage reports on push to main

### DIFF
--- a/.github/workflows/release_staging.yaml
+++ b/.github/workflows/release_staging.yaml
@@ -43,6 +43,11 @@ jobs:
     - name: Test
       run: make test
 
+    - name: Upload coverage reports to Codecov with GitHub Action
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./coverage1.txt,./coverage2.txt,./coverage3.txt,./addons/coverage.txt,./addons/pinniped/post-deploy/coverage.txt,./addons/pinniped/tanzu-auth-controller-manager/coverage.txt
+
     - id: upload-cli-artifacts
       # do not upload unsigned/untested artifacts to GCP bucket
       if: ${{ false }}


### PR DESCRIPTION
Follow up to https://github.com/vmware-tanzu/tanzu-framework/pull/2280 to ensure main branch has reports uploaded.

Signed-off-by: Vijay Katam <vkatam@vmware.com>

### What this PR does / why we need it
PR 2280 did not upload reports on push to main.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes: #2408

### Describe testing done for PR  

N/A
<!-- Example: Created vSphere workload cluster to verify change. -->



### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access

