### PR TITLE
Skip reconciling for config CRs used as template

### DIFF
--- a/addons/config/expected/cni.tanzu.vmware.com/v1alpha1/antreaconfig/default.yaml
+++ b/addons/config/expected/cni.tanzu.vmware.com/v1alpha1/antreaconfig/default.yaml
@@ -3,6 +3,8 @@ kind: AntreaConfig
 metadata:
   name: v1.23.3---vmware.1-tkg.1
   namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   antrea:
     config:
@@ -24,6 +26,8 @@ kind: AntreaConfig
 metadata:
   name: v1.23.3---vmware.1-tkg.1-routable
   namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   antrea:
     config:

--- a/addons/config/expected/cni.tanzu.vmware.com/v1alpha1/calicoconfig/default.yaml
+++ b/addons/config/expected/cni.tanzu.vmware.com/v1alpha1/calicoconfig/default.yaml
@@ -3,6 +3,8 @@ kind: CalicoConfig
 metadata:
   name: v1.23.3---vmware.1-tkg.1
   namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   calico:
     config:
@@ -14,6 +16,8 @@ kind: CalicoConfig
 metadata:
   name: v1.23.3---vmware.1-tkg.1-docker
   namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   calico:
     config:

--- a/addons/config/expected/cpi.tanzu.vmware.com/v1alpha1/vspherecpiconfig/default.yaml
+++ b/addons/config/expected/cpi.tanzu.vmware.com/v1alpha1/vspherecpiconfig/default.yaml
@@ -3,6 +3,8 @@ kind: VSphereCPIConfig
 metadata:
   name: v1.23.3---vmware.1-tkg.1
   namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   vsphereCPI:
     mode: vsphereCPI

--- a/addons/config/expected/cpi.tanzu.vmware.com/v1alpha1/vspherecpiconfig/tkgs.yaml
+++ b/addons/config/expected/cpi.tanzu.vmware.com/v1alpha1/vspherecpiconfig/tkgs.yaml
@@ -3,6 +3,8 @@ kind: VSphereCPIConfig
 metadata:
   name: v1.23.3---vmware.1-tkg.1
   namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   vsphereCPI:
     mode: vsphereParavirtualCPI

--- a/addons/config/expected/csi.tanzu.vmware.com/v1alpha1/vspherecsiconfig/default.yaml
+++ b/addons/config/expected/csi.tanzu.vmware.com/v1alpha1/vspherecsiconfig/default.yaml
@@ -3,6 +3,8 @@ kind: VSphereCSIConfig
 metadata:
   name: v1.23.3---vmware.1-tkg.1
   namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   vsphereCSI:
     mode: vsphereCSI

--- a/addons/config/expected/csi.tanzu.vmware.com/v1alpha1/vspherecsiconfig/tkgs.yaml
+++ b/addons/config/expected/csi.tanzu.vmware.com/v1alpha1/vspherecsiconfig/tkgs.yaml
@@ -3,6 +3,8 @@ kind: VSphereCSIConfig
 metadata:
   name: v1.23.3---vmware.1-tkg.1
   namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   vsphereCSI:
     mode: vsphereParavirtualCSI

--- a/addons/config/expected/run.tanzu.vmware.com/v1alpha3/kappcontrollerconfig/default.yaml
+++ b/addons/config/expected/run.tanzu.vmware.com/v1alpha3/kappcontrollerconfig/default.yaml
@@ -3,6 +3,8 @@ kind: KappControllerConfig
 metadata:
   name: v1.23.3---vmware.1-tkg.1
   namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   namespace: tkg-system
   kappController:

--- a/addons/config/templates/cni.tanzu.vmware.com/v1alpha1/antreaconfig.yaml
+++ b/addons/config/templates/cni.tanzu.vmware.com/v1alpha1/antreaconfig.yaml
@@ -5,6 +5,8 @@ kind: AntreaConfig
 metadata:
   name: #@ data.values.TKR_VERSION
   namespace: #@ data.values.GLOBAL_NAMESPACE
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   antrea:
     config:
@@ -26,6 +28,8 @@ kind: AntreaConfig
 metadata:
   name: #@ "{}-routable".format(data.values.TKR_VERSION)
   namespace: #@ data.values.GLOBAL_NAMESPACE
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   antrea:
     config:

--- a/addons/config/templates/cni.tanzu.vmware.com/v1alpha1/calicoconfig.yaml
+++ b/addons/config/templates/cni.tanzu.vmware.com/v1alpha1/calicoconfig.yaml
@@ -5,6 +5,8 @@ kind: CalicoConfig
 metadata:
   name: #@ data.values.TKR_VERSION
   namespace: #@ data.values.GLOBAL_NAMESPACE
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   calico:
     config:
@@ -16,6 +18,8 @@ kind: CalicoConfig
 metadata:
   name: #@ "{}-docker".format(data.values.TKR_VERSION)
   namespace: #@ data.values.GLOBAL_NAMESPACE
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   calico:
     config:

--- a/addons/config/templates/cpi.tanzu.vmware.com/v1alpha1/vspherecpiconfig.yaml
+++ b/addons/config/templates/cpi.tanzu.vmware.com/v1alpha1/vspherecpiconfig.yaml
@@ -5,6 +5,8 @@ kind: VSphereCPIConfig
 metadata:
   name: #@ data.values.TKR_VERSION
   namespace: #@ data.values.GLOBAL_NAMESPACE
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   vsphereCPI:
     mode: #@ "vsphereCPI" if data.values.IAAS != "tkgs" else "vsphereParavirtualCPI"

--- a/addons/config/templates/csi.tanzu.vmware.com/v1alpha1/vspherecsiconfig.yaml
+++ b/addons/config/templates/csi.tanzu.vmware.com/v1alpha1/vspherecsiconfig.yaml
@@ -5,6 +5,8 @@ kind: VSphereCSIConfig
 metadata:
   name: #@ data.values.TKR_VERSION
   namespace: #@ data.values.GLOBAL_NAMESPACE
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   vsphereCSI:
     mode: #@ "vsphereCSI" if data.values.IAAS != "tkgs" else "vsphereParavirtualCSI"

--- a/addons/config/templates/run.tanzu.vmware.com/v1alpha3/kappcontrollerconfig.yaml
+++ b/addons/config/templates/run.tanzu.vmware.com/v1alpha3/kappcontrollerconfig.yaml
@@ -5,6 +5,8 @@ kind: KappControllerConfig
 metadata:
   name: #@ data.values.TKR_VERSION
   namespace: #@ data.values.GLOBAL_NAMESPACE
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   namespace: #@ data.values.GLOBAL_NAMESPACE
   kappController:

