### PR TITLE
CPIController should list vSphereCluster within the same namespace as cluster.

### DIFF
--- a/addons/controllers/cpi/vspherecpiconfig_controller.go
+++ b/addons/controllers/cpi/vspherecpiconfig_controller.go
@@ -203,7 +203,7 @@ func (r *VSphereCPIConfigReconciler) reconcileVSphereCPIConfigNormal(ctx context
 		}
 		labelSelector := labels.NewSelector()
 		labelSelector = labelSelector.Add(*labelMatch)
-		if err := r.Client.List(ctx, vsphereClusters, &client.ListOptions{LabelSelector: labelSelector}); err != nil {
+		if err := r.Client.List(ctx, vsphereClusters, &client.ListOptions{LabelSelector: labelSelector, Namespace: cluster.Namespace}); err != nil {
 			r.Log.Error(err, "error retrieving clusters")
 			return err
 		}

--- a/addons/controllers/testdata/test-vsphere-cpi-paravirtual-clusters-same-name.yaml
+++ b/addons/controllers/testdata/test-vsphere-cpi-paravirtual-clusters-same-name.yaml
@@ -1,0 +1,70 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: test-cluster-cpi-paravirtual
+  namespace: default
+spec:
+  infrastructureRef:
+    kind: VSphereCluster
+  clusterNetwork:
+    pods:
+      cidrBlocks: [ "192.168.0.0/16","fd00:100:96::/48" ]
+---
+apiVersion: cpi.tanzu.vmware.com/v1alpha1
+kind: VSphereCPIConfig
+metadata:
+  name: test-cluster-cpi-paravirtual
+  namespace: default
+spec:
+  vsphereCPI:
+    mode: vsphereParavirtualCPI
+---
+apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereCluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test-cluster-cpi-paravirtual
+    topology.cluster.x-k8s.io/owned: ""
+  name: test-cluster-cpi-paravirtual
+  namespace: default
+spec:
+  controlPlaneEndpoint:
+    host: 192.168.116.1
+    port: 6443
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: another-ns
+---
+apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
+kind: VSphereCluster
+metadata:
+  labels:
+    cluster.x-k8s.io/cluster-name: test-cluster-cpi-paravirtual
+    topology.cluster.x-k8s.io/owned: ""
+  name: test-cluster-cpi-paravirtual
+  namespace: another-ns
+spec:
+  controlPlaneEndpoint:
+    host: 192.168.116.2
+    port: 6443
+---
+apiVersion: v1
+data:
+  kubeconfig: |
+    apiVersion: v1
+    clusters:
+    - cluster:
+        certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1ETXlOVEExTkRNd01Wb1hEVE15TURNeU1qQTFORE13TVZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT25TClZOTlFzb043bExlekdxcmFpb01EOHJDeU9JSDFVVnJqT0x3YWp5UXZQeHRaYjdRdE9DRTJia282RytJcFJlQzYKZ3hIZi9aQi83VXNvTzVqaXpvcWpJUVpsdjZzSm9zR0I0c1Q4NG9hTGtIT21ISEU5a0w5U09Wa1FuT2J5ZWUzNApFaExnUHZWb1pKc05xMTRVWXJsS1R1dnBxNGhpY2pNU1Vua3ZpQmtiY3BCL0oxaUpBbXpIV2tnSkdlSk5HYTNnCk1lSXUxSzJVZ1I3NWp5bkpJSUsvdHFOMyt3VGl1TEcyNDhzZkVCY29pSWFYNTdoQ0E3d0hKR3RaZVJDQmlhNTAKc2JqbFFGd0hEblJldjBPZlNxeE4wZVE3ZVZwQ1NKWWFIQWtmc0t4ZXBSNXNTMnRrRFBVMlg4cHNmcEVQZGdwaApXUS9MN1JiYWdvbE91VkRzdkdVQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFCZmp0dFp6NDNwU3NUelM5ZVFzK0lkL3VjOVcKZkxWL2VCMXhOaUJWbXN6MUNsZldaZ1VIeWFsZ1RtRTlHdGtQVnhja2pSczNXQ0hlRUY4N1psOENobEFFMnFrZwpRcE5BVDMyM3RpOVk1TWk3bWZvOFl2OXdOL0ZPNzRwbnB2OElUVXpoRVlJaGxUZFYrd3RmWHUvTmNzN1Z0akNBCkNWNnExeU5lbG05eU9CVW51RElRNVo0L1AvYXFLRDFzSXNCSFJZZVU3SzVEaklSTGNpN3gvb2dlQ2F0ZVowNFoKeWExd2NXVXB3SnNpaGxIOCtHUkJkZ2h1RzZ4aC9ka1JhNmRLbHpYdVRManpsdVYyRUp6N29hZGthSUUybzM3RQpoazZ2aERBc1JHSCtCdnJtcFZJYjNsYTVGbDZHRkd2VElKMGFNT0pMTTVFa3pHNFlUeWpNRi9qK3Joaz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+        server: https://172.17.0.3:6773
+      name: ""
+    contexts: null
+    current-context: ""
+    kind: Config
+    preferences: {}
+    users: null
+kind: ConfigMap
+metadata:
+  name: cluster-info
+  namespace: kube-public


### PR DESCRIPTION
### What this PR does / why we need it
When two vSphereClusters have the same name but under different namespace, the CPIConfig controller will error out.

```
I0621 19:15:05.303834       1 vspherecpiconfig_controller.go:118] VSphereCPIConfig "msg"="Patching VSphereCPIConfig" "VSphereCPIConfig"={"Namespace":"utkg-ns-a2","Name":"utkc-vsphere-cpi-package"}
I0621 19:15:05.304223       1 vspherecpiconfig_controller.go:123] VSphereCPIConfig "msg"="Successfully patched VSphereCPIConfig" "VSphereCPIConfig"={"Namespace":"utkg-ns-a2","Name":"utkc-vsphere-cpi-package"}
E0621 19:15:05.304288       1 vspherecpiconfig_controller.go:104] VSphereCPIConfig "msg"="Failed to reconcile VSphereCPIConfig" "error"="expected to find 1 VSphereCluster object for label key cluster.x-k8s.io/cluster-name and value utkc but found 2" "VSphereCPIConfig"={"Namespace":"utkg-ns-a2","Name":"utkc-vsphere-cpi-package"}
E0621 19:15:05.304795       1 controller.go:317] controller/vspherecpiconfig "msg"="Reconciler error" "error"="expected to find 1 VSphereCluster object for label key cluster.x-k8s.io/cluster-name and value utkc but found 2" "name"="utkc-vsphere-cpi-package" "namespace"="utkg-ns-a2" "reconciler group"="cpi.tanzu.vmware.com" "reconciler kind"="VSphereCPIConfig"
```

Specifying the namespace in the ListOption when listing the VSphereClusters.

Related bug for CSI: https://github.com/vmware-tanzu/tanzu-framework/pull/2553


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes # https://github.com/vmware-tanzu/tanzu-framework/issues/2714

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: CPIController should list vSphereCluster within the same namespace as cluster.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
