### PR TITLE
kubeconfig generation logic respects new <cluster-name>-<cluster-uuid> audience format

### DIFF
--- a/cmd/cli/plugin/cluster/kubeconfig_get.go
+++ b/cmd/cli/plugin/cluster/kubeconfig_get.go
@@ -97,7 +97,11 @@ func getPinnipedKubeconfig(tkgctlClient tkgctl.TKGClient, workloadClusterName st
 	}
 
 	// for workload cluster the audience would be set to the clustername
+	// ...unless we have specified the audience in the pinniped-info CM
 	audience := clusterPinnipedInfo.ClusterName
+	if clusterPinnipedInfo.PinnipedInfo.Data.ConciergeAudience != nil {
+		audience = *clusterPinnipedInfo.PinnipedInfo.Data.ConciergeAudience
+	}
 
 	kubeconfig, err := tkgauth.GetPinnipedKubeconfig(clusterPinnipedInfo.ClusterInfo, clusterPinnipedInfo.PinnipedInfo,
 		clusterPinnipedInfo.ClusterName, audience)

--- a/pkg/v1/tkg/client/get_cluster_pinniped_info.go
+++ b/pkg/v1/tkg/client/get_cluster_pinniped_info.go
@@ -92,6 +92,7 @@ func (c *TkgClient) GetWCClusterPinnipedInfo(regionalClusterClient clusterclient
 	if workloadClusterPinnipedInfo != nil {
 		// Get ConciergeIsClusterScoped from workload cluster in case it is different from the management cluster
 		pinnipedInfo.Data.ConciergeIsClusterScoped = workloadClusterPinnipedInfo.Data.ConciergeIsClusterScoped
+		pinnipedInfo.Data.ConciergeAudience = workloadClusterPinnipedInfo.Data.ConciergeAudience
 	} else {
 		// If workloadClusterPinnipedInfo is nil, assume it is an older TKG cluster and set ConciergeIsClusterScoped to defaults
 		pinnipedInfo.Data.ConciergeIsClusterScoped = false

--- a/pkg/v1/tkg/client/get_cluster_pinniped_info_test.go
+++ b/pkg/v1/tkg/client/get_cluster_pinniped_info_test.go
@@ -55,6 +55,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 		issuerCA                          string
 		conciergeIsClusterScoped          bool
 		conciergeIsClusterScopedWLCluster bool
+		conciergeAudience                 string
 		servCert                          *x509.Certificate
 		clusterPinnipedInfo               *ClusterPinnipedInfo
 	)
@@ -363,6 +364,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 				issuerCA = fakeCAData
 				conciergeIsClusterScoped = false
 				conciergeIsClusterScopedWLCluster = true
+				conciergeAudience = "some-concierge-audience"
 				pinnipedInfo = fakehelper.GetFakePinnipedInfo(fakehelper.PinnipedInfo{
 					ClusterName:              mgmtClusterName,
 					Issuer:                   issuer,
@@ -371,6 +373,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 				})
 				pinnipedInfoWorkloadCluster := fakehelper.GetFakePinnipedInfo(fakehelper.PinnipedInfo{
 					ConciergeIsClusterScoped: conciergeIsClusterScopedWLCluster,
+					ConciergeAudience:        &conciergeAudience,
 				})
 				searchNamespace = constants.DefaultNamespace
 				// create a fake controller-runtime cluster with the []runtime.Object mentioned with createClusterOptions
@@ -396,6 +399,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.Issuer).To(Equal(issuer))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.IssuerCABundle).To(Equal(issuerCA))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.ConciergeIsClusterScoped).To(Equal(conciergeIsClusterScopedWLCluster))
+				Expect(clusterPinnipedInfo.PinnipedInfo.Data.ConciergeAudience).To(Equal(&conciergeAudience))
 			})
 		})
 	})

