### PR TITLE
Support vSphere Supervisor login using Pinniped

### DIFF
--- a/pkg/v1/auth/tkg/kube_config_test.go
+++ b/pkg/v1/auth/tkg/kube_config_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Unit tests for tkg auth", func() {
 						ghttp.RespondWith(http.StatusNotFound, "not found"),
 					),
 				)
-				_, _, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, nil)
+				_, _, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, nil, tkgauth.DiscoveryStrategy{ClusterInfoConfigMap: tkgauth.DefaultClusterInfoConfigMap})
 			})
 			It("should return the error", func() {
 				Expect(err).To(HaveOccurred())
@@ -87,7 +87,7 @@ var _ = Describe("Unit tests for tkg auth", func() {
 						ghttp.RespondWith(http.StatusNotFound, "not found"),
 					),
 				)
-				_, _, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, nil)
+				_, _, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, nil, tkgauth.DiscoveryStrategy{ClusterInfoConfigMap: tkgauth.DefaultClusterInfoConfigMap})
 			})
 			It("should return the error", func() {
 				Expect(err).To(HaveOccurred())
@@ -119,7 +119,7 @@ var _ = Describe("Unit tests for tkg auth", func() {
 				options := &tkgauth.KubeConfigOptions{
 					MergeFilePath: kubeconfigMergeFilePath,
 				}
-				kubeConfigPath, kubeContext, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, options)
+				kubeConfigPath, kubeContext, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, options, tkgauth.DiscoveryStrategy{ClusterInfoConfigMap: tkgauth.DefaultClusterInfoConfigMap})
 			})
 			It("should set default values", func() {
 				Expect(err).ToNot(HaveOccurred())
@@ -163,7 +163,7 @@ var _ = Describe("Unit tests for tkg auth", func() {
 				options := &tkgauth.KubeConfigOptions{
 					MergeFilePath: kubeconfigMergeFilePath,
 				}
-				kubeConfigPath, kubeContext, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, options)
+				kubeConfigPath, kubeContext, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, options, tkgauth.DiscoveryStrategy{ClusterInfoConfigMap: tkgauth.DefaultClusterInfoConfigMap})
 			})
 			It("should not include --concierge-namespace arg in kubeconfig", func() {
 				Expect(err).ToNot(HaveOccurred())
@@ -208,7 +208,7 @@ var _ = Describe("Unit tests for tkg auth", func() {
 				options := &tkgauth.KubeConfigOptions{
 					MergeFilePath: kubeconfigMergeFilePath,
 				}
-				kubeConfigPath, kubeContext, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, options)
+				kubeConfigPath, kubeContext, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, options, tkgauth.DiscoveryStrategy{ClusterInfoConfigMap: tkgauth.DefaultClusterInfoConfigMap})
 			})
 			It("should generate the kubeconfig and merge the kubeconfig to given path", func() {
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/v1/auth/wcp/discovery.go
+++ b/pkg/v1/auth/wcp/discovery.go
@@ -1,0 +1,42 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package wcp provides helpers to interact with a vSphere Supervisor.
+package wcp
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/aunum/log"
+)
+
+const (
+	SupervisorVIPConfigMapName = "vip-cluster-info"
+)
+
+// IsVSphereSupervisor probes the given endpoint on a well known vSphere
+// Supervisor 'login banner' endpoint.
+// Returns true iff it was able to successfully determine that the endpoint was
+// a vSphere Supervisor.
+func IsVSphereSupervisor(endpoint string, httpClient *http.Client) (bool, error) {
+	loginBannerURL := fmt.Sprintf("%s/wcp/loginbanner", endpoint)
+
+	//nolint:noctx
+	req, _ := http.NewRequest("GET", loginBannerURL, http.NoBody)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		log.Debug("Failed to test for vSphere supervisor: %+v", err)
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		log.Debug("Got login banner from server")
+		return true, nil
+	}
+
+	log.Debug("Could not get login banner from server, response code = %+v", resp.StatusCode)
+	return false, nil
+}

