### PR TITLE
Support 'tanzu cluster kubeconfig get' with a vSphere Supervisor

### DIFF
--- a/cmd/cli/plugin/cluster/kubeconfig_get.go
+++ b/cmd/cli/plugin/cluster/kubeconfig_get.go
@@ -96,8 +96,11 @@ func getPinnipedKubeconfig(tkgctlClient tkgctl.TKGClient, workloadClusterName st
 		return err
 	}
 
-	// for workload cluster the audience would be set to the clustername
+	// For (legacy) workload clusters, the audience is just <cluster-name>
 	audience := clusterPinnipedInfo.ClusterName
+	if clusterPinnipedInfo.ClusterAudience != nil {
+		audience = *clusterPinnipedInfo.ClusterAudience
+	}
 
 	kubeconfig, err := tkgauth.GetPinnipedKubeconfig(clusterPinnipedInfo.ClusterInfo, clusterPinnipedInfo.PinnipedInfo,
 		clusterPinnipedInfo.ClusterName, audience)

--- a/pkg/v1/tkg/client/get_cluster_pinniped_info.go
+++ b/pkg/v1/tkg/client/get_cluster_pinniped_info.go
@@ -4,10 +4,13 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
+	"github.com/aunum/log"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
@@ -51,12 +54,12 @@ func (c *TkgClient) GetClusterPinnipedInfo(options GetClusterPinnipedInfoOptions
 	if err != nil {
 		return nil, errors.Wrap(err, "error determining 'Tanzu Kubernetes Cluster service for vSphere' management cluster")
 	}
-	if isPacific {
-		// XXX: Override this path? (is there existing work to remove these pacific specific conditionals?)
-		return nil, errors.New("getting pinniped information not supported for 'Tanzu Kubernetes Cluster service for vSphere' cluster")
+	if isPacific && options.IsManagementCluster {
+		return nil, errors.New("getting pinniped information not supported for 'Tanzu Kubernetes Cluster service for vSphere' management cluster")
 	}
 
 	if options.IsManagementCluster {
+		// XXX See if anything needs to be fixed here. Or do we want to leave this unsupported?
 		return c.GetMCClusterPinnipedInfo(regionalClusterClient, curRegion, options)
 	}
 
@@ -71,18 +74,33 @@ func (c *TkgClient) GetWCClusterPinnipedInfo(regionalClusterClient clusterclient
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get workload cluster information")
 	}
-	// for workload cluster pinniped-info should be available on management cluster
-	mcClusterInfo, err := getClusterInfo(regionalClusterClient, curRegion.ClusterName, TKGsystemNamespace)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get management cluster information")
-	}
-	managementClusterPinnipedInfo, err := utils.GetPinnipedInfoFromCluster(mcClusterInfo, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get pinniped-info from management cluster")
-	}
-	if managementClusterPinnipedInfo == nil {
+
+	// The existing PinnipedInfoConfigMap struct is a marshalled form of a
+	// ConfigMap. Marshal and unmarshal the raw CM into that struct so we can
+	// use it.
+	// TODO(mayankbh) This is a shorter term approach. The _right_ thing might
+	// be to significantly refactor the PinnipedConfigMapInfo struct so it can
+	// be constructed from an existing ConfigMap.
+	configMap := corev1.ConfigMap{}
+
+	if err := regionalClusterClient.GetResource(&configMap, utils.PinnipedInfoConfigMapName, utils.KubePublicNamespace, nil, nil); err != nil {
 		return nil, errors.New("failed to get pinniped-info from management cluster")
 	}
+
+	log.Debugf("Management cluster pinniped ConfigMap: %+v", configMap)
+
+	marshalledCM, err := json.Marshal(configMap)
+	if err != nil {
+		return nil, errors.New("failed to marshal pinniped-info from management cluster")
+	}
+
+	managementClusterPinnipedInfo := &utils.PinnipedConfigMapInfo{}
+
+	if err := json.Unmarshal(marshalledCM, managementClusterPinnipedInfo); err != nil {
+		return nil, errors.New("failed to unmarshal pinniped-info from management cluster")
+	}
+
+	log.Debugf("Management cluster pinniped info: %+v", managementClusterPinnipedInfo)
 
 	workloadClusterPinnipedInfo, err := utils.GetPinnipedInfoFromCluster(wcClusterInfo, nil)
 	if err != nil {

--- a/pkg/v1/tkg/client/get_cluster_pinniped_info_test.go
+++ b/pkg/v1/tkg/client/get_cluster_pinniped_info_test.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -57,6 +58,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 		conciergeIsClusterScopedWLCluster bool
 		servCert                          *x509.Certificate
 		clusterPinnipedInfo               *ClusterPinnipedInfo
+		isPacific                         bool
 	)
 
 	var (
@@ -126,7 +128,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 			BeforeEach(func() {
 				// create a fake controller-runtime cluster with the []runtime.Object mentioned with createClusterOptions
 				fakeClientSet = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(
-					createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, "invalid kubeconfig")...).Build()
+					createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, "invalid kubeconfig")...).Build()
 			})
 			It("should return an error", func() {
 				Expect(err).To(HaveOccurred())
@@ -137,7 +139,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 			BeforeEach(func() {
 				// create a fake controller-runtime cluster with the []runtime.Object mentioned with createClusterOptions
 				fakeClientSet = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(
-					createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, readFile(kubeconfig))...).Build()
+					createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, readFile(kubeconfig))...).Build()
 				tlsServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
@@ -165,7 +167,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 				})
 				// create a fake controller-runtime cluster with the []runtime.Object mentioned with createClusterOptions
 				fakeClientSet = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(
-					createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, readFile(kubeconfig))...).Build()
+					createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, readFile(kubeconfig))...).Build()
 				tlsServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
