### PR TITLE
Plumb legacy CLI Addon Configs to ClusterBootstrap and AddonConfig API

### DIFF
--- a/pkg/v1/providers/infrastructure-aws/v1.2.0/cluster-template-definition-devcc.yaml
+++ b/pkg/v1/providers/infrastructure-aws/v1.2.0/cluster-template-definition-devcc.yaml
@@ -2,6 +2,7 @@ apiVersion: providers.tanzu.vmware.com/v1alpha1
 kind: TemplateDefinition
 spec:
   paths:
+    - path: providers/yttcb
     - path: providers/infrastructure-aws/v1.2.0/yttcc
     - path: providers/infrastructure-aws/yttcc
     - path: providers/yttcc

--- a/pkg/v1/providers/infrastructure-aws/v1.2.0/cluster-template-definition-prodcc.yaml
+++ b/pkg/v1/providers/infrastructure-aws/v1.2.0/cluster-template-definition-prodcc.yaml
@@ -2,6 +2,7 @@ apiVersion: providers.tanzu.vmware.com/v1alpha1
 kind: TemplateDefinition
 spec:
   paths:
+    - path: providers/yttcb
     - path: providers/infrastructure-aws/v1.2.0/yttcc
     - path: providers/infrastructure-aws/yttcc
     - path: providers/yttcc

--- a/pkg/v1/providers/infrastructure-azure/v1.2.1/cluster-template-definition-devcc.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.2.1/cluster-template-definition-devcc.yaml
@@ -2,6 +2,7 @@ apiVersion: providers.tanzu.vmware.com/v1alpha1
 kind: TemplateDefinition
 spec:
   paths:
+    - path: providers/yttcb
     - path: providers/infrastructure-azure/v1.2.1/yttcc
     - path: providers/infrastructure-azure/yttcc
     - path: providers/yttcc

--- a/pkg/v1/providers/infrastructure-azure/v1.2.1/cluster-template-definition-prodcc.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.2.1/cluster-template-definition-prodcc.yaml
@@ -2,6 +2,7 @@ apiVersion: providers.tanzu.vmware.com/v1alpha1
 kind: TemplateDefinition
 spec:
   paths:
+    - path: providers/yttcb
     - path: providers/infrastructure-azure/v1.2.1/yttcc
     - path: providers/infrastructure-azure/yttcc
     - path: providers/yttcc

--- a/pkg/v1/providers/infrastructure-vsphere/v1.1.0/cluster-template-definition-devcc.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.1.0/cluster-template-definition-devcc.yaml
@@ -2,6 +2,7 @@ apiVersion: providers.tanzu.vmware.com/v1alpha1
 kind: TemplateDefinition
 spec:
   paths:
+    - path: providers/yttcb
     - path: providers/infrastructure-vsphere/v1.1.0/yttcc
     - path: providers/infrastructure-vsphere/yttcc
     - path: providers/yttcc

--- a/pkg/v1/providers/infrastructure-vsphere/v1.1.0/cluster-template-definition-prodcc.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.1.0/cluster-template-definition-prodcc.yaml
@@ -2,6 +2,7 @@ apiVersion: providers.tanzu.vmware.com/v1alpha1
 kind: TemplateDefinition
 spec:
   paths:
+    - path: providers/yttcb
     - path: providers/infrastructure-vsphere/v1.1.0/yttcc
     - path: providers/infrastructure-vsphere/yttcc
     - path: providers/yttcc