--- a/pkg/v1/auth/wcp/discovery_test.go
+++ b/pkg/v1/auth/wcp/discovery_test.go
@@ -1,0 +1,81 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package wcp_test
+
+import (
+	"crypto/tls"
+	"errors"
+	"net/http"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/auth/wcp"
+)
+
+func TestWCPAuth(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "WCP Auth Suite")
+}
+
+type errorRoundTripper struct{}
+
+func (e *errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("an error occurred")
+}
+
+var _ = Describe("Tests for vSphere Supervisor discovery", func() {
+	var endpoint string
+	var httpClient *http.Client
+	var tlsServer *ghttp.Server
+	BeforeEach(func() {
+		tlsServer = ghttp.NewTLSServer()
+		endpoint = tlsServer.URL()
+		httpClient = &http.Client{
+			Transport: &http.Transport{
+				// #nosec
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: true,
+				},
+			},
+		}
+	})
+	Context("When the given endpoint exposes a login banner endpoint", func() {
+		It("returns true", func() {
+			tlsServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/wcp/loginbanner"),
+					ghttp.RespondWith(http.StatusOK, "Hello World! This is a login banner."),
+				),
+			)
+			result, err := wcp.IsVSphereSupervisor(endpoint, httpClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeTrue())
+		})
+	})
+	Context("When the given endpoint does not expose a login banner endpoint", func() {
+		It("returns false", func() {
+			tlsServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/wcp/loginbanner"),
+					ghttp.RespondWith(http.StatusNotFound, "I'm a 404"),
+				),
+			)
+			result, err := wcp.IsVSphereSupervisor(endpoint, httpClient)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeFalse())
+		})
+	})
+	Context("When an error occurs contacting the endpoint", func() {
+		It("returns an error", func() {
+			httpClient = &http.Client{
+				Transport: &errorRoundTripper{},
+			}
+			_, err := wcp.IsVSphereSupervisor(endpoint, httpClient)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("an error occurred"))
+		})
+	})
+})

--- a/pkg/v1/tkg/client/get_cluster_pinniped_info.go
+++ b/pkg/v1/tkg/client/get_cluster_pinniped_info.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc. All Rights Reserved.
+// Copyright 2021-2022 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package client
@@ -52,6 +52,7 @@ func (c *TkgClient) GetClusterPinnipedInfo(options GetClusterPinnipedInfoOptions
 		return nil, errors.Wrap(err, "error determining 'Tanzu Kubernetes Cluster service for vSphere' management cluster")
 	}
 	if isPacific {
+		// XXX: Override this path? (is there existing work to remove these pacific specific conditionals?)
 		return nil, errors.New("getting pinniped information not supported for 'Tanzu Kubernetes Cluster service for vSphere' cluster")
 	}
 
@@ -75,7 +76,7 @@ func (c *TkgClient) GetWCClusterPinnipedInfo(regionalClusterClient clusterclient
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get management cluster information")
 	}
-	managementClusterPinnipedInfo, err := utils.GetPinnipedInfoFromCluster(mcClusterInfo)
+	managementClusterPinnipedInfo, err := utils.GetPinnipedInfoFromCluster(mcClusterInfo, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get pinniped-info from management cluster")
 	}
@@ -83,7 +84,7 @@ func (c *TkgClient) GetWCClusterPinnipedInfo(regionalClusterClient clusterclient
 		return nil, errors.New("failed to get pinniped-info from management cluster")
 	}
 
-	workloadClusterPinnipedInfo, err := utils.GetPinnipedInfoFromCluster(wcClusterInfo)
+	workloadClusterPinnipedInfo, err := utils.GetPinnipedInfoFromCluster(wcClusterInfo, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get pinniped-info from workload cluster")
 	}
@@ -112,7 +113,7 @@ func (c *TkgClient) GetMCClusterPinnipedInfo(regionalClusterClient clusterclient
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get cluster information")
 	}
-	pinnipedInfo, err := utils.GetPinnipedInfoFromCluster(clusterInfo)
+	pinnipedInfo, err := utils.GetPinnipedInfoFromCluster(clusterInfo, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get pinniped-info from cluster")
 	}

--- a/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
+++ b/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
@@ -553,6 +553,7 @@ func GetFakeClusterInfo(server string, cert *x509.Certificate) string {
 // PinnipedInfo contains settings for the supervisor.
 type PinnipedInfo struct {
 	ClusterName              string `json:"cluster_name"`
+	ConciergeEndpoint        string `json:"concierge_endpoint"`
 	Issuer                   string `json:"issuer"`
 	IssuerCABundleData       string `json:"issuer_ca_bundle_data"`
 	ConciergeIsClusterScoped bool   `json:"concierge_is_cluster_scoped,string"`

--- a/pkg/v1/tkg/utils/kubeconfig.go
+++ b/pkg/v1/tkg/utils/kubeconfig.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc. All Rights Reserved.
+// Copyright 2021-2022 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package utils
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -16,6 +17,8 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	netutil "github.com/vmware-tanzu/tanzu-framework/pkg/v1/util/net"
 )
 
 // PinnipedConfigMapInfo defines the fields of pinniped-info configMap
@@ -26,6 +29,7 @@ type PinnipedConfigMapInfo struct {
 		ClusterName              string `json:"cluster_name" yaml:"cluster_name"`
 		Issuer                   string `json:"issuer" yaml:"issuer"`
 		IssuerCABundle           string `json:"issuer_ca_bundle_data" yaml:"issuer_ca_bundle_data"`
+		ConciergeEndpoint        string `json:"concierge_endpoint" yaml:"concierge_endpoint"`
 		ConciergeIsClusterScoped bool   `json:"concierge_is_cluster_scoped,string" yaml:"concierge_is_cluster_scoped"`
 	}
 }
