### PR TITLE
Remove redundant vet and fmt calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 BIN_DIR := bin
 ADDONS_DIR := addons
 YTT_TESTS_DIR := pkg/v1/providers/tests
-PACKAGE_TOOLING_DIR := hack/packages/package-tools
 PACKAGES_SCRIPTS_DIR := $(abspath hack/packages/scripts)
 UI_DIR := pkg/v1/tkg/web
 GO_MODULES=$(shell find . -path "*/go.mod" | grep -v "^./pinniped" | xargs -I _ dirname _)
@@ -152,10 +151,10 @@ help: ## Display this help (default)
 
 all: manager ui-build build-cli
 
-manager: generate fmt vet ## Build manager binary
+manager: generate ## Build manager binary
 	$(GO) build -ldflags "$(LD_FLAGS)" -o bin/manager main.go
 
-run: generate fmt vet manifests ## Run against the configured Kubernetes cluster in ~/.kube/config
+run: generate manifests ## Run against the configured Kubernetes cluster in ~/.kube/config
 	$(GO) run -ldflags "$(LD_FLAGS)" ./main.go
 
 install: manifests tools ## Install CRDs into a cluster
@@ -472,7 +471,7 @@ release-%: ## Create release for a platform
 ## --------------------------------------
 
 .PHONY: test
-test: generate fmt vet manifests build-cli-mocks ## Run tests
+test: generate manifests build-cli-mocks ## Run tests
 	## Skip running TKG integration tests
 	$(MAKE) ytt -C $(TOOLS_DIR)
 
@@ -506,9 +505,6 @@ test-cli: build-cli-mocks ## Run tests
 fmt: tools ## Run goimports
 	$(GOIMPORTS) -w -local github.com/vmware-tanzu ./
 
-vet: ## Run go vet
-	$(GO) vet ./...
-
 lint: tools go-lint doc-lint misspell yamllint ## Run linting and misspell checks
 	# Check licenses in shell scripts and Makefiles
 	hack/check-license.sh
@@ -526,9 +522,6 @@ go-lint: tools ## Run linting of go source
 		$(GOLANGCI_LINT) run -v --timeout=10m || exit 1; \
 		popd; \
 	done
-
-	# Linting for package tooling
-	cd $(PACKAGE_TOOLING_DIR); $(GOLANGCI_LINT) run -v
 
 	# Prevent use of deprecated ioutils module
 	@CHECK=$$(grep -r --include="*.go" --exclude-dir="pinniped" --exclude="zz_generated*" ioutil .); \


### PR DESCRIPTION
### What this PR does / why we need it

This removes the `vet` target as that (and more) is covered by our
golangci-lint configuration. Running vet would add a large delay, so
this speeds things up for any targets that would call that.

A few dependencies on the `fmt` target were removed where `generate` was
also listed. `generate` calls `fmt` internally at the end of its
execution, so this was just causing `fmt` to be run twice in a row.

Also cleaned up an extra golangci-lint call in the `go-lint` target.
This was in-flight at the same time that the target was updated to
automatically detect all modules, so when it merged it created a second
run for the same module.

### Describe testing done for PR

Ran `make test ENVS=darwin-amd64` locally and verified there were no errors. Further validation will be done as part of the GitHub Actions that will run when this PR is submitted.
