### PR TITLE
Support clusterclass based TKGS workload cluster upgrade

### DIFF
--- a/pkg/v1/tkg/client/upgrade_cluster.go
+++ b/pkg/v1/tkg/client/upgrade_cluster.go
@@ -50,6 +50,7 @@ type UpgradeClusterOptions struct {
 	IsRegionalCluster   bool
 	SkipAddonUpgrade    bool
 	SkipPrompt          bool
+	IsTKGSCluster       bool
 	// Tanzu edition (either tce or tkg)
 	Edition string
 }
@@ -134,11 +135,14 @@ func (c *TkgClient) UpgradeCluster(options *UpgradeClusterOptions) error {
 		return errors.Wrap(err, "unable to get cluster client while upgrading cluster")
 	}
 
-	isPacific, err := regionalClusterClient.IsPacificRegionalCluster()
+	// Check if Cluster is ClusterClass based cluster or not
+	isClusterClassBased, err := regionalClusterClient.IsClusterClassBased(options.ClusterName, options.Namespace)
 	if err != nil {
-		return errors.Wrap(err, "error determining 'Tanzu Kubernetes Cluster service for vSphere' management cluster")
+		return errors.Wrap(err, "unable to determine cluster type")
 	}
-	if isPacific {
+
+	// If this is TKGS cluster and using TKC API then upgrade using legacy TKC based approach
+	if options.IsTKGSCluster && !isClusterClassBased {
 		return c.DoPacificClusterUpgrade(regionalClusterClient, options)
 	}
 
@@ -150,12 +154,6 @@ func (c *TkgClient) UpgradeCluster(options *UpgradeClusterOptions) error {
 		}
 		options.ClusterName = clusterName
 		options.Namespace = namespace
-	} else {
-		log.Info("Validating configuration...")
-		err = c.ValidateSupportOfK8sVersionForManagmentCluster(regionalClusterClient, options.KubernetesVersion, false)
-		if err != nil {
-			return errors.Wrap(err, "validation error")
-		}
 	}
 
 	if options.Namespace == "" {
@@ -165,18 +163,12 @@ func (c *TkgClient) UpgradeCluster(options *UpgradeClusterOptions) error {
 	var currentClusterClient clusterclient.Client
 	if options.IsRegionalCluster {
 		currentClusterClient = regionalClusterClient
-	} else {
+	} else if !options.IsTKGSCluster {
 		log.V(4).Info("Creating workload cluster client...")
 		currentClusterClient, err = c.getWorkloadClusterClient(options.ClusterName, options.Namespace)
 		if err != nil {
 			return errors.Wrap(err, "unable to get workload cluster client")
 		}
-	}
-
-	// Check if Cluster is ClusterClass based cluster or not
-	isClusterClassBased, err := regionalClusterClient.IsClusterClassBased(options.ClusterName, options.Namespace)
-	if err != nil {
-		return errors.Wrap(err, "unable to determine cluster type")
 	}
 
 	// If cluster is ClusterClass based cluster upgrade the cluster with different path

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -669,7 +669,7 @@ func verifyKubernetesUpgradeForCPNodes(clusterStatusInfo *ClusterStatusInfo, new
 			conditions.GetReason(clusterObj, capi.ControlPlaneReadyCondition), conditions.GetMessage(clusterObj, capi.ControlPlaneReadyCondition))
 	}
 
-	if clusterStatusInfo.KubernetesVersion != newK8sVersion {
+	if clusterStatusInfo.KubernetesVersion != "" && clusterStatusInfo.KubernetesVersion != newK8sVersion {
 		return errors.Errorf("waiting for kubernetes version update, current kubernetes version %s but expecting %s", clusterStatusInfo.KubernetesVersion, newK8sVersion)
 	}
 
@@ -702,7 +702,7 @@ func verifyKubernetesUpgradeForWorkerNodes(clusterStatusInfo *ClusterStatusInfo,
 
 	unupgradedMachineList := []string{}
 	for i := range clusterStatusInfo.WorkerMachineObjects {
-		if clusterStatusInfo.WorkerMachineObjects[i].Spec.Version == nil || *clusterStatusInfo.WorkerMachineObjects[i].Spec.Version != newK8sVersion {
+		if clusterStatusInfo.WorkerMachineObjects[i].Spec.Version == nil || !strings.HasPrefix(newK8sVersion, *clusterStatusInfo.WorkerMachineObjects[i].Spec.Version) {
 			unupgradedMachineList = append(unupgradedMachineList, clusterStatusInfo.WorkerMachineObjects[i].Name)
 		}
 	}

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -2352,6 +2352,17 @@ func (c *client) IsClusterClassBased(clusterName, namespace string) (bool, error
 	if clusterObj.Spec.Topology == nil || clusterObj.Spec.Topology.Class == "" {
 		return false, nil
 	}
+
+	// Make sure that Cluster resource doesn't have ownerRef indicating that other
+	// resource is managing this Cluster resource. When cluster is created through
+	// TKC API, the cluster resource will have ownerRef set
+	ownerRefs := clusterObj.GetOwnerReferences()
+	for i := range ownerRefs {
+		if ownerRefs[i].Kind == constants.KindTanzuKubernetesCluster {
+			return false, nil
+		}
+	}
+
 	return true, nil
 }
 

--- a/pkg/v1/tkg/clusterclient/clusterclient_test.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient_test.go
@@ -2670,6 +2670,26 @@ var _ = Describe("Cluster Client", func() {
 				Expect(isClusterClassBased).To(Equal(true))
 			})
 		})
+		Context("When cluster has ownerReference set", func() {
+			JustBeforeEach(func() {
+				clientset.GetCalls(func(ctx context.Context, namespace types.NamespacedName, cluster crtclient.Object) error {
+					tkcOwnerReference := metav1.OwnerReference{
+						Kind: "TanzuKubernetesCluster",
+					}
+					topology := &capi.Topology{
+						Class: "fake-cluster-class",
+					}
+					cluster.(*capi.Cluster).Spec.Topology = topology
+					cluster.(*capi.Cluster).ObjectMeta.OwnerReferences = append(cluster.(*capi.Cluster).ObjectMeta.OwnerReferences, tkcOwnerReference)
+					return nil
+				})
+				isClusterClassBased, err = clstClient.IsClusterClassBased("fake-clusterName", "fake-namespace")
+			})
+			It("should not return an error and isClusterClassBased to be false", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(isClusterClassBased).To(Equal(false))
+			})
+		})
 		Context("When cluster.spec.topology field is not defined", func() {
 			JustBeforeEach(func() {
 				clientset.GetCalls(func(ctx context.Context, namespace types.NamespacedName, cluster crtclient.Object) error {

--- a/pkg/v1/tkg/tkgctl/upgrade_cluster.go
+++ b/pkg/v1/tkg/tkgctl/upgrade_cluster.go
@@ -88,6 +88,7 @@ func (t *tkgctl) UpgradeCluster(options UpgradeClusterOptions) error {
 		OSVersion:           options.OSVersion,
 		OSArch:              options.OSArch,
 		Edition:             options.Edition,
+		IsTKGSCluster:       isPacific,
 	}
 	err = t.tkgClient.UpgradeCluster(&upgradeClusterOption)
 	if err != nil {


### PR DESCRIPTION
### What this PR does / why we need it
- Support Classy workload cluster upgrade for Supervisor cluster
- Support TKC based Supervisor cluster workload cluster upgrade
- 
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Related to #2504

### Describe testing done for PR
- Classy cluster upgrade
    - Create Classy workload cluster on Supervisor cluster
    - Upgrade the classy workload cluster
    - Verified the tanzu-cli is able to upgrade the cluster and cluster got upgraded successfully

- TKC cluster upgrade
    - Create TKC based workload cluster on Supervisor cluster
    - Upgrade the TKC based workload cluster
    - Verified the tanzu-cli is able to upgrade the cluster and cluster got upgraded successfully


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support clusterclass based TKGS workload cluster upgrade
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
