### PR TITLE
Fix: TKR resolver blocks cluster deletion

### DIFF
--- a/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster.go
+++ b/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster.go
@@ -81,7 +81,7 @@ func (cw *Webhook) getClusterClass(ctx context.Context, cluster *clusterv1.Clust
 	return clusterClass, nil
 }
 
-func respPtr(resp admission.Response) *admission.Response {
+func respPtr(resp admission.Response) *admission.Response { // nolint:gocritic // suppress hugeParam: resp is heavy
 	return &resp
 }
 

--- a/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster.go
+++ b/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster.go
@@ -47,6 +47,22 @@ func (cw *Webhook) Handle(ctx context.Context, req admission.Request) admission.
 	if err := cw.decoder.Decode(req, cluster); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
+
+	clusterClass, response := cw.getClusterClass(ctx, cluster)
+	if response != nil {
+		return *response
+	}
+
+	if err := cw.ResolveAndSetMetadata(cluster, clusterClass); err != nil {
+		return admission.Denied(err.Error())
+	}
+	return success(&req, cluster)
+}
+
+func (cw *Webhook) getClusterClass(ctx context.Context, cluster *clusterv1.Cluster) (*clusterv1.ClusterClass, *admission.Response) {
+	if !cluster.GetDeletionTimestamp().IsZero() {
+		return nil, respPtr(admission.Allowed("Doing nothing. Cluster is being deleted"))
+	}
 	cw.Log.Info("resolving cluster", "namespace", cluster.Namespace, "name", cluster.Name)
 	clusterClass, err := topology.GetClusterClass(ctx, cw.Client, cluster)
 	if err != nil {
@@ -54,20 +70,19 @@ func (cw *Webhook) Handle(ctx context.Context, req admission.Request) admission.
 			cw.Log.Info("ClusterClass not found",
 				"cluster", fmt.Sprintf("%s/%s", cluster.Namespace, cluster.Name),
 				"clusterClass", cluster.Spec.Topology.Class)
-			return admission.Denied("ClusterClass not found")
+			return nil, respPtr(admission.Denied("ClusterClass not found"))
 		}
 		cw.Log.Error(err, "error getting ClusterClass")
-		return admission.Errored(http.StatusBadGateway, errors.Wrap(err, "error getting ClusterClass"))
+		return nil, respPtr(admission.Errored(http.StatusBadGateway, errors.Wrap(err, "error getting ClusterClass")))
 	}
 	if clusterClass == nil {
-		return admission.Allowed("Skipping TKR resolution: cluster.spec.topology not present")
+		return nil, respPtr(admission.Allowed("Skipping TKR resolution: cluster.spec.topology not present"))
 	}
+	return clusterClass, nil
+}
 
-	if err := cw.ResolveAndSetMetadata(cluster, clusterClass); err != nil {
-		return admission.Denied(err.Error())
-	}
-
-	return success(&req, cluster)
+func respPtr(resp admission.Response) *admission.Response {
+	return &resp
 }
 
 // ResolveAndSetMetadata uses cw.TKRResolver and injects resolved metadata into the provided cluster.

--- a/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster_test.go
+++ b/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster_test.go
@@ -4,18 +4,23 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	runv1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/resolver"
@@ -83,6 +88,77 @@ var _ = Describe("cluster.Webhook", func() {
 	})
 
 	const strNonExistent = "non-existent"
+
+	Context("getClusterClass()", func() {
+		When("Cluster has deletionTimestamp set", func() {
+			It("should allow the request to pass", func() {
+				cluster.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				cc, resp := cw.getClusterClass(context.Background(), cluster)
+				Expect(cc).To(BeNil())
+				Expect(resp).ToNot(BeNil())
+				Expect(resp.Allowed).To(BeTrue())
+			})
+		})
+
+		When("Cluster has no topology set", func() {
+			BeforeEach(func() {
+				Expect(cluster.Spec.Topology).To(BeNil())
+			})
+			It("should allow the request to pass", func() {
+				cc, resp := cw.getClusterClass(context.Background(), cluster)
+				Expect(cc).To(BeNil())
+				Expect(resp).ToNot(BeNil())
+				Expect(resp.Allowed).To(BeTrue())
+			})
+		})
+
+		When("ClusterClass cannot be found", func() {
+			BeforeEach(func() {
+				cw.Client = fake.NewClientBuilder().WithScheme(newScheme()).Build() // no initial objects
+				cluster.Spec.Topology = &clusterv1.Topology{
+					Class: strNonExistent,
+				}
+			})
+			It("should deny the request", func() {
+				cc, resp := cw.getClusterClass(context.Background(), cluster)
+				Expect(cc).To(BeNil())
+				Expect(resp).ToNot(BeNil())
+				Expect(resp.Allowed).To(BeFalse())
+			})
+		})
+
+		When("the client returns an error getting ClusterClass", func() {
+			var expectedErr error
+			BeforeEach(func() {
+				expectedErr = errors.New("something bad")
+				cw.Client = errorClient{Client: fake.NewClientBuilder().WithScheme(newScheme()).Build(), err: expectedErr}
+				cluster.Spec.Topology = &clusterv1.Topology{
+					Class: strNonExistent,
+				}
+			})
+			It("should deny the request", func() {
+				cc, resp := cw.getClusterClass(context.Background(), cluster)
+				Expect(cc).To(BeNil())
+				Expect(resp).ToNot(BeNil())
+				Expect(resp.Allowed).To(BeFalse())
+				Expect(resp.Result.Message).To(ContainSubstring(expectedErr.Error()))
+			})
+		})
+
+		When("ClusterClass exists", func() {
+			BeforeEach(func() {
+				cw.Client = fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(clusterClass).Build()
+				cluster.Spec.Topology = &clusterv1.Topology{
+					Class: clusterClass.Name,
+				}
+			})
+			It("should deny the request", func() {
+				cc, resp := cw.getClusterClass(context.Background(), cluster)
+				Expect(cc).ToNot(BeNil(), "expecting to be able to get ClusterClass if it exists")
+				Expect(resp).To(BeNil())
+			})
+		})
+	})
 
 	Context("constructQuery()", func() {
 		When("'resolve-tkr' annotation is not present", func() {
@@ -482,4 +558,20 @@ func repeat(numTimes int, f func()) {
 	for i := 0; i < numTimes; i++ {
 		f()
 	}
+}
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = runv1.AddToScheme(s)
+	_ = clusterv1.AddToScheme(s)
+	return s
+}
+
+type errorClient struct {
+	client.Client
+	err error
+}
+
+func (c errorClient) Get(_ context.Context, _ client.ObjectKey, _ client.Object) error {
+	return c.err
 }


### PR DESCRIPTION
### What this PR does / why we need it

Make TKR Resolver Cluster Webhook allow requests when deletionTimestamp
is set. No need to resolve anything as the cluster is being deleted.

Add more unit tests to test this and other cases related to obtaining
ClusterClass for the Cluster.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2543 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Added unit tests for the changed behavior.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixed #2543 TKR resolver blocks cluster update even when cluster is marked for deletion: 
TKR Resolver now allows the request to pass through for Clusters with deletionTimestamp set. 
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
