### PR TITLE
Update node pool API for new clusters

### DIFF
--- a/docs/design/node-pool/package-based-lcm-node-pools.md
+++ b/docs/design/node-pool/package-based-lcm-node-pools.md
@@ -1,0 +1,71 @@
+# Node Pools configuration for ClusterClass-based clusters
+
+This doc provides an overview of differences in behavior when using the node pool API against a cluster using a clusterclass definition. The one thing that all of these APIs have in common when operating against a clusterclass based cluster is the need to update the cluster, specifically the cluster topology.
+
+## Delete
+
+Delete is the most straight forward change. The cluster resource is updated to remove the definition of the machine deployment with the name of the node pool that is passed to the delete API. The API does still prohibit the deletion of the final node pool in the cluster.
+
+```bash
+tanzu cluster node-pool delete tkg-wc-vsphere -n md–0
+```
+
+## List
+
+List retrieves the MachineDeployment resources as in the non clusterclass based case and matches these resources against the machine deployments in the cluster topology. This allows the list API to return the same MachineDeployment resources with the names updated to match the machine deployments defined in the cluster topology.
+
+```bash
+tanzu cluster node-pool list tkg-wc-vsphere
+  NAME  NAMESPACE  PHASE      REPLICAS  READY  UPDATED  UNAVAILABLE
+  md-0  default    Ready      1         1      1        0
+```
+
+## Properties on Node Pools in ClusterClass based Clusters
+
+Properties that can be updated on node pools in clusterclass based clusters can be broken down into two types. Direct properties of the machine deployment topology resources and variables overrides. Direct properties, like replica count, modify the machine deployment topolgy direct. Variable overrides rely on the definition of variables at the clusterclass level. When deploying a cluster based on a clusterclass, the cluster definition must specify a number of these variables, which apply to all machine deployments by default. The machine deployment topology allows these variables to be overridden on a machine deployment basis.
+
+The definitive source for properties that can be modified are the clusterclasses themselves. The TKGm clusterclasses all define a variable `worker` that contains worker node vm properties. This includes `instanceType` and `vmSize` for AWS and Azure respectively. The vSphere version includes properties for `diskGiB`, `memoryMiB`, and `numCPU`. TKGs defines top level variables for `vmClass` and `storageClass` as well as an array for `nodePoolVolumes` for customzing worker nodes. TKGm vSphere also defines a vcenter variable for updating properties related to the vcenter server.
+
+All TKG clusterclasses define a `nodePoolLabels` variable that specifies the node labels on the worker nodes.
+
+### Special Note
+
+The node pool API provided by the Tanzu CLI requires the above variables to be defined on the clusterclass to support creating and updating node pools. If you use a custom clusterclass these variables are required as top level variable definitions in the clusterclass. It is still possible to get and delete node pools on custom clusterclass based clusters using the Tanzu CLI. There is a special case where create and update will work for custom clusterclasses. Specifically if the node pool definition passed to the Tanzu cli specifies at most the `replicas`, `az`, `name`, `workerClass`, and `tkrResolver`. In this case the `workerClass` must match a `workerClass` definition in the custom clusterclass.
+
+## Set (Update)
+
+When the Set API is called using the name of an existing node pool the update will only modify the replica count and labels of the named node pool, if provided. Any other provided options will be ignored. Specifically the cluster's topology will be update with a new replica count and a nodePoolLabels variable override if these values are provided.
+
+## Set (Create)
+
+Creating node pools can follow one of two paths. A user can pass a base machine deployment that is used as the starting point for the new node pool. A deep copy of the named base machine deployment acts as a basis on which the user passed properties will be layered. In general this means all of the variable overrides of the copied machine deployment will be updated with new values provided by the user. This is different from the case where a base machine deployment is not provided. In this case, variable overrides will be copied from the global variable definitions defined in the cluster topology and then the user provided values will be layered on those. Additionally when a user does not provide a base machine deployment, they must provide a workerClass and tkrResolver definition. TKG ClusterClasses have a `tkg-worker` class defined by default, and should be used unless a user have added their own worker class definition. The tkrResolver is the value of the tkr-resolver annotation.
+
+Using a base machine deployment to create a new node pool.
+
+```bash
+tanzu cluster node-pool set tkg-wc-vsphere -f /path/to/node-pool.yml –-base-machine-deployment md-0
+```
+
+node-pool.yml
+
+```yaml
+name: np-1
+replicas: 1
+nodeMachineType: t3.large
+```
+
+Without using a base machine deployment to create a new node pool.
+
+```bash
+tanzu cluster node-pool set tkg-wc-vsphere -f /path/to/node-pool.yml
+```
+
+node-pool.yml
+
+```yaml
+name: np-1
+replicas: 1
+nodeMachineType: t3.large
+workerClass: tkg-worker
+tkrResolver: os-name=ubuntu,os-arch=amd64
+```

--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
@@ -240,6 +240,19 @@ spec:
         - enabled
         default:
           enabled: false
+  - name: nodePoolLabels
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+            values:
+              type: string
+        default: []
   - name: TKR_DATA
     required: false
     schema:
@@ -519,8 +532,20 @@ spec:
             {{- else -}}
               ,
             {{- end }}
