### PR TITLE
Remove the CLI validation check for TKGS API version

### DIFF
--- a/pkg/v1/tkg/client/cluster.go
+++ b/pkg/v1/tkg/client/cluster.go
@@ -104,12 +104,6 @@ func (c *TkgClient) CreateCluster(options *CreateClusterOptions, waitForCluster 
 		return false, errors.Wrap(err, "error determining Tanzu Kubernetes Cluster service for vSphere management cluster ")
 	}
 	if isPacific {
-		if !options.IsInputFileClusterClassBased {
-			err := c.ValidatePacificVersionWithCLI(regionalClusterClient)
-			if err != nil {
-				return false, err
-			}
-		}
 		return true, c.createPacificCluster(options, waitForCluster)
 	}
 

--- a/pkg/v1/tkg/client/get_cluster.go
+++ b/pkg/v1/tkg/client/get_cluster.go
@@ -57,10 +57,6 @@ func (c *TkgClient) ListTKGClusters(options ListTKGClustersOptions) ([]ClusterIn
 		return nil, errors.Wrap(err, "error determining 'Tanzu Kubernetes Cluster service for vSphere' management cluster")
 	}
 	if isPacific {
-		err := c.ValidatePacificVersionWithCLI(regionalClusterClient)
-		if err != nil {
-			return nil, err
-		}
 		return c.GetClusterObjectsForPacific(regionalClusterClient, "", listOptions)
 	}
 

