### PR TITLE
Support building and publishing multiple versions of specific package as part of package repository and updated tkg-autoscaler package to use multiple versions

### DIFF
--- a/hack/packages/package-tools/cmd/helpers.go
+++ b/hack/packages/package-tools/cmd/helpers.go
@@ -37,9 +37,9 @@ func getPackageFromPackageValues(projectRootDir, packageName string) (Package, e
 
 	for i := range packageValues.Repositories {
 		packages := packageValues.Repositories[i].Packages
-		for _, pkg := range packages {
-			if pkg.Name == packageName {
-				return pkg, nil
+		for i := range packages {
+			if packages[i].Name == packageName {
+				return packages[i], nil
 			}
 		}
 	}
@@ -74,8 +74,8 @@ func filterPackageRepos(pkgVals PackageValues) ([]string, error) {
 
 // packagesContains checks if a package is in the given collection of packages.
 func packagesContains(packagesList []Package, pkg string) bool {
-	for _, p := range packagesList {
-		if p.Name == pkg {
+	for i := range packagesList {
+		if packagesList[i].Name == pkg {
 			return true
 		}
 	}

--- a/hack/packages/package-tools/cmd/helpers.go
+++ b/hack/packages/package-tools/cmd/helpers.go
@@ -28,23 +28,32 @@ func readPackageValues(projectRootDir string) (PackageValues, error) {
 	return packageValues, nil
 }
 
-// getPackageFromPackageValues returns the package definition from the package-values.yaml file.
-func getPackageFromPackageValues(projectRootDir, packageName string) (Package, error) {
+// getPackageFromPackageValues returns the list of package definition from the package-values.yaml file.
+func getPackageFromPackageValues(projectRootDir, packageName string) ([]Package, error) {
 	packageValues, err := readPackageValues(projectRootDir)
 	if err != nil {
-		return Package{}, err
+		return []Package{}, err
 	}
 
+	matchingPackages := []Package{}
 	for i := range packageValues.Repositories {
 		packages := packageValues.Repositories[i].Packages
 		for i := range packages {
 			if packages[i].Name == packageName {
-				return packages[i], nil
+				if packages[i].Version == version {
+					return []Package{packages[i]}, nil
+				}
+				matchingPackages = append(matchingPackages, packages[i])
 			}
 		}
 	}
 
-	return Package{}, fmt.Errorf("package %q not found in %s", packageName, constants.PackageValuesFilePath)
+	// Found packages but no matching version found, returning all matching package
+	if len(matchingPackages) >= 1 {
+		return matchingPackages, nil
+	}
+
+	return []Package{}, fmt.Errorf("package %q not found in %s", packageName, constants.PackageValuesFilePath)
 }
 
 // filterPackageRepos returns a list of repos that should be generated.

--- a/hack/packages/package-tools/cmd/helpers.go
+++ b/hack/packages/package-tools/cmd/helpers.go
@@ -89,6 +89,23 @@ type formattedVersion struct {
 }
 
 func formatVersion(pkg *Package, concatenator string) formattedVersion {
+	if pkg != nil && pkg.SkipVersionOverride {
+		fv := formattedVersion{
+			version:      pkg.Version,
+			noV:          getPackageVersion(pkg.Version),
+			concatenator: concatenator,
+			subVersion:   pkg.PackageSubVersion,
+		}
+
+		fv.concat = fv.version
+		fv.concatNoV = fv.noV
+		if fv.subVersion != "" {
+			fv.concat = fv.version + concatenator + fv.subVersion
+			fv.concatNoV = fv.noV + concatenator + fv.subVersion
+		}
+		return fv
+	}
+
 	fv := formattedVersion{
 		version:      version,
 		noV:          getPackageVersion(version),
@@ -119,4 +136,12 @@ func getPackageVersion(version string) string {
 		pkgVersion = version[1:]
 	}
 	return pkgVersion
+}
+
+func getEnvArrayFromMap(env map[string]string) []string {
+	var arrEnv []string
+	for k, v := range env {
+		arrEnv = append(arrEnv, fmt.Sprintf("%s=%s", k, v))
+	}
+	return arrEnv
 }

--- a/hack/packages/package-tools/cmd/package-bundle-generate.go
+++ b/hack/packages/package-tools/cmd/package-bundle-generate.go
@@ -62,23 +62,25 @@ func runPackageBundleGenerate(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Printf("Generating %q package bundle...\n", packageName)
 
-		pkg, err := getPackageFromPackageValues(projectRootDir, packageName)
+		pkgs, err := getPackageFromPackageValues(projectRootDir, packageName)
 		if err != nil {
 			return err
 		}
 
-		packagePath := filepath.Join(projectRootDir, "packages", packageName)
-		if err := generateSingleImgpkgLockOutput(toolsBinDir, packagePath, getEnvArrayFromMap(pkg.Env)...); err != nil {
-			return fmt.Errorf("couldn't generate imgpkg lock output file: %w", err)
-		}
+		for i := range pkgs {
+			packagePath := filepath.Join(projectRootDir, "packages", packageName)
+			if err := generateSingleImgpkgLockOutput(toolsBinDir, packagePath, getEnvArrayFromMap(pkgs[i].Env)...); err != nil {
+				return fmt.Errorf("couldn't generate imgpkg lock output file: %w", err)
+			}
 
-		if err := generatePackageBundle(&pkg, projectRootDir, toolsBinDir, packageName, packagePath); err != nil {
-			return fmt.Errorf("couldn't generate the package bundle: %w", err)
-		}
-		buildPkgDir := filepath.Join(projectRootDir, "build", "packages")
-		pkgValsDir := filepath.Join(projectRootDir, constants.PackageValuesFilePath)
-		if err := generatePackageCR(projectRootDir, toolsBinDir, registry, buildPkgDir, pkgValsDir, &pkg); err != nil {
-			return err
+			if err := generatePackageBundle(&pkgs[i], projectRootDir, toolsBinDir, packageName, packagePath); err != nil {
+				return fmt.Errorf("couldn't generate the package bundle: %w", err)
+			}
+			buildPkgDir := filepath.Join(projectRootDir, "build", "packages")
+			pkgValsDir := filepath.Join(projectRootDir, constants.PackageValuesFilePath)
+			if err := generatePackageCR(projectRootDir, toolsBinDir, registry, buildPkgDir, pkgValsDir, &pkgs[i]); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/hack/packages/package-tools/cmd/package-bundle-push.go
+++ b/hack/packages/package-tools/cmd/package-bundle-push.go
@@ -64,7 +64,8 @@ func runPackageBundlePush(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, repo := range repos {
-		for i, pkg := range packageValues.Repositories[repo].Packages {
+		for i := range packageValues.Repositories[repo].Packages {
+			pkg := packageValues.Repositories[repo].Packages[i]
 			fmt.Printf("Pushing %q package bundle...\n", pkg.Name)
 			imagePackageVersion := formatVersion(&packageValues.Repositories[repo].Packages[i], "_").concat
 
@@ -135,7 +136,8 @@ func prunePackages(repos map[string]Repository, csvBundles string) error {
 
 	RepoLoop:
 		for repoName := range repos {
-			for _, pkg := range repos[repoName].Packages {
+			for i := range repos[repoName].Packages {
+				pkg := repos[repoName].Packages[i]
 				if pkg.Name == bundle {
 					bundleFound = true
 					prunedPkgs[repoName] = append(prunedPkgs[repoName], pkg)

--- a/hack/packages/package-tools/cmd/packageValues.go
+++ b/hack/packages/package-tools/cmd/packageValues.go
@@ -33,11 +33,13 @@ type Deploy struct {
 
 // Package holds the information about a package
 type Package struct {
-	Name              string `yaml:"name"`
-	DisplayName       string `yaml:"displayName"`
-	Path              string `yaml:"path"`
-	Domain            string `yaml:"domain"`
-	Version           string `yaml:"version"`
-	Sha256            string `yaml:"sha256"`
-	PackageSubVersion string `yaml:"packageSubVersion,omitempty"`
+	Name                string            `yaml:"name"`
+	DisplayName         string            `yaml:"displayName"`
+	Path                string            `yaml:"path"`
+	Domain              string            `yaml:"domain"`
+	Version             string            `yaml:"version"`
+	Sha256              string            `yaml:"sha256"`
+	PackageSubVersion   string            `yaml:"packageSubVersion,omitempty"`
+	SkipVersionOverride bool              `yaml:"skipVersionOverride,omitempty"`
+	Env                 map[string]string `yaml:"env,omitempty"`
 }

--- a/hack/packages/package-tools/cmd/repo-bundle-generate.go
+++ b/hack/packages/package-tools/cmd/repo-bundle-generate.go
@@ -91,7 +91,8 @@ func generatePackageBundlesSha256(projectRootDir, localRegistry string) error {
 		return fmt.Errorf("repository not found %s", packageRepository)
 	}
 
-	for i, pkg := range repository.Packages {
+	for i := range repository.Packages {
+		pkg := repository.Packages[i]
 		formattedVer := formatVersion(&repository.Packages[i], "_")
 		packagePath := filepath.Join(projectRootDir, "packages", pkg.Name)
 		toolsBinDir := filepath.Join(projectRootDir, constants.ToolsBinDirPath)

--- a/hack/packages/package-tools/cmd/repo-bundle-generate.go
+++ b/hack/packages/package-tools/cmd/repo-bundle-generate.go
@@ -96,7 +96,7 @@ func generatePackageBundlesSha256(projectRootDir, localRegistry string) error {
 		packagePath := filepath.Join(projectRootDir, "packages", pkg.Name)
 		toolsBinDir := filepath.Join(projectRootDir, constants.ToolsBinDirPath)
 
-		if err := utils.RunMakeTarget(packagePath, "configure-package"); err != nil {
+		if err := utils.RunMakeTarget(packagePath, "configure-package", getEnvArrayFromMap(pkg.Env)...); err != nil {
 			return err
 		}
 

--- a/hack/packages/package-tools/cmd/repo-bundle-generate.go
+++ b/hack/packages/package-tools/cmd/repo-bundle-generate.go
@@ -228,7 +228,7 @@ func generateRepoBundle(projectRootDir string) error {
 
 func generatePackageCR(projectRootDir, toolsBinDir, registry, packageArtifactDirectory, packageValuesFile string, pkg *Package) error {
 	// package values file
-	fmt.Printf("Generating Package CR for package %q...\n", pkg.Name)
+	fmt.Printf("Generating Package CR for package '%s:%s'...\n", pkg.Name, pkg.Version)
 	if err := utils.CreateDir(filepath.Join(packageArtifactDirectory, pkg.Name+"."+pkg.Domain)); err != nil {
 		return err
 	}

--- a/hack/packages/package-tools/utils/utils.go
+++ b/hack/packages/package-tools/utils/utils.go
@@ -34,10 +34,12 @@ func CreateDir(path string) error {
 }
 
 // RunMakeTarget runs a make target
-func RunMakeTarget(path, target string) error {
+func RunMakeTarget(path, target string, envArray ...string) error {
 	cmd := exec.Command("make", "-C", path, target)
 	var errBytes bytes.Buffer
 	cmd.Stderr = &errBytes
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, envArray...)
 	err := cmd.Run()
 	if err != nil {
 		return fmt.Errorf("couldn't run the make target %s: %s", target, errBytes.String())

--- a/hack/packages/templates/repo-utils/package-cr-overlay.yaml
+++ b/hack/packages/templates/repo-utils/package-cr-overlay.yaml
@@ -5,9 +5,10 @@
 #@ package_repository = get_package_repository(data.values.packageRepository, data.values.packageName)
 #@ package = get_package(package_repository, data.values.packageName)
 #@ packageSpec = get_package_spec(package_repository, package)
+#@ skipVersionOverride = hasattr(package, "skipVersionOverride") and package.skipVersionOverride
 
 #@ if not hasattr(package, "packageSubVersion") and data.values.subVersion == "":
-#@  if package.version == "latest":
+#@  if package.version == "latest" or skipVersionOverride:
 #@    packageVersion = data.values.version
 #@  else:
 #@    packageVersion = package.version
@@ -17,7 +18,7 @@
 #@  if subVersion == "":
 #@    subVersion = package.packageSubVersion
 #@  end
-#@  if package.version == "latest":
+#@  if package.version == "latest" or skipVersionOverride:
 #@    packageVersion = data.values.version + "+" + subVersion
 #@  else:
 #@    packageVersion = package.version + "+" + subVersion
@@ -25,7 +26,7 @@
 #@ end
 
 #@ if not hasattr(package, "packageSubVersion") and data.values.subVersion == "":
-#@  if package.version == "latest":
+#@  if package.version == "latest" or skipVersionOverride:
 #@    imagePackageVersion = "v" + data.values.version
 #@  else:
 #@    imagePackageVersion = "v" + package.version
@@ -35,7 +36,7 @@
 #@  if subVersion == "":
 #@    subVersion = package.packageSubVersion
 #@  end
-#@  if package.version == "latest":
+#@  if package.version == "latest" or skipVersionOverride:
 #@    imagePackageVersion = "v" + data.values.version + "_" + subVersion
 #@  else:
 #@    imagePackageVersion = "v" + package.version + "_" + subVersion

--- a/packages/package-values.yaml
+++ b/packages/package-values.yaml
@@ -72,14 +72,41 @@ repositories:
         version: latest
         #! Gets replaced with imgpkg sha256 at build, this should be name:version
         sha256: "tkg-clusterclass:latest"
+
       - name: tkg-autoscaler
         displayName: tkg-autoscaler
         #! Relative path to package bundle
         path: packages/tkg-autoscaler
         domain: tanzu.vmware.com
-        version: latest
+        version: v1.21.0
         #! Gets replaced with imgpkg sha256 at build, this should be name:version
         sha256: "tkg-autoscaler:latest"
+        skipVersionOverride: true
+        env:
+          AUTOSCALER_IMAGE: projects-stg.registry.vmware.com\/tkg\/cluster-autoscaler:v1.21.0_vmware.1
+      - name: tkg-autoscaler
+        displayName: tkg-autoscaler
+        #! Relative path to package bundle
+        path: packages/tkg-autoscaler
+        domain: tanzu.vmware.com
+        version: v1.22.0
+        #! Gets replaced with imgpkg sha256 at build, this should be name:version
+        sha256: "tkg-autoscaler:latest"
+        skipVersionOverride: true
+        env:
+          AUTOSCALER_IMAGE: projects-stg.registry.vmware.com\/tkg\/cluster-autoscaler:v1.22.0_vmware.1
+      - name: tkg-autoscaler
+        displayName: tkg-autoscaler
+        #! Relative path to package bundle
+        path: packages/tkg-autoscaler
+        domain: tanzu.vmware.com
+        version: v1.23.0
+        #! Gets replaced with imgpkg sha256 at build, this should be name:version
+        sha256: "tkg-autoscaler:latest"
+        skipVersionOverride: true
+        env:
+          AUTOSCALER_IMAGE: projects-stg.registry.vmware.com\/tkg\/cluster-autoscaler:v1.23.0_vmware.1
+
       - name: tkg-clusterclass-docker
         displayName: tkg-clusterclass-docker
         #! Relative path to package bundle

--- a/packages/package-values.yaml
+++ b/packages/package-values.yaml
@@ -72,7 +72,6 @@ repositories:
         version: latest
         #! Gets replaced with imgpkg sha256 at build, this should be name:version
         sha256: "tkg-clusterclass:latest"
-
       - name: tkg-autoscaler
         displayName: tkg-autoscaler
         #! Relative path to package bundle
@@ -106,7 +105,6 @@ repositories:
         skipVersionOverride: true
         env:
           AUTOSCALER_IMAGE: projects-stg.registry.vmware.com\/tkg\/cluster-autoscaler:v1.23.0_vmware.1
-
       - name: tkg-clusterclass-docker
         displayName: tkg-clusterclass-docker
         #! Relative path to package bundle

--- a/packages/tkg-autoscaler/Makefile
+++ b/packages/tkg-autoscaler/Makefile
@@ -1,6 +1,10 @@
 # Copyright 2022 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+include ../../common.mk
+
 configure-package: ## Configure package before creating the package
+	sed -e 's/\IMAGE/${AUTOSCALER_IMAGE}/' values.template.yaml > bundle/config/zz_generated_values.yaml
 
 reset-package: ## Reset configured package
+	rm bundle/config/zz_generated_values.yaml | true

--- a/packages/tkg-autoscaler/bundle/config/upstream/tkg-autoscaler.yaml
+++ b/packages/tkg-autoscaler/bundle/config/upstream/tkg-autoscaler.yaml
@@ -23,7 +23,6 @@
 #@   return args
 #@ end
 
-#@ if data.values.TKG_CLUSTER_ROLE == "workload" and data.values.PROVIDER_TYPE != "tkg-service-vsphere":
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -43,7 +42,7 @@ spec:
         app: #@ "{}-cluster-autoscaler".format(data.values.CLUSTER_NAME)
     spec:
       containers:
-        - image: tkg-autoscaler:latest
+        - image: #@ data.values.autoscaler_image
           name: #@ "{}-cluster-autoscaler".format(data.values.CLUSTER_NAME)
           volumeMounts:
             - name: #@ autoscaler_volume_name()
@@ -208,4 +207,3 @@ rules:
       - get
       - update
 
-#@ end

--- a/packages/tkg-autoscaler/bundle/config/values.yaml
+++ b/packages/tkg-autoscaler/bundle/config/values.yaml
@@ -5,7 +5,7 @@
 
 #! User configurable values for tkg-autoscaler
 
-CLUSTER_NAME:
+CLUSTER_NAME: ""
 NAMESPACE:
 AUTOSCALER_MAX_NODES_TOTAL: "0"
 AUTOSCALER_SCALE_DOWN_DELAY_AFTER_ADD: "10m"

--- a/packages/tkg-autoscaler/values.template.yaml
+++ b/packages/tkg-autoscaler/values.template.yaml
@@ -1,0 +1,5 @@
+#@data/values
+#@overlay/match-child-defaults missing_ok=True
+
+---
+autoscaler_image: IMAGE


### PR DESCRIPTION
### What this PR does / why we need it
- Support building multiple packages of different version
- Updated `tkg-autoscaler` package to support building different version of same package with different autoscaler image

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2580

### Describe testing done for PR

#### Building package repository and deploying the package repository 
1. Build and publish all management packages
```
$ export OCI_REGISTRY=gcr.io/eminent-nation-87317/tkg/test24
$ make package-push-bundles-repo PACKAGE_REPOSITORY=management 
```
3. Create a bootstrap kind cluster and install kapp-controller to the cluster
4. Install management package repository to the cluster
```
$ tanzu package repository update tanzu-management --create --url gcr.io/eminent-nation-87317/tkg/test24/management:v0.23.0-dev
```
5. Verify the installed packages on the cluster.
```
~ $ kubectl get package -A
NAMESPACE   NAME                                                      PACKAGEMETADATA NAME                           VERSION      AGE
default     addons-manager.tanzu.vmware.com.0.23.0-dev                addons-manager.tanzu.vmware.com                0.23.0-dev   3s
default     cliplugins.tanzu.vmware.com.0.23.0-dev                    cliplugins.tanzu.vmware.com                    0.23.0-dev   3s
default     featuregates.tanzu.vmware.com.0.23.0-dev                  featuregates.tanzu.vmware.com                  0.23.0-dev   3s
default     framework.tanzu.vmware.com.0.23.0-dev                     framework.tanzu.vmware.com                     0.23.0-dev   3s
default     tanzu-auth.tanzu.vmware.com.0.23.0-dev                    tanzu-auth.tanzu.vmware.com                    0.23.0-dev   3s
default     tkg-autoscaler.tanzu.vmware.com.1.21.0                    tkg-autoscaler.tanzu.vmware.com                1.21.0       3s
default     tkg-autoscaler.tanzu.vmware.com.1.22.0                    tkg-autoscaler.tanzu.vmware.com                1.22.0       3s
default     tkg-autoscaler.tanzu.vmware.com.1.23.0                    tkg-autoscaler.tanzu.vmware.com                1.23.0       3s
default     tkg-clusterclass-aws.tanzu.vmware.com.0.23.0-dev          tkg-clusterclass-aws.tanzu.vmware.com          0.23.0-dev   3s
default     tkg-clusterclass-azure.tanzu.vmware.com.0.23.0-dev        tkg-clusterclass-azure.tanzu.vmware.com        0.23.0-dev   3s
default     tkg-clusterclass-docker.tanzu.vmware.com.0.23.0-dev       tkg-clusterclass-docker.tanzu.vmware.com       0.23.0-dev   3s
default     tkg-clusterclass-vsphere.tanzu.vmware.com.0.23.0-dev      tkg-clusterclass-vsphere.tanzu.vmware.com      0.23.0-dev   3s
default     tkg-clusterclass.tanzu.vmware.com.0.23.0-dev              tkg-clusterclass.tanzu.vmware.com              0.23.0-dev   3s
default     tkg.tanzu.vmware.com.0.23.0-dev                           tkg.tanzu.vmware.com                           0.23.0-dev   3s
default     tkr-aws-machine-webhook.tanzu.vmware.com.0.23.0-dev       tkr-aws-machine-webhook.tanzu.vmware.com       0.23.0-dev   3s
default     tkr-azure-machine-webhook.tanzu.vmware.com.0.23.0-dev     tkr-azure-machine-webhook.tanzu.vmware.com     0.23.0-dev   3s
default     tkr-docker-machine-webhook.tanzu.vmware.com.0.23.0-dev    tkr-docker-machine-webhook.tanzu.vmware.com    0.23.0-dev   3s
default     tkr-service.tanzu.vmware.com.0.23.0-dev                   tkr-service.tanzu.vmware.com                   0.23.0-dev   3s
default     tkr-source-controller.tanzu.vmware.com.0.23.0-dev         tkr-source-controller.tanzu.vmware.com         0.23.0-dev   3s
default     tkr-vsphere-machine-webhook.tanzu.vmware.com.0.23.0-dev   tkr-vsphere-machine-webhook.tanzu.vmware.com   0.23.0-dev   3s
```
6. Verified the output has 3 different versions of tkg-autoscaler package.

#### Building a single package
```
$ make package-bundle PACKAGE_NAME=tkg-autoscaler
.
.
cd hack/packages/package-tools && go run main.go package-bundle generate tkg-autoscaler --thick --version=v0.23.0-dev --sub-version= --registry=gcr.io/eminent-nation-87317/tkg/test25
Generating "tkg-autoscaler" package bundle...
Including thick tarball...
Generating Package CR for package 'tkg-autoscaler:v1.21.0'...
Including thick tarball...
Generating Package CR for package 'tkg-autoscaler:v1.22.0'...
Including thick tarball...
Generating Package CR for package 'tkg-autoscaler:v1.23.0'...
```
```
$ make package-bundle PACKAGE_NAME=tkg-autoscaler PACKAGE_VERSION=v1.22.0
.
.
cd hack/packages/package-tools && go run main.go package-bundle generate tkg-autoscaler --thick --version=v0.23.0-dev --sub-version= --registry=gcr.io/eminent-nation-87317/tkg/test25
Generating "tkg-autoscaler" package bundle...
Including thick tarball...
Generating Package CR for package 'tkg-autoscaler:v1.22.0'...
```


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support building and publishing multiple versions of specific package as part of package repository
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
