### PR TITLE
Update cluster upgrade and available-upgrades commands to support clu…

### DIFF
--- a/cmd/cli/plugin/cluster/available_upgrade_test.go
+++ b/cmd/cli/plugin/cluster/available_upgrade_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	runv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
+)
+
+var _ = Describe("availableUpgradesFromCluster", func() {
+	var (
+		tkrs    []runv1alpha1.TanzuKubernetesRelease
+		cluster *clusterv1.Cluster
+		err     error
+		writer  bytes.Buffer
+	)
+	JustBeforeEach(func() {
+		err = availableUpgradesFromCluster(cluster, tkrs, &writer)
+	})
+
+	Context("When cluster doesn't have available upgrades", func() {
+		BeforeEach(func() {
+			//availableUpdates := fmt.Sprintf("[%s %s %s]", "v1.18.18+vmware.1-tkg.2", "v1.18.8+vmware.1-tkg.1", "v1.18.14+vmware.1-tkg.1-rc.1")
+			cluster = getFakeCluster("fake-cluster", "")
+
+		})
+		It("should not return error", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(writer.String()).To(BeEmpty())
+		})
+	})
+	Context("When cluster have available upgrades", func() {
+		BeforeEach(func() {
+			tkr1 := getFakeTKR("v1.17.18---vmware.1-tkg.2", "v1.17.18+vmware.1", corev1.ConditionTrue, "")
+			tkr2 := getFakeTKR("v1.18.8---vmware.1-tkg.1", "v1.18.8+vmware.1", corev1.ConditionTrue, "")
+			tkr3 := getFakeTKR("v1.18.17---vmware.2-tkg.1", "v1.18.17+vmware.2", corev1.ConditionTrue, "")
+			tkr4 := getFakeTKR("v1.18.14---vmware.1-tkg.1-rc.1", "v1.18.14+vmware.1", corev1.ConditionTrue, "")
+			tkr5 := getFakeTKR("v1.18.18---vmware.1-tkg.2", "v1.18.18+vmware.1", corev1.ConditionTrue, "")
+			tkrs = []runv1alpha1.TanzuKubernetesRelease{tkr1, tkr4, tkr3, tkr2, tkr5}
+
+			availableUpdates := fmt.Sprintf("[%s %s %s]", "v1.18.18+vmware.1-tkg.2", "v1.18.17+vmware.2-tkg.1", "v1.18.14+vmware.1-tkg.1-rc.1")
+			cluster = getFakeCluster("fake-cluster", availableUpdates)
+
+		})
+		It("should show the TKRs versions that are part of 'updatesAvailable' condition message value list ", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(writer.String()).To(ContainSubstring("v1.18.18+vmware.1-tkg.2"))
+			Expect(writer.String()).To(ContainSubstring("1.18.17+vmware.2-tkg.1"))
+			Expect(writer.String()).To(ContainSubstring("v1.18.14+vmware.1-tkg.1-rc.1"))
+			Expect(writer.String()).ToNot(ContainSubstring("v1.18.8+vmware.1-tkg.1"))
+
+		})
+	})
+
+})

--- a/pkg/v2/tkr/util/sets/strings.go
+++ b/pkg/v2/tkr/util/sets/strings.go
@@ -73,3 +73,13 @@ func (set StringSet) Union(sets ...StringSet) StringSet {
 	}
 	return r
 }
+
+func (set StringSet) Slice() []string {
+	r := make([]string, len(set))
+	i := 0
+	for key := range set {
+		r[i] = key
+		i++
+	}
+	return r
+}

--- a/pkg/v2/tkr/util/topology/cluster.go
+++ b/pkg/v2/tkr/util/topology/cluster.go
@@ -6,10 +6,16 @@ package topology
 import (
 	"encoding/json"
 	"reflect"
+	"strings"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+
+	runv1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/util/sets"
 )
 
 // SetVariable sets the cluster variable, to the given value.
@@ -153,4 +159,22 @@ func removeMDVariableForName(md *clusterv1.MachineDeploymentTopology, name strin
 			return
 		}
 	}
+}
+
+// AvailableUpgrades returns the available upgrade versions of the cluster
+func AvailableUpgrades(cluster *clusterv1.Cluster) sets.StringSet {
+	updatesMsg := ""
+	if condition := conditions.Get(cluster, runv1.ConditionUpdatesAvailable); condition != nil && condition.Status == corev1.ConditionTrue {
+		updatesMsg = condition.Message
+	}
+	return updatesFromConditionMessage(updatesMsg)
+}
+
+func updatesFromConditionMessage(updatesMsg string) sets.StringSet {
+	if updatesMsg == "" {
+		return sets.Strings()
+	}
+	// Example for message - [<tkr-version-1> <tkr-version-2>]"
+	updates := strings.Split(strings.TrimRight(strings.TrimLeft(updatesMsg, "["), "]"), " ")
+	return sets.Strings(updates...)
 }


### PR DESCRIPTION
…sterclass based clusters

Signed-off-by: PremKumar Kalle <pkalle@vmware.com>

### What this PR does / why we need it
This PR is to update `cluster upgrade` and cluster available-upgrades` command to support clusterclass based cluster(and TKR API version v1alpha3) where the `updatesAvailable` conditions are no longer available in TKR and instead would be available as part of cluster status.
Note: TKR controller supports the `updatesAvailabble` status condition reconcilation for clusterclass based clusters and reconcilation for classic clusters will be implemented soon.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2744 

### Describe testing done for PR

Added unit tests

tested tanzu cluster upgrade command with TKGs cluster
```
❯ tanzu cluster upgrade prem-ccluster01  -n ns03 --tkr v1.23.5---vmware.1-tkg.1-zshippable
Error: no available upgrades for cluster 'prem-ccluster01', namespace 'ns03'
Error: exit status 1


❯ tanzu cluster upgrade prem-ccluster01  -n ns03 --tkr v1.22.8---vmware.1-tkg.2-zshippable -v 6
compatibility file (/Users/pkalle/.config/tanzu/tkg/compatibility/tkg-compatibility.yaml) already exists, skipping download
BOM files inside /Users/pkalle/.config/tanzu/tkg/bom already exists, skipping download
writing checksum "29952e2231d011c7dc3c86ded337168a14058e6fd21ec24ee44d8a7092f13be8" to file "/Users/pkalle/.config/tanzu/tkg/providers/providers.sha256sum"
Upgrading workload cluster 'prem-ccluster01' to kubernetes version 'v1.22.8+vmware.1-tkg.2-zshippable'. Are you sure? [y/N]: y
```

Tested `tanzu cluster upgrades-available` with TKGs cluster
```
❯ tanzu cluster available-upgrades get prem-ccluster01 -n ns03
no available upgrades for cluster 'prem-ccluster01', namespace 'ns03'
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Update cluster upgrade and available-upgrades commands to support clusterclass based clusters
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
