### PR TITLE
Package unit tests return non 0 on fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -486,7 +486,8 @@ test: generate fmt vet manifests build-cli-mocks ## Run tests
 	echo "... ytt cluster template verification complete!"
 
 	echo "Verifying package tests..."
-	find ./packages/ -name "test" -type d -exec sh -c "cd {} && $(GO) test -coverprofile coverage2.txt -v -timeout 120s  ./..." \;
+	find ./packages/ -name "test" -type d | \
+		xargs -n1  -I {} bash -c 'cd {} && PATH=$(abspath hack/tools/bin):"$(PATH)" $(GO) test -coverprofile coverage2.txt -v -timeout 120s ./...' \;
 	echo "... package tests complete!"
 
 	PATH=$(abspath hack/tools/bin):"$(PATH)" $(GO) test -coverprofile coverage3.txt -v `go list ./... | grep -v github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/test`


### PR DESCRIPTION
### What this PR does / why we need it

Package tests had been failing but the command that ran the tests were not returning non zero when tests failed. This PR causes the command that runs the tests to return non zero on failure.

### Describe testing done for PR

Running the tests with a failing assertion shows that `make test` stops and returns an error, as expected.
Running the tests without a failing assertion shows that `make test` continues onto later stages, as expeected.

Here's a snippet proving that piping to xargs will cause the back command to return non-zero
when there's a problem: 

```
$ find ./packages/ -name "test" -type d | xargs -n1  -I {} bash -c 'cd {} && /usr/bin/false' \;
$ echo $?
123
$ find ./packages/ -name "test" -type d | xargs -n1  -I {} bash -c 'cd {} && /usr/bin/true' \;
$ echo $?
0
```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
