### PR TITLE
TKGS Validation changes for cluster class use case

### DIFF
--- a/pkg/v1/tkg/client/cluster.go
+++ b/pkg/v1/tkg/client/cluster.go
@@ -104,9 +104,11 @@ func (c *TkgClient) CreateCluster(options *CreateClusterOptions, waitForCluster 
 		return false, errors.Wrap(err, "error determining Tanzu Kubernetes Cluster service for vSphere management cluster ")
 	}
 	if isPacific {
-		err := c.ValidatePacificVersionWithCLI(regionalClusterClient)
-		if err != nil {
-			return false, err
+		if !options.IsInputFileClusterClassBased {
+			err := c.ValidatePacificVersionWithCLI(regionalClusterClient)
+			if err != nil {
+				return false, err
+			}
 		}
 		return true, c.createPacificCluster(options, waitForCluster)
 	}

--- a/pkg/v1/tkg/client/get_kubernetes_versions_test.go
+++ b/pkg/v1/tkg/client/get_kubernetes_versions_test.go
@@ -4,7 +4,6 @@
 package client_test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -44,10 +43,13 @@ var _ = Describe("Unit tests for GetTanzuKubernetesReleases", func() {
 				regionalClusterClient.GetPacificTKCAPIVersionReturns("fake-api-versions", nil)
 				tkrInfo, err = tkgClient.DoGetTanzuKubernetesReleases(regionalClusterClient)
 			})
-			It("should return error", func() {
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Only %q Tanzu Kubernetes Cluster API version is supported by current version of Tanzu CLI", constants.DefaultPacificClusterAPIVersion)))
-			})
+			/*
+				TODO: (chandrareddyp) we need revisit below API Version validation, for now we disabled it.
+				It("should return error", func() {
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Only %q Tanzu Kubernetes Cluster API version is supported by current version of Tanzu CLI", constants.DefaultPacificClusterAPIVersion)))
+				})
+			*/
 		})
 		Context("When vSphere with Kubernetes does not support tanzukuberenetesrelease objects", func() {
 			JustBeforeEach(func() {

--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -1481,14 +1481,17 @@ func (c *TkgClient) EncodeAWSCredentialsAndGetClient(clusterClient clusterclient
 
 // ValidatePacificVersionWithCLI validate Pacific TKC API version with cli version
 func (c *TkgClient) ValidatePacificVersionWithCLI(regionalClusterClient clusterclient.Client) error {
-	tkcAPIVersion, err := regionalClusterClient.GetPacificTKCAPIVersion()
-	if err != nil {
-		return errors.Wrap(err, "error determining the Tanzu Kubernetes Cluster API version")
-	}
-	if tkcAPIVersion != constants.DefaultPacificClusterAPIVersion {
-		return errors.Errorf("Only %q Tanzu Kubernetes Cluster API version is supported by current version of Tanzu CLI. Please upgrade 'Tanzu Kubernetes Cluster service for vSphere' to latest version if you are using older version",
-			constants.DefaultPacificClusterAPIVersion)
-	}
+	/*
+		TODO: (chandrareddyp) we need revisit below API Version validation, for now we disabled it.
+		tkcAPIVersion, err := regionalClusterClient.GetPacificTKCAPIVersion()
+		if err != nil {
+			return errors.Wrap(err, "error determining the Tanzu Kubernetes Cluster API version")
+		}
+		if tkcAPIVersion != constants.DefaultPacificClusterAPIVersion {
+			return errors.Errorf("Only %q Tanzu Kubernetes Cluster API version is supported by current version of Tanzu CLI. Please upgrade 'Tanzu Kubernetes Cluster service for vSphere' to latest version if you are using older version",
+				constants.DefaultPacificClusterAPIVersion)
+		}
+	*/
 	return nil
 }
 

--- a/pkg/v1/tkg/constants/cluster_internal.go
+++ b/pkg/v1/tkg/constants/cluster_internal.go
@@ -9,8 +9,8 @@ const (
 	KindCluster                = "Cluster"
 	KindTanzuKubernetesCluster = "TanzuKubernetesCluster"
 	KindClusterClass           = "ClusterClass"
-	CCFeature                  = "clusterclass"
-	TKGSClusterClassNamespace  = "vmware-system-capw"
+	CCFeature                  = "vmware-system-tkg-clusterclass"
+	TKGSClusterClassNamespace  = "vmware-system-tkg"
 	TKGStkcapiNamespace        = "vmware-system-tkg"
 
 	PacificGCMControllerDeployment = "vmware-system-tkg-controller-manager"

--- a/pkg/v1/tkg/tkgctl/create_cluster.go
+++ b/pkg/v1/tkg/tkgctl/create_cluster.go
@@ -4,8 +4,6 @@
 package tkgctl
 
 import (
-	"context"
-	"fmt"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -57,14 +55,11 @@ func (t *tkgctl) CreateCluster(cc CreateClusterOptions) error {
 	if cc.GenerateOnly {
 		return t.ConfigCluster(cc)
 	}
-	isInputFileClusterClassBased := false
-	isTKGSCluster := false
-	var err error
-	isInputFileClusterClassBased, err = t.processWorkloadClusterInputFile(&cc)
+	isTKGSCluster, err := t.tkgClient.IsPacificManagementCluster()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "unable to determine if management cluster is on vSphere with Tanzu")
 	}
-	isTKGSCluster, err = t.processManagementClusterForTKGSCluster(isInputFileClusterClassBased)
+	isInputFileClusterClassBased, err := t.processWorkloadClusterInputFile(&cc, isTKGSCluster)
 	if err != nil {
 		return err
 	}
@@ -155,45 +150,50 @@ func (t *tkgctl) processManagementClusterInputFile(ir *InitRegionOptions) (bool,
 	return isInputFileClusterClassBased, nil
 }
 
-func (t *tkgctl) processWorkloadClusterInputFile(cc *CreateClusterOptions) (bool, error) {
+func (t *tkgctl) processWorkloadClusterInputFile(cc *CreateClusterOptions, isTKGSCluster bool) (bool, error) {
 	var clusterobj unstructured.Unstructured
 	var err error
 	isInputFileClusterClassBased := false
-
 	if t.tkgClient.IsFeatureActivated(config.FeatureFlagPackageBasedLCM) {
 		isInputFileClusterClassBased, clusterobj, err = t.checkIfInputFileIsClusterClassBased(cc.ClusterConfigFile)
 		if err != nil {
 			return isInputFileClusterClassBased, err
 		}
 		if isInputFileClusterClassBased {
-			err = t.processClusterObjectForConfigurationVariables(clusterobj)
-			if err != nil {
-				return isInputFileClusterClassBased, err
+			if isTKGSCluster {
+				t.TKGConfigReaderWriter().Set(constants.ConfigVariableClusterName, clusterobj.GetName())
+				t.TKGConfigReaderWriter().Set(constants.ConfigVariableNamespace, clusterobj.GetNamespace())
+			} else {
+				err = t.processClusterObjectForConfigurationVariables(clusterobj)
+				if err != nil {
+					return isInputFileClusterClassBased, err
+				}
 			}
 			t.overrideClusterOptionsWithLatestEnvironmentConfigurationValues(cc)
 		}
 	}
+	err = t.validateTKGSClusterClassFeatureGate(isInputFileClusterClassBased, isTKGSCluster)
+	if err != nil {
+		return isInputFileClusterClassBased, err
+	}
 	return isInputFileClusterClassBased, nil
 }
 
-func (t *tkgctl) processManagementClusterForTKGSCluster(isInputFileClusterClassBased bool) (bool, error) {
-	isTKGSCluster, err := t.tkgClient.IsPacificManagementCluster()
-	if err != nil {
-		return isTKGSCluster, errors.Wrap(err, "unable to determine if management cluster is on vSphere with Tanzu")
-	}
-
-	if t.tkgClient.IsFeatureActivated(config.FeatureFlagPackageBasedLCM) {
-		if isInputFileClusterClassBased && isTKGSCluster {
+// validateTKGSClusterClassFeatureGate validates the TKGS clusterclass feature gate state
+func (t *tkgctl) validateTKGSClusterClassFeatureGate(isInputFileClusterClassBased, isTKGSCluster bool) error {
+	/*
+		// TODO (chandrareddyp): We have disabled it because the feature gate is not fully implemented in TKGS
+		if t.tkgClient.IsFeatureActivated(config.FeatureFlagPackageBasedLCM) && isInputFileClusterClassBased && isTKGSCluster {
 			isFeatureActivated, err := t.featureGateHelper.FeatureActivatedInNamespace(context.Background(), constants.CCFeature, constants.TKGSClusterClassNamespace)
 			if err != nil {
-				return isTKGSCluster, errors.Wrap(err, fmt.Sprintf("error while checking feature '%v' status in namespace '%v'", constants.CCFeature, constants.TKGSClusterClassNamespace))
+				return errors.Wrap(err, fmt.Sprintf("error while checking feature '%v' status in namespace '%v'", constants.CCFeature, constants.TKGSClusterClassNamespace))
 			}
 			if !isFeatureActivated {
-				return isTKGSCluster, fmt.Errorf("vSphere with Tanzu environment detected, however, the feature '%v' is not activated in '%v' namespace ", constants.CCFeature, constants.TKGSClusterClassNamespace)
+				return fmt.Errorf("vSphere with Tanzu environment detected, however, the feature '%v' is not activated in '%v' namespace ", constants.CCFeature, constants.TKGSClusterClassNamespace)
 			}
 		}
-	}
-	return isTKGSCluster, nil
+	*/
+	return nil
 }
 
 func (t *tkgctl) getCreateClusterOptions(name string, cc *CreateClusterOptions, isInputFileClusterClassBased bool) (client.CreateClusterOptions, error) {

--- a/pkg/v1/tkg/tkgctl/create_cluster_test.go
+++ b/pkg/v1/tkg/tkgctl/create_cluster_test.go
@@ -247,7 +247,7 @@ var _ = Describe("Unit tests for (AWS)  cluster_aws.yaml as input file for 'tanz
 			// Process input cluster yaml file, this should process input cluster yaml file
 			// and update the environment with legacy name and values
 			// most of cluster yaml attributes are mapped to legacy variable for more look this - constants.ClusterToLegacyVariablesMapAws
-			IsInputFileClusterClassBased, err := ctl.processWorkloadClusterInputFile(&options)
+			IsInputFileClusterClassBased, err := ctl.processWorkloadClusterInputFile(&options, false)
 			Expect(IsInputFileClusterClassBased).Should(BeTrue())
 			Expect(err).To(BeNil())
 
@@ -324,7 +324,7 @@ var _ = Describe("Unit tests for (AWS)  cluster_aws.yaml as input file for 'tanz
 			// and update the environment with legacy name and values
 			// most of cluster yaml attributes are mapped to legacy variable for more look this - constants.ClusterToLegacyVariablesMapAws
 			options.ClusterConfigFile = clusterInputFileMultipleObjectsAws
-			IsInputFileClusterClassBased, err := ctl.processWorkloadClusterInputFile(&options)
+			IsInputFileClusterClassBased, err := ctl.processWorkloadClusterInputFile(&options, false)
 			Expect(IsInputFileClusterClassBased).Should(BeTrue())
 			Expect(err).To(BeNil())
 
@@ -349,33 +349,33 @@ var _ = Describe("Unit tests for (AWS)  cluster_aws.yaml as input file for 'tanz
 			// and update the environment with legacy name and values
 			// most of cluster.yaml attributes are mapped to legacy variable for more look this - constants.clusterToLegacyVariablesMapAws
 			options.ClusterConfigFile = classInputFileAwsEmptyClass
-			_, err := ctl.processWorkloadClusterInputFile(&options)
+			_, err := ctl.processWorkloadClusterInputFile(&options, false)
 			Expect(fmt.Sprint(err)).To(Equal(constants.TopologyClassIncorrectValueErrMsg))
 		})
 
 		It("When Input file is aws clusterclass.yaml file, but in-correct spec.topology.class name:", func() {
 			options.ClusterConfigFile = classInputFileAwsIncorrectClass
-			IsInputFileClusterClassBased, err := ctl.processWorkloadClusterInputFile(&options)
+			IsInputFileClusterClassBased, err := ctl.processWorkloadClusterInputFile(&options, false)
 			Expect(IsInputFileClusterClassBased).Should(BeTrue())
 			Expect(fmt.Sprint(err)).To(Equal(constants.TopologyClassIncorrectValueErrMsg))
 		})
 
 		It("When Input file is config.yaml file not cluster.yaml file", func() {
 			options.ClusterConfigFile = inputFileLegacy
-			IsInputFileClusterClassBased, err := ctl.processWorkloadClusterInputFile(&options)
+			IsInputFileClusterClassBased, err := ctl.processWorkloadClusterInputFile(&options, false)
 			Expect(IsInputFileClusterClassBased).Should(BeFalse())
 			Expect(err).To(BeNil())
 		})
 
 		It("When Input file is not specified, return an error", func() {
 			options.ClusterConfigFile = ""
-			IsInputFileClusterClassBased, _ := ctl.processWorkloadClusterInputFile(&options)
+			IsInputFileClusterClassBased, _ := ctl.processWorkloadClusterInputFile(&options, false)
 			Expect(IsInputFileClusterClassBased).Should(BeFalse())
 		})
 
 		It("When Input file not exists, return an error", func() {
 			options.ClusterConfigFile = "NOT-EXISTS"
-			_, err := ctl.processWorkloadClusterInputFile(&options)
+			_, err := ctl.processWorkloadClusterInputFile(&options, false)
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -418,7 +418,7 @@ var _ = Describe("Unit tests for - (Vsphere) - cluster_vsphere.yaml as input fil
 			// Process input cluster.yaml file, this should process input cluster.yaml file
 			// and update the environment with legacy name and values
 			// most of cluster.yaml attributes are mapped to legacy variable for more look this - constants.ClusterToLegacyVariablesMapVsphere
-			IsInputFileClusterClassBased, err := ctl.processWorkloadClusterInputFile(&options)
+			IsInputFileClusterClassBased, err := ctl.processWorkloadClusterInputFile(&options, false)
 			Expect(IsInputFileClusterClassBased).Should(BeTrue())
 			Expect(err).To(BeNil())
 
@@ -522,7 +522,7 @@ var _ = Describe("Unit tests for - (Azure) - cluster_azure.yaml as input file fo
 			// Process input cluster yaml file, this should process input cluster yaml file
 			// and update the environment with legacy name and values
 			// most of cluster yaml attributes are mapped to legacy variable for more look this - constants.ClusterToLegacyVariablesMapAzure
-			IsInputFileClusterClassBased, err := ctl.processWorkloadClusterInputFile(&options)
+			IsInputFileClusterClassBased, err := ctl.processWorkloadClusterInputFile(&options, false)
 			Expect(IsInputFileClusterClassBased).Should(BeTrue())
 			Expect(err).To(BeNil())
 
@@ -645,67 +645,71 @@ var _ = Describe("Unit tests for feature flag (config.FeatureFlagPackageBasedLCM
 			cname, _ := tkgctlClient.tkgConfigReaderWriter.Get("CLUSTER_NAME")
 			Expect(cname).To(Equal(""))
 		})
-		It("When Feature 'clusterclass' is disabled in featuregate, return error", func() {
-			kubeConfigPath := getConfigFilePath()
-			regionContext := region.RegionContext{
-				ContextName:    "queen-anne-context",
-				SourceFilePath: kubeConfigPath,
-			}
+		/*
+			TODO: (chandrareddyp) enable this test cases once the TKGS fixes feature gate issues
+			It("When Feature 'clusterclass' is disabled in featuregate, return error", func() {
+				kubeConfigPath := getConfigFilePath()
+				regionContext := region.RegionContext{
+					ContextName:    "queen-anne-context",
+					SourceFilePath: kubeConfigPath,
+				}
 
-			tkgClient = &fakes.Client{}
-			tkgClient.IsPacificManagementClusterReturnsOnCall(0, true, nil)
-			tkgClient.GetCurrentRegionContextReturns(regionContext, nil)
-			tkgClient.IsFeatureActivatedReturns(true)
-			tkgClient.CreateClusterReturnsOnCall(0, false, nil)
-			options.ClusterConfigFile = classInputFileAzure
-			tkgConfigReaderWriter, _ := tkgconfigreaderwriter.NewReaderWriterFromConfigFile(configFilePath, configFilePath)
-			fg := &fakes.FakeFeatureGateHelper{}
-			fg.FeatureActivatedInNamespaceReturns(false, nil)
-			tkgctlClient := &tkgctl{
-				configDir:              testingDir,
-				tkgClient:              tkgClient,
-				kubeconfig:             kubeConfigPath,
-				tkgConfigReaderWriter:  tkgConfigReaderWriter,
-				tkgConfigUpdaterClient: tkgconfigupdater.New(testingDir, nil, tkgConfigReaderWriter),
-				featureGateHelper:      fg,
-			}
-			// feature flag (config.FeatureFlagPackageBasedLCM) activated, its clusterclass input file, but "clusterclass" feature in FeatureGate is disabled, so throws error
-			err := tkgctlClient.CreateCluster(options)
-			expectedErrMsg := "vSphere with Tanzu environment detected, however, the feature 'clusterclass' is not activated in 'vmware-system-capw' namespace "
-			Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
-		})
+				tkgClient = &fakes.Client{}
+				tkgClient.IsPacificManagementClusterReturnsOnCall(0, true, nil)
+				tkgClient.GetCurrentRegionContextReturns(regionContext, nil)
+				tkgClient.IsFeatureActivatedReturns(true)
+				tkgClient.CreateClusterReturnsOnCall(0, false, nil)
+				options.ClusterConfigFile = classInputFileAzure
+				tkgConfigReaderWriter, _ := tkgconfigreaderwriter.NewReaderWriterFromConfigFile(configFilePath, configFilePath)
+				fg := &fakes.FakeFeatureGateHelper{}
+				fg.FeatureActivatedInNamespaceReturns(false, nil)
+				tkgctlClient := &tkgctl{
+					configDir:              testingDir,
+					tkgClient:              tkgClient,
+					kubeconfig:             kubeConfigPath,
+					tkgConfigReaderWriter:  tkgConfigReaderWriter,
+					tkgConfigUpdaterClient: tkgconfigupdater.New(testingDir, nil, tkgConfigReaderWriter),
+					featureGateHelper:      fg,
+				}
+				// feature flag (config.FeatureFlagPackageBasedLCM) activated, its clusterclass input file, but "clusterclass" feature in FeatureGate is disabled, so throws error
+				err := tkgctlClient.CreateCluster(options)
+				expectedErrMsg := "vSphere with Tanzu environment detected, however, the feature 'clusterclass' is not activated in 'vmware-system-capw' namespace "
+				Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
+			})
 
-		It("When featuregate api it self throws error", func() {
-			kubeConfigPath := getConfigFilePath()
-			regionContext := region.RegionContext{
-				ContextName:    "queen-anne-context",
-				SourceFilePath: kubeConfigPath,
-			}
 
-			tkgClient = &fakes.Client{}
-			tkgClient.IsPacificManagementClusterReturnsOnCall(0, true, nil)
-			tkgClient.GetCurrentRegionContextReturns(regionContext, nil)
-			tkgClient.IsFeatureActivatedReturns(true)
-			tkgClient.CreateClusterReturnsOnCall(0, false, nil)
-			options.ClusterConfigFile = classInputFileAzure
-			tkgConfigReaderWriter, _ := tkgconfigreaderwriter.NewReaderWriterFromConfigFile(configFilePath, configFilePath)
-			fg := &fakes.FakeFeatureGateHelper{}
-			errorMsg := "error while feature status in featuregate"
-			fg.FeatureActivatedInNamespaceReturns(true, fmt.Errorf(errorMsg))
-			tkgctlClient := &tkgctl{
-				configDir:              testingDir,
-				tkgClient:              tkgClient,
-				kubeconfig:             kubeConfigPath,
-				tkgConfigReaderWriter:  tkgConfigReaderWriter,
-				tkgConfigUpdaterClient: tkgconfigupdater.New(testingDir, nil, tkgConfigReaderWriter),
-				featureGateHelper:      fg,
-			}
-			// feature flag (config.FeatureFlagPackageBasedLCM) activated, its clusterclass config input file, but "clusterclass" feature in FeatureGate is enabled,
-			// but throws error for the FeatureGate api, so we expect error here.
-			err := tkgctlClient.CreateCluster(options)
-			// as FeatureGate api throws error, we expect error.
-			Expect(err.Error()).To(ContainSubstring(errorMsg))
-		})
+			It("When featuregate api it self throws error", func() {
+				kubeConfigPath := getConfigFilePath()
+				regionContext := region.RegionContext{
+					ContextName:    "queen-anne-context",
+					SourceFilePath: kubeConfigPath,
+				}
+
+				tkgClient = &fakes.Client{}
+				tkgClient.IsPacificManagementClusterReturnsOnCall(0, true, nil)
+				tkgClient.GetCurrentRegionContextReturns(regionContext, nil)
+				tkgClient.IsFeatureActivatedReturns(true)
+				tkgClient.CreateClusterReturnsOnCall(0, false, nil)
+				options.ClusterConfigFile = classInputFileAzure
+				tkgConfigReaderWriter, _ := tkgconfigreaderwriter.NewReaderWriterFromConfigFile(configFilePath, configFilePath)
+				fg := &fakes.FakeFeatureGateHelper{}
+				errorMsg := "error while feature status in featuregate"
+				fg.FeatureActivatedInNamespaceReturns(true, fmt.Errorf(errorMsg))
+				tkgctlClient := &tkgctl{
+					configDir:              testingDir,
+					tkgClient:              tkgClient,
+					kubeconfig:             kubeConfigPath,
+					tkgConfigReaderWriter:  tkgConfigReaderWriter,
+					tkgConfigUpdaterClient: tkgconfigupdater.New(testingDir, nil, tkgConfigReaderWriter),
+					featureGateHelper:      fg,
+				}
+				// feature flag (config.FeatureFlagPackageBasedLCM) activated, its clusterclass config input file, but "clusterclass" feature in FeatureGate is enabled,
+				// but throws error for the FeatureGate api, so we expect error here.
+				err := tkgctlClient.CreateCluster(options)
+				// as FeatureGate api throws error, we expect error.
+				Expect(err.Error()).To(ContainSubstring(errorMsg))
+			})
+		*/
 	})
 })
 


### PR DESCRIPTION
### What this PR does / why we need it
It disables the legacy validation for the TKGS workload cluster creation if the input config file is cluster class based. 
Also, it disables the TKC Version validation with the CLI version for TKGS legacy cluster creation.
### Which issue(s) this PR fixes

Fixes #

### Describe testing done for PR
Create TKGS workload cluster with Cluster Class yaml file
`tanzu cluster create -f TKGSCluster.yaml`

Create TKGS workload cluster with legacy config file
`tanzu cluster create -f legacyConfig.yaml --tkr TKR-version-In-TKGS-Cluster`

### Release note

```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
