### PR TITLE
TKR conversion to v1a3: spec.kubernetes.version should start with v

### DIFF
--- a/apis/run/v1alpha1/conversion.go
+++ b/apis/run/v1alpha1/conversion.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	v1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/util/version"
 	utilconversion "github.com/vmware-tanzu/tanzu-framework/util/conversion"
 )
 
@@ -58,6 +59,8 @@ func (spoke *TanzuKubernetesRelease) ConvertFrom(hubRaw conversion.Hub) error {
 		return err
 	} else if ok {
 		// Annotations contain data, restore the relevant ones.
+		spoke.Spec.Version = restored.Spec.Version
+		spoke.Spec.KubernetesVersion = restored.Spec.KubernetesVersion
 		spoke.Spec.NodeImageRef = restored.Spec.NodeImageRef
 		if restored.Spec.Images != nil {
 			spoke.Spec.Images = restored.Spec.Images
@@ -75,7 +78,8 @@ func (spoke *TanzuKubernetesRelease) ConvertFrom(hubRaw conversion.Hub) error {
 // Convert_v1alpha1_TanzuKubernetesReleaseSpec_To_v1alpha3_TanzuKubernetesReleaseSpec  will convert the compatible types in TanzuKubernetesReleaseSpec v1alpha1 to v1alpha3 equivalent.
 // nolint:revive,stylecheck // Generated conversion stubs have underscores in function names.
 func Convert_v1alpha1_TanzuKubernetesReleaseSpec_To_v1alpha3_TanzuKubernetesReleaseSpec(in *TanzuKubernetesReleaseSpec, out *v1alpha3.TanzuKubernetesReleaseSpec, s apiconversion.Scope) error {
-	out.Kubernetes.Version = in.KubernetesVersion
+	out.Version = version.WithV(in.Version)
+	out.Kubernetes.Version = version.WithV(in.KubernetesVersion)
 	out.Kubernetes.ImageRepository = in.Repository
 
 	// Transform the container images.
@@ -106,7 +110,7 @@ func Convert_v1alpha1_TanzuKubernetesReleaseSpec_To_v1alpha3_TanzuKubernetesRele
 		}
 	}
 
-	return autoConvert_v1alpha1_TanzuKubernetesReleaseSpec_To_v1alpha3_TanzuKubernetesReleaseSpec(in, out, s)
+	return nil
 }
 
 // Convert_v1alpha3_TanzuKubernetesReleaseSpec_To_v1alpha1_TanzuKubernetesReleaseSpec will convert the compatible types in TanzuKubernetesReleaseSpec v1alpha3 to v1alpha1 equivalent.

--- a/apis/run/v1alpha1/conversion_test.go
+++ b/apis/run/v1alpha1/conversion_test.go
@@ -9,10 +9,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	v1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/util/version"
 	utilconversion "github.com/vmware-tanzu/tanzu-framework/util/conversion"
 )
 