--- a/pkg/v1/providers/yttcb/clusterbootstrap.yaml
+++ b/pkg/v1/providers/yttcb/clusterbootstrap.yaml
@@ -1,0 +1,223 @@
+#@ load("@ytt:assert", "assert")
+#@ load("@ytt:data", "data")
+#@ load("@ytt:ip", "ip")
+#@ load("lib/helpers.star", "get_tkr_version_from_tkr_name")
+
+#@ vsphereControlPlaneEndpointAsCidr = ""
+#@ if data.values.VSPHERE_CONTROL_PLANE_ENDPOINT:
+#@   vsphereControlPlaneEndpoint, err = assert.try_to(lambda : ip.parse_addr(data.values.VSPHERE_CONTROL_PLANE_ENDPOINT))
+#@   if err == None:
+#@     if vsphereControlPlaneEndpoint.is_ipv4():
+#@       vsphereControlPlaneEndpointAsCidr = vsphereControlPlaneEndpoint.string() + "/32"
+#@     end
+#@     if vsphereControlPlaneEndpoint.is_ipv6():
+#@       vsphereControlPlaneEndpointAsCidr = vsphereControlPlaneEndpoint.string() + "/128"
+#@     end
+#@   end
+#@ end
+
+#@ def antrea_configs_exist():
+#@   return (data.values.NSXT_POD_ROUTING_ENABLED or
+#@           data.values.ANTREA_NO_SNAT or
+#@           data.values.ANTREA_TRAFFIC_ENCAP_MODE != "encap" or
+#@           not data.values.ANTREA_PROXY or
+#@           not data.values.ANTREA_ENDPOINTSLICE or
+#@           not data.values.ANTREA_POLICY or
+#@           not data.values.ANTREA_NODEPORTLOCAL or
+#@           not data.values.ANTREA_TRACEFLOW or
+#@           not data.values.ANTREA_EGRESS or
+#@           data.values.ANTREA_FLOWEXPORTER or
+#@           data.values.ANTREA_DISABLE_UDP_TUNNEL_OFFLOAD)
+#@ end
+
+#@ def vspherecpi_configs_exist():
+#@   return data.values.PROVIDER_TYPE == "vsphere" and (data.values.VSPHERE_SERVER or data.values.NSXT_MANAGER_HOST)
+#@ end
+
+#@ def vspherecsi_configs_exist():
+#@   return data.values.PROVIDER_TYPE == "vsphere" and (not data.values.VSPHERE_INSECURE or
+#@           data.values.USE_TOPOLOGY_CATEGORIES)
+#@ end
+
+#@ def should_create_clusterbootstrap():
+#@   return data.values.CNI != "antrea" or antrea_configs_exist() or vspherecsi_configs_exist() or vspherecpi_configs_exist()
+#@ end
+
+#@ if antrea_configs_exist():
+---
+apiVersion: cni.tanzu.vmware.com/v1alpha1
+kind: AntreaConfig
+metadata:
+  name: #@ data.values.CLUSTER_NAME
+  namespace: #@ data.values.NAMESPACE
+spec:
+  antrea:
+    config:
+      #@ if data.values.NSXT_POD_ROUTING_ENABLED:
+      trafficEncapMode: "noEncap"
+      noSNAT: true
+      #@ else:
+      trafficEncapMode: #@ data.values.ANTREA_TRAFFIC_ENCAP_MODE
+      noSNAT: #@ data.values.ANTREA_NO_SNAT
+      #@ end
+      disableUdpTunnelOffload: #@ data.values.ANTREA_DISABLE_UDP_TUNNEL_OFFLOAD
+      featureGates:
+        #@ if data.values.NSXT_POD_ROUTING_ENABLED:
+        AntreaProxy: true
+        #@ else:
+        AntreaProxy: #@ data.values.ANTREA_PROXY
+        #@ end
+        EndpointSlice: #@ data.values.ANTREA_ENDPOINTSLICE
+        AntreaPolicy: #@ data.values.ANTREA_POLICY
+        NodePortLocal: #@ data.values.ANTREA_NODEPORTLOCAL
+        AntreaTraceflow: #@ data.values.ANTREA_TRACEFLOW
+        Egress: #@ data.values.ANTREA_EGRESS
+        FlowExporter: #@ data.values.ANTREA_FLOWEXPORTER
+#@ end
+---
+#@ if data.values.CNI == "calico":
+apiVersion: cni.tanzu.vmware.com/v1alpha1
+kind: CalicoConfig
+metadata:
+  name: #@ data.values.CLUSTER_NAME
+  namespace: #@ data.values.NAMESPACE
+spec:
+  calico:
+    config:
+      vethMTU: 0
+#@ end
+---
+#@ if vspherecpi_configs_exist() and data.values.PROVIDER_TYPE == "vsphere" and not data.values.IS_WINDOWS_WORKLOAD_CLUSTER:
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #@ data.values.CLUSTER_NAME + "-vsphere-credential"
+  namespace: #@ data.values.NAMESPACE
+data:
+  password: #@ data.values.VSPHERE_USERNAME
+  username: #@ data.values.VSPHERE_PASSWORD
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #@ data.values.CLUSTER_NAME + "-nsxt-credential"
+  namespace: #@ data.values.NAMESPACE
+data:
+  password: #@ data.values.NSXT_USERNAME
+  username: #@ data.values.NSXT_PASSWORD
+---
+apiVersion: cpi.tanzu.vmware.com/v1alpha1
+kind: VSphereCPIConfig
+metadata:
+  name: #@ data.values.CLUSTER_NAME
+  namespace: #@ data.values.NAMESPACE
+spec:
+  vsphereCPI:
+    mode: vsphereCPI
+    vCenterAPIEndpoint: #@ data.values.VSPHERE_SERVER
+    datacenter: #@ data.values.VSPHERE_DATACENTER
+    vSphereCredentialLocalObjRef:
+      kind: Secret
+      name: #@ data.values.CLUSTER_NAME + "-vsphere-credential"
+    tlsThumbprint: #@ data.values.VSPHERE_TLS_THUMBPRINT
+    region: #@ data.values.VSPHERE_REGION
+    zone: #@ data.values.VSPHERE_ZONE
+    insecure: #@ data.values.VSPHERE_INSECURE
+    ipFamily: #@ data.values.TKG_IP_FAMILY
+    vmNetwork:
+      excludeInternalSubnetCidr: #@ vsphereControlPlaneEndpointAsCidr
+      excludeExternalSubnetCidr: #@ vsphereControlPlaneEndpointAsCidr
+    tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+    nsxt:
+      podRoutingEnabled: #@ data.values.NSXT_POD_ROUTING_ENABLED
+      route:
+        routerPath: #@ data.values.NSXT_ROUTER_PATH
+      credentialLocalObjRef:
+        kind: Secret
+        name: #@ data.values.CLUSTER_NAME + "-nsxt-credential"
+      apiHost: #@ data.values.NSXT_MANAGER_HOST
+      insecure: #@ data.values.NSXT_ALLOW_UNVERIFIED_SSL
+      remoteAuth: #@ data.values.NSXT_REMOTE_AUTH
+      vmcAccessToken: #@ data.values.NSXT_VMC_ACCESS_TOKEN
+      vmcAuthHost: #@ data.values.NSXT_VMC_AUTH_HOST
+      clientCertKeyData: #@ data.values.NSXT_CLIENT_CERT_KEY_DATA
+      clientCertData: #@ data.values.NSXT_CLIENT_CERT_DATA
+      rootCAData: #@ data.values.NSXT_ROOT_CA_DATA_B64
+    proxy:
+      http_proxy: #@ data.values.TKG_HTTP_PROXY
+      https_proxy: #@ data.values.TKG_HTTPS_PROXY
+      no_proxy: #@ data.values.TKG_NO_PROXY
+#@ end
+---
+#@ if vspherecsi_configs_exist() and data.values.PROVIDER_TYPE == "vsphere" and not data.values.IS_WINDOWS_WORKLOAD_CLUSTER:
+apiVersion: csi.tanzu.vmware.com/v1alpha1
+kind: VSphereCSIConfig
+metadata:
+  name: #@ data.values.CLUSTER_NAME
+  namespace: #@ data.values.NAMESPACE
+spec:
+  vsphereCSI:
+    mode: vsphereCSI
+    config:
+      #@ if data.values.VSPHERE_INSECURE:
+      insecureFlag: #@ data.values.VSPHERE_INSECURE
+      #@ else:
+      tlsThumbprint: #@ data.values.VSPHERE_TLS_THUMBPRINT
+      #@ end
+      datacenter: #@ data.values.VSPHERE_DATACENTER
+      zone: #@ data.values.VSPHERE_ZONE
+      region: #@ data.values.VSPHERE_REGION
+      useTopologyCategories: #@ data.values.USE_TOPOLOGY_CATEGORIES
+#@ end
+---
+#@ if should_create_clusterbootstrap():
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: ClusterBootstrap
+metadata:
+  name: #@ data.values.CLUSTER_NAME
+  namespace: #@ data.values.NAMESPACE
+  annotations:
+    tkg.tanzu.vmware.com/add-missing-fields-from-tkr: #@ data.values.KUBERNETES_RELEASE
+spec:
+  cni:
+    #@ if data.values.CNI == "antrea":
+    refName: antrea*
+    valuesFrom:
+      providerRef:
+        apiGroup: cni.tanzu.vmware.com
+        kind: AntreaConfig
+        name: #@ data.values.CLUSTER_NAME
+    #@ elif data.values.CNI == "calico":
+    refName: calico*
+    valuesFrom:
+      providerRef:
+        apiGroup: cni.tanzu.vmware.com
+        kind: CalicoConfig
+        name: #@ data.values.CLUSTER_NAME
+    #@ end
+  #@ if vspherecpi_configs_exist() and not data.values.IS_WINDOWS_WORKLOAD_CLUSTER:
+  cpi:
+    refName: vsphere-cpi*
+    valuesFrom:
+      providerRef:
+        apiGroup: cpi.tanzu.vmware.com
+        kind: VSphereCPIConfig
+        name: #@ data.values.CLUSTER_NAME
+  #@ end
+  #@ if vspherecsi_configs_exist() and not data.values.IS_WINDOWS_WORKLOAD_CLUSTER:
+  csi:
+    refName: vsphere-csi*
+    valuesFrom:
+      providerRef:
+        apiGroup: csi.tanzu.vmware.com
+        kind: VSphereCSIConfig
+        name: #@ data.values.CLUSTER_NAME
+  #@ end
+  kapp:
+    refName: kapp-controller*
+  additionalPackages:
+    - refName: metrics-server*
+    - refName: secretgen-controller*
+    - refName: pinniped*
+#@ end
+