--- a/addons/controllers/antrea/antreaconfig_controller.go
+++ b/addons/controllers/antrea/antreaconfig_controller.go
@@ -62,6 +62,11 @@ func (r *AntreaConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// deep copy AntreaConfig to avoid issues if in the future other controllers where interacting with the same copy
 	antreaConfig = antreaConfig.DeepCopy()
 
+	// skip reconciliation for AntreaConfig CR used as template
+	if _, ok := antreaConfig.Annotations[constants.TKGAnnotationTemplateConfig]; ok {
+		return ctrl.Result{}, nil
+	}
+
 	// get the parent cluster name from owner reference
 	// if the owner reference doesn't exist, use the same name as config CRD
 	clusterNamespacedName := req.NamespacedName

--- a/addons/controllers/antrea/antreaconfig_controller.go
+++ b/addons/controllers/antrea/antreaconfig_controller.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	addonconfig "github.com/vmware-tanzu/tanzu-framework/addons/pkg/config"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
 	"github.com/vmware-tanzu/tanzu-framework/addons/predicates"
@@ -33,6 +34,7 @@ type AntreaConfigReconciler struct {
 	client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
+	Config addonconfig.AntreaConfigControllerConfig
 }
 
 // +kubebuilder:rbac:groups=addons.tanzu.vmware.com,resources=antreaconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -98,7 +100,7 @@ func (r *AntreaConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&cniv1alpha1.AntreaConfig{}).
 		WithOptions(options).
-		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.AntreaConfigKind, r.Log)).
+		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.AntreaConfigKind, r.Config.SystemNamespace, r.Log)).
 		Complete(r)
 }
 

--- a/addons/controllers/antreaconfig_controller_test.go
+++ b/addons/controllers/antreaconfig_controller_test.go
@@ -29,6 +29,7 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 
 	const (
 		antreaManifestsTestFile1 = "testdata/antrea-test-1.yaml"
+		antreaTemplateConfigManifestsTestFile1 = "testdata/antrea-test-template-config-1.yaml"
 		antreaTestCluster1       = "test-cluster-4"
 	)
 
@@ -182,6 +183,27 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 
 		})
 
+	})
+
+	Context("Reconcile AntreaConfig used as template", func() {
+
+		BeforeEach(func() {
+			configCRName = antreaTestCluster1
+			clusterResourceFilePath = antreaTemplateConfigManifestsTestFile1
+		})
+
+		It("Should skip the reconciliation", func() {
+
+			key := client.ObjectKey{
+				Namespace: "default",
+				Name:      configCRName,
+			}
+			config := &cniv1alpha1.AntreaConfig{}
+			Expect(k8sClient.Get(ctx, key, config)).To(Succeed())
+
+			By("OwnerReferences is not set")
+			Expect(len(config.OwnerReferences)).Should(Equal(0))
+		})
 	})
 
 	Context("Mutating webhooks for AntreaConfig", func() {

--- a/addons/controllers/antreaconfig_controller_test.go
+++ b/addons/controllers/antreaconfig_controller_test.go
@@ -28,9 +28,9 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 	)
 
 	const (
-		antreaManifestsTestFile1 = "testdata/antrea-test-1.yaml"
+		antreaManifestsTestFile1               = "testdata/antrea-test-1.yaml"
 		antreaTemplateConfigManifestsTestFile1 = "testdata/antrea-test-template-config-1.yaml"
-		antreaTestCluster1       = "test-cluster-4"
+		antreaTestCluster1                     = "test-cluster-4"
 	)
 
 	JustBeforeEach(func() {
@@ -195,7 +195,7 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 		It("Should skip the reconciliation", func() {
 
 			key := client.ObjectKey{
-				Namespace: "default",
+				Namespace: addonNamespace,
 				Name:      configCRName,
 			}
 			config := &cniv1alpha1.AntreaConfig{}

--- a/addons/controllers/calico/calicoconfig_controller.go
+++ b/addons/controllers/calico/calicoconfig_controller.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
+	"github.com/vmware-tanzu/tanzu-framework/addons/predicates"
 	cniv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cni/v1alpha1"
 )
 
@@ -59,11 +60,6 @@ func (r *CalicoConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	// deep copy CalicoConfig to avoid issues if in the future other controllers where interacting with the same copy
 	calicoConfig = calicoConfig.DeepCopy()
-
-	// skip reconciliation for CalicoConfig CR used as template
-	if _, ok := calicoConfig.Annotations[constants.TKGAnnotationTemplateConfig]; ok {
-		return ctrl.Result{}, nil
-	}
 
 	// config resources are expected to have the same name as the cluster. However, we ideally try to read the cluster name from the owner reference of the addon config object
 	clusterNamespacedName := req.NamespacedName
@@ -100,6 +96,7 @@ func (r *CalicoConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&cniv1alpha1.CalicoConfig{}).
 		WithOptions(options).
+		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.CalicoConfigKind, r.Log)).
 		Complete(r)
 }
 

--- a/addons/controllers/calico/calicoconfig_controller.go
+++ b/addons/controllers/calico/calicoconfig_controller.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	addonconfig "github.com/vmware-tanzu/tanzu-framework/addons/pkg/config"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
 	"github.com/vmware-tanzu/tanzu-framework/addons/predicates"
@@ -35,6 +36,7 @@ type CalicoConfigReconciler struct {
 	Log    logr.Logger
 	Scheme *runtime.Scheme
 	Ctx    context.Context
+	Config addonconfig.CalicoConfigControllerConfig
 }
 
 //+kubebuilder:rbac:groups=cni.tanzu.vmware.com,resources=calicoconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -96,7 +98,7 @@ func (r *CalicoConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&cniv1alpha1.CalicoConfig{}).
 		WithOptions(options).
-		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.CalicoConfigKind, r.Log)).
+		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.CalicoConfigKind, r.Config.SystemNamespace, r.Log)).
 		Complete(r)
 }
 

