### PR TITLE
Support for ClusterClass based cluster upgrades

### DIFF
--- a/pkg/v1/tkg/client/upgrade_cluster.go
+++ b/pkg/v1/tkg/client/upgrade_cluster.go
@@ -117,7 +117,7 @@ type ClusterUpgradeInfo struct {
 // 5. Wait for k8s version to be updated for the cluster
 // 6. Patch MachineDeployment object to upgrade worker nodes
 // 7. Wait for k8s version to be updated for all worker nodes
-func (c *TkgClient) UpgradeCluster(options *UpgradeClusterOptions) error { // nolint:funlen,gocyclo
+func (c *TkgClient) UpgradeCluster(options *UpgradeClusterOptions) error {
 	if options == nil {
 		return errors.New("invalid upgrade cluster options nil")
 	}
@@ -177,7 +177,21 @@ func (c *TkgClient) UpgradeCluster(options *UpgradeClusterOptions) error { // no
 		}
 	}
 
-	err = c.addKubernetesReleaseLabel(regionalClusterClient, options)
+	// Check if Cluster is ClusterClass based cluster or not
+	isClusterClassBased, err := regionalClusterClient.IsClusterClassBased(options.ClusterName, options.Namespace)
+	if err != nil {
+		return errors.Wrap(err, "unable to determine cluster type")
+	}
+
+	// If cluster is ClusterClass based cluster upgrade the cluster with different path
+	if isClusterClassBased {
+		return c.DoClassyClusterUpgrade(regionalClusterClient, currentClusterClient, options)
+	}
+	return c.DoLegacyClusterUpgrade(regionalClusterClient, currentClusterClient, options)
+}
+
+func (c *TkgClient) DoLegacyClusterUpgrade(regionalClusterClient, currentClusterClient clusterclient.Client, options *UpgradeClusterOptions) error {
+	err := c.addKubernetesReleaseLabel(regionalClusterClient, options)
 	if err != nil {
 		return errors.Wrapf(err, "unable to patch the cluster object with TanzuKubernetesRelease label")
 	}

--- a/pkg/v1/tkg/client/upgrade_cluster_clusterclass.go
+++ b/pkg/v1/tkg/client/upgrade_cluster_clusterclass.go
@@ -1,0 +1,41 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
+)
+
+func (c *TkgClient) DoClassyClusterUpgrade(regionalClusterClient clusterclient.Client,
+	currentClusterClient clusterclient.Client, options *UpgradeClusterOptions) error {
+
+	kubernetesVersion := options.KubernetesVersion
+
+	log.Infof("Upgrading kubernetes cluster to `%v` version", kubernetesVersion)
+	patchJSONString := fmt.Sprintf(`{"spec": {"topology": {"version": "%v"}}}`, kubernetesVersion)
+
+	err := regionalClusterClient.PatchClusterObject(options.ClusterName, options.Namespace, patchJSONString)
+	if err != nil {
+		return errors.Wrap(err, "unable to patch kubernetes version to cluster")
+	}
+
+	log.Info("Waiting for kubernetes version to be updated for control plane nodes...")
+	err = regionalClusterClient.WaitK8sVersionUpdateForCPNodes(options.ClusterName, options.Namespace, kubernetesVersion, currentClusterClient)
+	if err != nil {
+		return errors.Wrap(err, "error waiting for kubernetes version update for kubeadm control plane")
+	}
+
+	log.Info("Waiting for kubernetes version to be updated for worker nodes...")
+	err = regionalClusterClient.WaitK8sVersionUpdateForWorkerNodes(options.ClusterName, options.Namespace, kubernetesVersion, currentClusterClient)
+	if err != nil {
+		return errors.Wrap(err, "error waiting for kubernetes version update for worker nodes")
+	}
+
+	return nil
+}

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -321,6 +321,8 @@ type Client interface {
 	ListCLIPluginResources() ([]cliv1alpha1.CLIPlugin, error)
 	// VerifyCLIPluginCRD returns true if CRD exists else return false
 	VerifyCLIPluginCRD() (bool, error)
+	// IsClusterClassBased check whether cluster is ClusterClass based or not
+	IsClusterClassBased(clusterName, namespace string) (bool, error)
 }
 
 // PollOptions is options for polling
@@ -2339,6 +2341,18 @@ func (c *client) ListCLIPluginResources() ([]cliv1alpha1.CLIPlugin, error) {
 		return nil, err
 	}
 	return cliPlugins.Items, nil
+}
+
+// IsClusterClassBased check whether cluster is ClusterClass based or not
+func (c *client) IsClusterClassBased(clusterName, namespace string) (bool, error) {
+	clusterObj := &capi.Cluster{}
+	if err := c.GetResource(clusterObj, clusterName, namespace, nil, nil); err != nil {
+		return false, err
+	}
+	if clusterObj.Spec.Topology.Class == "" {
+		return false, nil
+	}
+	return true, nil
 }
 
 // Options provides way to customize creation of clusterClient