### PR DESCRIPTION
### What this PR does / why we need it
1. Plumb legacy CLI Addon Configs to ClusterBootstrap and AddonConfig APIs for the following Components:
- Antrea
- Calico
- vsphere-csi
- vsphere-cpi

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2368 

### Describe testing done for PR
1. **Testcase 1**: For CNI as `calico`, Dryrun generated as follows:
<!-- Example: Created vSphere workload cluster to verify change. -->
```
apiVersion: cni.tanzu.vmware.com/v1alpha1
kind: CalicoConfig
metadata:
  name: sg-cluster
  namespace: default
spec:
  calico:
    config:
      vethMTU: 0
---
apiVersion: run.tanzu.vmware.com/v1alpha3
kind: ClusterBootstrap
metadata:
  annotations:
    tkg.tanzu.vmware.com/add-missing-fields-from-tkr: v1.23.5---vmware.1-tkg.1-zshippable
  name: sg-cluster
  namespace: default
spec:
  additionalPackages:
  - refName: metrics-server*
  - refName: secretgen-controller*
  - refName: pinniped*
  cni:
    refName: calico*
    valuesFrom:
      providerRef:
        apiGroup: cni.tanzu.vmware.com
        kind: CalicoConfig
        name: sg-cluster
  kapp:
    refName: kapp-controller*
---
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  annotations:
    run.tanzu.vmware.com/resolve-tkr: ""
  labels:
    tkg.tanzu.vmware.com/cluster-name: sg-cluster
  name: sg-cluster
  namespace: default
spec:
  clusterNetwork:
    pods:
      cidrBlocks:
      - 100.96.0.0/11
    services:
      cidrBlocks:
      - 100.64.0.0/13
  topology:
    class: tkg-aws-default
    controlPlane:
      metadata:
        annotations:
          run.tanzu.vmware.com/resolve-os-image: ami-region=us-west-2,os-name=ubuntu
      replicas: 1
    variables:
    - name: cni
      value: calico
    - name: auditLogging
      value:
        enabled: false
    - name: region
      value: us-west-2
    - name: sshKeyName
      value: tkgtest
    - name: loadBalancerSchemeInternal
      value: false
    - name: bastion
      value:
        enabled: true
    - name: network
      value:
        subnets:
        - az: us-west-2a
          private:
            id: subnet-008e7fead36b71f3d
          public:
            id: subnet-0ae6b7a92953d00fe
        vpc:
          existingID: vpc-07ce38addc21aa1d0
    - name: identityRef
      value: {}
    - name: worker
      value:
        instanceType: t3.xlarge
        rootVolume:
          sizeGiB: 80
    - name: controlPlane
      value:
        instanceType: t3.xlarge
        rootVolume:
          sizeGiB: 80
    version: v1.23.5+vmware.1
    workers:
      machineDeployments:
      - class: tkg-worker
        failureDomain: us-west-2a
        metadata:
          annotations:
            run.tanzu.vmware.com/resolve-os-image: ami-region=us-west-2,os-name=ubuntu
        name: md-0
        replicas: 1
```