@@ -83,7 +87,7 @@ func GetClusterServerFromKubeconfigAndContext(kubeConfigPath, context string) (s
 }
 
 // GetClusterInfoFromCluster gets the cluster Info by accessing the cluster-info configMap in kube-public namespace
-func GetClusterInfoFromCluster(clusterAPIServerURL string) (*clientcmdapi.Cluster, error) {
+func GetClusterInfoFromCluster(clusterAPIServerURL, configmapName string) (*clientcmdapi.Cluster, error) {
 	clusterAPIServerURL = strings.TrimSpace(clusterAPIServerURL)
 	if !strings.HasPrefix(clusterAPIServerURL, "https://") && !strings.HasPrefix(clusterAPIServerURL, "http://") {
 		clusterAPIServerURL = "https://" + clusterAPIServerURL
@@ -94,7 +98,8 @@ func GetClusterInfoFromCluster(clusterAPIServerURL string) (*clientcmdapi.Cluste
 	}
 
 	clusterAPIServerURL = strings.TrimRight(clusterAPIServerURL, " /")
-	clusterInfoURL := clusterAPIServerURL + "/api/v1/namespaces/kube-public/configmaps/cluster-info"
+	clusterInfoURL := clusterAPIServerURL + fmt.Sprintf("/api/v1/namespaces/kube-public/configmaps/%s", configmapName)
+
 	//nolint:noctx
 	req, _ := http.NewRequest("GET", clusterInfoURL, http.NoBody)
 	// To get the cluster ca certificate first time, we need to use skip verify the server certificate,
@@ -148,8 +153,18 @@ func GetClusterInfoFromCluster(clusterAPIServerURL string) (*clientcmdapi.Cluste
 }
 
 // GetPinnipedInfoFromCluster gets the Pinniped Info by accessing the pinniped-info configMap in kube-public namespace
-func GetPinnipedInfoFromCluster(clusterInfo *clientcmdapi.Cluster) (*PinnipedConfigMapInfo, error) {
+// 'discoveryPort' is used to optionally override the port used for discovery. This may be needed on setups that expose
+// discovery information to unauthenticated users on a different port (for instance, to avoid the need to anonymous auth
+// on the apiserver). By default, the endpoint from the cluster-info is used.
+func GetPinnipedInfoFromCluster(clusterInfo *clientcmdapi.Cluster, discoveryPort *int) (*PinnipedConfigMapInfo, error) {
 	endpoint := strings.TrimRight(clusterInfo.Server, " /")
+	var err error
+	if discoveryPort != nil {
+		endpoint, err = netutil.SetPort(clusterInfo.Server, *discoveryPort)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to override discovery port")
+		}
+	}
 	pinnipedInfoURL := endpoint + "/api/v1/namespaces/kube-public/configmaps/pinniped-info"
 	//nolint:noctx
 	req, _ := http.NewRequest("GET", pinnipedInfoURL, http.NoBody)

--- a/pkg/v1/util/net/set_port.go
+++ b/pkg/v1/util/net/set_port.go
@@ -1,0 +1,34 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package net provides helpers to work with network addresses.
+package net
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// SetPort takes a URL and returns it with the HTTPS scheme and the
+// given port.
+// If the endpoint is missing an HTTP(S) scheme, assumes input of the form
+// host[:port].
+// This is mainly meant to handle the typical case of a user entering either
+// just a host, host:port, or http(s)://host:port
+func SetPort(endpoint string, portOverride int) (string, error) {
+	prefix := ""
+	// Preprocess the string depending on whether it has a scheme or not.
+	if strings.HasPrefix(endpoint, "https:") || strings.HasPrefix(endpoint, "http:") {
+		u, err := url.Parse(endpoint)
+		if err != nil {
+			return "", err
+		}
+		prefix = u.Hostname()
+	} else {
+		// No scheme. Strip out a port if it exists.
+		prefix = strings.Split(endpoint, ":")[0]
+	}
+
+	return fmt.Sprintf("https://%s:%d", prefix, portOverride), nil
+}

--- a/pkg/v1/util/net/set_port_test.go
+++ b/pkg/v1/util/net/set_port_test.go
@@ -1,0 +1,52 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package net_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	netutil "github.com/vmware-tanzu/tanzu-framework/pkg/v1/util/net"
+)
+
+func TestNetUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Net util suite")
+}
+
+var _ = Describe("Overriding ports in an endpoint", func() {
+	Context("when a port is provided", func() {
+		It("should override the port", func() {
+			endpoint := "https://foo.com:1234"
+			result, err := netutil.SetPort(endpoint, 443)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("https://foo.com:443"))
+		})
+	})
+	Context("when no scheme is provided", func() {
+		It("should override the port", func() {
+			endpoint := "foo.com"
+			result, err := netutil.SetPort(endpoint, 443)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("https://foo.com:443"))
+		})
+	})
+	Context("when no scheme is provided, but a port is set", func() {
+		It("should override the port", func() {
+			endpoint := "foo.com:6443"
+			result, err := netutil.SetPort(endpoint, 443)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("https://foo.com:443"))
+		})
+	})
+	Context("when a port with the same value as the overridden value is in the endpoint", func() {
+		It("should preserve the port", func() {
+			endpoint := "https://foo.com:443"
+			result, err := netutil.SetPort(endpoint, 443)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("https://foo.com:443"))
+		})
+	})
+})