--- a/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
+++ b/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
@@ -552,10 +552,11 @@ func GetFakeClusterInfo(server string, cert *x509.Certificate) string {
 
 // PinnipedInfo contains settings for the supervisor.
 type PinnipedInfo struct {
-	ClusterName              string `json:"cluster_name"`
-	Issuer                   string `json:"issuer"`
-	IssuerCABundleData       string `json:"issuer_ca_bundle_data"`
-	ConciergeIsClusterScoped bool   `json:"concierge_is_cluster_scoped,string"`
+	ClusterName              string  `json:"cluster_name"`
+	Issuer                   string  `json:"issuer"`
+	IssuerCABundleData       string  `json:"issuer_ca_bundle_data"`
+	ConciergeIsClusterScoped bool    `json:"concierge_is_cluster_scoped,string"`
+	ConciergeAudience        *string `json:"concierge_audience,omitempty"`
 }
 
 // GetFakePinnipedInfo returns the pinniped-info configmap

--- a/pkg/v1/tkg/utils/kubeconfig.go
+++ b/pkg/v1/tkg/utils/kubeconfig.go
@@ -23,10 +23,11 @@ type PinnipedConfigMapInfo struct {
 	Kind    string `json:"kind" yaml:"kind"`
 	Version string `json:"apiVersion" yaml:"apiVersion"`
 	Data    struct {
-		ClusterName              string `json:"cluster_name" yaml:"cluster_name"`
-		Issuer                   string `json:"issuer" yaml:"issuer"`
-		IssuerCABundle           string `json:"issuer_ca_bundle_data" yaml:"issuer_ca_bundle_data"`
-		ConciergeIsClusterScoped bool   `json:"concierge_is_cluster_scoped,string" yaml:"concierge_is_cluster_scoped"`
+		ClusterName              string  `json:"cluster_name" yaml:"cluster_name"`
+		Issuer                   string  `json:"issuer" yaml:"issuer"`
+		IssuerCABundle           string  `json:"issuer_ca_bundle_data" yaml:"issuer_ca_bundle_data"`
+		ConciergeIsClusterScoped bool    `json:"concierge_is_cluster_scoped,string" yaml:"concierge_is_cluster_scoped"`
+		ConciergeAudience        *string `json:"concierge_audience,omitempty" yaml:"concierge_audience"`
 	}
 }
 

--- a/pkg/v1/tkg/utils/kubeconfig_test.go
+++ b/pkg/v1/tkg/utils/kubeconfig_test.go
@@ -26,6 +26,7 @@ var _ = Describe("Kubeconfig Tests", func() {
 		issuer                   string
 		issuerCA                 string
 		conciergeIsClusterScoped bool
+		conciergeAudience        string
 		servCert                 *x509.Certificate
 	)
 
@@ -210,11 +211,14 @@ var _ = Describe("Kubeconfig Tests", func() {
 				issuer = "https://fakeissuer.com"
 				issuerCA = "fakeCAData"
 				conciergeIsClusterScoped = false
+				conciergeAudience = "some-concierge-audience"
 				pinnipedInfo := fakehelper.GetFakePinnipedInfo(fakehelper.PinnipedInfo{
 					ClusterName:              clustername,
 					Issuer:                   issuer,
 					IssuerCABundleData:       issuerCA,
-					ConciergeIsClusterScoped: conciergeIsClusterScoped})
+					ConciergeIsClusterScoped: conciergeIsClusterScoped,
+					ConciergeAudience:        &conciergeAudience,
+				})
 				tlsserver.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
@@ -232,6 +236,7 @@ var _ = Describe("Kubeconfig Tests", func() {
 				Expect(gotPinnipedInfo.Data.Issuer).Should(Equal(issuer))
 				Expect(gotPinnipedInfo.Data.IssuerCABundle).Should(Equal(issuerCA))
 				Expect(gotPinnipedInfo.Data.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
+				Expect(gotPinnipedInfo.Data.ConciergeAudience).Should(Equal(&conciergeAudience))
 			})
 		})
 	})


### PR DESCRIPTION
### What this PR does / why we need it
```
    Kubeconfig generation follows <name>-<uuid> audience format

    Currently, we use a workload cluster's name as its audience, and then we tell
    Pinniped to issue tokens with that audience for that workload cluster. We want
    to move to using both the workload cluster's name and its uuid for its audience
    to support systems that allow workload clusters to have the same name as long as
    they exist in separate namespaces.

    This implementation optionally discovers a workload cluster's audience from its
    pinniped-info ConfigMap. If there is no audience, then we fall back to old
    behavior (using just the workload cluster's name as the audience).

    Signed-off-by: Andrew Keesler <akeesler@vmware.com>
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

None

### Describe testing done for PR

* Created a TKGm environment via `/test install-vc7` and ensured that I could authenticate to 1) old workload clusters with audience format `<cluster-name>` and 2) new workload clusters with audience format `<cluster-name>-<cluster-uuid>` (using https://github.com/vmware-tanzu/tanzu-framework/pull/2551 and https://github.com/vmware-tanzu/community-edition/pull/4721)

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

None

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
None