--- a/addons/controllers/calico/calicoconfig_controller.go
+++ b/addons/controllers/calico/calicoconfig_controller.go
@@ -60,6 +60,11 @@ func (r *CalicoConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// deep copy CalicoConfig to avoid issues if in the future other controllers where interacting with the same copy
 	calicoConfig = calicoConfig.DeepCopy()
 
+	// skip reconciliation for CalicoConfig CR used as template
+	if _, ok := calicoConfig.Annotations[constants.TKGAnnotationTemplateConfig]; ok {
+		return ctrl.Result{}, nil
+	}
+
 	// config resources are expected to have the same name as the cluster. However, we ideally try to read the cluster name from the owner reference of the addon config object
 	clusterNamespacedName := req.NamespacedName
 	cluster := &clusterapiv1beta1.Cluster{}

--- a/addons/controllers/calicoconfig_controller_test.go
+++ b/addons/controllers/calicoconfig_controller_test.go
@@ -20,11 +20,11 @@ import (
 )
 
 const (
-	testClusterCalico1 = "test-cluster-calico-1"
-	testClusterCalico2 = "test-cluster-calico-2"
-	testDataCalico1    = "testdata/test-calico-1.yaml"
-	testDataCalico2    = "testdata/test-calico-2.yaml"
-	testDataCalicoTemplateConfig1    = "testdata/test-calico-template-config-1.yaml"
+	testClusterCalico1            = "test-cluster-calico-1"
+	testClusterCalico2            = "test-cluster-calico-2"
+	testDataCalico1               = "testdata/test-calico-1.yaml"
+	testDataCalico2               = "testdata/test-calico-2.yaml"
+	testDataCalicoTemplateConfig1 = "testdata/test-calico-template-config-1.yaml"
 )
 
 var _ = Describe("CalicoConfig Reconciler and Webhooks", func() {
@@ -232,7 +232,7 @@ var _ = Describe("CalicoConfig Reconciler and Webhooks", func() {
 		It("Should skip the reconciliation", func() {
 
 			key := client.ObjectKey{
-				Namespace: "default",
+				Namespace: addonNamespace,
 				Name:      clusterName,
 			}
 			config := &cniv1alpha1.CalicoConfig{}

--- a/addons/controllers/calicoconfig_controller_test.go
+++ b/addons/controllers/calicoconfig_controller_test.go
@@ -24,6 +24,7 @@ const (
 	testClusterCalico2 = "test-cluster-calico-2"
 	testDataCalico1    = "testdata/test-calico-1.yaml"
 	testDataCalico2    = "testdata/test-calico-2.yaml"
+	testDataCalicoTemplateConfig1    = "testdata/test-calico-template-config-1.yaml"
 )
 
 var _ = Describe("CalicoConfig Reconciler and Webhooks", func() {
@@ -221,4 +222,24 @@ var _ = Describe("CalicoConfig Reconciler and Webhooks", func() {
 		})
 	})
 
+	Context("Reconcile CalicoConfig used as template", func() {
+
+		BeforeEach(func() {
+			clusterName = testClusterCalico1
+			clusterResourceFilePath = testDataCalicoTemplateConfig1
+		})
+
+		It("Should skip the reconciliation", func() {
+
+			key := client.ObjectKey{
+				Namespace: "default",
+				Name:      clusterName,
+			}
+			config := &cniv1alpha1.CalicoConfig{}
+			Expect(k8sClient.Get(ctx, key, config)).To(Succeed())
+
+			By("OwnerReferences is not set")
+			Expect(len(config.OwnerReferences)).Should(Equal(0))
+		})
+	})
 })

--- a/addons/controllers/cpi/vspherecpiconfig_controller.go
+++ b/addons/controllers/cpi/vspherecpiconfig_controller.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
+	"github.com/vmware-tanzu/tanzu-framework/addons/predicates"
 	cpiv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cpi/v1alpha1"
 )
 
@@ -93,11 +94,6 @@ func (r *VSphereCPIConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// deep copy VSphereCPIConfig to avoid issues if in the future other controllers where interacting with the same copy
 	cpiConfig = cpiConfig.DeepCopy()
-
-	// skip reconciliation for VSphereCPIConfig CR used as template
-	if _, ok := cpiConfig.Annotations[constants.TKGAnnotationTemplateConfig]; ok {
-		return ctrl.Result{}, nil
-	}
 
 	cluster, err := r.getOwnerCluster(ctx, cpiConfig)
 	if cluster == nil {
@@ -245,5 +241,6 @@ func (r *VSphereCPIConfigReconciler) SetupWithManager(_ context.Context, mgr ctr
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&cpiv1alpha1.VSphereCPIConfig{}).
 		WithOptions(options).
+		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.VSphereCPIConfigKind, r.Log)).
 		Complete(r)
 }

--- a/addons/controllers/cpi/vspherecpiconfig_controller.go
+++ b/addons/controllers/cpi/vspherecpiconfig_controller.go
@@ -91,10 +91,10 @@ func (r *VSphereCPIConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	// deep copy CPIConfig to avoid issues if in the future other controllers where interacting with the same copy
+	// deep copy VSphereCPIConfig to avoid issues if in the future other controllers where interacting with the same copy
 	cpiConfig = cpiConfig.DeepCopy()
 
-	// skip reconciliation for CPIConfig CR used as template
+	// skip reconciliation for VSphereCPIConfig CR used as template
 	if _, ok := cpiConfig.Annotations[constants.TKGAnnotationTemplateConfig]; ok {
 		return ctrl.Result{}, nil
 	}

--- a/addons/controllers/cpi/vspherecpiconfig_controller.go
+++ b/addons/controllers/cpi/vspherecpiconfig_controller.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	addonconfig "github.com/vmware-tanzu/tanzu-framework/addons/pkg/config"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
 	"github.com/vmware-tanzu/tanzu-framework/addons/predicates"
@@ -36,6 +37,7 @@ type VSphereCPIConfigReconciler struct {
 	client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
+	Config addonconfig.VSphereCPIConfigControllerConfig
 }
 
 var providerServiceAccountRBACRules = []rbacv1.PolicyRule{
@@ -241,6 +243,6 @@ func (r *VSphereCPIConfigReconciler) SetupWithManager(_ context.Context, mgr ctr
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&cpiv1alpha1.VSphereCPIConfig{}).
 		WithOptions(options).
-		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.VSphereCPIConfigKind, r.Log)).
+		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.VSphereCPIConfigKind, r.Config.SystemNamespace, r.Log)).
 		Complete(r)
 }

--- a/addons/controllers/cpi/vspherecpiconfig_controller.go
+++ b/addons/controllers/cpi/vspherecpiconfig_controller.go
@@ -91,7 +91,14 @@ func (r *VSphereCPIConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
+	// deep copy CPIConfig to avoid issues if in the future other controllers where interacting with the same copy
 	cpiConfig = cpiConfig.DeepCopy()
+
+	// skip reconciliation for CPIConfig CR used as template
+	if _, ok := cpiConfig.Annotations[constants.TKGAnnotationTemplateConfig]; ok {
+		return ctrl.Result{}, nil
+	}
+
 	cluster, err := r.getOwnerCluster(ctx, cpiConfig)
 	if cluster == nil {
 		return ctrl.Result{}, err // no need to requeue if cluster is not found

--- a/addons/controllers/csi/vspherecsiconfig_controller.go
+++ b/addons/controllers/csi/vspherecsiconfig_controller.go
@@ -149,10 +149,10 @@ func (r *VSphereCSIConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
-	// deep copy CSIConfig to avoid issues if in the future other controllers where interacting with the same copy
+	// deep copy VSphereCSIConfig to avoid issues if in the future other controllers where interacting with the same copy
 	vcsiConfig = vcsiConfig.DeepCopy()
 
-	// skip reconciliation for CSIConfig CR used as template
+	// skip reconciliation for VSphereCSIConfig CR used as template
 	if _, ok := vcsiConfig.Annotations[constants.TKGAnnotationTemplateConfig]; ok {
 		return ctrl.Result{}, nil
 	}

--- a/addons/controllers/csi/vspherecsiconfig_controller.go
+++ b/addons/controllers/csi/vspherecsiconfig_controller.go
@@ -149,6 +149,14 @@ func (r *VSphereCSIConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, err
 	}
 
+	// deep copy CSIConfig to avoid issues if in the future other controllers where interacting with the same copy
+	vcsiConfig = vcsiConfig.DeepCopy()
+
+	// skip reconciliation for CSIConfig CR used as template
+	if _, ok := vcsiConfig.Annotations[constants.TKGAnnotationTemplateConfig]; ok {
+		return ctrl.Result{}, nil
+	}
+
 	cluster, err := r.getOwnerCluster(ctx, vcsiConfig)
 	if cluster == nil {
 		return ctrl.Result{RequeueAfter: 20 * time.Second}, err // retry until corresponding cluster is found

--- a/addons/controllers/kapp-controller/kappcontrollerconfig_controller.go
+++ b/addons/controllers/kapp-controller/kappcontrollerconfig_controller.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	addonconfig "github.com/vmware-tanzu/tanzu-framework/addons/pkg/config"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
 	"github.com/vmware-tanzu/tanzu-framework/addons/predicates"
@@ -35,6 +36,7 @@ type KappControllerConfigReconciler struct {
 	client.Client
 	Log    logr.Logger
 	Scheme *runtime.Scheme
+	Config addonconfig.KappControllerConfigControllerConfig
 }
 
 //+kubebuilder:rbac:groups=run.tanzu.vmware.com,resources=kappcontrollerconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -97,7 +99,7 @@ func (r *KappControllerConfigReconciler) SetupWithManager(ctx context.Context, m
 			handler.EnqueueRequestsFromMapFunc(r.ClusterToKappControllerConfig),
 		).
 		WithOptions(options).
-		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.KappControllerConfigKind, r.Log)).
+		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.KappControllerConfigKind, r.Config.SystemNamespace, r.Log)).
 		Complete(r)
 }
 