### PR DESCRIPTION
### What this PR does / why we need it

In order to support a single CLI experience for vSphere with Tanzu, add
support for detecting a vSphere Supervisor and obtaining a kubeconfig
that works with pinniped-auth.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes: #2660 

### Describe testing done for PR

- Added unit tests for port override. Updating existing tests for
  new discovery behavior.

- Manually validated by rebuilding/installing login plugin locally.

1) Login

```
➜  tanzu-framework git:(topic/bmayank/support-vsphere-supervisor-pinniped) ✗ tanzu login --endpoint https://192.168.0.2:443 --name foobarbaz --stderr-only
ℹ  Detected a vSphere Supervisor being used 
✔  successfully logged in to management cluster using the kubeconfig foobarbaz
Checking for required plugins...

2) Showing contexts created.

➜  tanzu-framework git:(topic/bmayank/support-vsphere-supervisor-pinniped) ✗ kubectl --kubeconfig ~/.kube-tanzu/config config get-contexts
CURRENT   NAME                                                                                  CLUSTER                                AUTHINFO                                         NAMESPACE
*         tanzu-cli-bc84d5af-6828-4bc6-bcc7-d248ecdece01@bc84d5af-6828-4bc6-bcc7-d248ecdece01   bc84d5af-6828-4bc6-bcc7-d248ecdece01   tanzu-cli-bc84d5af-6828-4bc6-bcc7-d248ecdece01

3) Verifying my identity.

➜  tanzu-framework git:(topic/bmayank/support-vsphere-supervisor-pinniped) ✗ kubectl --kubeconfig ~/.kube-tanzu/config get nodes
Error from server (Forbidden): nodes is forbidden: User "janedoe@example.com" cannot list resource "nodes" in API group "" at the cluster scope
```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```Add support for vSphere Supervisor login via Pinniped.

- You can now use 'tanzu login --endpoint ...' against a vSphere Supervisor configured with Pinniped.

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

- Detect that the endpoint is a vSphere Supervisor through a specific
  login banner endpoint it exposes. This avoids the need to add vSphere
  specific flags to the login command (at the cost of an extra HTTP
  round trip.)

- To avoid the need for anonymous authentication at the apiserver level,
  the vSphere Supervisor exposes discovery metadata at port 443.

- Likewise, the concierge endpoint (which needs to be accessed
  anonymously) is exposed on port 443. Allow the pinniped-info ConfigMap 
  to indicate the concierge endpoint, falling back to the cluster-info endpoint.

- The Supervisor uses a separate ConfigMap to expose the cluster CA
  (because it has two sets of certificates, management and user facing,
  and kube-public/cluster-info is used for the latter)

- To facilitate the above, this change allows the discovery logic to
  be more flexible and allow override of ConfigMap names and ports.

#### Special notes for your reviewer

(I'm attempting to validate this on an exiting tanzu-framework based environment, but I don't _think_ I should be breaking backwards compatibility since this patch mainly adds new branches/uses optional parameters to override behavior. That said, I am happy to do any other testing as requested)

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/2660