### PR TITLE
Create aggregate cluster role for CAPV

### DIFF
--- a/addons/controllers/cpi/vspherecpiconfig_utils.go
+++ b/addons/controllers/cpi/vspherecpiconfig_utils.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -339,29 +338,8 @@ func (r *VSphereCPIConfigReconciler) mapCPIConfigToDataValues(ctx context.Contex
 // mapCPIConfigToProviderServiceAccountSpec maps CPIConfig and cluster to the corresponding service account spec
 func (r *VSphereCPIConfigReconciler) mapCPIConfigToProviderServiceAccountSpec(vsphereCluster *capvvmwarev1beta1.VSphereCluster) capvvmwarev1beta1.ProviderServiceAccountSpec {
 	return capvvmwarev1beta1.ProviderServiceAccountSpec{
-		Ref: &v1.ObjectReference{Name: vsphereCluster.Name, Namespace: vsphereCluster.Namespace},
-		Rules: []rbacv1.PolicyRule{
-			{
-				Verbs:     []string{"get", "create", "update", "patch", "delete"},
-				APIGroups: []string{"vmoperator.vmware.com"},
-				Resources: []string{"virtualmachineservices", "virtualmachineservices/status"},
-			},
-			{
-				Verbs:     []string{"get", "list"},
-				APIGroups: []string{"vmoperator.vmware.com"},
-				Resources: []string{"virtualmachines", "virtualmachines/status"},
-			},
-			{
-				Verbs:     []string{"get", "create", "update", "list", "patch", "delete", "watch"},
-				APIGroups: []string{"nsx.vmware.com"},
-				Resources: []string{"ippools", "ippools/status"},
-			},
-			{
-				Verbs:     []string{"get", "create", "update", "list", "patch", "delete"},
-				APIGroups: []string{"nsx.vmware.com"},
-				Resources: []string{"routesets", "routesets/status"},
-			},
-		},
+		Ref:              &v1.ObjectReference{Name: vsphereCluster.Name, Namespace: vsphereCluster.Namespace},
+		Rules:            providerServiceAccountRBACRules,
 		TargetNamespace:  ProviderServiceAccountSecretNamespace,
 		TargetSecretName: ProviderServiceAccountSecretName,
 	}

--- a/addons/controllers/csi/vspherecsiconfig_utils.go
+++ b/addons/controllers/csi/vspherecsiconfig_utils.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -172,39 +171,8 @@ func (r *VSphereCSIConfigReconciler) mapCSIConfigToProviderServiceAccount(vspher
 			Namespace: vsphereCluster.Namespace,
 		},
 		Spec: capvvmwarev1beta1.ProviderServiceAccountSpec{
-			Ref: &v1.ObjectReference{Name: vsphereCluster.Name, Namespace: vsphereCluster.Namespace},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups: []string{"vmoperator.vmware.com"},
-					Resources: []string{"virtualmachines"},
-					Verbs:     []string{"get", "list", "watch", "update", "patch"},
-				},
-				{
-					APIGroups: []string{"cns.vmware.com"},
-					Resources: []string{"cnsvolumemetadatas", "cnsfileaccessconfigs"},
-					Verbs:     []string{"get", "list", "watch", "update", "create", "delete"},
-				},
-				{
-					APIGroups: []string{"cns.vmware.com"},
-					Resources: []string{"cnscsisvfeaturestates"},
-					Verbs:     []string{"get", "list", "watch"},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"persistentvolumeclaims"},
-					Verbs:     []string{"get", "list", "watch", "update", "create", "delete"},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"persistentvolumeclaims/status"},
-					Verbs:     []string{"get", "update", "patch"},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"events"},
-					Verbs:     []string{"list"},
-				},
-			},
+			Ref:              &v1.ObjectReference{Name: vsphereCluster.Name, Namespace: vsphereCluster.Namespace},
+			Rules:            providerServiceAccountRBACRules,
 			TargetNamespace:  "vmware-system-csi",
 			TargetSecretName: "pvcsi-provider-creds",
 		},

--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -8,6 +8,8 @@ import (
 	"reflect"
 	"time"
 
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
@@ -197,7 +199,26 @@ const (
 	// AddCBMissingFieldsAnnotationKey is the annotation key used by ClusterBootstrap webhook to implement its defaulting
 	// logic
 	AddCBMissingFieldsAnnotationKey = "tkg.tanzu.vmware.com/add-missing-fields-from-tkr"
+
+	// ProviderServiceAccountAggregatedClusterRole is the name of ClusterRole created by controllers that use ProviderServiceAccount
+	ProviderServiceAccountAggregatedClusterRole = "tanzu-addons-manager-providerserviceaccount-aggregatedrole"
+
+	// CAPVClusterRoleAggregationRuleLabelSelectorKey is the label selector key used by aggregation rule in CAPV ClusterRole
+	CAPVClusterRoleAggregationRuleLabelSelectorKey = "capv.infrastucture.cluster.x-k8s.io/aggregate-to-manager"
+
+	// CAPVClusterRoleAggregationRuleLabelSelectorValue is the label selector value used by aggregation rule in CAPV ClusterRole
+	CAPVClusterRoleAggregationRuleLabelSelectorValue = "true"
 )
 
 // ClusterKind is the Kind for cluster-api Cluster object
 var ClusterKind = reflect.TypeOf(clusterapiv1beta1.Cluster{}).Name()
+
+// CAPVAggregatedClusterRole is the cluster role to assign permissions to capv provider
+var CAPVAggregatedClusterRole = &rbacv1.ClusterRole{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: ProviderServiceAccountAggregatedClusterRole,
+		Labels: map[string]string{
+			CAPVClusterRoleAggregationRuleLabelSelectorKey: CAPVClusterRoleAggregationRuleLabelSelectorValue,
+		},
+	},
+}


### PR DESCRIPTION
Create aggregated cluster role that will be inherited by CAPV. CAPV needs to hold these rules before it can grant it to serviceAccount for CPI and CSI.

Signed-off-by: Vijay Katam <vkatam@vmware.com>

### What this PR does / why we need it
Create aggregated cluster role that will be inherited by CAPV. 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2367 

### Describe testing done for PR

Env tests.
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Create aggregate cluster role for CAPV
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information
Relates to https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1529
#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
