### PR TITLE
UI/CLI: Set AviControlPlaneEndpointProvider false by default

### DIFF
--- a/pkg/v1/tkg/tkgconfigproviders/vsphere.go
+++ b/pkg/v1/tkg/tkgconfigproviders/vsphere.go
@@ -83,7 +83,7 @@ type VSphereConfig struct {
 	AviLabels                          string `yaml:"AVI_LABELS"`
 	AviEnable                          string `yaml:"AVI_ENABLE"`
 	EnableAuditLogging                 string `yaml:"ENABLE_AUDIT_LOGGING"`
-	AviControlPlaneEndpointProvider    string `yaml:"AVI_CONTROL_PLANE_HA_PROVIDER"`
+	AviControlPlaneEndpointProvider    string `yaml:"AVI_CONTROL_PLANE_HA_PROVIDER,omitempty"`
 	AviManagementClusterVipNetworkName string `yaml:"AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_NAME"`
 	AviManagementClusterVipNetworkCidr string `yaml:"AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_CIDR"`
 	IDPConfig                          `yaml:",inline"`
@@ -107,6 +107,8 @@ func (c *client) NewVSphereConfig(params *models.VsphereRegionalClusterParams) (
 		ControlPlaneEndpoint: params.ControlPlaneEndpoint,
 		IPFamily:             params.IPFamily,
 		HTTPProxyEnabled:     falseConst,
+
+		AviControlPlaneEndpointProvider:    falseConst,
 	}
 	if params.Os != nil {
 		if params.Os.OsInfo != nil {
@@ -219,7 +221,6 @@ func (c *client) NewVSphereConfig(params *models.VsphereRegionalClusterParams) (
 		res.AviLabels = mapToYamlStr(params.AviConfig.Labels)
 		res.AviEnable = trueConst
 
-		res.AviControlPlaneEndpointProvider = falseConst
 		if params.AviConfig.ControlPlaneHaProvider {
 			res.AviControlPlaneEndpointProvider = trueConst
 		}


### PR DESCRIPTION
### What this PR does / why we need it
Resolves issue when configuring vsphere management cluster via UI, using default
Kube VIP would result in AviControlPlaneEndpointProvider never getting set to a
boolean value. This caused AVI_CONTROL_PLANE_HA_PROVIDER value to be written as a
blank string in the config yaml.

The fix is to add omitempty as a catch-all, but also to intialize AviControlPlaneEndpointProvider
to a boolean false value by default.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
confirmed config yaml AVI_CONTROL_PLANE_HA_PROVIDER value is written as false by default


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
none
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