2. **Testcase 2**: Customising AntreaConfig by setting `ANTREA_TRACEFLOW: false`:

Dryrun generated:
```
apiVersion: cni.tanzu.vmware.com/v1alpha1
kind: AntreaConfig
metadata:
  name: sg-cluster
  namespace: default
spec:
  antrea:
    config:
      disableUdpTunnelOffload: false
      featureGates:
        AntreaPolicy: true
        AntreaProxy: true
        AntreaTraceflow: false
        Egress: true
        EndpointSlice: true
        FlowExporter: false
        NodePortLocal: true
      noSNAT: false
      trafficEncapMode: encap
---
apiVersion: run.tanzu.vmware.com/v1alpha3
kind: ClusterBootstrap
metadata:
  annotations:
    tkg.tanzu.vmware.com/add-missing-fields-from-tkr: v1.23.5---vmware.1-tkg.1-zshippable
  name: sg-cluster
  namespace: default
spec:
  additionalPackages:
  - refName: metrics-server*
  - refName: secretgen-controller*
  - refName: pinniped*
  cni:
    refName: antrea*
    valuesFrom:
      providerRef:
        apiGroup: cni.tanzu.vmware.com
        kind: AntreaConfig
        name: sg-cluster
  kapp:
    refName: kapp-controller*
---
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  annotations:
    run.tanzu.vmware.com/resolve-tkr: ""
  labels:
    tkg.tanzu.vmware.com/cluster-name: sg-cluster
  name: sg-cluster
  namespace: default
spec:
  clusterNetwork:
    pods:
      cidrBlocks:
      - 100.96.0.0/11
    services:
      cidrBlocks:
      - 100.64.0.0/13
  topology:
    class: tkg-aws-default
    controlPlane:
      metadata:
        annotations:
          run.tanzu.vmware.com/resolve-os-image: ami-region=us-west-2,os-name=ubuntu
      replicas: 1
    variables:
    - name: cni
      value: antrea
    - name: auditLogging
      value:
        enabled: false
    - name: region
      value: us-west-2
    - name: sshKeyName
      value: tkgtest
    - name: loadBalancerSchemeInternal
      value: false
    - name: bastion
      value:
        enabled: true
    - name: network
      value:
        subnets:
        - az: us-west-2a
          private:
            id: subnet-008e7fead36b71f3d
          public:
            id: subnet-0ae6b7a92953d00fe
        vpc:
          existingID: vpc-07ce38addc21aa1d0
    - name: identityRef
      value: {}
    - name: worker
      value:
        instanceType: t3.xlarge
        rootVolume:
          sizeGiB: 80
    - name: controlPlane
      value:
        instanceType: t3.xlarge
        rootVolume:
          sizeGiB: 80
    version: v1.23.5+vmware.1
    workers:
      machineDeployments:
      - class: tkg-worker
        failureDomain: us-west-2a
        metadata:
          annotations:
            run.tanzu.vmware.com/resolve-os-image: ami-region=us-west-2,os-name=ubuntu
        name: md-0
        replicas: 1
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Plumb legacy CLI Addon Configs to ClusterBootstrap and AddonConfig APIs
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
