### PR TITLE
Fix vsphereCSIConfig controller bug where multiple vsphereclusters are resolved for 1 capicluster

### DIFF
--- a/addons/controllers/testdata/test-vsphere-csi-paravirtual.yaml
+++ b/addons/controllers/testdata/test-vsphere-csi-paravirtual.yaml
@@ -39,8 +39,45 @@ metadata:
   labels:
     cluster.x-k8s.io/cluster-name: test-cluster-pv-csi
     topology.cluster.x-k8s.io/owned: ""
-  name: test-cluster-pv-csi-kl5tl
+  name: test-cluster-pv-csi-kl5tm
   namespace: default
+spec:
+  controlPlaneEndpoint:
+    host: 192.168.116.1
+    port: 6443
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: test-cluster-pv-csi
+  namespace: tkr-system
+spec:
+  infrastructureRef:
+    kind: VSphereCluster
+  clusterNetwork:
+    pods:
+      cidrBlocks: [ "192.168.0.0/16","fd00:100:96::/48" ]
+  topology:
+    class: test-clusterclass-tcbt
+    version: v1.22.3
+---
+apiVersion: csi.tanzu.vmware.com/v1alpha1
+kind: VSphereCSIConfig
+metadata:
+  name: test-cluster-pv-csi
+  namespace: tkr-system
+spec:
+  vsphereCSI:
+    mode: vsphereParavirtualCSI
+---
+apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereCluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test-cluster-pv-csi
+    topology.cluster.x-k8s.io/owned: ""
+  name: test-cluster-pv-csi-kl5tm
+  namespace: tkr-system
 spec:
   controlPlaneEndpoint:
     host: 192.168.116.1

