### PR TITLE
Add tests for MHC on classy clusters

### DIFF
--- a/cmd/cli/plugin/cluster/machinehealthcheck.go
+++ b/cmd/cli/plugin/cluster/machinehealthcheck.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	controlPlaneLabel = "cluster.x-k8s.io/control-plane"
-	nodePoolLabel     = "node-pool"
+	controlPlaneLabel      = "cluster.x-k8s.io/control-plane"
+	nodePoolLabel          = "node-pool"
+	machineDeploymentLabel = "topology.cluster.x-k8s.io/deployment-name"
 )
 
 var machineHealthCheckCmd = &cobra.Command{

--- a/pkg/v1/tkg/client/machine_health_check.go
+++ b/pkg/v1/tkg/client/machine_health_check.go
@@ -89,6 +89,11 @@ func (c *TkgClient) DeleteMachineHealthCheck(options MachineHealthCheckOptions) 
 	if err != nil {
 		return err
 	}
+
+	if cluster.Spec.Topology != nil {
+		return errors.New("deleting machine health checks on clusterclass based clusters is not supported")
+	}
+
 	if options.Namespace == "" {
 		options.Namespace = cluster.Namespace
 		log.Infof("use %s as default namespace", options.Namespace)
@@ -230,6 +235,11 @@ func (c *TkgClient) SetMachineHealthCheck(options *SetMachineHealthCheckOptions)
 	if err != nil {
 		return err
 	}
+
+	if cluster.Spec.Topology != nil {
+		return errors.New("setting machine health checks on clusterclass based clusters is not supported")
+	}
+
 	if options.Namespace == "" {
 		options.Namespace = cluster.Namespace
 		log.Infof("use %s as default namespace", options.Namespace)

--- a/pkg/v1/tkg/test/tkgctl/aws_cc/aws_cc_mhc_test.go
+++ b/pkg/v1/tkg/test/tkgctl/aws_cc/aws_cc_mhc_test.go
@@ -1,0 +1,25 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// nolint:typecheck,nolintlint
+package aws_cc
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+
+	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/test/tkgctl/shared"
+)
+
+var _ = Describe("MHC tests for capa classy clusters", func() {
+	E2EMhcCCSpec(context.TODO(), func() E2ECommonSpecInput {
+		return E2ECommonSpecInput{
+			E2EConfig:       e2eConfig,
+			ArtifactsFolder: artifactsFolder,
+			Cni:             "antrea",
+			Plan:            "devcc",
+			Namespace:       "tkg-system",
+		}
+	})
+})

--- a/pkg/v1/tkg/test/tkgctl/shared/mhc_cc.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/mhc_cc.go
@@ -1,0 +1,184 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// nolint:typecheck,goconst,gocritic,stylecheck,nolintlint
+package shared
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/test/framework"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgctl"
+)
+
+func E2EMhcCCSpec(context context.Context, inputGetter func() E2ECommonSpecInput) { //nolint:funlen
+	var (
+		input         E2ECommonSpecInput
+		tkgCtlClient  tkgctl.TKGClient
+		tkgCtlClient2 tkgctl.TKGClient
+		logsDir       string
+		clusterName   string
+		namespace     string
+
+		mcProxy *framework.ClusterProxy
+		wcProxy *framework.ClusterProxy
+	)
+
+	BeforeEach(func() {
+		var err error
+		namespace = input.Namespace
+		input = inputGetter()
+		logsDir = filepath.Join(input.ArtifactsFolder, "logs")
+
+		mcClusterName := input.E2EConfig.ManagementClusterName
+		mcContextName := mcClusterName + "-admin@" + mcClusterName
+		mcProxy = framework.NewClusterProxy(mcClusterName, "", mcContextName)
+
+		rand.Seed(time.Now().UnixNano())
+		clusterName = input.E2EConfig.ClusterPrefix + "wc"
+
+		tkgCtlClient, err = tkgctl.New(tkgctl.Options{
+			ConfigDir: input.E2EConfig.TkgConfigDir,
+			LogOptions: tkgctl.LoggingOptions{
+				File:      filepath.Join(logsDir, clusterName+".log"),
+				Verbosity: input.E2EConfig.TkgCliLogLevel,
+			},
+		})
+
+		Expect(err).To(BeNil())
+
+		By(fmt.Sprintf("Creating a workload cluster %q", clusterName))
+		options := framework.CreateClusterOptions{
+			ClusterName: clusterName,
+			Namespace:   namespace,
+			Plan:        input.Plan,
+			CniType:     input.Cni,
+		}
+
+		if input.E2EConfig.InfrastructureName == "vsphere" {
+			if endpointIP, ok := os.LookupEnv("CLUSTER_ENDPOINT_2"); ok {
+				options.VsphereControlPlaneEndpoint = endpointIP
+			}
+		}
+
+		clusterConfigFile, err := framework.GetTempClusterConfigFile(input.E2EConfig.TkgClusterConfigPath, &options)
+		Expect(err).To(BeNil())
+
+		defer os.Remove(clusterConfigFile)
+		err = tkgCtlClient.CreateCluster(tkgctl.CreateClusterOptions{
+			ClusterConfigFile: clusterConfigFile,
+			Edition:           "tkg",
+		})
+		Expect(err).To(BeNil())
+
+		// Create a new client to prevent it from reusing in memory configs of the old client
+		tkgCtlClient2, _ = tkgctl.New(tkgctl.Options{
+			ConfigDir: input.E2EConfig.TkgConfigDir,
+			LogOptions: tkgctl.LoggingOptions{
+				File:      filepath.Join(logsDir, clusterName+".log"),
+				Verbosity: input.E2EConfig.TkgCliLogLevel,
+			},
+		})
+
+		By(fmt.Sprintf("Generating credentials for workload cluster %q", clusterName))
+		err = tkgCtlClient2.GetCredentials(tkgctl.GetWorkloadClusterCredentialsOptions{
+			ClusterName: clusterName,
+			Namespace:   namespace,
+			ExportFile:  "",
+		})
+		Expect(err).To(BeNil())
+
+		By(fmt.Sprintf("Waiting for workload cluster %q nodes to be up and running", clusterName))
+		contextName := clusterName + "-admin@" + clusterName
+		framework.WaitForNodes(framework.NewClusterProxy(clusterName, "", contextName), 2)
+
+		By(fmt.Sprintf("Generating credentials for workload cluster %q", clusterName))
+		err = tkgCtlClient2.GetCredentials(tkgctl.GetWorkloadClusterCredentialsOptions{
+			ClusterName: clusterName,
+			Namespace:   namespace,
+		})
+		Expect(err).To(BeNil())
+
+		wcContextName := clusterName + "-admin@" + clusterName
+		wcProxy = framework.NewClusterProxy(clusterName, "", wcContextName)
+	})
+
+	It("mhc should remediate unhealthy machine", func() {
+		// Validate MHC
+		By(fmt.Sprintf("Getting MHC for cluster %q", clusterName))
+		mhcList, err := tkgCtlClient2.GetMachineHealthCheck(tkgctl.GetMachineHealthCheckOptions{
+			ClusterName: clusterName,
+			Namespace:   namespace,
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(len(mhcList)).To(Equal(2))
+		mhc := mhcList[0]
+		Expect(mhc.Spec.ClusterName).To(Equal(clusterName))
+		Expect(len(mhc.Spec.UnhealthyConditions)).To(Equal(2)) // nolint:gomnd
+
+		// Delete MHC and verify if MHC is deleted
+		By(fmt.Sprintf("Deleting MHC for cluster %q", clusterName))
+		if tkgCtlClient2 == nil {
+			_, _ = GinkgoWriter.Write([]byte("tkgCtlClient is nil"))
+		}
+		err = tkgCtlClient2.DeleteMachineHealthCheck(tkgctl.DeleteMachineHealthCheckOptions{
+			ClusterName:            clusterName,
+			MachinehealthCheckName: mhc.Name,
+			Namespace:              namespace,
+			SkipPrompt:             true,
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("deleting machine health checks on clusterclass based clusters is not supported"))
+
+		// Set MHC and verify if it is set
+		By(fmt.Sprintf("Updating MHC for cluster %q", clusterName))
+		err = tkgCtlClient2.SetMachineHealthCheck(tkgctl.SetMachineHealthCheckOptions{
+			ClusterName:            clusterName,
+			Namespace:              namespace,
+			MachineHealthCheckName: mhc.Name,
+			UnhealthyConditions:    fmt.Sprintf("%s:%s:%s", string(corev1.NodeReady), string(corev1.ConditionFalse), "5m"),
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("setting machine health checks on clusterclass based clusters is not supported"))
+
+		mhcList, err = tkgCtlClient2.GetMachineHealthCheck(tkgctl.GetMachineHealthCheckOptions{
+			ClusterName: clusterName,
+			Namespace:   namespace,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(mhcList)).To(Equal(2))
+
+		mhc = mhcList[0]
+		Expect(mhc.Spec.ClusterName).To(Equal(clusterName))
+		Expect(len(mhc.Spec.UnhealthyConditions)).To(Equal(2))
+
+		// Set machine to unhealthy and see if that machine is remediated
+		Expect(len(mhc.Status.Targets)).To(Equal(1))
+		machine := mhc.Status.Targets[0]
+		By(fmt.Sprintf("Patching Node to make it fail the MHC %q", machine))
+		_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Context : %s \n", context)))
+		patchNodeUnhealthy(context, wcProxy, machine, "", mcProxy)
+
+		By("Waiting for the Node to be remediated")
+		WaitForNodeRemediation(context, clusterName, "", mcProxy, wcProxy)
+	})
+
+	AfterEach(func() {
+		err := tkgCtlClient.DeleteCluster(tkgctl.DeleteClustersOptions{
+			ClusterName: clusterName,
+			Namespace:   namespace,
+			SkipPrompt:  true,
+		})
+		Expect(err).To(BeNil())
+	})
+}


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds MachineHealthCheck tests to the CC test suite. The tests exercise the new behavior of the machinehealthcheck API when using classy clusters. In particular, create, update, and delete are not supported for classy clusters and those those operations now return errors. Machine health checks must be modified at the clusterclass level for classy clusters. This change also updates the tanzu cli to properly retrieve machine health checks for nodes in either legacy clusters or classy clusters.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
E2E tests retrieve machine health checks and then verifies errors on set/delete operations. The test also causes a node failure state and waits for the cluster remediation to finish.
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Modifying machinehealthchecks on classy clusters is not supported. The API will return an error when performing these operations on classy clusters.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