@@ -20,6 +23,11 @@ func TestConversion(t *testing.T) {
 	t.Run("for TanzuKubernetesRelease", utilconversion.FuzzTestFunc(&utilconversion.FuzzTestFuncInput{
 		Hub:   &v1alpha3.TanzuKubernetesRelease{},
 		Spoke: &TanzuKubernetesRelease{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{
+			func(_ serializer.CodecFactory) []interface{} {
+				return []interface{}{v1alpha3.FuzzTKRSpec, v1alpha3.FuzzTKRSpecKubernetes, version.Fuzz}
+			},
+		},
 	}))
 
 	// Add other types here in future
@@ -30,9 +38,9 @@ func TestHubSpokeHub(t *testing.T) {
 	t.Run("for TanzuKubernetesRelease", func(t *testing.T) {
 		hub := &v1alpha3.TanzuKubernetesRelease{
 			Spec: v1alpha3.TanzuKubernetesReleaseSpec{
-				Version: "#ŉƈOƕʘ賡谒湪ȥ#4",
+				Version: "v#ŉƈOƕʘ賡谒湪ȥ#4",
 				Kubernetes: v1alpha3.KubernetesSpec{
-					Version:         `ìd/i涇u趗\庰鏜`,
+					Version:         `vìd/i涇u趗\庰鏜`,
 					ImageRepository: "辑",
 					Etcd: &v1alpha3.ContainerImageInfo{
 						ImageRepository: "9ŉ劆掬ȳƤʟNʮ犓ȓ峌堲Ȥ:ě",
@@ -152,9 +160,9 @@ func TestContainerImagesConversionFromSpokeToHubWithNoAnnotations(t *testing.T) 
 	t.Run("for TanzuKubernetesRelease", func(t *testing.T) {
 		hub := &v1alpha3.TanzuKubernetesRelease{
 			Spec: v1alpha3.TanzuKubernetesReleaseSpec{
-				Version: "#ŉƈOƕʘ賡谒湪ȥ#4",
+				Version: "v#ŉƈOƕʘ賡谒湪ȥ#4",
 				Kubernetes: v1alpha3.KubernetesSpec{
-					Version:         `ìd/i涇u趗\庰鏜`,
+					Version:         `vìd/i涇u趗\庰鏜`,
 					ImageRepository: "辑",
 					Etcd: &v1alpha3.ContainerImageInfo{
 						ImageRepository: "9ŉ劆掬ȳƤʟNʮ犓ȓ峌堲Ȥ:ě",
@@ -184,8 +192,8 @@ func TestContainerImagesConversionFromSpokeToHubWithNoAnnotations(t *testing.T) 
 
 		expectedSpoke := &TanzuKubernetesRelease{
 			Spec: TanzuKubernetesReleaseSpec{
-				Version:           "#ŉƈOƕʘ賡谒湪ȥ#4",
-				KubernetesVersion: `ìd/i涇u趗\庰鏜`,
+				Version:           "v#ŉƈOƕʘ賡谒湪ȥ#4", // prefixed with `v` coming from v1alpha3
+				KubernetesVersion: `vìd/i涇u趗\庰鏜`,   // prefixed with `v` coming from v1alpha3
 				Repository:        "辑",
 				Images: []ContainerImage{
 					{

--- a/apis/run/v1alpha1/conversion_test.go
+++ b/apis/run/v1alpha1/conversion_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/kubectl/pkg/scheme"
 	v1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
@@ -31,6 +32,55 @@ func TestConversion(t *testing.T) {
 	}))
 
 	// Add other types here in future
+}
+
+func TestConvertNodeImageRef(t *testing.T) {
+	g := NewWithT(t)
+	fuzzr := utilconversion.GetFuzzer(scheme.Scheme, func(_ serializer.CodecFactory) []interface{} {
+		return []interface{}{FuzzTKRSpec, v1alpha3.FuzzTKRSpec, v1alpha3.FuzzTKRSpecKubernetes, version.Fuzz}
+	})
+
+	repeat(1000, func() {
+		tkrOrig := &TanzuKubernetesRelease{}
+		fuzzr.Fuzz(tkrOrig)
+		nodeImageRefs := ptrAsSliceForObjectReference(tkrOrig.Spec.NodeImageRef)
+
+		tkrV1a3 := &v1alpha3.TanzuKubernetesRelease{}
+		g.Expect(tkrOrig.ConvertTo(tkrV1a3)).To(Succeed())
+
+		g.Expect(tkrV1a3.Spec.OSImages).To(HaveLen(len(nodeImageRefs)))
+		for i, nodeImageRef := range nodeImageRefs {
+			g.Expect(nodeImageRef.Name).To(Equal(tkrV1a3.Spec.OSImages[i].Name))
+		}
+	})
+
+	repeat(1000, func() {
+		tkrV1a3 := &v1alpha3.TanzuKubernetesRelease{}
+		fuzzr.Fuzz(tkrV1a3)
+
+		tkrConverted := &TanzuKubernetesRelease{}
+		g.Expect(tkrConverted.ConvertFrom(tkrV1a3)).To(Succeed())
+
+		nodeImageRefs := ptrAsSliceForObjectReference(tkrConverted.Spec.NodeImageRef)
+		g.Expect(len(nodeImageRefs) == 0).To(Equal(len(tkrV1a3.Spec.OSImages) == 0),
+			"nodeImageRef should be set iff there's at least 1 osImage")
+		for i, nodeImageRef := range nodeImageRefs {
+			g.Expect(nodeImageRef.Name).To(Equal(tkrV1a3.Spec.OSImages[i].Name))
+		}
+	})
+}
+
+func repeat(times int, f func()) {
+	for i := 0; i < times; i++ {
+		f()
+	}
+}
+
+func ptrAsSliceForObjectReference(ptr *v1.ObjectReference) []v1.ObjectReference {
+	if ptr == nil {
+		return nil
+	}
+	return []v1.ObjectReference{*ptr}
 }
 
 // TestHubSpokeHub covers scenarios where all the slice fields are set, there is an off-chance that the fuzz conversion does not cover this.
@@ -69,22 +119,22 @@ func TestHubSpokeHub(t *testing.T) {
 			Status: v1alpha3.TanzuKubernetesReleaseStatus{Conditions: []v1beta1.Condition{{Type: "ŭVɮǔ恴n-禷Ţ焆輦ƹ(4`", Status: "7犃蘹燡~ȥ囹烝Y秽#", Severity: "=Ĩ[塻QfĈQ鸀ð猲虘"}}}}
 
 		t.Run("hub-spoke-hub", func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			hubBefore := hub
 
 			// First convert hub to spoke
 			dstCopy := &TanzuKubernetesRelease{}
-			g.Expect(dstCopy.ConvertFrom(hubBefore)).To(gomega.Succeed())
+			g.Expect(dstCopy.ConvertFrom(hubBefore)).To(Succeed())
 
 			// Convert spoke back to hub and check if the resulting hub is equal to the hub before the round trip
 			hubAfter := &v1alpha3.TanzuKubernetesRelease{}
-			g.Expect(dstCopy.ConvertTo(hubAfter)).To(gomega.Succeed())
+			g.Expect(dstCopy.ConvertTo(hubAfter)).To(Succeed())
 
 			// The hub doesn't start with annotations, so the comparison will fail.
 			// To avoid this, we copy over the annotations from after the round-trip into the initial hub.
 			hubBefore.ObjectMeta.Annotations = hubAfter.ObjectMeta.Annotations
 
-			g.Expect(apiequality.Semantic.DeepEqual(hubBefore, hubAfter)).To(gomega.BeTrue(), cmp.Diff(hubBefore, hubAfter))
+			g.Expect(apiequality.Semantic.DeepEqual(hubBefore, hubAfter)).To(BeTrue(), cmp.Diff(hubBefore, hubAfter))
 		})
 	})
 }
@@ -133,16 +183,16 @@ func TestRoundTripWithMultiplePauseImagesInSpoke(t *testing.T) {
 		}
 
 		t.Run("spoke-hub-spoke", func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			spokeBefore := spoke
 
 			// First convert spoke to hub
 			hub := &v1alpha3.TanzuKubernetesRelease{}
-			g.Expect(spokeBefore.ConvertTo(hub)).To(gomega.Succeed())
+			g.Expect(spokeBefore.ConvertTo(hub)).To(Succeed())
 
 			// Convert hub back to spoke
 			spokeAfter := &TanzuKubernetesRelease{}
-			g.Expect(spokeAfter.ConvertFrom(hub)).To(gomega.Succeed())
+			g.Expect(spokeAfter.ConvertFrom(hub)).To(Succeed())
 
 			// The spoke at the beginning doesn't start with annotations.
 			// For the comparison to pass, we need to either remove the annotations, or copy them into the spoke reference from before conversion.
@@ -150,7 +200,7 @@ func TestRoundTripWithMultiplePauseImagesInSpoke(t *testing.T) {
 			spokeBefore.ObjectMeta.Annotations = spokeAfter.ObjectMeta.Annotations
 
 			// check if the post-covnersion spoke is equal to the spoke before the round trip.
-			g.Expect(apiequality.Semantic.DeepEqual(spokeBefore, spokeAfter)).To(gomega.BeTrue(), cmp.Diff(spokeBefore, spokeAfter))
+			g.Expect(apiequality.Semantic.DeepEqual(spokeBefore, spokeAfter)).To(BeTrue(), cmp.Diff(spokeBefore, spokeAfter))
 		})
 	})
 }
@@ -217,21 +267,22 @@ func TestContainerImagesConversionFromSpokeToHubWithNoAnnotations(t *testing.T) 
 						Tag:        "Eĺ垦婽Ô驽伕WƇ|q`1老縜",
 					},
 				},
+				NodeImageRef: &v1.ObjectReference{Name: "F"},
 			},
 		}
 
 		t.Run("hub-spoke", func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			hubBefore := hub
 
 			// Convert from hub to spoke.
 			dstCopy := &TanzuKubernetesRelease{}
-			g.Expect(dstCopy.ConvertFrom(hubBefore)).To(gomega.Succeed())
+			g.Expect(dstCopy.ConvertFrom(hubBefore)).To(Succeed())
 
 			// Sync annotations in expected and real.
 			expectedSpoke.ObjectMeta.Annotations = dstCopy.ObjectMeta.Annotations
 
-			g.Expect(apiequality.Semantic.DeepEqual(expectedSpoke, dstCopy)).To(gomega.BeTrue(), cmp.Diff(expectedSpoke, dstCopy))
+			g.Expect(apiequality.Semantic.DeepEqual(expectedSpoke, dstCopy)).To(BeTrue(), cmp.Diff(expectedSpoke, dstCopy))
 		})
 	})
 }

--- a/apis/run/v1alpha1/fuzz.go
+++ b/apis/run/v1alpha1/fuzz.go
@@ -1,0 +1,20 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha1
+
+import (
+	fuzz "github.com/google/gofuzz"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func FuzzTKRSpec(tkrSpec *TanzuKubernetesReleaseSpec, c fuzz.Continue) {
+	c.Fuzz(&tkrSpec.Version)
+	c.Fuzz(&tkrSpec.KubernetesVersion)
+	c.Fuzz(&tkrSpec.Repository)
+	c.Fuzz(&tkrSpec.Images)
+	tkrSpec.NodeImageRef = nil
+	if c.RandBool() {
+		tkrSpec.NodeImageRef = &corev1.ObjectReference{Name: c.RandString()}
+	}
+}

--- a/apis/run/v1alpha2/conversion.go
+++ b/apis/run/v1alpha2/conversion.go
@@ -4,6 +4,7 @@
 package v1alpha2
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	apiconversion "k8s.io/apimachinery/pkg/conversion"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
@@ -23,7 +24,7 @@ func (spoke *TanzuKubernetesRelease) ConvertTo(hubRaw conversion.Hub) error {
 	hub := hubRaw.(*v1alpha3.TanzuKubernetesRelease)
 
 	if err := autoConvert_v1alpha2_TanzuKubernetesRelease_To_v1alpha3_TanzuKubernetesRelease(spoke, hub, nil); err != nil {
-		return nil
+		return err
 	}
 
 	// Some Hub types not present in spoke, and might be stored in spoke annotations.
@@ -81,6 +82,9 @@ func Convert_v1alpha2_TanzuKubernetesReleaseSpec_To_v1alpha3_TanzuKubernetesRele
 	out.Version = version.WithV(in.Version)
 	out.Kubernetes.Version = version.WithV(in.KubernetesVersion)
 	out.Kubernetes.ImageRepository = in.Repository
+	if in.NodeImageRef != nil {
+		out.OSImages = []corev1.LocalObjectReference{{Name: in.NodeImageRef.Name}}
+	}
 
 	// Transform the container images.
 	for index, image := range in.Images {
@@ -118,6 +122,10 @@ func Convert_v1alpha2_TanzuKubernetesReleaseSpec_To_v1alpha3_TanzuKubernetesRele
 func Convert_v1alpha3_TanzuKubernetesReleaseSpec_To_v1alpha2_TanzuKubernetesReleaseSpec(in *v1alpha3.TanzuKubernetesReleaseSpec, out *TanzuKubernetesReleaseSpec, s apiconversion.Scope) error {
 	out.KubernetesVersion = in.Kubernetes.Version
 	out.Repository = in.Kubernetes.ImageRepository
+	for _, osImageRef := range in.OSImages {
+		out.NodeImageRef = &corev1.ObjectReference{Name: osImageRef.Name}
+		break // can only convert the first osImageRef to nodeImageRef
+	}
 
 	// Transform the containerimages.
 	// Container images are completely restored from the annotations later.

--- a/apis/run/v1alpha2/conversion.go
+++ b/apis/run/v1alpha2/conversion.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 
 	v1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/util/version"
 	utilconversion "github.com/vmware-tanzu/tanzu-framework/util/conversion"
 )
 
@@ -58,6 +59,8 @@ func (spoke *TanzuKubernetesRelease) ConvertFrom(hubRaw conversion.Hub) error {
 		return err
 	} else if ok {
 		// Annotations contain data, restore the relevant ones.
+		spoke.Spec.Version = restored.Spec.Version
+		spoke.Spec.KubernetesVersion = restored.Spec.KubernetesVersion
 		spoke.Spec.NodeImageRef = restored.Spec.NodeImageRef
 		if restored.Spec.Images != nil {
 			spoke.Spec.Images = restored.Spec.Images
@@ -75,7 +78,8 @@ func (spoke *TanzuKubernetesRelease) ConvertFrom(hubRaw conversion.Hub) error {
 // Convert_v1alpha2_TanzuKubernetesReleaseSpec_To_v1alpha3_TanzuKubernetesReleaseSpec  will convert the compatible types in TanzuKubernetesReleaseSpec v1alpha2 to v1alpha3 equivalent.
 // nolint:revive,stylecheck // Generated conversion stubs have underscores in function names.
 func Convert_v1alpha2_TanzuKubernetesReleaseSpec_To_v1alpha3_TanzuKubernetesReleaseSpec(in *TanzuKubernetesReleaseSpec, out *v1alpha3.TanzuKubernetesReleaseSpec, s apiconversion.Scope) error {
-	out.Kubernetes.Version = in.KubernetesVersion
+	out.Version = version.WithV(in.Version)
+	out.Kubernetes.Version = version.WithV(in.KubernetesVersion)
 	out.Kubernetes.ImageRepository = in.Repository
 
 	// Transform the container images.
@@ -106,7 +110,7 @@ func Convert_v1alpha2_TanzuKubernetesReleaseSpec_To_v1alpha3_TanzuKubernetesRele
 		}
 	}
 
-	return autoConvert_v1alpha2_TanzuKubernetesReleaseSpec_To_v1alpha3_TanzuKubernetesReleaseSpec(in, out, s)
+	return nil
 }
 
 // Convert_v1alpha3_TanzuKubernetesReleaseSpec_To_v1alpha2_TanzuKubernetesReleaseSpec will convert the compatible types in TanzuKubernetesReleaseSpec v1alpha3 to v1alpha2 equivalent.

--- a/apis/run/v1alpha2/conversion_test.go
+++ b/apis/run/v1alpha2/conversion_test.go
@@ -9,10 +9,13 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	v1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/util/version"
 	utilconversion "github.com/vmware-tanzu/tanzu-framework/util/conversion"
 )
 
@@ -20,6 +23,11 @@ func TestConversion(t *testing.T) {
 	t.Run("for TanzuKubernetesRelease", utilconversion.FuzzTestFunc(&utilconversion.FuzzTestFuncInput{
 		Hub:   &v1alpha3.TanzuKubernetesRelease{},
 		Spoke: &TanzuKubernetesRelease{},
+		FuzzerFuncs: []fuzzer.FuzzerFuncs{
+			func(_ serializer.CodecFactory) []interface{} {
+				return []interface{}{v1alpha3.FuzzTKRSpec, v1alpha3.FuzzTKRSpecKubernetes, version.Fuzz}
+			},
+		},
 	}))
 
 	// Add other types here in future
@@ -30,9 +38,9 @@ func TestHubSpokeHub(t *testing.T) {
 	t.Run("for TanzuKubernetesRelease", func(t *testing.T) {
 		hub := &v1alpha3.TanzuKubernetesRelease{
 			Spec: v1alpha3.TanzuKubernetesReleaseSpec{
-				Version: "#ŉƈOƕʘ賡谒湪ȥ#4",
+				Version: "v#ŉƈOƕʘ賡谒湪ȥ#4",
 				Kubernetes: v1alpha3.KubernetesSpec{
-					Version:         `ìd/i涇u趗\庰鏜`,
+					Version:         `vìd/i涇u趗\庰鏜`,
 					ImageRepository: "辑",
 					Etcd: &v1alpha3.ContainerImageInfo{
 						ImageRepository: "9ŉ劆掬ȳƤʟNʮ犓ȓ峌堲Ȥ:ě",
@@ -152,9 +160,9 @@ func TestContainerImagesConversionFromSpokeToHubWithNoAnnotations(t *testing.T) 
 	t.Run("for TanzuKubernetesRelease", func(t *testing.T) {
 		hub := &v1alpha3.TanzuKubernetesRelease{
 			Spec: v1alpha3.TanzuKubernetesReleaseSpec{
-				Version: "#ŉƈOƕʘ賡谒湪ȥ#4",
+				Version: "v#ŉƈOƕʘ賡谒湪ȥ#4",
 				Kubernetes: v1alpha3.KubernetesSpec{
-					Version:         `ìd/i涇u趗\庰鏜`,
+					Version:         `vìd/i涇u趗\庰鏜`,
 					ImageRepository: "辑",
 					Etcd: &v1alpha3.ContainerImageInfo{
 						ImageRepository: "9ŉ劆掬ȳƤʟNʮ犓ȓ峌堲Ȥ:ě",
@@ -184,8 +192,8 @@ func TestContainerImagesConversionFromSpokeToHubWithNoAnnotations(t *testing.T) 
 
 		expectedSpoke := &TanzuKubernetesRelease{
 			Spec: TanzuKubernetesReleaseSpec{
-				Version:           "#ŉƈOƕʘ賡谒湪ȥ#4",
-				KubernetesVersion: `ìd/i涇u趗\庰鏜`,
+				Version:           "v#ŉƈOƕʘ賡谒湪ȥ#4", // prefixed with `v` coming from v1alpha3
+				KubernetesVersion: `vìd/i涇u趗\庰鏜`,   // prefixed with `v` coming from v1alpha3
 				Repository:        "辑",
 				Images: []ContainerImage{
 					{

--- a/apis/run/v1alpha2/conversion_test.go
+++ b/apis/run/v1alpha2/conversion_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/kubectl/pkg/scheme"
 	v1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
@@ -31,6 +32,55 @@ func TestConversion(t *testing.T) {
 	}))
 
 	// Add other types here in future
+}
+
+func TestConvertNodeImageRef(t *testing.T) {
+	g := NewWithT(t)
+	fuzzr := utilconversion.GetFuzzer(scheme.Scheme, func(_ serializer.CodecFactory) []interface{} {
+		return []interface{}{FuzzTKRSpec, v1alpha3.FuzzTKRSpec, v1alpha3.FuzzTKRSpecKubernetes, version.Fuzz}
+	})
+
+	repeat(1000, func() {
+		tkrOrig := &TanzuKubernetesRelease{}
+		fuzzr.Fuzz(tkrOrig)
+		nodeImageRefs := ptrAsSliceForObjectReference(tkrOrig.Spec.NodeImageRef)
+
+		tkrV1a3 := &v1alpha3.TanzuKubernetesRelease{}
+		g.Expect(tkrOrig.ConvertTo(tkrV1a3)).To(Succeed())
+
+		g.Expect(tkrV1a3.Spec.OSImages).To(HaveLen(len(nodeImageRefs)))
+		for i, nodeImageRef := range nodeImageRefs {
+			g.Expect(nodeImageRef.Name).To(Equal(tkrV1a3.Spec.OSImages[i].Name))
+		}
+	})
+
+	repeat(1000, func() {
+		tkrV1a3 := &v1alpha3.TanzuKubernetesRelease{}
+		fuzzr.Fuzz(tkrV1a3)
+
+		tkrConverted := &TanzuKubernetesRelease{}
+		g.Expect(tkrConverted.ConvertFrom(tkrV1a3)).To(Succeed())
+
+		nodeImageRefs := ptrAsSliceForObjectReference(tkrConverted.Spec.NodeImageRef)
+		g.Expect(len(nodeImageRefs) == 0).To(Equal(len(tkrV1a3.Spec.OSImages) == 0),
+			"nodeImageRef should be set iff there's at least 1 osImage")
+		for i, nodeImageRef := range nodeImageRefs {
+			g.Expect(nodeImageRef.Name).To(Equal(tkrV1a3.Spec.OSImages[i].Name))
+		}
+	})
+}
+
+func repeat(times int, f func()) {
+	for i := 0; i < times; i++ {
+		f()
+	}
+}
+
+func ptrAsSliceForObjectReference(ptr *v1.ObjectReference) []v1.ObjectReference {
+	if ptr == nil {
+		return nil
+	}
+	return []v1.ObjectReference{*ptr}
 }
 
 // TestHubSpokeHub covers scenarios where all the slice fields are set, there is an off-chance that the fuzz conversion does not cover this.
@@ -69,22 +119,22 @@ func TestHubSpokeHub(t *testing.T) {
 			Status: v1alpha3.TanzuKubernetesReleaseStatus{Conditions: []v1beta1.Condition{{Type: "ŭVɮǔ恴n-禷Ţ焆輦ƹ(4`", Status: "7犃蘹燡~ȥ囹烝Y秽#", Severity: "=Ĩ[塻QfĈQ鸀ð猲虘"}}}}
 
 		t.Run("hub-spoke-hub", func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			hubBefore := hub
 
 			// First convert hub to spoke
 			dstCopy := &TanzuKubernetesRelease{}
-			g.Expect(dstCopy.ConvertFrom(hubBefore)).To(gomega.Succeed())
+			g.Expect(dstCopy.ConvertFrom(hubBefore)).To(Succeed())
 
 			// Convert spoke back to hub and check if the resulting hub is equal to the hub before the round trip
 			hubAfter := &v1alpha3.TanzuKubernetesRelease{}
-			g.Expect(dstCopy.ConvertTo(hubAfter)).To(gomega.Succeed())
+			g.Expect(dstCopy.ConvertTo(hubAfter)).To(Succeed())
 
 			// The hub doesn't start with annotations, so the comparison will fail.
 			// To avoid this, we copy over the annotations from after the round-trip into the initial hub.
 			hubBefore.ObjectMeta.Annotations = hubAfter.ObjectMeta.Annotations
 
-			g.Expect(apiequality.Semantic.DeepEqual(hubBefore, hubAfter)).To(gomega.BeTrue(), cmp.Diff(hubBefore, hubAfter))
+			g.Expect(apiequality.Semantic.DeepEqual(hubBefore, hubAfter)).To(BeTrue(), cmp.Diff(hubBefore, hubAfter))
 		})
 	})
 }
@@ -133,16 +183,16 @@ func TestRoundTripWithMultiplePauseImagesInSpoke(t *testing.T) {
 		}
 
 		t.Run("spoke-hub-spoke", func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			spokeBefore := spoke
 
 			// First convert spoke to hub
 			hub := &v1alpha3.TanzuKubernetesRelease{}
-			g.Expect(spokeBefore.ConvertTo(hub)).To(gomega.Succeed())
+			g.Expect(spokeBefore.ConvertTo(hub)).To(Succeed())
 
 			// Convert hub back to spoke
 			spokeAfter := &TanzuKubernetesRelease{}
-			g.Expect(spokeAfter.ConvertFrom(hub)).To(gomega.Succeed())
+			g.Expect(spokeAfter.ConvertFrom(hub)).To(Succeed())
 
 			// The spoke at the beginning doesn't start with annotations.
 			// For the comparison to pass, we need to either remove the annotations, or copy them into the spoke reference from before conversion.
@@ -150,7 +200,7 @@ func TestRoundTripWithMultiplePauseImagesInSpoke(t *testing.T) {
 			spokeBefore.ObjectMeta.Annotations = spokeAfter.ObjectMeta.Annotations
 
 			// check if the post-covnersion spoke is equal to the spoke before the round trip.
-			g.Expect(apiequality.Semantic.DeepEqual(spokeBefore, spokeAfter)).To(gomega.BeTrue(), cmp.Diff(spokeBefore, spokeAfter))
+			g.Expect(apiequality.Semantic.DeepEqual(spokeBefore, spokeAfter)).To(BeTrue(), cmp.Diff(spokeBefore, spokeAfter))
 		})
 	})
 }
@@ -217,21 +267,22 @@ func TestContainerImagesConversionFromSpokeToHubWithNoAnnotations(t *testing.T) 
 						Tag:        "Eĺ垦婽Ô驽伕WƇ|q`1老縜",
 					},
 				},
+				NodeImageRef: &v1.ObjectReference{Name: "F"},
 			},
 		}
 
 		t.Run("hub-spoke", func(t *testing.T) {
-			g := gomega.NewWithT(t)
+			g := NewWithT(t)
 			hubBefore := hub
 
 			// Convert from hub to spoke.
 			dstCopy := &TanzuKubernetesRelease{}
-			g.Expect(dstCopy.ConvertFrom(hubBefore)).To(gomega.Succeed())
+			g.Expect(dstCopy.ConvertFrom(hubBefore)).To(Succeed())
 
 			// Sync annotations in expected and real.
 			expectedSpoke.ObjectMeta.Annotations = dstCopy.ObjectMeta.Annotations
 
-			g.Expect(apiequality.Semantic.DeepEqual(expectedSpoke, dstCopy)).To(gomega.BeTrue(), cmp.Diff(expectedSpoke, dstCopy))
+			g.Expect(apiequality.Semantic.DeepEqual(expectedSpoke, dstCopy)).To(BeTrue(), cmp.Diff(expectedSpoke, dstCopy))
 		})
 	})
 }

--- a/apis/run/v1alpha2/fuzz.go
+++ b/apis/run/v1alpha2/fuzz.go
@@ -1,0 +1,20 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha2
+
+import (
+	fuzz "github.com/google/gofuzz"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func FuzzTKRSpec(tkrSpec *TanzuKubernetesReleaseSpec, c fuzz.Continue) {
+	c.Fuzz(&tkrSpec.Version)
+	c.Fuzz(&tkrSpec.KubernetesVersion)
+	c.Fuzz(&tkrSpec.Repository)
+	c.Fuzz(&tkrSpec.Images)
+	tkrSpec.NodeImageRef = nil
+	if c.RandBool() {
+		tkrSpec.NodeImageRef = &corev1.ObjectReference{Name: c.RandString()}
+	}
+}

--- a/apis/run/v1alpha3/fuzz.go
+++ b/apis/run/v1alpha3/fuzz.go
@@ -1,0 +1,32 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1alpha3
+
+import (
+	fuzz "github.com/google/gofuzz"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/util/version"
+)
+
+// FuzzTKRSpec fuzzes the passed TanzuKubernetesReleaseSpec.
+func FuzzTKRSpec(spec *TanzuKubernetesReleaseSpec, c fuzz.Continue) {
+	v := &version.Version{}
+	c.Fuzz(v)
+	spec.Version = v.String()
+	c.Fuzz(&spec.Kubernetes)
+	c.Fuzz(&spec.OSImages)
+	c.Fuzz(&spec.BootstrapPackages)
+}
+
+// FuzzTKRSpecKubernetes fuzzes the passed TKR KubernetesSpec.
+func FuzzTKRSpecKubernetes(kubernetesSpec *KubernetesSpec, c fuzz.Continue) {
+	v := &version.Version{}
+	c.Fuzz(v)
+	kubernetesSpec.Version = v.String()
+	c.Fuzz(&kubernetesSpec.ImageRepository)
+	c.Fuzz(kubernetesSpec.Etcd)
+	c.Fuzz(kubernetesSpec.Pause)
+	c.Fuzz(kubernetesSpec.CoreDNS)
+	c.Fuzz(kubernetesSpec.KubeVIP)
+}

--- a/pkg/v2/tkr/util/version/fuzz.go
+++ b/pkg/v2/tkr/util/version/fuzz.go
@@ -1,0 +1,28 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package version
+
+import (
+	"fmt"
+	"strings"
+
+	fuzz "github.com/google/gofuzz"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+// Fuzz fuzzes the passed version.
+func Fuzz(v *Version, _ fuzz.Continue) {
+	major := rand.Intn(3)
+	minor := rand.Intn(50)
+	patch := rand.Intn(30)
+	var ss []string
+	bmCount := rand.Intn(3)
+	for i := 0; i < bmCount; i++ {
+		ss = append(ss, fmt.Sprintf("%s.%v", rand.String(rand.IntnRange(3, 10)), rand.IntnRange(1, 5)))
+	}
+	buildMeta := strings.Join(ss, "-")
+	vString := strings.TrimSuffix(fmt.Sprintf("%v.%v.%v+%s", major, minor, patch, buildMeta), "+")
+	vNew, _ := ParseSemantic(vString)
+	*v = *vNew
+}

--- a/pkg/v2/tkr/util/version/version.go
+++ b/pkg/v2/tkr/util/version/version.go
@@ -20,6 +20,10 @@ type Version struct {
 	buildMetadata BuildMetadata
 }
 
+func (v Version) String() string {
+	return "v" + v.version.String()
+}
+
 // ParseSemantic constructs a structured representation of a semantic version string including build metadata,
 // producing comparable structural representation.
 func ParseSemantic(s string) (*Version, error) {
@@ -144,4 +148,12 @@ var plusReplacer = strings.NewReplacer("+", "---")
 // Label converts version string in SemVer format to label format.
 func Label(v string) string {
 	return "v" + plusReplacer.Replace(strings.TrimPrefix(v, "v"))
+}
+
+// WithV makes sure 'v' is prepended to the version string.
+func WithV(s string) string {
+	if strings.HasPrefix(s, "v") {
+		return s
+	}
+	return "v" + s
 }

--- a/pkg/v2/tkr/util/version/version_test.go
+++ b/pkg/v2/tkr/util/version/version_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	fuzz "github.com/google/gofuzz"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/labels"
@@ -218,3 +219,23 @@ var _ = Describe("Label()", func() {
 		Expect(Label(v)).To(Equal("v1.22.0---vmware.1-tkg.3"))
 	})
 })
+
+var _ = Describe("Fuzz()", func() {
+	fuzzer := fuzz.New().Funcs(Fuzz)
+
+	repeat(1000, func() {
+		It("produces a randomized *Version", func() {
+			v := &Version{}
+			fuzzer.Fuzz(v)
+			vString := v.String()
+			Expect(v.version).ToNot(BeNil())
+			Expect(vString).To(HavePrefix("v"))
+		})
+	})
+})
+
+func repeat(times int, f func()) {
+	for i := 0; i < times; i++ {
+		f()
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it

#### Modify TKR conversion webhooks, to make sure that in TKR v1alpha3 `spec.version` and `spec.kubernetes.version` are prefixed with `v`.

Version string from TKR `spec.kubernetes.version` is injected into Cluster `spec.topology.version`. Without this fix, this Kubernetes version string, coming from a TKR converted from v1alpha2, may not be prefixed with `v` and will be rejected by the Cluster validation webhook.

#### Convert to/from TKR v1alpha3 `spec.osImages`

TKR v1alpha1 and v1alpha2 use `spec.nodeImageRef` to refer to the VM image to be used as the node image for the target clusters. TKR v1alpha3 uses the `spec.osImages` list to refer to available node images.

Without this change, when converting to and from TKR v1alpha3, this information was lost.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

N/A

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Updated unit tests to test conversion correctness.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
