### PR TITLE
CB controller should ignore clusters tied to a TKR with legacy-tkr label

### DIFF
--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -170,6 +170,11 @@ func (r *ClusterBootstrapReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
+	if _, labelFound := tkr.Labels[constants.TKRLableLegacyClusters]; labelFound {
+		log.Info("Skipping reconciling due to tkr label", "name", tkrName, "label", constants.TKRLableLegacyClusters)
+		return ctrl.Result{}, nil
+	}
+
 	log.Info("Reconciling cluster")
 
 	// if deletion timestamp is set, handle cluster deletion

--- a/addons/controllers/clusterbootstrap_controller_test.go
+++ b/addons/controllers/clusterbootstrap_controller_test.go
@@ -924,6 +924,22 @@ var _ = Describe("ClusterBootstrap Reconciler", func() {
 		})
 	})
 
+	When("Legacy cluster is created", func() {
+		BeforeEach(func() {
+			clusterName = "test-cluster-legacy"
+			clusterNamespace = "legacy-namespace"
+			clusterResourceFilePath = "testdata/test-cluster-legacy.yaml"
+		})
+		Context("and clusterboostrap template does not exists", func() {
+			It("clusterbootstrap controller should not attempt to reconcile it", func() {
+				By("verifying CAPI cluster is created properly")
+				cluster := &clusterapiv1beta1.Cluster{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: clusterNamespace, Name: clusterName}, cluster)).To(Succeed())
+				cluster.Status.Phase = string(clusterapiv1beta1.ClusterPhaseProvisioned)
+				Expect(k8sClient.Status().Update(ctx, cluster)).To(Succeed())
+			})
+		})
+	})
 })
 
 func assertSecretContains(ctx context.Context, k8sClient client.Client, namespace, name string, secretContent map[string][]byte) {

--- a/addons/controllers/testdata/test-cluster-legacy.yaml
+++ b/addons/controllers/testdata/test-cluster-legacy.yaml
@@ -1,0 +1,69 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: legacy-namespace
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: test-cluster-legacy
+  namespace: legacy-namespace
+  labels:
+    tkg.tanzu.vmware.com/cluster-name: test-cluster-legacy
+    run.tanzu.vmware.com/tkr: v1.12.1
+spec:
+  infrastructureRef:
+    kind: VSphereCluster
+  clusterNetwork:
+    pods:
+      cidrBlocks: [ "192.168.0.0/16","fd00:100:96::/48" ]
+    services:
+      cidrBlocks: [ "192.168.0.0/16","fd00:100:96::/48" ]
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: test-cluster-legacy-control-plane
+    namespace: legacy-namespace
+  topology:
+    class: test-clusterclass-legasy
+    version: v1.22.3
+    variables:
+      - name: tkg.tanzu.vmware.com/tkg-ip-family
+        value: "ipv4"
+      - name: proxy
+        value:
+          httpProxy: "foo.com"
+          httpsProxy: "bar.com"
+          noProxy: "foobar.com"
+      - name: trust
+        value:
+          additionalTrustedCAs:
+            - name: CompanyInternalCA-1
+              data: aGVsbG8=
+            - name: CompanyInternalCA-2
+              data: bHWtcH9=
+      - name: skipTLSVerify
+        value:
+          - registry1
+          - registry2
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: test-cluster-legacy-control-plane
+  namespace: legacy-namespace
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      kind: Cluster
+      name: test-cluster-legacy
+      uid: bd834522-d9a5-4841-beac-991ff3798c01
+spec:
+  kubeadmConfigSpec: {}
+  machineTemplate:
+    infrastructureRef: {}
+  replicas: 3
+  version: v1.22.3
+
+
+

--- a/addons/controllers/testdata/test-tkg-system-ns-resources.yaml
+++ b/addons/controllers/testdata/test-tkg-system-ns-resources.yaml
@@ -23,6 +23,20 @@ spec:
   osImages: []
   bootstrapPackages: []
 ---
+  apiVersion: run.tanzu.vmware.com/v1alpha3
+  kind: TanzuKubernetesRelease
+  metadata:
+    name: v1.12.1
+    labels:
+      run.tanzu.vmware.com/legacy-tkr: ""
+  spec:
+    version: v1.12.1
+    kubernetes:
+      version: v1.12.1
+      imageRepository: foo
+    osImages: [ ]
+    bootstrapPackages: [ ]
+---
 apiVersion: run.tanzu.vmware.com/v1alpha3
 kind: ClusterBootstrapTemplate
 metadata:

--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -35,6 +35,9 @@ const (
 	// TKRLabelClassyClusters is the TKR label for the clusters created using cluster-class
 	TKRLabelClassyClusters = "run.tanzu.vmware.com/tkr"
 
+	// TKRLabelLegacyClusters is the TKR label for legacy clusters
+	TKRLableLegacyClusters = "run.tanzu.vmware.com/legacy-tkr"
+
 	// TKGBomContent is the TKG BOM content.
 	TKGBomContent = "bomContent"
 


### PR DESCRIPTION
Addons manager needs to only process TKRs which do NOT
 have "run.tanzu.vmware.com/legacy-tkr" label

Fixes #2546


### Describe testing done for PR

Locally run debugger and run unit tests to verify cluster with label is skipped. 
CI/CD

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Ignore clusters tied to TKR with legacy tkr label
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