--- a/addons/controllers/kapp-controller/kappcontrollerconfig_controller.go
+++ b/addons/controllers/kapp-controller/kappcontrollerconfig_controller.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
+	"github.com/vmware-tanzu/tanzu-framework/addons/predicates"
 	runv1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
 )
 
@@ -56,11 +57,6 @@ func (r *KappControllerConfigReconciler) Reconcile(ctx context.Context, req ctrl
 	}
 	// Deepcopy to prevent client-go cache conflict
 	kappControllerConfig = kappControllerConfig.DeepCopy()
-
-	// skip reconciliation for KappControllerConfig CR used as template
-	if _, ok := kappControllerConfig.Annotations[constants.TKGAnnotationTemplateConfig]; ok {
-		return ctrl.Result{}, nil
-	}
 
 	// get the parent cluster name from owner reference
 	// if the owner reference doesn't exist, use the same name as config CR
@@ -101,6 +97,7 @@ func (r *KappControllerConfigReconciler) SetupWithManager(ctx context.Context, m
 			handler.EnqueueRequestsFromMapFunc(r.ClusterToKappControllerConfig),
 		).
 		WithOptions(options).
+		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.KappControllerConfigKind, r.Log)).
 		Complete(r)
 }
 

--- a/addons/controllers/kapp-controller/kappcontrollerconfig_controller.go
+++ b/addons/controllers/kapp-controller/kappcontrollerconfig_controller.go
@@ -57,6 +57,11 @@ func (r *KappControllerConfigReconciler) Reconcile(ctx context.Context, req ctrl
 	// Deepcopy to prevent client-go cache conflict
 	kappControllerConfig = kappControllerConfig.DeepCopy()
 
+	// skip reconciliation for KappControllerConfig CR used as template
+	if _, ok := kappControllerConfig.Annotations[constants.TKGAnnotationTemplateConfig]; ok {
+		return ctrl.Result{}, nil
+	}
+
 	// get the parent cluster name from owner reference
 	// if the owner reference doesn't exist, use the same name as config CR
 	clusterNamespacedName := req.NamespacedName

--- a/addons/controllers/kappcontrollerconfig_controller_test.go
+++ b/addons/controllers/kappcontrollerconfig_controller_test.go
@@ -147,4 +147,24 @@ var _ = Describe("KappControllerConfig Reconciler", func() {
 
 	})
 
+	Context("Reconcile KappControllerConfig used as template", func() {
+
+		BeforeEach(func() {
+			kappConfigCRName = "test-kapp-controller-1"
+			clusterResourceFilePath = "testdata/test-kapp-controller-template-config-1.yaml"
+		})
+
+		It("Should skip the reconciliation", func() {
+
+			key := client.ObjectKey{
+				Namespace: "default",
+				Name:      kappConfigCRName,
+			}
+			config := &runv1alpha3.KappControllerConfig{}
+			Expect(k8sClient.Get(ctx, key, config)).To(Succeed())
+
+			By("OwnerReferences is not set")
+			Expect(len(config.OwnerReferences)).Should(Equal(0))
+		})
+	})
 })