--- a/addons/controllers/vspherecsiconfig_controller_test.go
+++ b/addons/controllers/vspherecsiconfig_controller_test.go
@@ -31,7 +31,6 @@ var _ = Describe("VSphereCSIConfig Reconciler", func() {
 		key                       client.ObjectKey
 		clusterName               string
 		clusterResourceFilePath   string
-		vsphereClusterName        string
 		enduringResourcesFilePath string
 	)
 
@@ -76,24 +75,23 @@ var _ = Describe("VSphereCSIConfig Reconciler", func() {
 			BeforeEach(func() {
 				clusterName = testClusterCsiName
 				clusterResourceFilePath = "testdata/test-vsphere-csi-non-paravirtual.yaml"
-				vsphereClusterName = "test-cluster-pv-csi-kl5tl"
 				enduringResourcesFilePath = ""
 			})
 
 			It("Should reconcile VSphereCSIConfig and create data values secret for VSphereCSIConfig on management cluster", func() {
 				cluster := &clusterapiv1beta1.Cluster{}
-				Eventually(func() bool {
+				Eventually(func() error {
 					if err := k8sClient.Get(ctx, key, cluster); err != nil {
-						return false
+						return fmt.Errorf("Failed to get Cluster '%v': '%v'", key, err)
 					}
-					return true
-				}, waitTimeout, pollingInterval).Should(BeTrue())
+					return nil
+				}, waitTimeout, pollingInterval).Should(Succeed())
 
 				// the csi config object should be deployed
 				config := &csiv1alpha1.VSphereCSIConfig{}
-				Eventually(func() bool {
+				Eventually(func() error {
 					if err := k8sClient.Get(ctx, key, config); err != nil {
-						return false
+						return fmt.Errorf("Failed to get VSphereCSIConfig '%v': '%v'", key, err)
 					}
 					Expect(config.Spec.VSphereCSI.Mode).Should(Equal("vsphereCSI"))
 					Expect(config.Spec.VSphereCSI.NonParavirtualConfig).NotTo(BeZero())
@@ -122,23 +120,23 @@ var _ = Describe("VSphereCSIConfig Reconciler", func() {
 					Expect(*config.Spec.VSphereCSI.NonParavirtualConfig.WindowsSupport).Should(Equal(true))
 
 					if len(config.OwnerReferences) == 0 {
-						return false
+						return fmt.Errorf("OwnerReferences not yet set")
 					}
 					Expect(len(config.OwnerReferences)).Should(Equal(1))
 					Expect(config.OwnerReferences[0].Name).Should(Equal(clusterName))
 
-					return true
-				}, waitTimeout, pollingInterval).Should(BeTrue())
+					return nil
+				}, waitTimeout, pollingInterval).Should(Succeed())
 
 				// the data values secret should be generated
 				secret := &v1.Secret{}
-				Eventually(func() bool {
+				Eventually(func() error {
 					secretKey := client.ObjectKey{
 						Namespace: clusterNamespace,
 						Name:      fmt.Sprintf("%s-%s-data-values", clusterName, constants.CSIAddonName),
 					}
 					if err := k8sClient.Get(ctx, secretKey, secret); err != nil {
-						return false
+						return fmt.Errorf("Failed to get Secret '%v': '%v'", secretKey, err)
 					}
 					secretData := string(secret.Data["values.yaml"])
 					Expect(len(secretData)).Should(Not(BeZero()))
@@ -165,17 +163,17 @@ var _ = Describe("VSphereCSIConfig Reconciler", func() {
 					Expect(strings.Contains(secretData, "deployment_replicas: 3")).Should(BeTrue())
 					Expect(strings.Contains(secretData, "windows_support: true")).Should(BeTrue())
 
-					return true
-				}, waitTimeout, pollingInterval).Should(BeTrue())
+					return nil
+				}, waitTimeout, pollingInterval).Should(Succeed())
 
 				// eventually the secret ref to the data values should be updated
-				Eventually(func() bool {
+				Eventually(func() error {
 					if err := k8sClient.Get(ctx, key, config); err != nil {
-						return false
+						return fmt.Errorf("Failed to get VSphereCSIConfig '%v': '%v'", key, err)
 					}
-					Expect(config.Status.SecretRef).To(Equal(fmt.Sprintf("%s-%s-data-values", clusterName, constants.CSIAddonName)))
-					return true
-				})
+					Expect(*config.Status.SecretRef).To(Equal(fmt.Sprintf("%s-%s-data-values", clusterName, constants.CSIAddonName)))
+					return nil
+				}, waitTimeout, pollingInterval).Should(Succeed())
 			})
 
 		})
@@ -189,40 +187,42 @@ var _ = Describe("VSphereCSIConfig Reconciler", func() {
 
 			It("Should reconcile VSphereCSIConfig and create data values secret for VSphereCSIConfig", func() {
 				cluster := &clusterapiv1beta1.Cluster{}
-				Eventually(func() bool {
-					if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test-cluster-csi-minimal"}, cluster); err != nil {
-						return false
+				Eventually(func() error {
+					objKey := client.ObjectKey{Namespace: "default", Name: "test-cluster-csi-minimal"}
+					if err := k8sClient.Get(ctx, objKey, cluster); err != nil {
+						return fmt.Errorf("Failed to get Cluster '%v': '%v'", objKey, err)
 					}
-					return true
-				}, waitTimeout, pollingInterval).Should(BeTrue())
+					return nil
+				}, waitTimeout, pollingInterval).Should(Succeed())
 
 				// the csi config object should be deployed
 				config := &csiv1alpha1.VSphereCSIConfig{}
-				Eventually(func() bool {
-					if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test-cluster-csi-minimal"}, config); err != nil {
-						return false
+				Eventually(func() error {
+					objKey := client.ObjectKey{Namespace: "default", Name: "test-cluster-csi-minimal"}
+					if err := k8sClient.Get(ctx, objKey, config); err != nil {
+						return fmt.Errorf("Failed to get VSphereCSIConfig '%v': '%v'", objKey, err)
 					}
 					Expect(config.Spec.VSphereCSI.Mode).Should(Equal("vsphereCSI"))
-					Expect(config.Spec.VSphereCSI.NonParavirtualConfig).To(BeZero())
+					Expect(config.Spec.VSphereCSI.NonParavirtualConfig).To(BeNil())
 
 					if len(config.OwnerReferences) == 0 {
-						return false
+						return fmt.Errorf("Owner references not yet set")
 					}
 					Expect(len(config.OwnerReferences)).Should(Equal(1))
 					Expect(config.OwnerReferences[0].Name).Should(Equal(clusterName))
 
-					return true
-				}, waitTimeout, pollingInterval).Should(BeTrue())
+					return nil
+				}, waitTimeout, pollingInterval).Should(Succeed())
 
 				// the data values secret should be generated
 				secret := &v1.Secret{}
-				Eventually(func() bool {
+				Eventually(func() error {
 					secretKey := client.ObjectKey{
 						Namespace: clusterNamespace,
 						Name:      fmt.Sprintf("%s-%s-data-values", clusterName, constants.CSIAddonName),
 					}
 					if err := k8sClient.Get(ctx, secretKey, secret); err != nil {
-						return false
+						return fmt.Errorf("Failed to get secret '%v' : '%v'", secretKey, err)
 					}
 					secretData := string(secret.Data["values.yaml"])
 					Expect(len(secretData)).Should(Not(BeZero()))
@@ -249,17 +249,21 @@ var _ = Describe("VSphereCSIConfig Reconciler", func() {
 					Expect(strings.Contains(secretData, "deployment_replicas: 2")).Should(BeTrue())
 					Expect(strings.Contains(secretData, "windows_support: true")).Should(BeTrue())
 
-					return true
-				}, waitTimeout, pollingInterval).Should(BeTrue())
+					return nil
+				}, waitTimeout, pollingInterval).Should(Succeed())
 
 				// eventually the secret ref to the data values should be updated
-				Eventually(func() bool {
-					if err := k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "test-cluster-csi-minimal"}, config); err != nil {
-						return false
+				Eventually(func() error {
+					objKey := client.ObjectKey{Namespace: "default", Name: "test-cluster-csi-minimal"}
+					if err := k8sClient.Get(ctx, objKey, config); err != nil {
+						return fmt.Errorf("Failed to get VSphereCSIConfig '%v' : '%v", objKey, err)
 					}
-					Expect(config.Status.SecretRef).To(Equal(fmt.Sprintf("%s-%s-data-values", clusterName, constants.CSIAddonName)))
-					return true
-				})
+					if config.Status.SecretRef == nil {
+						return fmt.Errorf("Secret status of VSphereCSIConfig is not yet updated: '%v'", objKey)
+					}
+					Expect(*config.Status.SecretRef).To(Equal(fmt.Sprintf("%s-%s-data-values", clusterName, constants.CSIAddonName)))
+					return nil
+				}, waitTimeout, pollingInterval).Should(Succeed())
 			})
 
 		})
@@ -275,13 +279,13 @@ var _ = Describe("VSphereCSIConfig Reconciler", func() {
 		It("Should reconcile VSphereCSIConfig and create data values secret for VSphereCSIConfig on management cluster", func() {
 			// the data values secret should be generated
 			secret := &v1.Secret{}
-			Eventually(func() bool {
+			Eventually(func() error {
 				secretKey := client.ObjectKey{
 					Namespace: clusterNamespace,
 					Name:      fmt.Sprintf("%s-%s-data-values", clusterName, constants.PVCSIAddonName),
 				}
 				if err := k8sClient.Get(ctx, secretKey, secret); err != nil {
-					return false
+					return fmt.Errorf("Failed to get Secret '%v': '%v'", secretKey, err)
 				}
 				secretData := string(secret.Data["values.yaml"])
 				fmt.Println(secretData) // debug dump
@@ -298,54 +302,62 @@ var _ = Describe("VSphereCSIConfig Reconciler", func() {
 				Expect(strings.Contains(secretData, "state2: value2")).Should(BeTrue())
 				Expect(strings.Contains(secretData, "state3: value3")).Should(BeTrue())
 
-				return true
-			}, waitTimeout, pollingInterval).Should(BeTrue())
+				return nil
+			}, waitTimeout, pollingInterval).Should(Succeed())
 
 			// eventually the secret ref to the data values should be updated
 			config := &csiv1alpha1.VSphereCSIConfig{}
-			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, key, config); err != nil {
-					return false
+			Eventually(func() error {
+				configKey := client.ObjectKey{
+					Namespace: clusterNamespace,
+					Name:      clusterName,
 				}
-				Expect(config.Status.SecretRef).To(Equal(fmt.Sprintf("%s-%s-data-values", clusterName, constants.PVCSIAddonName)))
-				return true
-			})
+				if err := k8sClient.Get(ctx, configKey, config); err != nil {
+					return fmt.Errorf("Failed to get vsphereconfig '%v': '%v'", configKey, err)
+				}
+				if config.Status.SecretRef == nil {
+					return fmt.Errorf("VSphereConfig status not yet updated: %v", configKey)
+				}
+				Expect(*config.Status.SecretRef).To(Equal(fmt.Sprintf("%s-%s-data-values", clusterName, constants.PVCSIAddonName)))
+				return nil
+			}, waitTimeout, pollingInterval).Should(Succeed())
 		})
 
 		It("Should reconcile ProviderServiceAccount", func() {
+			vsphereClusterName := "test-cluster-pv-csi-kl5tm"
 			serviceAccount := &capvvmwarev1beta1.ProviderServiceAccount{}
-			Eventually(func() bool {
+			Eventually(func() error {
 				serviceAccountKey := client.ObjectKey{
 					Namespace: clusterNamespace,
 					Name:      fmt.Sprintf("%s-%s", vsphereClusterName, "pvcsi"),
 				}
 				if err := k8sClient.Get(ctx, serviceAccountKey, serviceAccount); err != nil {
-					return false
+					return fmt.Errorf("Failed to get provider service account '%v' : '%v'", serviceAccountKey, err)
 				}
 				Expect(serviceAccount.Spec.Ref.Name).To(Equal(vsphereClusterName))
 				Expect(serviceAccount.Spec.Ref.Namespace).To(Equal(key.Namespace))
 				Expect(serviceAccount.Spec.Rules).To(HaveLen(6))
 				Expect(serviceAccount.Spec.TargetNamespace).To(Equal("vmware-system-csi"))
 				Expect(serviceAccount.Spec.TargetSecretName).To(Equal("pvcsi-provider-creds"))
-				return true
-			})
+				return nil
+			}, waitTimeout, pollingInterval).Should(Succeed())
 		})
 
 		It("Should reconcile aggregated cluster role", func() {
 			clusterRole := &rbacv1.ClusterRole{}
-			Eventually(func() bool {
+			Eventually(func() error {
 				key := client.ObjectKey{
 					Name: constants.ProviderServiceAccountAggregatedClusterRole,
 				}
 				if err := k8sClient.Get(ctx, key, clusterRole); err != nil {
-					return false
+					return fmt.Errorf("Failed to get ClusterRole '%v': '%v'", key, err)
 				}
 				Expect(clusterRole.Labels).To(Equal(map[string]string{
 					constants.CAPVClusterRoleAggregationRuleLabelSelectorKey: constants.CAPVClusterRoleAggregationRuleLabelSelectorValue,
 				}))
 				Expect(clusterRole.Rules).To(HaveLen(6))
-				return true
-			})
+				return nil
+			}, waitTimeout, pollingInterval).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
fix for issue where multiple vspherecluster objects are resolved from 1 capi cluster object.

### What this PR does / why we need it
- it scopes searching for a capi cluster's corresponding vspherecluster to the same namespace

### Which issue(s) this PR fixes
- integration testing issue that resulted in the following error:
"E0604 12:33:10.186237       1 vspherecsiconfig_controller.go:114] VSphereCSIConfig "msg"="Error reconciling VSphereCSIConfig" "error"="expected to find 1 VSphereCluster object for label key cluster.x-k8s.io/cluster-name and value tkc2cc but found 2" "VSphereCSIConfig"={"Namespace":"ns02","Name":"tkc2cc-vsphere-pv-csi-package"}"
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2569

### Describe testing done for PR
env tests

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Fix vsphereCSIConfig controller bug where multiple vsphereclusters are resolved for 1 capicluster
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
