### PR TITLE
Convert the user provided values to appropriate type before generating values file for TKG package

### DIFF
--- a/pkg/v1/tkg/client/management_components.go
+++ b/pkg/v1/tkg/client/management_components.go
@@ -105,7 +105,7 @@ func (c *TkgClient) InstallOrUpgradeManagementComponents(kubeconfig, kubecontext
 }
 
 func (c *TkgClient) getTKGPackageConfigValuesFile(managementPackageVersion, kubeconfig, kubecontext string, upgrade bool) (string, error) {
-	var userProviderConfigValues map[string]string
+	var userProviderConfigValues map[string]interface{}
 	var err error
 
 	if upgrade {
@@ -126,7 +126,7 @@ func (c *TkgClient) getTKGPackageConfigValuesFile(managementPackageVersion, kube
 	return valuesFile, nil
 }
 
-func (c *TkgClient) getUserConfigVariableValueMap() (map[string]string, error) {
+func (c *TkgClient) getUserConfigVariableValueMap() (map[string]interface{}, error) {
 	path, err := c.tkgConfigPathsClient.GetConfigDefaultsFilePath()
 	if err != nil {
 		return nil, err
@@ -135,7 +135,7 @@ func (c *TkgClient) getUserConfigVariableValueMap() (map[string]string, error) {
 	return c.GetUserConfigVariableValueMap(path, c.TKGConfigReaderWriter())
 }
 
-func (c *TkgClient) getUserConfigVariableValueMapForUpgrade(kubeconfig, kubecontext string) (map[string]string, error) {
+func (c *TkgClient) getUserConfigVariableValueMapForUpgrade(kubeconfig, kubecontext string) (map[string]interface{}, error) {
 	clusterClient, err := clusterclient.NewClient(kubeconfig, kubecontext, clusterclient.Options{})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get cluster client")
@@ -282,7 +282,7 @@ func GetKappControllerConfigValuesFile(userConfigValuesFile, kappControllerValue
 // file to provide a source of keys to filter for the valid user provided values.
 // For example, this function uses config_default.yaml filepath to find relevant config variables
 // and returns the config map of user provided variable among all applicable config variables
-func (c *TkgClient) GetUserConfigVariableValueMap(configDefaultFilePath string, rw tkgconfigreaderwriter.TKGConfigReaderWriter) (map[string]string, error) {
+func (c *TkgClient) GetUserConfigVariableValueMap(configDefaultFilePath string, rw tkgconfigreaderwriter.TKGConfigReaderWriter) (map[string]interface{}, error) {
 	bytes, err := os.ReadFile(configDefaultFilePath)
 	if err != nil {
 		return nil, err
@@ -293,10 +293,10 @@ func (c *TkgClient) GetUserConfigVariableValueMap(configDefaultFilePath string, 
 		return nil, err
 	}
 
-	userProvidedConfigValues := map[string]string{}
+	userProvidedConfigValues := map[string]interface{}{}
 	for _, k := range variables {
 		if v, e := rw.Get(k); e == nil {
-			userProvidedConfigValues[k] = v
+			userProvidedConfigValues[k] = utils.Convert(v)
 		}
 	}
 

--- a/pkg/v1/tkg/client/management_components_test.go
+++ b/pkg/v1/tkg/client/management_components_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Unit tests for GetUserConfigVariableValueMap", func() {
 		tkgClient                *TkgClient
 		configFilePath           string
 		configFileData           string
-		userProviderConfigValues map[string]string
+		userProviderConfigValues map[string]interface{}
 		rw                       tkgconfigreaderwriter.TKGConfigReaderWriter
 	)
 
@@ -32,6 +32,10 @@ var _ = Describe("Unit tests for GetUserConfigVariableValueMap", func() {
 ---
 ABC:
 PQR: ""
+Test1:
+Test2:
+Test3:
+Test4:
 `
 	sampleConfigFileData2 := ``
 
@@ -49,11 +53,19 @@ PQR: ""
 		BeforeEach(func() {
 			configFileData = sampleConfigFileData1
 			rw.Set("ABC", "abc-value")
+			rw.Set("Test1", "true")
+			rw.Set("Test2", "null")
+			rw.Set("Test3", "1")
+			rw.Set("Test4", "1.2")
 		})
 		It("returns userProviderConfigValues with ABC", func() {
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(userProviderConfigValues)).To(Equal(1))
+			Expect(len(userProviderConfigValues)).To(Equal(5))
 			Expect(userProviderConfigValues["ABC"]).To(Equal("abc-value"))
+			Expect(userProviderConfigValues["Test1"]).To(Equal(true))
+			Expect(userProviderConfigValues["Test2"]).To(BeNil())
+			Expect(userProviderConfigValues["Test3"]).To(Equal(uint64(1)))
+			Expect(userProviderConfigValues["Test4"]).To(Equal(1.2))
 		})
 	})
 

--- a/pkg/v1/tkg/managementcomponents/helper.go
+++ b/pkg/v1/tkg/managementcomponents/helper.go
@@ -21,7 +21,7 @@ const (
 )
 
 // GetTKGPackageConfigValuesFileFromUserConfig returns values file from user configuration
-func GetTKGPackageConfigValuesFileFromUserConfig(managementPackageVersion string, userProviderConfigValues map[string]string) (string, error) {
+func GetTKGPackageConfigValuesFileFromUserConfig(managementPackageVersion string, userProviderConfigValues map[string]interface{}) (string, error) {
 	// TODO: Temporary hack(hard coded values) to configure TKR source controller package values. This should be replaced with the logic
 	// that fetches these values from tkg-bom(for bom related urls) and set the TKR source controller package values
 	var tkrRepoImagePath string
@@ -37,7 +37,7 @@ func GetTKGPackageConfigValuesFileFromUserConfig(managementPackageVersion string
 
 	tkgPackageConfig := TKGPackageConfig{
 		Metadata: Metadata{
-			InfraProvider: userProviderConfigValues[constants.ConfigVariableProviderType],
+			InfraProvider: userProviderConfigValues[constants.ConfigVariableProviderType].(string),
 		},
 		ConfigValues: userProviderConfigValues,
 		FrameworkPackage: FrameworkPackage{

--- a/pkg/v1/tkg/managementcomponents/management_component_install_test.go
+++ b/pkg/v1/tkg/managementcomponents/management_component_install_test.go
@@ -11,9 +11,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/managementcomponents"
-
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/managementcomponents"
 )
 
 func Test(t *testing.T) {

--- a/pkg/v1/tkg/managementcomponents/types.go
+++ b/pkg/v1/tkg/managementcomponents/types.go
@@ -6,7 +6,7 @@ package managementcomponents
 // TKGPackageConfig defines TKG package configuration
 type TKGPackageConfig struct {
 	Metadata                     Metadata                     `yaml:"metadata"`
-	ConfigValues                 map[string]string            `yaml:"configvalues"`
+	ConfigValues                 map[string]interface{}       `yaml:"configvalues"`
 	FrameworkPackage             FrameworkPackage             `yaml:"frameworkPackage"`
 	ClusterClassPackage          ClusterClassPackage          `yaml:"clusterclassPackage"`
 	TKRSourceControllerPackage   TKRSourceControllerPackage   `yaml:"tkrSourceControllerPackage"`

--- a/pkg/v1/tkg/utils/converter.go
+++ b/pkg/v1/tkg/utils/converter.go
@@ -1,0 +1,63 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+func Convert(in string) interface{} {
+	convs := []yamlScalarConvertable{
+		nullConvertable,
+		integerConvertable,
+		booleanConvertable,
+		floatConvertable,
+		structuredConvertable,
+	}
+
+	for _, conv := range convs {
+		value, convertable := conv(in)
+		if convertable {
+			return value
+		}
+	}
+	return in
+}
+
+type yamlScalarConvertable func(in string) (interface{}, bool)
+
+func structuredConvertable(in string) (interface{}, bool) {
+	var result interface{}
+	if err := yaml.Unmarshal([]byte(in), &result); err == nil && result != nil {
+		return result, true
+	}
+	return result, false
+}
+
+func nullConvertable(in string) (interface{}, bool) {
+	return nil, (in == "~" || in == "null")
+}
+
+func booleanConvertable(in string) (interface{}, bool) {
+	if v, err := strconv.ParseBool(in); err == nil {
+		return v, true
+	}
+	return false, false
+}
+
+func integerConvertable(in string) (interface{}, bool) {
+	if v, err := strconv.ParseUint(in, 0, 0); err == nil {
+		return v, true
+	}
+	return 0, false
+}
+
+func floatConvertable(in string) (interface{}, bool) {
+	if v, err := strconv.ParseFloat(in, 64); err == nil {
+		return v, true
+	}
+	return 0, false
+}

--- a/pkg/v1/tkg/utils/converter_test.go
+++ b/pkg/v1/tkg/utils/converter_test.go
@@ -1,0 +1,51 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/utils"
+)
+
+var _ = Describe("Test Converter function Tests", func() {
+	Context("Test conversion with string types", func() {
+		It("Should return the expected output", func() {
+			Expect(Convert("abc")).To(Equal("abc"))
+			Expect(Convert("pqr")).To(Equal("pqr"))
+			Expect(Convert("a")).To(Equal("a"))
+		})
+	})
+
+	Context("Test conversion with int types", func() {
+		It("Should return the expected output", func() {
+			Expect(Convert("1")).To(Equal(uint64(1)))
+			Expect(Convert("22")).To(Equal(uint64(22)))
+			Expect(Convert("100")).To(Equal(uint64(100)))
+		})
+	})
+
+	Context("Test conversion with boolean types", func() {
+		It("Should return the expected output", func() {
+			Expect(Convert("true")).To(Equal(true))
+			Expect(Convert("false")).To(Equal(false))
+			Expect(Convert("True")).To(Equal(true))
+			Expect(Convert("False")).To(Equal(false))
+		})
+	})
+
+	Context("Test conversion with null value", func() {
+		It("Should return the expected output", func() {
+			Expect(Convert("null")).To(BeNil())
+		})
+	})
+
+	Context("Test conversion with float value", func() {
+		It("Should return the expected output", func() {
+			Expect(Convert("1.2")).To(Equal(1.2))
+			Expect(Convert("100.212")).To(Equal(100.212))
+		})
+	})
+})


### PR DESCRIPTION
### What this PR does / why we need it

Convert the user provided values to appropriate type before generating values file for TKG package

- This change will convert the user-provided values to appropriate type
  for creating TKG package values file so that userprovidedvalues gets
  propagated correctly to the ClusterClass

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2609

### Describe testing done for PR

- Create AWS management-cluster with `package-based-lcm` feature-flag enabled
- Pass `BASTION_HOST_ENABLED: "true"` as part of clusterconfig file
- Verify that the packages gets installed correctly
- Verify the content of `secret` named `tkg-clusterclass-infra-values` has `BASTION_HOST_ENABLED: true` without quotes
```
$ kubectl get secret/tkg-clusterclass-infra-values -n tkg-system -ojson | jq '.data."values.yaml"' |  tr -d '"' | base64 -d
.
AWS_AMI_ID: ami-0f4f2a28ec92c7aff
AWS_NODE_AZ: us-west-2a
AWS_PRIVATE_NODE_CIDR: ""
AWS_PRIVATE_SUBNET_ID: subnet-008e7fead36b71f3d
AWS_PUBLIC_NODE_CIDR: ""
AWS_PUBLIC_SUBNET_ID: subnet-0ae6b7a92953d00fe
AWS_REGION: us-west-2
AWS_SSH_KEY_NAME: tkgtest
AWS_VPC_CIDR: ""
AWS_VPC_ID: vpc-07ce38addc21aa1d0
BASTION_HOST_ENABLED: true
BUILD_EDITION: tkg
CLUSTER_CIDR: 100.96.0.0/11
CLUSTER_NAME: aws-mc-46
CLUSTER_PLAN: dev
CNI: antrea
CONTROL_PLANE_MACHINE_TYPE: t3.xlarge
CORE_DNS_IP: 100.64.0.10
INFRASTRUCTURE_PROVIDER: aws
KUBERNETES_RELEASE: v1.23.5---vmware.1-tkg.1-zshippable
KUBERNETES_VERSION: v1.23.5+vmware.1
NODE_MACHINE_TYPE: t3.xlarge
OS_ARCH: amd64
OS_NAME: ubuntu
OS_VERSION: 20.04
PROVIDER_TYPE: aws
SERVICE_CIDR: 100.64.0.0/13
TKG_CLUSTER_ROLE: management
TKG_DEFAULT_BOM: tkg-bom-v1.6.0-zshippable.yaml
TKG_HTTP_PROXY: ""
TKG_HTTPS_PROXY: ""
TKG_NO_PROXY: ""
TKG_VERSION: v1.6.0-zshippable
WORKER_MACHINE_COUNT: 1
WORKER_MACHINE_COUNT_0: 1
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Convert the user provided values to appropriate type before generating values file for TKG package
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