--- a/addons/controllers/kappcontrollerconfig_controller_test.go
+++ b/addons/controllers/kappcontrollerconfig_controller_test.go
@@ -157,7 +157,7 @@ var _ = Describe("KappControllerConfig Reconciler", func() {
 		It("Should skip the reconciliation", func() {
 
 			key := client.ObjectKey{
-				Namespace: "default",
+				Namespace: addonNamespace,
 				Name:      kappConfigCRName,
 			}
 			config := &runv1alpha3.KappControllerConfig{}

--- a/addons/controllers/suite_test.go
+++ b/addons/controllers/suite_test.go
@@ -271,30 +271,40 @@ var _ = BeforeSuite(func(done Done) {
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("CalicoConfig"),
 		Scheme: mgr.GetScheme(),
+		Config: addonconfig.CalicoConfigControllerConfig{
+			ConfigControllerConfig: addonconfig.ConfigControllerConfig{SystemNamespace: constants.TKGSystemNS}},
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
 
 	Expect((&cpi.VSphereCPIConfigReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("VSphereCPIConfig"),
 		Scheme: mgr.GetScheme(),
+		Config: addonconfig.VSphereCPIConfigControllerConfig{
+			ConfigControllerConfig: addonconfig.ConfigControllerConfig{SystemNamespace: constants.TKGSystemNS}},
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
 
 	Expect((&csi.VSphereCSIConfigReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("VSphereCSIConfig"),
 		Scheme: mgr.GetScheme(),
+		Config: addonconfig.VSphereCSIConfigControllerConfig{
+			ConfigControllerConfig: addonconfig.ConfigControllerConfig{SystemNamespace: constants.TKGSystemNS}},
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
 
 	Expect((&antrea.AntreaConfigReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("AntreaConfig"),
 		Scheme: mgr.GetScheme(),
+		Config: addonconfig.AntreaConfigControllerConfig{
+			ConfigControllerConfig: addonconfig.ConfigControllerConfig{SystemNamespace: constants.TKGSystemNS}},
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
 
 	Expect((&kappcontroller.KappControllerConfigReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("KappController"),
 		Scheme: mgr.GetScheme(),
+		Config: addonconfig.KappControllerConfigControllerConfig{
+			ConfigControllerConfig: addonconfig.ConfigControllerConfig{SystemNamespace: constants.TKGSystemNS}},
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
 
 	Expect((&MachineReconciler{

--- a/addons/controllers/testdata/antrea-test-template-config-1.yaml
+++ b/addons/controllers/testdata/antrea-test-template-config-1.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: cni.tanzu.vmware.com/v1alpha1
+kind: AntreaConfig
+metadata:
+  name: test-cluster-4
+  namespace: default
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
+spec:
+  antrea:
+    config:
+      egress:
+        exceptCIDRs: []
+      nodePortLocal:
+        enabled: true
+        portRange: 61000-62000
+      antreaProxy:
+        proxyAll: false
+        nodePortAddresses: []
+        skipServices: []
+        proxyLoadBalancerIPs: false
+      kubeAPIServerOverride: null
+      transportInterface: null
+      transportInterfaceCIDRs: []
+      multicastInterfaces: []
+      tunnelType: geneve
+      trafficEncryptionMode: none
+      wireGuard:
+        port: 51820
+      serviceCIDR: 10.96.0.0/12
+      serviceCIDRv6: null
+      enableUsageReporting: false
+      trafficEncapMode: encap
+      noSNAT: false
+      disableUdpTunnelOffload: false
+      defaultMTU: ""
+      tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+      featureGates:
+        AntreaProxy: true
+        EndpointSlice: false
+        AntreaPolicy: true
+        FlowExporter: false
+        Egress: false
+        NodePortLocal: true
+        AntreaTraceflow: false
+        NetworkPolicyStats: false
+        AntreaIPAM: false
+        ServiceExternalIP: false
+        Multicast: false

--- a/addons/controllers/testdata/antrea-test-template-config-1.yaml
+++ b/addons/controllers/testdata/antrea-test-template-config-1.yaml
@@ -3,7 +3,7 @@ apiVersion: cni.tanzu.vmware.com/v1alpha1
 kind: AntreaConfig
 metadata:
   name: test-cluster-4
-  namespace: default
+  namespace: tkg-system
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:

--- a/addons/controllers/testdata/test-calico-template-config-1.yaml
+++ b/addons/controllers/testdata/test-calico-template-config-1.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: cni.tanzu.vmware.com/v1alpha1
+kind: CalicoConfig
+metadata:
+  name: test-cluster-calico-1
+  namespace: default
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
+spec:
+  calico:
+    config:
+      vethMTU: 0
+      skipCNIBinaries: true

--- a/addons/controllers/testdata/test-calico-template-config-1.yaml
+++ b/addons/controllers/testdata/test-calico-template-config-1.yaml
@@ -3,7 +3,7 @@ apiVersion: cni.tanzu.vmware.com/v1alpha1
 kind: CalicoConfig
 metadata:
   name: test-cluster-calico-1
-  namespace: default
+  namespace: tkg-system
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:

--- a/addons/controllers/testdata/test-kapp-controller-template-config-1.yaml
+++ b/addons/controllers/testdata/test-kapp-controller-template-config-1.yaml
@@ -3,7 +3,7 @@ apiVersion: run.tanzu.vmware.com/v1alpha3
 kind: KappControllerConfig
 metadata:
   name: test-kapp-controller-1
-  namespace: default
+  namespace: tkg-system
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:

--- a/addons/controllers/testdata/test-kapp-controller-template-config-1.yaml
+++ b/addons/controllers/testdata/test-kapp-controller-template-config-1.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: KappControllerConfig
+metadata:
+  name: test-kapp-controller-1
+  namespace: default
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
+spec:
+  namespace: test-ns
+  kappController:
+    createNamespace: true
+    globalNamespace: tanzu-package-repo-global
+    deployment:
+      concurrency: 4
+      hostNetwork: true
+      priorityClassName: system-cluster-critical
+      apiPort: 10100
+      metricsBindAddress: "0"
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+    config:
+      httpProxy: "overwrite.foo.com"
+      dangerousSkipTLSVerify: "registry1,registry2"

--- a/addons/controllers/testdata/test-vsphere-cpi-template-config.yaml
+++ b/addons/controllers/testdata/test-vsphere-cpi-template-config.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: cpi.tanzu.vmware.com/v1alpha1
+kind: VSphereCPIConfig
+metadata:
+  name: test-cluster-cpi
+  namespace: default
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
+spec:
+  vsphereCPI:
+    mode: vsphereCPI

--- a/addons/controllers/testdata/test-vsphere-cpi-template-config.yaml
+++ b/addons/controllers/testdata/test-vsphere-cpi-template-config.yaml
@@ -2,8 +2,8 @@
 apiVersion: cpi.tanzu.vmware.com/v1alpha1
 kind: VSphereCPIConfig
 metadata:
-  name: test-cluster-cpi
-  namespace: default
+  name: test-cluster-cpi-template
+  namespace: tkg-system
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:

--- a/addons/controllers/testdata/test-vsphere-csi-template-config.yaml
+++ b/addons/controllers/testdata/test-vsphere-csi-template-config.yaml
@@ -2,8 +2,8 @@
 apiVersion: csi.tanzu.vmware.com/v1alpha1
 kind: VSphereCSIConfig
 metadata:
-  name: test-cluster-csi
-  namespace: default
+  name: test-cluster-csi-template
+  namespace: tkg-system
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:

--- a/addons/controllers/testdata/test-vsphere-csi-template-config.yaml
+++ b/addons/controllers/testdata/test-vsphere-csi-template-config.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: csi.tanzu.vmware.com/v1alpha1
+kind: VSphereCSIConfig
+metadata:
+  name: test-cluster-csi
+  namespace: default
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
+spec:
+  vsphereCSI:
+    mode: vsphereCSI

--- a/addons/controllers/vspherecpiconfig_controller_test.go
+++ b/addons/controllers/vspherecpiconfig_controller_test.go
@@ -352,6 +352,27 @@ var _ = Describe("VSphereCPIConfig Reconciler", func() {
 			})
 		})
 	})
+
+	Context("Reconcile VSphereCPIConfig used as template", func() {
+
+		BeforeEach(func() {
+			clusterName = "test-cluster-cpi"
+			clusterResourceFilePath = "testdata/test-vsphere-cpi-template-config.yaml"
+		})
+
+		It("Should skip the reconciliation", func() {
+
+			key := client.ObjectKey{
+				Namespace: "default",
+				Name:      clusterName,
+			}
+			config := &cpiv1alpha1.VSphereCPIConfig{}
+			Expect(k8sClient.Get(ctx, key, config)).To(Succeed())
+
+			By("OwnerReferences is not set")
+			Expect(len(config.OwnerReferences)).Should(Equal(0))
+		})
+	})
 })
 
 var _ = Describe("VSphereCPIConfig Reconciler with existing endpoint from LB service", func() {

--- a/addons/controllers/vspherecpiconfig_controller_test.go
+++ b/addons/controllers/vspherecpiconfig_controller_test.go
@@ -356,16 +356,13 @@ var _ = Describe("VSphereCPIConfig Reconciler", func() {
 	Context("Reconcile VSphereCPIConfig used as template", func() {
 
 		BeforeEach(func() {
-			clusterName = "test-cluster-cpi"
+			clusterName = "test-cluster-cpi-template"
 			clusterResourceFilePath = "testdata/test-vsphere-cpi-template-config.yaml"
 		})
 
 		It("Should skip the reconciliation", func() {
 
-			key := client.ObjectKey{
-				Namespace: "default",
-				Name:      clusterName,
-			}
+			key.Namespace = addonNamespace
 			config := &cpiv1alpha1.VSphereCPIConfig{}
 			Expect(k8sClient.Get(ctx, key, config)).To(Succeed())
 

--- a/addons/controllers/vspherecsiconfig_controller_test.go
+++ b/addons/controllers/vspherecsiconfig_controller_test.go
@@ -360,4 +360,26 @@ var _ = Describe("VSphereCSIConfig Reconciler", func() {
 			}, waitTimeout, pollingInterval).Should(Succeed())
 		})
 	})
+
+	Context("Reconcile VSphereCSIConfig used as template", func() {
+
+		BeforeEach(func() {
+			clusterName = "test-cluster-csi"
+			clusterResourceFilePath = "testdata/test-vsphere-csi-template-config.yaml"
+			enduringResourcesFilePath = ""
+		})
+
+		It("Should skip the reconciliation", func() {
+
+			key := client.ObjectKey{
+				Namespace: "default",
+				Name:      clusterName,
+			}
+			config := &csiv1alpha1.VSphereCSIConfig{}
+			Expect(k8sClient.Get(ctx, key, config)).To(Succeed())
+
+			By("OwnerReferences is not set")
+			Expect(len(config.OwnerReferences)).Should(Equal(0))
+		})
+	})
 })

--- a/addons/controllers/vspherecsiconfig_controller_test.go
+++ b/addons/controllers/vspherecsiconfig_controller_test.go
@@ -364,17 +364,14 @@ var _ = Describe("VSphereCSIConfig Reconciler", func() {
 	Context("Reconcile VSphereCSIConfig used as template", func() {
 
 		BeforeEach(func() {
-			clusterName = "test-cluster-csi"
+			clusterName = "test-cluster-csi-template"
 			clusterResourceFilePath = "testdata/test-vsphere-csi-template-config.yaml"
 			enduringResourcesFilePath = ""
 		})
 
 		It("Should skip the reconciliation", func() {
 
-			key := client.ObjectKey{
-				Namespace: "default",
-				Name:      clusterName,
-			}
+			key.Namespace = addonNamespace
 			config := &csiv1alpha1.VSphereCSIConfig{}
 			Expect(k8sClient.Get(ctx, key, config)).To(Succeed())
 

--- a/addons/main.go
+++ b/addons/main.go
@@ -232,6 +232,8 @@ func enableClusterBootstrapAndConfigControllers(ctx context.Context, mgr ctrl.Ma
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("CalicoConfigController"),
 		Scheme: mgr.GetScheme(),
+		Config: addonconfig.CalicoConfigControllerConfig{
+			ConfigControllerConfig: addonconfig.ConfigControllerConfig{SystemNamespace: flags.addonNamespace}},
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		setupLog.Error(err, "unable to create CalicoConfigController", "controller", "calico")
 		os.Exit(1)
@@ -241,6 +243,8 @@ func enableClusterBootstrapAndConfigControllers(ctx context.Context, mgr ctrl.Ma
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("AntreaConfigController"),
 		Scheme: mgr.GetScheme(),
+		Config: addonconfig.AntreaConfigControllerConfig{
+			ConfigControllerConfig: addonconfig.ConfigControllerConfig{SystemNamespace: flags.addonNamespace}},
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		setupLog.Error(err, "unable to create AntreaConfigController", "controller", "antrea")
 		os.Exit(1)
@@ -249,6 +253,8 @@ func enableClusterBootstrapAndConfigControllers(ctx context.Context, mgr ctrl.Ma
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("KappControllerConfig"),
 		Scheme: mgr.GetScheme(),
+		Config: addonconfig.KappControllerConfigControllerConfig{
+			ConfigControllerConfig: addonconfig.ConfigControllerConfig{SystemNamespace: flags.addonNamespace}},
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		setupLog.Error(err, "unable to create KappControllerConfig", "controller", "kapp")
 		os.Exit(1)
@@ -257,6 +263,8 @@ func enableClusterBootstrapAndConfigControllers(ctx context.Context, mgr ctrl.Ma
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("VSphereCPIConfig"),
 		Scheme: mgr.GetScheme(),
+		Config: addonconfig.VSphereCPIConfigControllerConfig{
+			ConfigControllerConfig: addonconfig.ConfigControllerConfig{SystemNamespace: flags.addonNamespace}},
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		setupLog.Error(err, "unable to create CPIConfigController", "controller", "vspherecpi")
 		os.Exit(1)
@@ -266,6 +274,8 @@ func enableClusterBootstrapAndConfigControllers(ctx context.Context, mgr ctrl.Ma
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("VSphereCSIConfig"),
 		Scheme: mgr.GetScheme(),
+		Config: addonconfig.VSphereCSIConfigControllerConfig{
+			ConfigControllerConfig: addonconfig.ConfigControllerConfig{SystemNamespace: flags.addonNamespace}},
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		setupLog.Error(err, "unable to create CSIConfigController", "controller", "vspherecsi")
 		os.Exit(1)

--- a/addons/pkg/config/config.go
+++ b/addons/pkg/config/config.go
@@ -42,3 +42,34 @@ type PackageInstallStatusControllerConfig struct {
 	// The namespace where the bootstrap objects will be created, i.e., tkg-system
 	SystemNamespace string
 }
+
+// ConfigControllerConfig contains common configuration information of config controller
+type ConfigControllerConfig struct {
+	// The namespace where the template config objects will be created, i.e., tkg-system
+	SystemNamespace string
+}
+
+// AntreaConfigControllerConfig contains configuration information of AntreaConfig controller
+type AntreaConfigControllerConfig struct {
+	ConfigControllerConfig
+}
+
+// CalicoConfigControllerConfig contains configuration information of CalicoConfig controller
+type CalicoConfigControllerConfig struct {
+	ConfigControllerConfig
+}
+
+// KappControllerConfigControllerConfig contains configuration information of KappControllerConfig controller
+type KappControllerConfigControllerConfig struct {
+	ConfigControllerConfig
+}
+
+// VSphereCPIConfigControllerConfig contains configuration information of VSphereCPIConfig controller
+type VSphereCPIConfigControllerConfig struct {
+	ConfigControllerConfig
+}
+
+// VSphereCSIConfigControllerConfig contains configuration information of VSphereCSIConfig controller
+type VSphereCSIConfigControllerConfig struct {
+	ConfigControllerConfig
+}

--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -38,6 +38,9 @@ const (
 	// TKRLabelLegacyClusters is the TKR label for legacy clusters
 	TKRLableLegacyClusters = "run.tanzu.vmware.com/legacy-tkr"
 
+	// TKGAnnotationTemplateConfig is the TKG annotation for addon config CRs used by ClusterBootstrapTemplate
+	TKGAnnotationTemplateConfig = "tkg.tanzu.vmware.com/template-config"
+
 	// TKGBomContent is the TKG BOM content.
 	TKGBomContent = "bomContent"
 

--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -9,6 +9,11 @@ import (
 	"time"
 
 	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	cniv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cni/v1alpha1"
+	cpiv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cpi/v1alpha1"
+	csiv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/csi/v1alpha1"
+	runv1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
 )
 
 const (
@@ -223,5 +228,22 @@ const (
 	CAPVClusterRoleAggregationRuleLabelSelectorValue = "true"
 )
 
-// ClusterKind is the Kind for cluster-api Cluster object
-var ClusterKind = reflect.TypeOf(clusterapiv1beta1.Cluster{}).Name()
+var (
+	// ClusterKind is the Kind for cluster-api Cluster object
+	ClusterKind = reflect.TypeOf(clusterapiv1beta1.Cluster{}).Name()
+
+	// AntreaConfigKind is the Kind for cni AntreaConfig object
+	AntreaConfigKind = reflect.TypeOf(cniv1alpha1.AntreaConfig{}).Name()
+
+	// CalicoConfigKind is the Kind for cni CalicoConfig object
+	CalicoConfigKind = reflect.TypeOf(cniv1alpha1.CalicoConfig{}).Name()
+
+	// VSphereCSIConfigKind is the Kind for csi VSphereCSIConfig object
+	VSphereCSIConfigKind = reflect.TypeOf(csiv1alpha1.VSphereCSIConfig{}).Name()
+
+	// VSphereCPIConfigKind is the Kind for cpi VSphereCPIConfig object
+	VSphereCPIConfigKind = reflect.TypeOf(cpiv1alpha1.VSphereCPIConfig{}).Name()
+
+	// KappControllerConfigKind is the Kind for KappControllerConfig object
+	KappControllerConfigKind = reflect.TypeOf(runv1alpha3.KappControllerConfig{}).Name()
+)

--- a/addons/predicates/addon_config.go
+++ b/addons/predicates/addon_config.go
@@ -1,0 +1,47 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package predicates
+
+import (
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// ConfigOfKindWithoutAnnotation checks if the config is of the given Kind and does not have the given annotation
+func ConfigOfKindWithoutAnnotation(annotation string, configKind string, logger logr.Logger) predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return processIfConfigOfKindWithoutAnnotation(annotation, configKind, e.ObjectNew, logger.WithValues("predicate", "updateEvent"))
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return processIfConfigOfKindWithoutAnnotation(annotation, configKind, e.Object, logger.WithValues("predicate", "createEvent"))
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return processIfConfigOfKindWithoutAnnotation(annotation, configKind, e.Object, logger.WithValues("predicate", "deleteEvent"))
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return processIfConfigOfKindWithoutAnnotation(annotation, configKind, e.Object, logger.WithValues("predicate", "genericEvent"))
+		},
+	}
+}
+
+// processIfConfigOfKindWithoutAnnotation determines if the input object is of the specified Kind without the
+// given annotation. For input objects do not match with the specified Kind, it returns true.
+func processIfConfigOfKindWithoutAnnotation(annotation string, configKind string, obj client.Object, logger logr.Logger) bool {
+	if kind := obj.GetObjectKind().GroupVersionKind().Kind; kind != configKind {
+		return true
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations != nil {
+		if _, ok := annotations[annotation]; ok {
+			log := logger.WithValues("kind", configKind, "namespace", obj.GetNamespace(), "name", obj.GetName())
+			log.V(6).Info("resource has annotation", "annotation", annotation)
+			return false
+		}
+	}
+	return true
+}

--- a/addons/predicates/addon_config.go
+++ b/addons/predicates/addon_config.go
@@ -11,27 +11,30 @@ import (
 )
 
 // ConfigOfKindWithoutAnnotation checks if the config is of the given Kind and does not have the given annotation
-func ConfigOfKindWithoutAnnotation(annotation string, configKind string, logger logr.Logger) predicate.Funcs {
+func ConfigOfKindWithoutAnnotation(annotation, configKind, namespace string, logger logr.Logger) predicate.Funcs {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return processIfConfigOfKindWithoutAnnotation(annotation, configKind, e.ObjectNew, logger.WithValues("predicate", "updateEvent"))
+			return processIfConfigOfKindWithoutAnnotation(annotation, configKind, namespace, e.ObjectNew, logger.WithValues("predicate", "updateEvent"))
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			return processIfConfigOfKindWithoutAnnotation(annotation, configKind, e.Object, logger.WithValues("predicate", "createEvent"))
+			return processIfConfigOfKindWithoutAnnotation(annotation, configKind, namespace, e.Object, logger.WithValues("predicate", "createEvent"))
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return processIfConfigOfKindWithoutAnnotation(annotation, configKind, e.Object, logger.WithValues("predicate", "deleteEvent"))
+			return processIfConfigOfKindWithoutAnnotation(annotation, configKind, namespace, e.Object, logger.WithValues("predicate", "deleteEvent"))
 		},
 		GenericFunc: func(e event.GenericEvent) bool {
-			return processIfConfigOfKindWithoutAnnotation(annotation, configKind, e.Object, logger.WithValues("predicate", "genericEvent"))
+			return processIfConfigOfKindWithoutAnnotation(annotation, configKind, namespace, e.Object, logger.WithValues("predicate", "genericEvent"))
 		},
 	}
 }
 
-// processIfConfigOfKindWithoutAnnotation determines if the input object is of the specified Kind without the
-// given annotation. For input objects do not match with the specified Kind, it returns true.
-func processIfConfigOfKindWithoutAnnotation(annotation string, configKind string, obj client.Object, logger logr.Logger) bool {
+// processIfConfigOfKindWithoutAnnotation determines if the input object is of the specified Kind in the given namespace
+// without the given annotation. For input objects do not match with the specified Kind or not in the given namespace, it returns true.
+func processIfConfigOfKindWithoutAnnotation(annotation, configKind, namespace string, obj client.Object, logger logr.Logger) bool {
 	if kind := obj.GetObjectKind().GroupVersionKind().Kind; kind != configKind {
+		return true
+	}
+	if obj.GetNamespace() != namespace {
 		return true
 	}
 

--- a/addons/predicates/addon_config_test.go
+++ b/addons/predicates/addon_config_test.go
@@ -19,17 +19,19 @@ var _ = Describe("Addon config annotation predicate", func() {
 		var (
 			antreaConfigObj *cniv1alpha1.AntreaConfig
 			configKind      string
+			namespace       string
 			logger          logr.Logger
 			result          bool
 		)
 
 		BeforeEach(func() {
+			namespace = "test-ns"
 			logger = ctrl.Log.WithName("processIfConfigOfKindWithoutAnnotation")
 			antreaConfigObj = &cniv1alpha1.AntreaConfig{
 				TypeMeta: metav1.TypeMeta{Kind: constants.AntreaConfigKind},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-config-name",
-					Namespace: "test-ns",
+					Namespace: namespace,
 					Annotations: map[string]string{
 						constants.TKGAnnotationTemplateConfig: "true",
 					}},
@@ -39,7 +41,7 @@ var _ = Describe("Addon config annotation predicate", func() {
 
 		When("input config matches with specified Kind and has the annotation", func() {
 			BeforeEach(func() {
-				result = processIfConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, configKind, antreaConfigObj, logger)
+				result = processIfConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, configKind, namespace, antreaConfigObj, logger)
 			})
 
 			It("should return false", func() {
@@ -50,7 +52,7 @@ var _ = Describe("Addon config annotation predicate", func() {
 		When("input config does not have the specified annotation", func() {
 			BeforeEach(func() {
 				delete(antreaConfigObj.Annotations, constants.TKGAnnotationTemplateConfig)
-				result = processIfConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, configKind, antreaConfigObj, logger)
+				result = processIfConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, configKind, namespace, antreaConfigObj, logger)
 			})
 
 			It("should return true", func() {
@@ -61,7 +63,7 @@ var _ = Describe("Addon config annotation predicate", func() {
 		When("input config's annotations is nil", func() {
 			BeforeEach(func() {
 				antreaConfigObj.Annotations = nil
-				result = processIfConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, configKind, antreaConfigObj, logger)
+				result = processIfConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, configKind, namespace, antreaConfigObj, logger)
 			})
 
 			It("should return true", func() {
@@ -72,7 +74,17 @@ var _ = Describe("Addon config annotation predicate", func() {
 		When("input config does not match with the given Kind", func() {
 			BeforeEach(func() {
 				configKind = constants.CalicoConfigKind
-				result = processIfConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, configKind, antreaConfigObj, logger)
+				result = processIfConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, configKind, namespace, antreaConfigObj, logger)
+			})
+
+			It("should return true", func() {
+				Expect(result).To(BeTrue())
+			})
+		})
+
+		When("input config is not in the given namespace", func() {
+			BeforeEach(func() {
+				result = processIfConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, configKind, "another-ns", antreaConfigObj, logger)
 			})
 
 			It("should return true", func() {

--- a/addons/predicates/addon_config_test.go
+++ b/addons/predicates/addon_config_test.go
@@ -4,8 +4,6 @@
 package predicates
 
 import (
-	"testing"
-
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,18 +14,13 @@ import (
 	cniv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cni/v1alpha1"
 )
 
-func TestAddonConfigPredicate(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "addon config predicate unit tests")
-}
-
 var _ = Describe("Addon config annotation predicate", func() {
 	Context("predicate: processIfConfigOfKindWithoutAnnotation()", func() {
 		var (
 			antreaConfigObj *cniv1alpha1.AntreaConfig
-			configKind string
-			logger logr.Logger
-			result bool
+			configKind      string
+			logger          logr.Logger
+			result          bool
 		)
 
 		BeforeEach(func() {
@@ -35,9 +28,9 @@ var _ = Describe("Addon config annotation predicate", func() {
 			antreaConfigObj = &cniv1alpha1.AntreaConfig{
 				TypeMeta: metav1.TypeMeta{Kind: constants.AntreaConfigKind},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-config-name",
+					Name:      "test-config-name",
 					Namespace: "test-ns",
-					Annotations: map[string]string {
+					Annotations: map[string]string{
 						constants.TKGAnnotationTemplateConfig: "true",
 					}},
 			}

--- a/addons/predicates/tkr_test.go
+++ b/addons/predicates/tkr_test.go
@@ -28,9 +28,9 @@ const (
 	testTKRLabel          = "v1.22.3"
 )
 
-func TestTKRTestUnit(t *testing.T) {
+func TestPredicates(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "predicates/TKR Unit Tests")
+	RunSpecs(t, "predicates unit tests")
 }
 
 var _ = Describe("Cluster Label Check", func() {


### PR DESCRIPTION
### What this PR does / why we need it
- Add annotations in the addon config CRs used by ClusterBootstrapTemplate, to identify they are template config CRs
- Add predicate for config controllers to filter out events of template config CRs in the system namespace
- Add positive tests to verify the reconciliation skip logic

**Note**:  `vspherecsiconfig_controller` uses both direct annotation check in addition to the new predicate. This is because `ConfigMapToVSphereCSIConfig` function will enqueue reconcile requests for `VSphereCSIConfig` CRs when related `ConfigMap` CRs are created/updated. So mere predicate doesn't work here.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #2258 .

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2258

### Describe testing done for PR
- Passed all unit/integration tests in local environment.
- Verified change in real cluster:
--   No errors about "cluster not found" for template config CRs in the controller log after starting controller:
```
I0625 00:28:48.329919       1 controller.go:220] controller/calicoconfig "msg"="Starting workers" "reconciler group"="cni.tanzu.vmware.com" "reconciler kind"="CalicoConfig" "worker count"=1
I0625 00:28:48.329980       1 controller.go:220] controller/cluster "msg"="Starting workers" "reconciler group"="cluster.x-k8s.io" "reconciler kind"="Cluster" "worker count"=10
I0625 00:28:48.330577       1 controller.go:220] controller/cluster "msg"="Starting workers" "reconciler group"="cluster.x-k8s.io" "reconciler kind"="Cluster" "worker count"=10
I0625 00:28:48.330642       1 controller.go:220] controller/cluster "msg"="Starting workers" "reconciler group"="cluster.x-k8s.io" "reconciler kind"="Cluster" "worker count"=1
I0625 00:28:48.328538       1 controller.go:220] controller/kappcontrollerconfig "msg"="Starting workers" "reconciler group"="run.tanzu.vmware.com" "reconciler kind"="KappControllerConfig" "worker count"=1
```
-- The config CRs cloned from template config CRs do not have such annotation after a new workload cluster is created:
```
# take antreaconfig for example:
[ ~ ]# k get -n test-ns-1 antreaconfig tkc-02-antrea-package -o yaml
apiVersion: cni.tanzu.vmware.com/v1alpha1
kind: AntreaConfig
metadata:
  creationTimestamp: "2022-06-25T00:12:22Z"
  generation: 1
  labels:
    tkg.tanzu.vmware.com/cluster-name: tkc-02
    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.5.2---vmware.3-tkg.1-advanced-zshippa
  name: tkc-02-antrea-package
  namespace: test-ns-1
  ownerReferences:
  - apiVersion: cluster.x-k8s.io/v1beta1
    kind: Cluster
    name: tkc-02
    uid: bd4de193-865a-42a9-96c7-0bdd2e985ed7
  - apiVersion: run.tanzu.vmware.com/v1alpha3
    blockOwnerDeletion: true
    controller: true
    kind: ClusterBootstrap
    name: tkc-02
    uid: 50117358-5165-4d4c-88b8-c5415b845109
  resourceVersion: "1872328"
  selfLink: /apis/cni.tanzu.vmware.com/v1alpha1/namespaces/test-ns-1/antreaconfigs/tkc-02-antrea-package
  uid: 8e2414c6-f0cf-46b5-a46c-f2ece320f15a
spec:
...
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
