### PR TITLE
Fix temp dir creation in client_test.go

### DIFF
--- a/pkg/v1/tkg/tkgctl/client_test.go
+++ b/pkg/v1/tkg/tkgctl/client_test.go
@@ -73,14 +73,14 @@ var _ = Describe("Unit test for New", func() {
 	var (
 		err       error
 		options   Options
-		configDir *os.File
+		configDir string
 		tkgClient TKGClient
 	)
 	JustBeforeEach(func() {
-		configDir, _ = os.CreateTemp("", "cluster_client_test")
-		prepareConfiDir(configDir.Name())
+		configDir, _ = os.MkdirTemp("", "cluster_client_test")
+		prepareConfiDir(configDir)
 		options = Options{
-			ConfigDir:      configDir.Name(),
+			ConfigDir:      configDir,
 			ProviderGetter: fakeproviders.FakeProviderGetter(),
 		}
 		tkgClient, err = New(options)
@@ -107,6 +107,6 @@ var _ = Describe("Unit test for New", func() {
 	})
 
 	AfterEach(func() {
-		os.Remove(configDir.Name())
+		os.Remove(configDir)
 	})
 })


### PR DESCRIPTION
### What this PR does / why we need it

Changes were recently made to remove the use of the deprecated ioutil
module. In `pkg/v1/tkg/tkgctl/client_test.go` there was a mistake made
switching from creating a temporary directory to creating a temporary
file. This corrects that error to use the proper replacement for the
original ioutil call.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2653 

### Describe testing done for PR

Running `make test` locally.