### PR TITLE
Enable metrics for addons-manager

### DIFF
--- a/addons/main.go
+++ b/addons/main.go
@@ -99,7 +99,11 @@ type addonFlags struct {
 
 func parseAddonFlags(addonFlags *addonFlags) {
 	// controller configurations
-	flag.StringVar(&addonFlags.metricsAddr, "metrics-bind-addr", ":8080", "The address the metric endpoint binds to.")
+
+	// Bind metrics endpoint to localhost, following the pattern in cluster-api projects where they moved away from kube-rbac-proxy for just guarding metrics endpoint.
+	// see https://github.com/kubernetes-sigs/cluster-api/issues/4679 and https://github.com/kubernetes-sigs/cluster-api/issues/4325
+	// 18317 is an available port in Supervisor cluster
+	flag.StringVar(&addonFlags.metricsAddr, "metrics-bind-addr", "localhost:18317", "The address the metric endpoint binds to.")
 	flag.BoolVar(&addonFlags.enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")

--- a/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
+++ b/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
@@ -337,7 +337,7 @@ spec:
       nodeSelector: #@ data.values.tanzuAddonsManager.deployment.nodeSelector
       containers:
       - args:
-        - --metrics-bind-addr=0
+        - #@ "--metrics-bind-addr={}".format(data.values.tanzuAddonsManager.deployment.metricsBindAddress)
         - --leader-elect=false
         - #@ "--health-addr=:{}".format(data.values.tanzuAddonsManager.deployment.healthzPort)
         - #@ "--webhook-server-port={}".format(data.values.tanzuAddonsManager.deployment.webhookServerPort)

--- a/packages/addons-manager/bundle/config/values.yaml
+++ b/packages/addons-manager/bundle/config/values.yaml
@@ -12,6 +12,7 @@ tanzuAddonsManager:
     tolerations: []
     webhookServerPort: 9865
     healthzPort: 18316
+    metricsBindAddress: "localhost:18317"
   featureGates:
     clusterBootstrapController: false
     packageInstallStatus: false

--- a/packages/framework/bundle/config/values.yaml
+++ b/packages/framework/bundle/config/values.yaml
@@ -32,6 +32,7 @@ addonsManagerPackageValues:
       tolerations: []
       webhookServerPort: 9865
       healthzPort: 18316
+      metricsBindAddress: "localhost:18317"
     featureGates:
       clusterBootstrapController: false
       packageInstallStatus: false

--- a/packages/tkg/bundle/config/values.yaml
+++ b/packages/tkg/bundle/config/values.yaml
@@ -43,6 +43,7 @@ frameworkPackage:
         tolerations: []
         webhookServerPort: 9865
         healthzPort: 18316
+        metricsBindAddress: "localhost:18317"
       featureGates:
         clusterBootstrapController: false
         packageInstallStatus: false


### PR DESCRIPTION
Enable metrics for addons-manager.

Signed-off-by: Vijay Katam <vkatam@vmware.com>

### What this PR does / why we need it
Enables metrics for addons-manager. Binds to localhost similar to the approach that capi projects as part of moving away from kube-rbac-proxy https://github.com/kubernetes-sigs/cluster-api/issues/4679 and https://github.com/kubernetes-sigs/cluster-api/issues/4325

### Which issue(s) this PR fixes

Fixes #1837

### Describe testing done for PR

Tested on supervisor cluster
```
curl -ivk http://localhost:18317/metrics
*   Trying 127.0.0.1:18317...
* Connected to localhost (127.0.0.1) port 18317 (#0)
> GET /metrics HTTP/1.1
> Host: localhost:18317
> User-Agent: curl/7.82.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Content-Type: text/plain; version=0.0.4; charset=utf-8
Content-Type: text/plain; version=0.0.4; charset=utf-8
< Date: Thu, 16 Jun 2022 22:53:18 GMT
Date: Thu, 16 Jun 2022 22:53:18 GMT
< Transfer-Encoding: chunked
Transfer-Encoding: chunked

< 
# HELP controller_runtime_active_workers Number of currently used workers per controller
# TYPE controller_runtime_active_workers gauge
controller_runtime_active_workers{controller="antreaconfig"} 0
controller_runtime_active_workers{controller="calicoconfig"} 0
controller_runtime_active_workers{controller="cluster"} 0
controller_runtime_active_workers{controller="kappcontrollerconfig"} 0
controller_runtime_active_workers{controller="machine"} 0
controller_runtime_active_workers{controller="vspherecpiconfig"} 0
controller_runtime_active_workers{controller="vspherecsiconfig"} 0
# HELP controller_runtime_max_concurrent_reconciles Maximum number of concurrent reconciles per controller
# TYPE controller_runtime_max_concurrent_reconciles gauge
controller_runtime_max_concurrent_reconciles{controller="antreaconfig"} 1
controller_runtime_max_concurrent_reconciles{controller="calicoconfig"} 1
controller_runtime_max_concurrent_reconciles{controller="cluster"} 10
controller_runtime_max_concurrent_reconciles{controller="kappcontrollerconfig"} 1
controller_runtime_max_concurrent_reconciles{controller="machine"} 1
controller_runtime_max_concurrent_reconciles{controller="vspherecpiconfig"} 1
controller_runtime_max_concurrent_reconciles{controller="vspherecsiconfig"} 1
# HELP controller_runtime_reconcile_errors_total Total number of reconciliation errors per controller
# TYPE controller_runtime_reconcile_errors_total counter
controller_runtime_reconcile_errors_total{controller="antreaconfig"} 0
controller_runtime_reconcile_errors_total{controller="calicoconfig"} 0
controller_runtime_reconcile_errors_total{controller="cluster"} 0
controller_runtime_reconcile_errors_total{controller="kappcontrollerconfig"} 0
controller_runtime_reconcile_errors_total{controller="machine"} 0
controller_runtime_reconcile_errors_total{controller="vspherecpiconfig"} 0
controller_runtime_reconcile_errors_total{controller="vspherecsiconfig"} 0
# HELP controller_runtime_reconcile_total Total number of reconciliations per controller
# TYPE controller_runtime_reconcile_total counter
controller_runtime_reconcile_total{controller="antreaconfig",result="error"} 0
controller_runtime_reconcile_total{controller="antreaconfig",result="requeue"} 0
controller_runtime_reconcile_total{controller="antreaconfig",result="requeue_after"} 0
controller_runtime_reconcile_total{controller="antreaconfig",result="success"} 0
controller_runtime_reconcile_total{controller="calicoconfig",result="error"} 0
controller_runtime_reconcile_total{controller="calicoconfig",result="requeue"} 0
controller_runtime_reconcile_total{controller="calicoconfig",result="requeue_after"} 0
controller_runtime_reconcile_total{controller="calicoconfig",result="success"} 0
controller_runtime_reconcile_total{controller="cluster",result="error"} 0
controller_runtime_reconcile_total{controller="cluster",result="requeue"} 0
controller_runtime_reconcile_total{controller="cluster",result="requeue_after"} 0
controller_runtime_reconcile_total{controller="cluster",result="success"} 0
controller_runtime_reconcile_total{controller="kappcontrollerconfig",result="error"} 0
controller_runtime_reconcile_total{controller="kappcontrollerconfig",result="requeue"} 0
controller_runtime_reconcile_total{controller="kappcontrollerconfig",result="requeue_after"} 0
controller_runtime_reconcile_total{controller="kappcontrollerconfig",result="success"} 0
controller_runtime_reconcile_total{controller="machine",result="error"} 0
controller_runtime_reconcile_total{controller="machine",result="requeue"} 0
controller_runtime_reconcile_total{controller="machine",result="requeue_after"} 0
controller_runtime_reconcile_total{controller="machine",result="success"} 0
controller_runtime_reconcile_total{controller="vspherecpiconfig",result="error"} 0
controller_runtime_reconcile_total{controller="vspherecpiconfig",result="requeue"} 0
controller_runtime_reconcile_total{controller="vspherecpiconfig",result="requeue_after"} 0
controller_runtime_reconcile_total{controller="vspherecpiconfig",result="success"} 0
controller_runtime_reconcile_total{controller="vspherecsiconfig",result="error"} 0
controller_runtime_reconcile_total{controller="vspherecsiconfig",result="requeue"} 0
controller_runtime_reconcile_total{controller="vspherecsiconfig",result="requeue_after"} 0
controller_runtime_reconcile_total{controller="vspherecsiconfig",result="success"} 0
# HELP controller_runtime_webhook_requests_in_flight Current number of admission requests being served.
# TYPE controller_runtime_webhook_requests_in_flight gauge
controller_runtime_webhook_requests_in_flight{webhook="/mutate-cluster-x-k8s-io-v1beta1-cluster"} 0
controller_runtime_webhook_requests_in_flight{webhook="/mutate-run-tanzu-vmware-com-v1alpha3-clusterbootstrap"} 0
controller_runtime_webhook_requests_in_flight{webhook="/validate-cluster-x-k8s-io-v1beta1-cluster"} 0
controller_runtime_webhook_requests_in_flight{webhook="/validate-cni-tanzu-vmware-com-v1alpha1-antreaconfig"} 0
controller_runtime_webhook_requests_in_flight{webhook="/validate-cni-tanzu-vmware-com-v1alpha1-calicoconfig"} 0
controller_runtime_webhook_requests_in_flight{webhook="/validate-run-tanzu-vmware-com-v1alpha3-clusterbootstrap"} 0
controller_runtime_webhook_requests_in_flight{webhook="/validate-run-tanzu-vmware-com-v1alpha3-clusterbootstraptemplate"} 0
# HELP controller_runtime_webhook_requests_total Total number of admission requests by HTTP status code.
# TYPE controller_runtime_webhook_requests_total counter
controller_runtime_webhook_requests_total{code="200",webhook="/mutate-cluster-x-k8s-io-v1beta1-cluster"} 0
controller_runtime_webhook_requests_total{code="200",webhook="/mutate-run-tanzu-vmware-com-v1alpha3-clusterbootstrap"} 0
controller_runtime_webhook_requests_total{code="200",webhook="/validate-cluster-x-k8s-io-v1beta1-cluster"} 0
controller_runtime_webhook_requests_total{code="200",webhook="/validate-cni-tanzu-vmware-com-v1alpha1-antreaconfig"} 0
controller_runtime_webhook_requests_total{code="200",webhook="/validate-cni-tanzu-vmware-com-v1alpha1-calicoconfig"} 0
controller_runtime_webhook_requests_total{code="200",webhook="/validate-run-tanzu-vmware-com-v1alpha3-clusterbootstrap"} 0
controller_runtime_webhook_requests_total{code="200",webhook="/validate-run-tanzu-vmware-com-v1alpha3-clusterbootstraptemplate"} 0
controller_runtime_webhook_requests_total{code="500",webhook="/mutate-cluster-x-k8s-io-v1beta1-cluster"} 0
controller_runtime_webhook_requests_total{code="500",webhook="/mutate-run-tanzu-vmware-com-v1alpha3-clusterbootstrap"} 0
controller_runtime_webhook_requests_total{code="500",webhook="/validate-cluster-x-k8s-io-v1beta1-cluster"} 0
controller_runtime_webhook_requests_total{code="500",webhook="/validate-cni-tanzu-vmware-com-v1alpha1-antreaconfig"} 0
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Enable metrics for addons-manager
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