--- a/pkg/v1/tkg/client/get_kubernetes_versions.go
+++ b/pkg/v1/tkg/client/get_kubernetes_versions.go
@@ -38,10 +38,6 @@ func (c *TkgClient) GetKubernetesVersions() (*KubernetesVersionsInfo, error) {
 func (c *TkgClient) DoGetTanzuKubernetesReleases(regionalClusterClient clusterclient.Client) (*KubernetesVersionsInfo, error) {
 	isPacific, err := regionalClusterClient.IsPacificRegionalCluster()
 	if err == nil && isPacific {
-		err := c.ValidatePacificVersionWithCLI(regionalClusterClient)
-		if err != nil {
-			return nil, err
-		}
 		availablek8sVersions, err := regionalClusterClient.GetPacificTanzuKubernetesReleases()
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get supported kubernetes release versions for vSphere with Kubernetes clusters")

--- a/pkg/v1/tkg/client/machine_deployment.go
+++ b/pkg/v1/tkg/client/machine_deployment.go
@@ -102,10 +102,6 @@ func (c *TkgClient) SetMachineDeployment(options *SetMachineDeploymentOptions) e
 		return errors.Wrap(err, "error determining Tanzu Kubernetes Cluster service for vSphere management cluster ")
 	}
 	if isPacific {
-		err := c.ValidatePacificVersionWithCLI(clusterClient)
-		if err != nil {
-			return err
-		}
 		return c.SetNodePoolsForPacificCluster(clusterClient, options)
 	}
 	return DoSetMachineDeployment(clusterClient, options)
@@ -306,10 +302,6 @@ func (c *TkgClient) DeleteMachineDeployment(options DeleteMachineDeploymentOptio
 		return errors.Wrap(err, "error determining Tanzu Kubernetes Cluster service for vSphere management cluster ")
 	}
 	if isPacific {
-		err := c.ValidatePacificVersionWithCLI(clusterClient)
-		if err != nil {
-			return err
-		}
 		return c.DeleteNodePoolForPacificCluster(clusterClient, options)
 	}
 	return DoDeleteMachineDeployment(clusterClient, &options)

--- a/pkg/v1/tkg/client/pacific_cluster.go
+++ b/pkg/v1/tkg/client/pacific_cluster.go
@@ -35,10 +35,6 @@ func (c *TkgClient) GetPacificClusterObject(clusterName, namespace string) (*tkg
 		return nil, errors.New("the management cluster is not 'Tanzu Kubernetes Cluster service for vSphere' management cluster")
 	}
 
-	err = c.ValidatePacificVersionWithCLI(regionalClusterClient)
-	if err != nil {
-		return nil, err
-	}
 	return regionalClusterClient.GetPacificClusterObject(clusterName, namespace)
 }
 

--- a/pkg/v1/tkg/client/scale.go
+++ b/pkg/v1/tkg/client/scale.go
@@ -61,10 +61,6 @@ func (c *TkgClient) DoScaleCluster(clusterClient clusterclient.Client, options *
 		return errors.Wrap(err, "error determining Tanzu Kubernetes Grid service for vSphere management cluster ")
 	}
 	if isPacific {
-		err := c.ValidatePacificVersionWithCLI(clusterClient)
-		if err != nil {
-			return err
-		}
 		return c.ScalePacificCluster(options, clusterClient)
 	}
 

--- a/pkg/v1/tkg/client/upgrade_cluster.go
+++ b/pkg/v1/tkg/client/upgrade_cluster.go
@@ -139,10 +139,6 @@ func (c *TkgClient) UpgradeCluster(options *UpgradeClusterOptions) error {
 		return errors.Wrap(err, "error determining 'Tanzu Kubernetes Cluster service for vSphere' management cluster")
 	}
 	if isPacific {
-		err := c.ValidatePacificVersionWithCLI(regionalClusterClient)
-		if err != nil {
-			return err
-		}
 		return c.DoPacificClusterUpgrade(regionalClusterClient, options)
 	}
 

--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -1479,22 +1479,6 @@ func (c *TkgClient) EncodeAWSCredentialsAndGetClient(clusterClient clusterclient
 	return awsClient, nil
 }
 
-// ValidatePacificVersionWithCLI validate Pacific TKC API version with cli version
-func (c *TkgClient) ValidatePacificVersionWithCLI(regionalClusterClient clusterclient.Client) error {
-	/*
-		TODO: (chandrareddyp) we need revisit below API Version validation, for now we disabled it.
-		tkcAPIVersion, err := regionalClusterClient.GetPacificTKCAPIVersion()
-		if err != nil {
-			return errors.Wrap(err, "error determining the Tanzu Kubernetes Cluster API version")
-		}
-		if tkcAPIVersion != constants.DefaultPacificClusterAPIVersion {
-			return errors.Errorf("Only %q Tanzu Kubernetes Cluster API version is supported by current version of Tanzu CLI. Please upgrade 'Tanzu Kubernetes Cluster service for vSphere' to latest version if you are using older version",
-				constants.DefaultPacificClusterAPIVersion)
-		}
-	*/
-	return nil
-}
-
 // ConfigureAndValidateHTTPProxyConfiguration configures and validates http proxy configuration
 func (c *TkgClient) ConfigureAndValidateHTTPProxyConfiguration(infrastructureName string) error {
 	c.SetDefaultProxySettings()

--- a/pkg/v1/tkg/client/workload_cluster.go
+++ b/pkg/v1/tkg/client/workload_cluster.go
@@ -120,13 +120,6 @@ func (c *TkgClient) DeleteWorkloadCluster(options DeleteWorkloadClusterOptions) 
 		}
 	}
 
-	if isPacific {
-		err := c.ValidatePacificVersionWithCLI(clusterClient)
-		if err != nil {
-			return err
-		}
-	}
-
 	return clusterClient.DeleteCluster(options.ClusterName, options.Namespace)
 }
 


### PR DESCRIPTION
### What this PR does / why we need it
This PR removes the CLI version validation with TKGS API version. Currently, CLI performs the validation check for TKGS API version and returns an error if the CLI version does not support TKGS API version, instead, CLI can rely on TKGS server side validation. The version validation has been removed in use cases like cluster creation, cluster deletion, scale cluster, get a cluster, machine deployment, get TKR release, and list clusters.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2770

### Describe testing done for PR
Create TKGS Cluster
Create TKC Cluster
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Removed the TKGS version validation check in CLI
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