@@ -176,6 +178,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 			It("should return the cluster pinniped information successfully", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(clusterPinnipedInfo.ClusterName).To(Equal(mgmtClusterName))
+				Expect(clusterPinnipedInfo.ClusterAudience).To(BeNil())
 				Expect(clusterPinnipedInfo.ClusterInfo.Server).To(Equal(endpoint))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.Issuer).To(Equal(issuer))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.IssuerCABundle).To(Equal(issuerCA))
@@ -200,7 +203,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 				Namespace:           constants.DefaultNamespace,
 				IsManagementCluster: false,
 			}
-			clusterPinnipedInfo, err = tkgClient.GetWCClusterPinnipedInfo(regionalClusterClient, region, options)
+			clusterPinnipedInfo, err = tkgClient.GetWCClusterPinnipedInfo(regionalClusterClient, region, options, isPacific)
 		})
 
 		Context("When workload cluster is not found", func() {
@@ -218,7 +221,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 				searchNamespace = constants.DefaultNamespace
 				// create a fake controller-runtime cluster with the []runtime.Object mentioned with createClusterOptions
 				fakeClientSet = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(
-					createFakeClusterRefObjects("fake-workload-cluster", searchNamespace, endpoint, "invalid kubeconfig")...).Build()
+					createFakeClusterRefObjects("fake-workload-cluster", searchNamespace, "some-uid", endpoint, "invalid kubeconfig")...).Build()
 			})
 			It("should return an error", func() {
 				Expect(err).To(HaveOccurred())
@@ -229,8 +232,8 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 		Context("When management cluster pinniped-info configmap is not present in kube-public namespace", func() {
 			BeforeEach(func() {
 				var clusterRefs []runtime.Object
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", wlClusterEndpoint, readFile(wlKubeconfig))...)
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, readFile(kubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", "some-uid", wlClusterEndpoint, readFile(wlKubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, "some-uid", searchNamespace, endpoint, readFile(kubeconfig))...)
 				searchNamespace = constants.DefaultNamespace
 				// create a fake controller-runtime cluster with the []runtime.Object mentioned with createClusterOptions
 				fakeClientSet = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(clusterRefs...).Build()
@@ -250,8 +253,8 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 		Context("When WL cluster pinniped-info configmap is not present in kube-public namespace", func() {
 			BeforeEach(func() {
 				var clusterRefs []runtime.Object
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", wlClusterEndpoint, readFile(wlKubeconfig))...)
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, readFile(kubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", "some-uid", wlClusterEndpoint, readFile(wlKubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, readFile(kubeconfig))...)
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
 				conciergeIsClusterScoped = false
@@ -280,6 +283,7 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 			It("should not return an error and utilize management cluster pinniped info", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(clusterPinnipedInfo.ClusterName).To(Equal(wlClusterName))
+				Expect(clusterPinnipedInfo.ClusterAudience).To(BeNil())
 				Expect(clusterPinnipedInfo.ClusterInfo.Server).To(Equal(wlClusterEndpoint))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.Issuer).To(Equal(issuer))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.IssuerCABundle).To(Equal(issuerCA))
@@ -291,8 +295,8 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 		Context("When WL cluster pinniped-info configmap is present and malformed in kube-public namespace", func() {
 			BeforeEach(func() {
 				var clusterRefs []runtime.Object
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", wlClusterEndpoint, readFile(wlKubeconfig))...)
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, readFile(kubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", "some-uid", wlClusterEndpoint, readFile(wlKubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, readFile(kubeconfig))...)
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
 				conciergeIsClusterScoped = false
@@ -323,8 +327,8 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 		Context("When cluster-info and pinniped-info configmap are present in kube-public namespace", func() {
 			BeforeEach(func() {
 				var clusterRefs []runtime.Object
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", wlClusterEndpoint, readFile(wlKubeconfig))...)
-				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, endpoint, readFile(kubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", "some-uid", wlClusterEndpoint, readFile(wlKubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, readFile(kubeconfig))...)
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
 				conciergeIsClusterScoped = false
@@ -354,6 +358,54 @@ var _ = Describe("Unit tests for get cluster pinniped info", func() {
 			It("should return the cluster pinniped information successfully", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(clusterPinnipedInfo.ClusterName).To(Equal(wlClusterName))
+				Expect(clusterPinnipedInfo.ClusterAudience).To(BeNil())
+				Expect(clusterPinnipedInfo.ClusterInfo.Server).To(Equal(wlClusterEndpoint))
+				Expect(clusterPinnipedInfo.PinnipedInfo.Data.Issuer).To(Equal(issuer))
+				Expect(clusterPinnipedInfo.PinnipedInfo.Data.IssuerCABundle).To(Equal(issuerCA))
+				Expect(clusterPinnipedInfo.PinnipedInfo.Data.ConciergeIsClusterScoped).To(Equal(conciergeIsClusterScopedWLCluster))
+			})
+		})
+
+		Context("When we are talking to a pacific cluster", func() {
+			const wlClusterUID = "some-pacific-cluster-uid"
+
+			BeforeEach(func() {
+				isPacific = true
+
+				var clusterRefs []runtime.Object
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(wlClusterName, "default", wlClusterUID, wlClusterEndpoint, readFile(wlKubeconfig))...)
+				clusterRefs = append(clusterRefs, createFakeClusterRefObjects(mgmtClusterName, searchNamespace, "some-uid", endpoint, readFile(kubeconfig))...)
+				issuer = fakeIssuer
+				issuerCA = fakeCAData
+				conciergeIsClusterScoped = false
+				conciergeIsClusterScopedWLCluster = true
+				pinnipedInfoCM := fakehelper.PinnipedInfo{
+					ClusterName:              mgmtClusterName,
+					Issuer:                   issuer,
+					IssuerCABundleData:       issuerCA,
+					ConciergeIsClusterScoped: conciergeIsClusterScoped,
+				}
+				clusterRefs = append(clusterRefs, getPinnipedInfoConfigMapObjectFromPinnipedInfo(pinnipedInfoCM))
+
+				pinnipedInfoWorkloadCluster := fakehelper.GetFakePinnipedInfo(fakehelper.PinnipedInfo{
+					ConciergeIsClusterScoped: conciergeIsClusterScopedWLCluster,
+				})
+				searchNamespace = constants.DefaultNamespace
+				// create a fake controller-runtime cluster with the []runtime.Object mentioned with createClusterOptions
+				fakeClientSet = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(clusterRefs...).Build()
+
+				tlsServerWLCluster.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
+						ghttp.RespondWith(http.StatusOK, pinnipedInfoWorkloadCluster),
+					),
+				)
+			})
+			It("should return the cluster pinniped information successfully with a special audience", func() {
+				wantClusterAudience := fmt.Sprintf("%s-%s", wlClusterName, wlClusterUID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(clusterPinnipedInfo.ClusterName).To(Equal(wlClusterName))
+				Expect(clusterPinnipedInfo.ClusterAudience).To(Equal(&wantClusterAudience))
 				Expect(clusterPinnipedInfo.ClusterInfo.Server).To(Equal(wlClusterEndpoint))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.Issuer).To(Equal(issuer))
 				Expect(clusterPinnipedInfo.PinnipedInfo.Data.IssuerCABundle).To(Equal(issuerCA))
@@ -384,7 +436,7 @@ func getFakeKubeConfigFilePathWithServer(testingDir, endpoint, clustername strin
 }
 
 // TODO: Should be merged to pkg/fakes/helpers/fakeobjectcreator.go
-func createFakeClusterRefObjects(name, namespace, endpoint, kubeconfig string) []runtime.Object {
+func createFakeClusterRefObjects(name, namespace, uid, endpoint, kubeconfig string) []runtime.Object {
 	u, _ := url.Parse(endpoint)
 	host, port, _ := net.SplitHostPort(u.Host)
 	portInt32, _ := strconv.ParseInt(port, 10, 32)
@@ -398,6 +450,7 @@ func createFakeClusterRefObjects(name, namespace, endpoint, kubeconfig string) [
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			UID:       types.UID(uid),
 		},
 
 		Spec: capi.ClusterSpec{

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -187,7 +187,7 @@ type Client interface {
 	// GetCurrentClusterName returns the current clusterName based on current context from kubeconfig file
 	// If context parameter is not empty, then return clusterName corresponding to the context
 	GetCurrentClusterName(context string) (string, error)
-	// GetCurrentKubeContext returns the current kube xontext
+	// GetCurrentKubeContext returns the current kube context
 	GetCurrentKubeContext() (string, error)
 	// IsRegionalCluster() checks if the current kube context point to a management cluster
 	IsRegionalCluster() error

--- a/pkg/v1/tkg/tkgctl/interface.go
+++ b/pkg/v1/tkg/tkgctl/interface.go
@@ -86,7 +86,7 @@ type TKGClient interface {
 	// Deprecated: This would not be supported from TKR API version v1alpha3,
 	// user can use go client to set the labels to activate/deactivate the TKR
 	DeactivateTanzuKubernetesReleases(tkrName string) error
-	// IsPacificRegionalCluster checks if the cluster pointed to by kubeconfig  is Pacific management cluster(supervisor)
+	// IsPacificRegionalCluster checks if the cluster pointed to by kubeconfig is Pacific management cluster(supervisor)
 	IsPacificRegionalCluster() (bool, error)
 	// GetPacificClusterObject gets Pacific cluster object
 	GetPacificClusterObject(clusterName, namespace string) (*tkgsv1alpha2.TanzuKubernetesCluster, error)


### PR DESCRIPTION
### What this PR does / why we need it

Allow fetching the workload cluster kubeconfig in vSphere with Tanzu 
when a vSphere Supervisor is configured with Pinniped. 

The existing 'cluster kubeconfig get' code path seems to rely on
fetching the admin kubeconfig from the tkg-system namespace on the
management cluster.

Since at this point the user is already authenticated to the management
cluster (as we have a regional cluster client) we can avoid fetching the
management cluster kubeconfig by directly using the user's identity and
fetching the kube-public/pinniped-info ConfigMap.

Misc: Also add some debug logging and plumb the log level configuration
into the aunum/log global logger. I'm not super familiar with logging
conventions in this repo so I'm happy to defer to review judgement.

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/2670

### Which issue(s) this PR fixes
 
N/A

### Describe testing done for PR

Testing:

- Updated unit tests to use fake pinniped-info ConfigMaps in the fake
  client, tests still pass.
- Removed the relevant unit tests that looked for the management
cluster kubeconfig.


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

'tanzu cluster kubeconfig get' now works with a vSphere Supervisor.

```

N/A

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

N/A

#### Special notes for your reviewer

One LoC has been commented out due to a dependency on https://github.com/vmware-tanzu/tanzu-framework/pull/2539

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
