### PR TITLE
Add permissions for CPI and CSI controller to create ClusterRole for CAPV to reconcile ProviderServiceAccount

### DIFF
--- a/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
+++ b/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
@@ -114,6 +114,99 @@ rules:
   - watch
   - update
   - patch
+#! permissions required by VsphereCPIConfig and VSphereCSIConfig controller to create ClusterRole for CAPV to reconcile ProviderServiceAccount
+- apiGroups:
+  - vmoperator.vmware.com
+  resources:
+  - virtualmachineservices
+  - virtualmachineservices/status
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - vmoperator.vmware.com
+  resources:
+  - virtualmachines
+  - virtualmachines/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - nsx.vmware.com
+  resources:
+  - ippools
+  - ippools/status
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - patch
+  - delete
+  - watch
+- apiGroups:
+  - nsx.vmware.com
+  resources:
+  - routesets
+  - routesets/status
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - patch
+  - delete
+- apiGroups:
+  - cns.vmware.com
+  resources:
+  - cnsvolumemetadatas
+  - cnsfileaccessconfigs
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+  - delete
+- apiGroups:
+  - cns.vmware.com
+  resources:
+  - cnscsisvfeaturestates
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
 #! permissions are required for addons-manager to create/update resources in the ProviderRef which are dynamic.
 - apiGroups: ['*']
   resources: ['*']


### PR DESCRIPTION
Add permissions required by VsphereCPIConfig and VSphereCSIConfig controller to create ClusterRole for CAPV to reconcile ProviderServiceAccount

Signed-off-by: Shyaam Nagarajan <nagarajans@vmware.com>

### What this PR does / why we need it
Addons-Manager creates ClusterRole with some permissions that is used by CAPV to reconcile ProviderServiceAccount.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2574 