--- a/pkg/v1/tkg/clusterclient/clusterclient_test.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient_test.go
@@ -2616,6 +2616,62 @@ var _ = Describe("Cluster Client", func() {
 			})
 		})
 	})
+
+	Describe("Unit tests for IsClusterClassBased", func() {
+		var isClusterClassBased bool
+
+		BeforeEach(func() {
+			reInitialize()
+			kubeConfigPath := getConfigFilePath("config1.yaml")
+			clstClient, err = NewClient(kubeConfigPath, "", clusterClientOptions)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		Context("When clientset Get api return error", func() {
+			JustBeforeEach(func() {
+				clientset.GetReturns(errors.New("fake-error"))
+				isClusterClassBased, err = clstClient.IsClusterClassBased("fake-clusterName", "fake-namespace")
+			})
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(isClusterClassBased).To(Equal(false))
+				Expect(err.Error()).To(ContainSubstring("fake-error"))
+			})
+		})
+		Context("When cluster is not using ClusterClass", func() {
+			JustBeforeEach(func() {
+				clientset.GetCalls(func(ctx context.Context, namespace types.NamespacedName, cluster crtclient.Object) error {
+					topology := &capi.Topology{
+						Class: "",
+					}
+					cluster.(*capi.Cluster).Spec.Topology = topology
+					return nil
+				})
+
+				isClusterClassBased, err = clstClient.IsClusterClassBased("fake-clusterName", "fake-namespace")
+			})
+			It("should not return an error and isClusterClassBased to be false", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isClusterClassBased).To(Equal(false))
+			})
+		})
+		Context("When cluster is using ClusterClass", func() {
+			JustBeforeEach(func() {
+				clientset.GetCalls(func(ctx context.Context, namespace types.NamespacedName, cluster crtclient.Object) error {
+					topology := &capi.Topology{
+						Class: "fake-cluster-class",
+					}
+					cluster.(*capi.Cluster).Spec.Topology = topology
+					return nil
+				})
+				isClusterClassBased, err = clstClient.IsClusterClassBased("fake-clusterName", "fake-namespace")
+			})
+			It("should not return an error and isClusterClassBased to be true", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isClusterClassBased).To(Equal(true))
+			})
+		})
+	})
+
 })
 
 func createTempDirectory() {

--- a/pkg/v1/tkg/fakes/clusterclient.go
+++ b/pkg/v1/tkg/fakes/clusterclient.go
@@ -553,6 +553,20 @@ type ClusterClient struct {
 		result1 bool
 		result2 error
 	}
+	IsClusterClassBasedStub        func(string, string) (bool, error)
+	isClusterClassBasedMutex       sync.RWMutex
+	isClusterClassBasedArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	isClusterClassBasedReturns struct {
+		result1 bool
+		result2 error
+	}
+	isClusterClassBasedReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	IsClusterRegisteredToTMCStub        func() (bool, error)
 	isClusterRegisteredToTMCMutex       sync.RWMutex
 	isClusterRegisteredToTMCArgsForCall []struct {
@@ -3659,6 +3673,71 @@ func (fake *ClusterClient) HasCEIPTelemetryJobReturnsOnCall(i int, result1 bool,
 	}{result1, result2}
 }
 
+func (fake *ClusterClient) IsClusterClassBased(arg1 string, arg2 string) (bool, error) {
+	fake.isClusterClassBasedMutex.Lock()
+	ret, specificReturn := fake.isClusterClassBasedReturnsOnCall[len(fake.isClusterClassBasedArgsForCall)]
+	fake.isClusterClassBasedArgsForCall = append(fake.isClusterClassBasedArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.IsClusterClassBasedStub
+	fakeReturns := fake.isClusterClassBasedReturns
+	fake.recordInvocation("IsClusterClassBased", []interface{}{arg1, arg2})
+	fake.isClusterClassBasedMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ClusterClient) IsClusterClassBasedCallCount() int {
+	fake.isClusterClassBasedMutex.RLock()
+	defer fake.isClusterClassBasedMutex.RUnlock()
+	return len(fake.isClusterClassBasedArgsForCall)
+}
+
+func (fake *ClusterClient) IsClusterClassBasedCalls(stub func(string, string) (bool, error)) {
+	fake.isClusterClassBasedMutex.Lock()
+	defer fake.isClusterClassBasedMutex.Unlock()
+	fake.IsClusterClassBasedStub = stub
+}
+
+func (fake *ClusterClient) IsClusterClassBasedArgsForCall(i int) (string, string) {
+	fake.isClusterClassBasedMutex.RLock()
+	defer fake.isClusterClassBasedMutex.RUnlock()
+	argsForCall := fake.isClusterClassBasedArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *ClusterClient) IsClusterClassBasedReturns(result1 bool, result2 error) {
+	fake.isClusterClassBasedMutex.Lock()
+	defer fake.isClusterClassBasedMutex.Unlock()
+	fake.IsClusterClassBasedStub = nil
+	fake.isClusterClassBasedReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ClusterClient) IsClusterClassBasedReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.isClusterClassBasedMutex.Lock()
+	defer fake.isClusterClassBasedMutex.Unlock()
+	fake.IsClusterClassBasedStub = nil
+	if fake.isClusterClassBasedReturnsOnCall == nil {
+		fake.isClusterClassBasedReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.isClusterClassBasedReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *ClusterClient) IsClusterRegisteredToTMC() (bool, error) {
 	fake.isClusterRegisteredToTMCMutex.Lock()
 	ret, specificReturn := fake.isClusterRegisteredToTMCReturnsOnCall[len(fake.isClusterRegisteredToTMCArgsForCall)]
@@ -6603,6 +6682,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.getVCServerMutex.RUnlock()
 	fake.hasCEIPTelemetryJobMutex.RLock()
 	defer fake.hasCEIPTelemetryJobMutex.RUnlock()
+	fake.isClusterClassBasedMutex.RLock()
+	defer fake.isClusterClassBasedMutex.RUnlock()
 	fake.isClusterRegisteredToTMCMutex.RLock()
 	defer fake.isClusterRegisteredToTMCMutex.RUnlock()
 	fake.isPacificRegionalClusterMutex.RLock()

--- a/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
+++ b/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
@@ -73,6 +73,10 @@ func NewCluster(options TestAllClusterComponentOptions) *capi.Cluster {
 			Name:       "kcp-" + options.ClusterName,
 			APIVersion: controlplanev1.GroupVersion.String(),
 		},
+		Topology: &capi.Topology{
+			Class:   options.ClusterTopology.Class,
+			Version: options.ClusterTopology.Version,
+		},
 	}
 	cluster.Status = capi.ClusterStatus{
 		Phase:               options.ClusterOptions.Phase,

--- a/pkg/v1/tkg/fakes/helper/types.go
+++ b/pkg/v1/tkg/fakes/helper/types.go
@@ -27,6 +27,7 @@ type TestAllClusterComponentOptions struct {
 	ListMDOptions               []TestMDOptions
 	MachineOptions              []TestMachineOptions
 	ClusterConfigurationOptions TestClusterConfiguration
+	ClusterTopology             TestClusterTopology
 	InfraComponentsOptions      TestInfraComponentsOptions
 }
 
@@ -47,6 +48,11 @@ type TestClusterConfiguration struct {
 	EtcdLocalDataDir    string
 	EtcdImageRepository string
 	EtcdImageTag        string
+}
+
+type TestClusterTopology struct {
+	Class   string
+	Version string
 }
 
 // TestClusterOptions describes options for CAPI/TKC cluster


### PR DESCRIPTION
### What this PR does / why we need it
- This PR adds support for ClusterClass based cluster upgrades

**Steps:**
- Update `.spec.topology.version` as part of Cluster resource
  - Package upgrade as handled by addons-controller running on the management-cluster and will be done before we start with the kubernetes version upgrade
- Wait for control plane node upgrade
- Wait for worker node upgrade

Currently, we support creating management and workload cluster using ClusterClass when package-based-lcm feature-flag is enabled. Along with cluster creation we should also support the cluster upgrade as well.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2504

### Describe testing done for PR
- Create classy workload cluster using v1.22.8 TKR
- Upgrade classy workload cluster to v1.23.5 TKR 
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Support for ClusterClass based cluster upgrades
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
