### PR TITLE
Add Sync period bootstrap packages on the workload cluster on workload cluster

### DIFF
--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -693,6 +693,7 @@ func (r *ClusterBootstrapReconciler) createOrPatchPackageInstallOnRemote(cluster
 
 	_, err = controllerutil.CreateOrPatch(r.context, clusterClient, remotePkgi, func() error {
 		remotePkgi.Spec.ServiceAccountName = r.Config.PkgiServiceAccount
+		remotePkgi.Spec.SyncPeriod = &metav1.Duration{Duration: r.Config.PkgiSyncPeriod}
 		// remotePackageRefName and remotePackageVersion are fetched from the Package CR on remote cluster.
 		remotePkgi.Spec.PackageRef = &kapppkgiv1alpha1.PackageRef{
 			RefName: remotePackageRefName,

--- a/addons/controllers/clusterbootstrap_controller_test.go
+++ b/addons/controllers/clusterbootstrap_controller_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	kapppkgiv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	kapppkgv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"

--- a/addons/controllers/clusterbootstrap_controller_test.go
+++ b/addons/controllers/clusterbootstrap_controller_test.go
@@ -12,7 +12,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	kapppkgiv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apis/packaging/v1alpha1"
 	kapppkgv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
@@ -471,6 +470,7 @@ var _ = Describe("ClusterBootstrap Reconciler", func() {
 					return true
 				}, waitTimeout, pollingInterval).Should(BeTrue())
 				Expect(remotePkgi.Spec.PackageRef.RefName).To(Equal(pkg.Spec.RefName))
+				Expect(remotePkgi.Spec.SyncPeriod.Seconds()).To(Equal(constants.PackageInstallSyncPeriod.Seconds()))
 				Expect(len(remotePkgi.Spec.Values)).NotTo(BeZero())
 				Expect(remotePkgi.Spec.Values[0].SecretRef.Name).To(Equal(util.GenerateDataValueSecretName(cluster.Name, pkg.Spec.RefName)))
 				Expect(remotePkgi.Annotations).ShouldNot(BeNil())


### PR DESCRIPTION
### What this PR does / why we need it
- Add Sync period bootstrap packages on the workload cluster on workload cluster
- Updated the test for verifying this

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1677 

### Describe testing done for PR

Tested on mgmt cluster for kapp-controller:
```
apiVersion: packaging.carvel.dev/v1alpha1
kind: PackageInstall
metadata:
  annotations:
    tkg.tanzu.vmware.com/cluster-name: wc-cluster-jun6
    tkg.tanzu.vmware.com/cluster-namespace: default
  creationTimestamp: "2022-06-06T19:55:06Z"
  finalizers:
  - finalizers.packageinstall.packaging.carvel.dev/delete
  generation: 2
  name: wc-cluster-jun6-kapp-controller
  namespace: default
  ownerReferences:
  - apiVersion: cluster.x-k8s.io/v1beta1
    kind: Cluster
    name: wc-cluster-jun6
    uid: b90b0f93-863c-4a38-b566-2bb9e6487a50
  resourceVersion: "1138134"
  uid: 540a0dc4-a75a-4f75-90e0-067c8dc9b473
spec:
  cluster:
    kubeconfigSecretRef:
      key: value
      name: wc-cluster-jun6-kubeconfig
  noopDelete: true
  packageRef:
    refName: kapp-controller.tanzu.vmware.com
    versionSelection:
      constraints: 0.34.0+vmware.1-tkg.1-zshippable
      prereleases: {}
  syncPeriod: 5m0s
  values:
  - secretRef:
      name: wc-cluster-jun6-kapp-controller-data-values

```

Tested on workload cluster for antrea:
```
apiVersion: packaging.carvel.dev/v1alpha1
kind: PackageInstall
metadata:
  annotations:
    tkg.tanzu.vmware.com/cluster-name: wc-cluster-jun8
    tkg.tanzu.vmware.com/cluster-namespace: default
  creationTimestamp: "2022-06-09T01:57:52Z"
  finalizers:
  - finalizers.packageinstall.packaging.carvel.dev/delete
  generation: 1
  name: wc-cluster-jun8-antrea
  namespace: tkg-system
  resourceVersion: "1462"
  uid: 60aabe20-7d28-4519-b8c3-d8c78efe3d37
spec:
  packageRef:
    refName: antrea.tanzu.vmware.com
    versionSelection:
      constraints: 1.5.2+vmware.3-tkg.1-advanced-zshippable
      prereleases: {}
  serviceAccountName: tanzu-cluster-bootstrap-sa
  syncPeriod: 5m0s
  values:
  - secretRef:
      name: wc-cluster-jun8-antrea-data-values
```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