### Describe testing done for PR
Built addons-manager package and tested on AWS cluster that package reconciles successfully.
```
kubectl --kubeconfig ~/.kube-tkg/config get pkgi -n  tkg-system | grep tanzu-addons

tanzu-addons-manager                          addons-manager.tanzu.vmware.com          0.23.2                                     Reconcile succeeded                                                    15m
```
```
kubectl --kubeconfig ~/.kube-tkg/config get clusterroles tanzu-addons-manager-clusterrole -o yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    kapp.k14s.io/identity: v1;/rbac.authorization.k8s.io/ClusterRole/tanzu-addons-manager-clusterrole;rbac.authorization.k8s.io/v1
    kapp.k14s.io/original: '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"labels":{"kapp.k14s.io/app":"1654665418647098368","kapp.k14s.io/association":"v1.74c0e3d69a95a4732db83d1b7a13f0a6"},"name":"tanzu-addons-manager-clusterrole"},"rules":[{"apiGroups":["run.tanzu.vmware.com"],"resources":["tanzukubernetesreleases","tanzukubernetesreleases/status","clusterbootstraps","clusterbootstraptemplates","kappcontrollerconfigs"],"verbs":["get","list","watch","create","update","patch","delete"]},{"apiGroups":["cni.tanzu.vmware.com"],"resources":["antreaconfigs","calicoconfigs"],"verbs":["get","list","watch","create","update","patch","delete"]},{"apiGroups":["cpi.tanzu.vmware.com"],"resources":["vspherecpiconfigs"],"verbs":["get","list","watch","create","update","patch","delete"]},{"apiGroups":["cpi.tanzu.vmware.com"],"resources":["vspherecpiconfigs/status"],"verbs":["get","update","patch"]},{"apiGroups":["vmware.infrastructure.cluster.x-k8s.io"],"resources":["providerserviceaccounts"],"verbs":["get","create","list","watch","update","patch"]},{"apiGroups":["csi.tanzu.vmware.com"],"resources":["vspherecsiconfigs"],"verbs":["get","list","watch","create","update","patch","delete"]},{"apiGroups":["csi.tanzu.vmware.com"],"resources":["vspherecsiconfigs/status"],"verbs":["get","update","patch"]},{"apiGroups":["vmware.infrastructure.cluster.x-k8s.io"],"resources":["providerserviceaccounts"],"verbs":["get","create","list","watch","update","patch"]},{"apiGroups":["vmoperator.vmware.com"],"resources":["virtualmachineservices","virtualmachineservices/status"],"verbs":["get","create","update","patch","delete"]},{"apiGroups":["vmoperator.vmware.com"],"resources":["virtualmachines","virtualmachines/status"],"verbs":["get","list","watch","update","patch"]},{"apiGroups":["nsx.vmware.com"],"resources":["ippools","ippools/status"],"verbs":["get","create","update","list","patch","delete","watch"]},{"apiGroups":["nsx.vmware.com"],"resources":["routesets","routesets/status"],"verbs":["get","create","update","list","patch","delete"]},{"apiGroups":["cns.vmware.com"],"resources":["cnsvolumemetadatas","cnsfileaccessconfigs"],"verbs":["get","list","watch","update","create","delete"]},{"apiGroups":["cns.vmware.com"],"resources":["cnscsisvfeaturestates"],"verbs":["get","list","watch"]},{"apiGroups":[""],"resources":["persistentvolumeclaims"],"verbs":["get","list","watch","update","create","delete"]},{"apiGroups":[""],"resources":["persistentvolumeclaims/status"],"verbs":["get","update","patch"]},{"apiGroups":[""],"resources":["events"],"verbs":["list"]},{"apiGroups":["*"],"resources":["*"],"verbs":["get","list","watch","create","update","patch"]},{"apiGroups":["cluster.x-k8s.io"],"resources":["clusters","clusters/status"],"verbs":["get","list","watch"]},{"apiGroups":["controlplane.cluster.x-k8s.io"],"resources":["kubeadmcontrolplanes","kubeadmcontrolplanes/status"],"verbs":["get","list","watch"]},{"apiGroups":[""],"resources":["secrets"],"verbs":["get","list","watch","create","update","patch","delete"]},{"apiGroups":[""],"resources":["configmaps"],"verbs":["get","list","watch"]},{"apiGroups":[""],"resources":["events"],"verbs":["create","patch"]},{"apiGroups":["kappctrl.k14s.io"],"resources":["apps"],"verbs":["get","list","watch","create","update","patch","delete"]},{"apiGroups":["packaging.carvel.dev"],"resources":["packagerepositories","packagerepositories/status"],"verbs":["get","list","watch","create","update","patch"]},{"apiGroups":["packaging.carvel.dev"],"resources":["packageinstalls","packageinstalls/status"],"verbs":["get","list","watch","create","update","patch","delete"]}]}'
    kapp.k14s.io/original-diff-md5: c6e94dc94aed3401b5d0f26ed6c0bff3
  creationTimestamp: "2022-06-08T05:17:02Z"
  labels:
    kapp.k14s.io/app: "1654665418647098368"
    kapp.k14s.io/association: v1.74c0e3d69a95a4732db83d1b7a13f0a6
  name: tanzu-addons-manager-clusterrole
  resourceVersion: "6710"
  uid: 788ecbee-ad21-48ac-b8c8-9231a3759f87
rules:
- apiGroups:
  - run.tanzu.vmware.com
  resources:
  - tanzukubernetesreleases
  - tanzukubernetesreleases/status
  - clusterbootstraps
  - clusterbootstraptemplates
  - kappcontrollerconfigs
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - patch
  - delete
- apiGroups:
  - cni.tanzu.vmware.com
  resources:
  - antreaconfigs
  - calicoconfigs
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - patch
  - delete
- apiGroups:
  - cpi.tanzu.vmware.com
  resources:
  - vspherecpiconfigs
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - patch
  - delete
- apiGroups:
  - cpi.tanzu.vmware.com
  resources:
  - vspherecpiconfigs/status
  verbs:
  - get
  - update
  - patch
- apiGroups:
  - vmware.infrastructure.cluster.x-k8s.io
  resources:
  - providerserviceaccounts
  verbs:
  - get
  - create
  - list
  - watch
  - update
  - patch
- apiGroups:
  - csi.tanzu.vmware.com
  resources:
  - vspherecsiconfigs
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - patch
  - delete
- apiGroups:
  - csi.tanzu.vmware.com
  resources:
  - vspherecsiconfigs/status
  verbs:
  - get
  - update
  - patch
- apiGroups:
  - vmware.infrastructure.cluster.x-k8s.io
  resources:
  - providerserviceaccounts
  verbs:
  - get
  - create
  - list
  - watch
  - update
  - patch
- apiGroups:
  - vmoperator.vmware.com
  resources:
  - virtualmachineservices
  - virtualmachineservices/status
  verbs:
  - get
  - create
  - update
  - patch
  - delete
- apiGroups:
  - vmoperator.vmware.com
  resources:
  - virtualmachines
  - virtualmachines/status
  verbs:
  - get
  - list
  - watch
  - update
  - patch
- apiGroups:
  - nsx.vmware.com
  resources:
  - ippools
  - ippools/status
  verbs:
  - get
  - create
  - update
  - list
  - patch
  - delete
  - watch
- apiGroups:
  - nsx.vmware.com
  resources:
  - routesets
  - routesets/status
  verbs:
  - get
  - create
  - update
  - list
  - patch
  - delete
- apiGroups:
  - cns.vmware.com
  resources:
  - cnsvolumemetadatas
  - cnsfileaccessconfigs
  verbs:
  - get
  - list
  - watch
  - update
  - create
  - delete
- apiGroups:
  - cns.vmware.com
  resources:
  - cnscsisvfeaturestates
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  - persistentvolumeclaims
  verbs:
  - get
  - list
  - watch
  - update
  - create
  - delete
- apiGroups:
  - ""
  resources:
  - persistentvolumeclaims/status
  verbs:
  - get
  - update
  - patch
- apiGroups:
  - ""
  resources:
  - events
  verbs:
  - list
- apiGroups:
  - '*'
  resources:
  - '*'
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - patch
- apiGroups:
  - cluster.x-k8s.io
  resources:
  - clusters
  - clusters/status
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - controlplane.cluster.x-k8s.io
  resources:
  - kubeadmcontrolplanes
  - kubeadmcontrolplanes/status
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  - secrets
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - patch
  - delete
- apiGroups:
  - ""
  resources:
  - configmaps
  verbs:
  - get
  - list
  - watch
- apiGroups:
  - ""
  resources:
  - events
  verbs:
  - create
  - patch
- apiGroups:
  - kappctrl.k14s.io
  resources:
  - apps
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - patch
  - delete
- apiGroups:
  - packaging.carvel.dev
  resources:
  - packagerepositories
  - packagerepositories/status
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - patch
- apiGroups:
  - packaging.carvel.dev
  resources:
  - packageinstalls
  - packageinstalls/status
  verbs:
  - get
  - list
  - watch
  - create
  - update
  - patch
  - delete
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
```release-note
package-based-lcm:  Add permissions required by VsphereCPIConfig and VSphereCSIConfig controller to create ClusterRole for CAPV to reconcile ProviderServiceAccount
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information
The permissions have been fetched from 
CPI: https://github.com/vmware-tanzu/tanzu-framework/blob/main/addons/controllers/cpi/vspherecpiconfig_controller.go#L40

CSI: https://github.com/vmware-tanzu/tanzu-framework/blob/main/addons/controllers/csi/vspherecsiconfig_controller.go#L47

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