-            {{- $key }}={{ $val }}
-            {{- end }}
+            {{- $key -}} = {{- $val }}
+            {{- end}}
+            {{- if .nodePoolLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .nodePoolLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
   - name: httpProxy
     enabledIf: '{{ not (empty .network.proxy) }}'
     definitions:

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -296,6 +296,19 @@ spec:
       openAPIV3Schema:
         type: string
         default: ""
+  - name: nodePoolLabels
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+            values:
+              type: string
+        default: []
   - name: TKR_DATA
     required: false
     schema:
@@ -707,7 +720,7 @@ spec:
           template: |
             frontendIPsCount: {{ .worker.outboundLB.frontendIPCount }}
             idleTimeoutInMinutes: {{ .worker.outboundLB.idleTimeoutInMinutes }}
-  - name: workerLabels
+  - name: nodeLabels
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -748,7 +761,19 @@ spec:
               ,
             {{- end }}
             {{- $key -}} = {{- $val }}
-            {{- end }}
+            {{- end}}
+            {{- if .nodePoolLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .nodePoolLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
   - name: httpProxy
     enabledIf: '{{ not (empty .network.proxy) }}'
     definitions:

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -407,7 +407,10 @@ spec:
             type: object
             properties:
               nameservers:
-                type: string
+                type: array
+                items:
+                  type: string
+                default: []
   - name: worker
     required: true
     schema:
@@ -430,7 +433,23 @@ spec:
             type: object
             properties:
               nameservers:
-                type: string
+                type: array
+                items:
+                  type: string
+                default: []
+  - name: nodePoolLabels
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+            values:
+              type: string
+        default: []
   - name: TKR_DATA
     required: false
     schema:
@@ -729,9 +748,14 @@ spec:
           template: |
             devices:
             - networkName: {{ .vcenter.network }}
-              {{ if .controlPlane.network.nameservers -}} nameservers: {{ .controlPlane.network.nameservers }} {{- end }}
-              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
-              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
+            {{ if .controlPlane.network.nameservers -}}
+              nameservers:
+              {{- range .controlPlane.network.nameservers }}
+            - {{ . }}
+              {{- end }}
+            {{- end }}
+            {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
+            {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
     - selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: VSphereMachineTemplate
@@ -747,9 +771,14 @@ spec:
           template: |
             devices:
             - networkName: {{ .vcenter.network }}
-              {{ if .worker.network.nameservers -}} nameservers: {{ .worker.network.nameservers }} {{- end }}
-              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
-              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
+            {{ if .worker.network.nameservers -}}
+              nameservers:
+              {{- range .worker.network.nameservers }}
+            - {{ . }}
+              {{- end }}
+            {{- end }}
+            {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
+            {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
   - name: clusterApiServerPort
     enabledIf: '{{ not (empty .apiServerPort) }}'
     definitions:
@@ -891,6 +920,18 @@ spec:
             {{- end }}
             {{- $key -}} = {{- $val }}
             {{- end}}
+            {{- if .nodePoolLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .nodePoolLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
   - name: httpProxy
     enabledIf: '{{ not (empty .network.proxy) }}'
     definitions:

--- a/pkg/v1/providers/infrastructure-aws/v1.2.0/cconly/base.yaml
+++ b/pkg/v1/providers/infrastructure-aws/v1.2.0/cconly/base.yaml
@@ -240,6 +240,19 @@ spec:
         - enabled
         default:
           enabled: false
+  - name: nodePoolLabels
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+            values:
+              type: string
+        default: []
   - name: TKR_DATA
     required: false
     schema:
@@ -519,8 +532,20 @@ spec:
             {{- else -}}
               ,
             {{- end }}
-            {{- $key }}={{ $val }}
-            {{- end }}
+            {{- $key -}} = {{- $val }}
+            {{- end}}
+            {{- if .nodePoolLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .nodePoolLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
   - name: httpProxy
     enabledIf: '{{ not (empty .network.proxy) }}'
     definitions:

--- a/pkg/v1/providers/infrastructure-azure/v1.2.1/cconly/base.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.2.1/cconly/base.yaml
@@ -296,6 +296,19 @@ spec:
       openAPIV3Schema:
         type: string
         default: ""
+  - name: nodePoolLabels
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+            values:
+              type: string
+        default: []
   - name: TKR_DATA
     required: false
     schema:
@@ -707,7 +720,7 @@ spec:
           template: |
             frontendIPsCount: {{ .worker.outboundLB.frontendIPCount }}
             idleTimeoutInMinutes: {{ .worker.outboundLB.idleTimeoutInMinutes }}
-  - name: workerLabels
+  - name: nodeLabels
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -748,7 +761,19 @@ spec:
               ,
             {{- end }}
             {{- $key -}} = {{- $val }}
-            {{- end }}
+            {{- end}}
+            {{- if .nodePoolLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .nodePoolLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
   - name: httpProxy
     enabledIf: '{{ not (empty .network.proxy) }}'
     definitions:

--- a/pkg/v1/providers/infrastructure-vsphere/v1.1.0/cconly/base.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.1.0/cconly/base.yaml
@@ -407,7 +407,10 @@ spec:
             type: object
             properties:
               nameservers:
-                type: string
+                type: array
+                items:
+                  type: string
+                default: []
   - name: worker
     required: true
     schema:
@@ -430,7 +433,23 @@ spec:
             type: object
             properties:
               nameservers:
-                type: string
+                type: array
+                items:
+                  type: string
+                default: []
+  - name: nodePoolLabels
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+            values:
+              type: string
+        default: []
   - name: TKR_DATA
     required: false
     schema:
@@ -729,9 +748,14 @@ spec:
           template: |
             devices:
             - networkName: {{ .vcenter.network }}
-              {{ if .controlPlane.network.nameservers -}} nameservers: {{ .controlPlane.network.nameservers }} {{- end }}
-              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
-              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
+            {{ if .controlPlane.network.nameservers -}}
+              nameservers:
+              {{- range .controlPlane.network.nameservers }}
+            - {{ . }}
+              {{- end }}
+            {{- end }}
+            {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
+            {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
     - selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: VSphereMachineTemplate
@@ -747,9 +771,14 @@ spec:
           template: |
             devices:
             - networkName: {{ .vcenter.network }}
-              {{ if .worker.network.nameservers -}} nameservers: {{ .worker.network.nameservers }} {{- end }}
-              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
-              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
+            {{ if .worker.network.nameservers -}}
+              nameservers:
+              {{- range .worker.network.nameservers }}
+            - {{ . }}
+              {{- end }}
+            {{- end }}
+            {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
+            {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
   - name: clusterApiServerPort
     enabledIf: '{{ not (empty .apiServerPort) }}'
     definitions:
@@ -891,6 +920,18 @@ spec:
             {{- end }}
             {{- $key -}} = {{- $val }}
             {{- end}}
+            {{- if .nodePoolLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .nodePoolLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
   - name: httpProxy
     enabledIf: '{{ not (empty .network.proxy) }}'
     definitions:

--- a/pkg/v1/tkg/client/machine_deployment_cc.go
+++ b/pkg/v1/tkg/client/machine_deployment_cc.go
@@ -1,0 +1,319 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
+)
+
+func DoSetMachineDeploymentCC(clusterClient clusterclient.Client, cluster *capi.Cluster, options *SetMachineDeploymentOptions) error {
+	var update *capi.MachineDeploymentTopology
+	var base *capi.MachineDeploymentTopology
+
+	if cluster.Spec.Topology.Workers == nil || len(cluster.Spec.Topology.Workers.MachineDeployments) < 1 {
+		return errors.New("cluster topology workers are not set. please repair your cluster before trying again")
+	}
+
+	for i := range cluster.Spec.Topology.Workers.MachineDeployments {
+		if cluster.Spec.Topology.Workers.MachineDeployments[i].Name == options.Name {
+			update = &cluster.Spec.Topology.Workers.MachineDeployments[i]
+		}
+		if cluster.Spec.Topology.Workers.MachineDeployments[i].Name == options.BaseMachineDeployment {
+			base = cluster.Spec.Topology.Workers.MachineDeployments[i].DeepCopy()
+		}
+	}
+
+	if update != nil && base != nil {
+		return errors.New("can not specify a base machine deployment when updating a node pool")
+	}
+
+	if update != nil {
+		base = update
+	} else {
+		if base == nil {
+			if options.NodePool.WorkerClass == "" || options.TKRResolver == "" {
+				return errors.New("workerClass and tkrResolver are required for new node pools without a baseMachineDeployment")
+			}
+			base = &capi.MachineDeploymentTopology{
+				Metadata: capi.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			}
+			if options.Replicas == nil {
+				base.Replicas = func(i int32) *int32 { return &i }(1) // default new node pool to 1 replica if not specified
+			}
+		}
+
+		cluster.Spec.Topology.Workers.MachineDeployments = append(cluster.Spec.Topology.Workers.MachineDeployments, *base)
+		base = &cluster.Spec.Topology.Workers.MachineDeployments[len(cluster.Spec.Topology.Workers.MachineDeployments)-1]
+	}
+
+	base.Name = options.Name
+
+	if options.Replicas != nil {
+		base.Replicas = options.Replicas
+	}
+
+	if options.WorkerClass != "" {
+		base.Class = options.WorkerClass
+	}
+
+	if options.TKRResolver != "" {
+		base.Metadata.Annotations["run.tanzu.vmware.com/resolve-os-image"] = options.TKRResolver
+	}
+
+	if base.Variables == nil {
+		base.Variables = &capi.MachineDeploymentVariables{}
+	}
+
+	if base.Variables.Overrides == nil {
+		base.Variables.Overrides = make([]capi.ClusterVariable, 0, 5)
+	}
+
+	if options.Labels != nil {
+		nodeLabelsVar := getClusterVariableByName("nodePoolLabels", base.Variables.Overrides)
+		if nodeLabelsVar == nil {
+			nodeLabelsVar = &capi.ClusterVariable{
+				Name:  "nodePoolLabels",
+				Value: v1.JSON{},
+			}
+			base.Variables.Overrides = append(base.Variables.Overrides, *nodeLabelsVar)
+			nodeLabelsVar = &base.Variables.Overrides[len(base.Variables.Overrides)-1]
+		}
+
+		var labels []map[string]string
+		// ignore nodePoolLabels not existing
+		_ = json.NewDecoder(bytes.NewBuffer(nodeLabelsVar.Value.Raw)).Decode(&labels)
+
+		for k, v := range *options.Labels {
+			labels = append(labels, map[string]string{
+				k: v,
+			})
+		}
+
+		output, _ := json.Marshal(labels)
+		nodeLabelsVar.Value.Raw = output
+	}
+
+	if update != nil {
+		return clusterClient.UpdateResource(cluster, options.ClusterName, options.Namespace)
+	}
+
+	return createNewMachineDeployment(clusterClient, cluster, options, base)
+}
+
+func createNewMachineDeployment(clusterClient clusterclient.Client, cluster *capi.Cluster, options *SetMachineDeploymentOptions, base *capi.MachineDeploymentTopology) error {
+	if options.NodeMachineType != "" {
+		var workerVariable = getClusterVariableByName("worker", base.Variables.Overrides)
+		if workerVariable == nil {
+			workerVariable = getClusterVariableByName("worker", cluster.Spec.Topology.Variables).DeepCopy()
+			base.Variables.Overrides = append(base.Variables.Overrides, *workerVariable)
+			workerVariable = &base.Variables.Overrides[len(base.Variables.Overrides)-1]
+		}
+
+		var worker map[string]interface{}
+		if err := json.NewDecoder(bytes.NewBuffer(workerVariable.Value.Raw)).Decode(&worker); err != nil {
+			return errors.New("unable to unmarshal worker")
+		}
+
+		if _, ok := worker["instanceType"]; ok {
+			worker["instanceType"] = options.NodeMachineType
+		} else if _, ok := worker["vmSize"]; ok {
+			worker["vmSize"] = options.NodeMachineType
+		}
+
+		output, _ := json.Marshal(worker)
+		workerVariable.Value.Raw = output
+	}
+
+	if options.AZ != "" {
+		base.FailureDomain = &options.AZ
+	}
+
+	if err := setVSphereWorkerOptions(options, base, cluster); err != nil {
+		return err
+	}
+
+	if err := setVSphereVCenterOptions(options, base, cluster); err != nil {
+		return err
+	}
+
+	return clusterClient.UpdateResource(cluster, options.ClusterName, options.Namespace)
+}
+
+func setVSphereVCenterOptions(options *SetMachineDeploymentOptions, base *capi.MachineDeploymentTopology, cluster *capi.Cluster) error {
+	if options.VSphere.CloneMode != "" || options.VSphere.Datacenter != "" || options.VSphere.Datastore != "" ||
+		options.VSphere.Folder != "" || options.VSphere.Network != "" || options.VSphere.ResourcePool != "" ||
+		options.VSphere.StoragePolicyName != "" || options.VSphere.VCIP != "" {
+		var vcenterVariable = getClusterVariableByName("vcenter", base.Variables.Overrides)
+		if vcenterVariable == nil {
+			vcenterVariable = getClusterVariableByName("vcenter", cluster.Spec.Topology.Variables).DeepCopy()
+			base.Variables.Overrides = append(base.Variables.Overrides, *vcenterVariable)
+			vcenterVariable = &base.Variables.Overrides[len(base.Variables.Overrides)-1]
+		}
+
+		var vcenter map[string]interface{}
+		if err := json.NewDecoder(bytes.NewBuffer(vcenterVariable.Value.Raw)).Decode(&vcenter); err != nil {
+			return errors.New("unable to unmarshal vcenter")
+		}
+
+		if options.VSphere.CloneMode != "" {
+			vcenter["cloneMode"] = options.VSphere.CloneMode
+		}
+
+		if options.VSphere.Datacenter != "" {
+			vcenter["datacenter"] = options.VSphere.Datacenter
+		}
+
+		if options.VSphere.Datastore != "" {
+			vcenter["datastore"] = options.VSphere.Datastore
+		}
+
+		if options.VSphere.Folder != "" {
+			vcenter["folder"] = options.VSphere.Folder
+		}
+
+		if options.VSphere.Network != "" {
+			vcenter["network"] = options.VSphere.Network
+		}
+
+		if options.VSphere.ResourcePool != "" {
+			vcenter["resourcePool"] = options.VSphere.ResourcePool
+		}
+
+		if options.VSphere.StoragePolicyName != "" {
+			vcenter["storagePolicyName"] = options.VSphere.StoragePolicyName
+		}
+
+		if options.VSphere.VCIP != "" {
+			vcenter["server"] = options.VSphere.VCIP
+		}
+
+		output, _ := json.Marshal(vcenter)
+		vcenterVariable.Value.Raw = output
+	}
+
+	return nil
+}
+
+func setVSphereWorkerOptions(options *SetMachineDeploymentOptions, base *capi.MachineDeploymentTopology, cluster *capi.Cluster) error {
+	if options.VSphere.NumCPUs > 0 || options.VSphere.DiskGiB > 0 || options.VSphere.MemoryMiB > 0 || len(options.VSphere.Nameservers) > 0 {
+		var workerVariable = getClusterVariableByName("worker", base.Variables.Overrides)
+		if workerVariable == nil {
+			workerVariable = getClusterVariableByName("worker", cluster.Spec.Topology.Variables).DeepCopy()
+			base.Variables.Overrides = append(base.Variables.Overrides, *workerVariable)
+			workerVariable = &base.Variables.Overrides[len(base.Variables.Overrides)-1]
+		}
+
+		var worker map[string]interface{}
+		if err := json.NewDecoder(bytes.NewBuffer(workerVariable.Value.Raw)).Decode(&worker); err != nil {
+			return errors.New("unable to unmarshal worker")
+		}
+
+		if machineInterface, ok := worker["machine"]; ok {
+			if machine, ok := machineInterface.(map[string]interface{}); ok {
+				if options.VSphere.NumCPUs > 0 {
+					machine["numCPUs"] = options.VSphere.NumCPUs
+				}
+				if options.VSphere.DiskGiB > 0 {
+					machine["diskGiB"] = options.VSphere.DiskGiB
+				}
+				if options.VSphere.MemoryMiB > 0 {
+					machine["memoryMiB"] = options.VSphere.MemoryMiB
+				}
+				worker["machine"] = machine
+			}
+		}
+
+		if networkInterface, ok := worker["network"]; ok {
+			if network, ok := networkInterface.(map[string]interface{}); ok {
+				if len(options.VSphere.Nameservers) > 0 {
+					network["nameservers"] = options.VSphere.Nameservers
+				}
+				worker["network"] = network
+			}
+		}
+
+		output, _ := json.Marshal(worker)
+		workerVariable.Value.Raw = output
+	}
+
+	return nil
+}
+
+func DoDeleteMachineDeploymentCC(clusterClient clusterclient.Client, cluster *capi.Cluster, options *DeleteMachineDeploymentOptions) error {
+	var mds []capi.MachineDeploymentTopology
+	for _, machineDeployment := range cluster.Spec.Topology.Workers.MachineDeployments {
+		if machineDeployment.Name != options.Name {
+			mds = append(mds, machineDeployment)
+		}
+	}
+
+	if len(mds) == 0 {
+		return errors.New("unable to delete last node pool")
+	}
+
+	if len(mds) == len(cluster.Spec.Topology.Workers.MachineDeployments) {
+		return fmt.Errorf("could not find node pool %s to delete", options.Name)
+	}
+
+	cluster.Spec.Topology.Workers.MachineDeployments = mds
+
+	if err := clusterClient.UpdateResource(cluster, cluster.ClusterName, cluster.Namespace); err != nil {
+		return fmt.Errorf("unable to delete node pools on cluster %s", options.ClusterName)
+	}
+
+	return nil
+}
+
+func DoGetMachineDeploymentsCC(clusterClient clusterclient.Client, cluster *capi.Cluster, options *GetMachineDeploymentOptions) ([]capi.MachineDeployment, error) {
+	workers, err := clusterClient.GetMDObjectForCluster(options.ClusterName, options.Namespace)
+	if err != nil {
+		return nil, errors.New("error retrieving node pools")
+	}
+
+	mds := make([]capi.MachineDeployment, 0, len(workers))
+	for i := range workers {
+		for _, md := range cluster.Spec.Topology.Workers.MachineDeployments {
+			if workers[i].Spec.Template.Labels["topology.cluster.x-k8s.io/deployment-name"] == md.Name {
+				workers[i].Name = md.Name
+				mds = append(mds, workers[i])
+			}
+		}
+	}
+
+	if options.Name != "" {
+		for i := range mds {
+			if mds[i].Name == options.Name {
+				return []capi.MachineDeployment{
+					mds[i],
+				}, nil
+			}
+		}
+
+		return nil, fmt.Errorf("node pool named %s not found", options.Name)
+	}
+
+	return mds, nil
+}
+
+func getClusterVariableByName(name string, variables []capi.ClusterVariable) *capi.ClusterVariable {
+	var variable *capi.ClusterVariable
+	for i := range variables {
+		if variables[i].Name == name {
+			variable = &variables[i]
+			break
+		}
+	}
+
+	return variable
+}

--- a/pkg/v1/tkg/client/machine_deployment_cc_test.go
+++ b/pkg/v1/tkg/client/machine_deployment_cc_test.go
@@ -1,0 +1,657 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client_test
+
+import (
+	"encoding/json"
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+)
+
+const (
+	md0Name     = "md-0"
+	md1Name     = "md-1"
+	unknownName = "unknown"
+)
+
+var _ = Describe("GetMachineDeploymentCC", func() {
+	var (
+		err                   error
+		regionalClusterClient *fakes.ClusterClient
+		cluster               capi.Cluster
+		options               GetMachineDeploymentOptions
+		mds                   []capi.MachineDeployment
+	)
+
+	BeforeEach(func() {
+		regionalClusterClient = &fakes.ClusterClient{}
+		options = GetMachineDeploymentOptions{
+			ClusterName: "test-cluster",
+			Namespace:   "default",
+		}
+	})
+
+	AfterEach(func() {
+		clusterName, namespace := regionalClusterClient.GetMDObjectForClusterArgsForCall(0)
+		Expect(clusterName).To(Equal(options.ClusterName))
+		Expect(namespace).To(Equal(options.Namespace))
+	})
+
+	JustBeforeEach(func() {
+		mds, err = DoGetMachineDeploymentsCC(regionalClusterClient, &cluster, &options)
+	})
+
+	When("There is one MachineDeployment for each defined in the cluster topology", func() {
+		BeforeEach(func() {
+			regionalClusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{
+				{
+					Spec: capi.MachineDeploymentSpec{
+						Template: capi.MachineTemplateSpec{
+							ObjectMeta: capi.ObjectMeta{
+								Labels: map[string]string{
+									"topology.cluster.x-k8s.io/deployment-name": md0Name,
+								},
+							},
+						},
+					},
+				},
+				{
+					Spec: capi.MachineDeploymentSpec{
+						Template: capi.MachineTemplateSpec{
+							ObjectMeta: capi.ObjectMeta{
+								Labels: map[string]string{
+									"topology.cluster.x-k8s.io/deployment-name": md1Name,
+								},
+							},
+						},
+					},
+				},
+			}, nil)
+
+			cluster = capi.Cluster{
+				Spec: capi.ClusterSpec{
+					Topology: &capi.Topology{
+						Workers: &capi.WorkersTopology{
+							MachineDeployments: []capi.MachineDeploymentTopology{
+								{
+									Name: md0Name,
+								},
+								{
+									Name: md1Name,
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("should return a list of all the MachineDeployments", func() {
+			Expect(err).To(BeNil())
+			Expect(len(mds)).To(Equal(2))
+			Expect(mds[0].Name).To(Equal(md0Name))
+			Expect(mds[1].Name).To(Equal(md1Name))
+		})
+	})
+
+	When("a node pool name is passed in options", func() {
+		BeforeEach(func() {
+			regionalClusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{
+				{
+					Spec: capi.MachineDeploymentSpec{
+						Template: capi.MachineTemplateSpec{
+							ObjectMeta: capi.ObjectMeta{
+								Labels: map[string]string{
+									"topology.cluster.x-k8s.io/deployment-name": md0Name,
+								},
+							},
+						},
+					},
+				},
+				{
+					Spec: capi.MachineDeploymentSpec{
+						Template: capi.MachineTemplateSpec{
+							ObjectMeta: capi.ObjectMeta{
+								Labels: map[string]string{
+									"topology.cluster.x-k8s.io/deployment-name": md1Name,
+								},
+							},
+						},
+					},
+				},
+			}, nil)
+
+			cluster = capi.Cluster{
+				Spec: capi.ClusterSpec{
+					Topology: &capi.Topology{
+						Workers: &capi.WorkersTopology{
+							MachineDeployments: []capi.MachineDeploymentTopology{
+								{
+									Name: md0Name,
+								},
+								{
+									Name: md1Name,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			options.Name = md1Name
+		})
+
+		It("should return a list of the named node pool", func() {
+			Expect(err).To(BeNil())
+			Expect(len(mds)).To(Equal(1))
+			Expect(mds[0].Name).To(Equal(md1Name))
+		})
+	})
+
+	When("a node pool name is passed in options", func() {
+		BeforeEach(func() {
+			regionalClusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{
+				{
+					Spec: capi.MachineDeploymentSpec{
+						Template: capi.MachineTemplateSpec{
+							ObjectMeta: capi.ObjectMeta{
+								Labels: map[string]string{
+									"topology.cluster.x-k8s.io/deployment-name": md0Name,
+								},
+							},
+						},
+					},
+				},
+				{
+					Spec: capi.MachineDeploymentSpec{
+						Template: capi.MachineTemplateSpec{
+							ObjectMeta: capi.ObjectMeta{
+								Labels: map[string]string{
+									"topology.cluster.x-k8s.io/deployment-name": md1Name,
+								},
+							},
+						},
+					},
+				},
+			}, nil)
+
+			cluster = capi.Cluster{
+				Spec: capi.ClusterSpec{
+					Topology: &capi.Topology{
+						Workers: &capi.WorkersTopology{
+							MachineDeployments: []capi.MachineDeploymentTopology{
+								{
+									Name: md0Name,
+								},
+								{
+									Name: md1Name,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			options.Name = md1Name
+		})
+
+		When("the node pool name is found", func() {
+			It("should return a list of the named node pool", func() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(mds)).To(Equal(1))
+				Expect(mds[0].Name).To(Equal(md1Name))
+			})
+		})
+
+		When("The node pool name is not found", func() {
+			BeforeEach(func() {
+				options.Name = unknownName
+			})
+
+			It("Should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("node pool named unknown not found"))
+			})
+		})
+	})
+
+	When("There are more MachineDeployments than defined in the cluster topology", func() {
+		BeforeEach(func() {
+			regionalClusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{
+				{
+					Spec: capi.MachineDeploymentSpec{
+						Template: capi.MachineTemplateSpec{
+							ObjectMeta: capi.ObjectMeta{
+								Labels: map[string]string{
+									"topology.cluster.x-k8s.io/deployment-name": md0Name,
+								},
+							},
+						},
+					},
+				},
+				{
+					Spec: capi.MachineDeploymentSpec{
+						Template: capi.MachineTemplateSpec{
+							ObjectMeta: capi.ObjectMeta{
+								Labels: map[string]string{
+									"topology.cluster.x-k8s.io/deployment-name": md1Name,
+								},
+							},
+						},
+					},
+				},
+			}, nil)
+
+			cluster = capi.Cluster{
+				Spec: capi.ClusterSpec{
+					Topology: &capi.Topology{
+						Workers: &capi.WorkersTopology{
+							MachineDeployments: []capi.MachineDeploymentTopology{
+								{
+									Name: md0Name,
+								},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("should only show the MachineDeployments defined in the cluster toplogy", func() {
+			Expect(err).To(BeNil())
+			Expect(len(mds)).To(Equal(1))
+			Expect(mds[0].Name).To(Equal(md0Name))
+		})
+	})
+
+	When("there is an error retrieving MachineDeployments", func() {
+		BeforeEach(func() {
+			regionalClusterClient.GetMDObjectForClusterReturns(nil, errors.New("error retrieving mds"))
+		})
+
+		It("should return an error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("error retrieving node pools"))
+		})
+	})
+})
+
+var _ = Describe("GetMachineDeploymentCC", func() {
+	var (
+		err                   error
+		regionalClusterClient *fakes.ClusterClient
+		cluster               capi.Cluster
+		options               DeleteMachineDeploymentOptions
+	)
+
+	BeforeEach(func() {
+		regionalClusterClient = &fakes.ClusterClient{}
+		options = DeleteMachineDeploymentOptions{
+			ClusterName: "test-cluster",
+			Namespace:   "default",
+		}
+	})
+
+	JustBeforeEach(func() {
+		err = DoDeleteMachineDeploymentCC(regionalClusterClient, &cluster, &options)
+	})
+
+	When("the MachineDeployment is found", func() {
+		BeforeEach(func() {
+			cluster = capi.Cluster{
+				Spec: capi.ClusterSpec{
+					Topology: &capi.Topology{
+						Workers: &capi.WorkersTopology{
+							MachineDeployments: []capi.MachineDeploymentTopology{
+								{
+									Name: md0Name,
+								},
+							},
+						},
+					},
+				},
+			}
+			options.Name = md0Name
+		})
+
+		Context("and it is the last remaining MachineDeployment", func() {
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("unable to delete last node pool"))
+			})
+		})
+
+		Context("and it is successfully deleted", func() {
+			BeforeEach(func() {
+				cluster.Spec.Topology.Workers.MachineDeployments = append(cluster.Spec.Topology.Workers.MachineDeployments,
+					capi.MachineDeploymentTopology{
+						Name: md1Name,
+					})
+			})
+
+			It("should delete the named node pool", func() {
+				Expect(err).ToNot(HaveOccurred())
+				clusterInterface, _, _, _ := regionalClusterClient.UpdateResourceArgsForCall(0)
+				cluster, ok := clusterInterface.(*capi.Cluster)
+				Expect(ok).To(BeTrue())
+				Expect(len(cluster.Spec.Topology.Workers.MachineDeployments)).To(Equal(1))
+				Expect(cluster.Spec.Topology.Workers.MachineDeployments[0].Name).To(Equal(md1Name))
+			})
+		})
+
+		Context("and updating the cluster returns an error", func() {
+			BeforeEach(func() {
+				cluster.Spec.Topology.Workers.MachineDeployments = append(cluster.Spec.Topology.Workers.MachineDeployments,
+					capi.MachineDeploymentTopology{
+						Name: md1Name,
+					})
+
+				regionalClusterClient.UpdateResourceReturns(errors.New("unable to update resource"))
+			})
+
+			It("return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("unable to delete node pools on cluster test-cluster"))
+				clusterInterface, _, _, _ := regionalClusterClient.UpdateResourceArgsForCall(0)
+				actual, ok := clusterInterface.(*capi.Cluster)
+				Expect(ok).To(BeTrue())
+				Expect(len(actual.Spec.Topology.Workers.MachineDeployments)).To(Equal(1))
+				Expect(actual.Spec.Topology.Workers.MachineDeployments[0].Name).To(Equal(md1Name))
+			})
+		})
+	})
+
+	When("the MachineDeployment is not found", func() {
+		BeforeEach(func() {
+			cluster = capi.Cluster{
+				Spec: capi.ClusterSpec{
+					Topology: &capi.Topology{
+						Workers: &capi.WorkersTopology{
+							MachineDeployments: []capi.MachineDeploymentTopology{
+								{
+									Name: md0Name,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			options.Name = unknownName
+		})
+
+		It("should return an error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("could not find node pool unknown to delete"))
+		})
+	})
+})
+
+var _ = Describe("SetMachineDeploymentCC", func() {
+	var (
+		err                   error
+		regionalClusterClient *fakes.ClusterClient
+		cluster               capi.Cluster
+		options               SetMachineDeploymentOptions
+		worker0Raw            []byte
+		worker1Raw            []byte
+		worker2Raw            []byte
+	)
+
+	BeforeEach(func() {
+		regionalClusterClient = &fakes.ClusterClient{}
+		options = SetMachineDeploymentOptions{
+			ClusterName: "test-cluster",
+			Namespace:   "default",
+			NodePool: NodePool{
+				Labels: &map[string]string{
+					"os":   "ubuntu",
+					"arch": "amd64",
+				},
+				Replicas: func(i int32) *int32 { return &i }(3),
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		err = DoSetMachineDeploymentCC(regionalClusterClient, &cluster, &options)
+	})
+
+	Context("adding a new MachineDeployment", func() {
+		BeforeEach(func() {
+			worker0Raw, _ = json.Marshal(map[string]interface{}{
+				"instanceType": "m5.large",
+			})
+			worker1Raw, _ = json.Marshal(map[string]interface{}{
+				"vmSize": "Standard_D2s_v3",
+			})
+			cluster = capi.Cluster{
+				Spec: capi.ClusterSpec{
+					Topology: &capi.Topology{
+						Workers: &capi.WorkersTopology{
+							MachineDeployments: []capi.MachineDeploymentTopology{
+								{
+									Name:     md0Name,
+									Replicas: func(i int32) *int32 { return &i }(1),
+									Class:    "tkg-worker",
+									Variables: &capi.MachineDeploymentVariables{
+										Overrides: []capi.ClusterVariable{
+											{
+												Name: "worker",
+												Value: v1.JSON{
+													Raw: worker0Raw,
+												},
+											},
+										},
+									},
+								},
+								{
+									Name:     md1Name,
+									Replicas: func(i int32) *int32 { return &i }(2),
+									Class:    "tkg-worker",
+									Variables: &capi.MachineDeploymentVariables{
+										Overrides: []capi.ClusterVariable{
+											{
+												Name: "worker",
+												Value: v1.JSON{
+													Raw: worker1Raw,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						Variables: []capi.ClusterVariable{
+							{
+								Name: "worker",
+								Value: v1.JSON{
+									Raw: worker0Raw,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			options.Name = "md-2"
+		})
+
+		Context("using a known base machine deployment", func() {
+			BeforeEach(func() {
+				options.BaseMachineDeployment = md1Name
+				options.NodeMachineType = "Standard_D3s_v3"
+			})
+
+			It("should populate the machine deployment", func() {
+				Expect(err).ToNot(HaveOccurred())
+				expected, _ := json.Marshal(map[string]interface{}{
+					"vmSize": "Standard_D3s_v3",
+				})
+				clusterInterface, _, _, _ := regionalClusterClient.UpdateResourceArgsForCall(0)
+				actual, ok := clusterInterface.(*capi.Cluster)
+				Expect(ok).To(BeTrue())
+				Expect(len(actual.Spec.Topology.Workers.MachineDeployments)).To(Equal(3))
+				Expect(actual.Spec.Topology.Workers.MachineDeployments[2].Variables.Overrides[0].Value.Raw).To(Equal(expected))
+			})
+		})
+
+		Context("without a base machine deployment", func() {
+			BeforeEach(func() {
+				options.NodeMachineType = "t3.large"
+				options.WorkerClass = "tkg-worker"
+				options.TKRResolver = "os-name=ubuntu"
+			})
+
+			It("should populate the machine deployment", func() {
+				Expect(err).ToNot(HaveOccurred())
+				expected, _ := json.Marshal(map[string]interface{}{
+					"instanceType": "t3.large",
+				})
+				clusterInterface, _, _, _ := regionalClusterClient.UpdateResourceArgsForCall(0)
+				actual, ok := clusterInterface.(*capi.Cluster)
+				Expect(ok).To(BeTrue())
+				Expect(len(actual.Spec.Topology.Workers.MachineDeployments)).To(Equal(3))
+				Expect(actual.Spec.Topology.Workers.MachineDeployments[2].Variables.Overrides[1].Value.Raw).To(Equal(expected))
+			})
+		})
+
+		Context("with a vsphere machine type", func() {
+			BeforeEach(func() {
+				worker2Raw, _ = json.Marshal(map[string]interface{}{
+					"machine": map[string]interface{}{
+						"numCPUs":   2,
+						"diskGiB":   40,
+						"memoryMiB": 8,
+					},
+					"network": map[string]interface{}{
+						"nameservers": []string{
+							"8.8.8.8",
+						},
+					},
+				})
+				cluster.Spec.Topology.Variables[0].Value.Raw = worker2Raw
+				vcenterRaw, _ := json.Marshal(map[string]interface{}{})
+				cluster.Spec.Topology.Variables = append(cluster.Spec.Topology.Variables, capi.ClusterVariable{
+					Name: "vcenter",
+					Value: v1.JSON{
+						Raw: vcenterRaw,
+					},
+				})
+
+				options.NodeMachineType = ""
+				options.VSphere.DiskGiB = 160
+				options.VSphere.MemoryMiB = 16
+				options.VSphere.NumCPUs = 8
+				options.VSphere.Nameservers = []string{
+					"8.8.8.8",
+					"8.8.4.4",
+				}
+
+				options.VSphere.CloneMode = "fullClone"
+				options.VSphere.Datacenter = "dc-0"
+				options.VSphere.Datastore = "iscsi-0"
+				options.VSphere.Folder = "folder-1"
+				options.VSphere.ResourcePool = "rp-1"
+				options.VSphere.Network = "VMNetwork"
+				options.VSphere.StoragePolicyName = "policy"
+				options.VSphere.VCIP = "1.1.1.1"
+
+				options.WorkerClass = "tkg-worker"
+				options.TKRResolver = "os-name=ubuntu"
+			})
+
+			It("should populate the vsphere machine", func() {
+				Expect(err).ToNot(HaveOccurred())
+				expected, _ := json.Marshal(map[string]interface{}{
+					"machine": map[string]interface{}{
+						"numCPUs":   8,
+						"memoryMiB": 16,
+						"diskGiB":   160,
+					},
+					"network": map[string]interface{}{
+						"nameservers": []string{
+							"8.8.8.8",
+							"8.8.4.4",
+						},
+					},
+				})
+				expectedLabels, _ := json.Marshal([]map[string]string{
+					{
+						"os": "ubuntu",
+					},
+					{
+						"arch": "amd64",
+					},
+				})
+				clusterInterface, _, _, _ := regionalClusterClient.UpdateResourceArgsForCall(0)
+				actual, ok := clusterInterface.(*capi.Cluster)
+				Expect(ok).To(BeTrue())
+				Expect(len(actual.Spec.Topology.Workers.MachineDeployments)).To(Equal(3))
+				Expect(len(actual.Spec.Topology.Workers.MachineDeployments[2].Variables.Overrides)).To(Equal(3))
+				Expect(actual.Spec.Topology.Workers.MachineDeployments[2].Variables.Overrides[0].Value.Raw).To(Equal(expectedLabels))
+				Expect(actual.Spec.Topology.Workers.MachineDeployments[2].Variables.Overrides[1].Value.Raw).To(Equal(expected))
+
+				expectedVcenter, _ := json.Marshal(map[string]interface{}{
+					"cloneMode":         "fullClone",
+					"datacenter":        "dc-0",
+					"datastore":         "iscsi-0",
+					"folder":            "folder-1",
+					"resourcePool":      "rp-1",
+					"network":           "VMNetwork",
+					"storagePolicyName": "policy",
+					"server":            "1.1.1.1",
+				})
+
+				Expect(actual.Spec.Topology.Workers.MachineDeployments[2].Variables.Overrides[2].Value.Raw).To(Equal(expectedVcenter))
+			})
+		})
+	})
+
+	Context("updating a machine deployment", func() {
+		BeforeEach(func() {
+			cluster = capi.Cluster{
+				Spec: capi.ClusterSpec{
+					Topology: &capi.Topology{
+						Workers: &capi.WorkersTopology{
+							MachineDeployments: []capi.MachineDeploymentTopology{
+								{
+									Name:     md0Name,
+									Replicas: func(i int32) *int32 { return &i }(1),
+									Class:    "tkg-worker",
+								},
+								{
+									Name:     md1Name,
+									Replicas: func(i int32) *int32 { return &i }(2),
+									Class:    "tkg-worker",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			options.Name = md0Name
+		})
+
+		It("should update the machine deployment", func() {
+			Expect(err).ToNot(HaveOccurred())
+			clusterInterface, _, _, _ := regionalClusterClient.UpdateResourceArgsForCall(0)
+			actual, ok := clusterInterface.(*capi.Cluster)
+			Expect(ok).To(BeTrue())
+			Expect(len(actual.Spec.Topology.Workers.MachineDeployments)).To(Equal(2))
+			Expect(actual.Spec.Topology.Workers.MachineDeployments[0].Name).To(Equal(md0Name))
+			Expect(len(actual.Spec.Topology.Workers.MachineDeployments[0].Variables.Overrides)).To(Equal(1))
+			Expect(actual.Spec.Topology.Workers.MachineDeployments[0].Variables.Overrides[0].Name).To(Equal("nodePoolLabels"))
+			Expect(*actual.Spec.Topology.Workers.MachineDeployments[0].Replicas).To(Equal(int32(3)))
+		})
+	})
+})


### PR DESCRIPTION
### What this PR does / why we need it
Updates the node pool API to support clusterclass based clusters. Node pools are now machineDeployment definitions in the worker topology. This code flow kicks in when the cluster has a topology definition.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2946

### Describe testing done for PR

Suite of tests written to cover get, set and delete node pool. These unit tests cover 95%+ of the statements in this new logic.
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: updates node pool API to support clusterclass based clusters [doc](docs/design/node-pool/package-based-lcm-node-pools.md)
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
