### PR TITLE
Speed up CI builds by only building needed platform

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -63,7 +63,7 @@ jobs:
         fi
         env | sort
         make configure-bom
-        make all
+        make all ENVS=linux-amd64
 
     - name: Verify
       run: |
@@ -75,7 +75,7 @@ jobs:
           export TKG_DEFAULT_COMPATIBILITY_IMAGE_PATH=${{ steps.extract_bom.outputs.bompath }}
         fi
         make configure-bom
-        make test
+        make test ENVS=linux-amd64
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
### What this PR does / why we need it

Our GitHub actions run on x86 Linux machines, yet our current job
configuration will compile the code for all supported platforms
(linux-amd64, windows-amd64, and darwin-amd64). This build time can take
a not-insignificant amount of time for each platform, so we have a 66%
overhead. Every patch runs these checks, so that overhead time is
compounded by each PR.

Since we know what platform these actions will be run on, this updates
our main job definition to explicitly set the platform to only build for
linux-amd64.

### Describe testing done for PR

Partly this will be tested by the CI jobs run when it is submitted since it's hard to reproduce that locally. But ran individual make targets to verify it would only build the platform specified.