### PR TITLE
Fix GVR lookup errors seen in Kind cluster during mgmt cluster bootstrap

### DIFF
--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -1139,6 +1139,8 @@ func (r *ClusterBootstrapReconciler) GetDataValueSecretNameFromBootstrapPackage(
 				return packageSecretName, nil
 			}
 		}
+		// cbPkg.ValuesFrom is nil and not TKGS
+		return "", nil
 	}
 
 	// When valuesFrom is not nil, but either valuesFrom.Inline, valuesFrom.SecretRef, or valuesFrom.providerRef is empty or nil,

--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -19,8 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/discovery"
-	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
@@ -67,12 +65,10 @@ type ClusterBootstrapReconciler struct {
 	controller    controller.Controller
 	dynamicClient dynamic.Interface
 	// on demand dynamic watches for provider refs
-	providerWatches map[string]client.Object
-	// discovery client for looking up api-resources and preferred versions
-	cachedDiscoveryClient discovery.CachedDiscoveryInterface
-	// cache for resolved api-resources so that look up is fast (cleared periodically)
-	providerGVR                  map[schema.GroupKind]*schema.GroupVersionResource
+	providerWatches              map[string]client.Object
 	aggregatedAPIResourcesClient client.Client
+	// helper for looking up api-resources and getting preferred versions
+	gvrHelper util.GVRHelper
 }
 
 // NewClusterBootstrapReconciler returns a reconciler for ClusterBootstrap
@@ -123,11 +119,8 @@ func (r *ClusterBootstrapReconciler) SetupWithManager(ctx context.Context, mgr c
 	r.dynamicClient = dynClient
 	r.providerWatches = make(map[string]client.Object)
 
-	r.providerGVR = make(map[schema.GroupKind]*schema.GroupVersionResource)
 	clientset := kubernetes.NewForConfigOrDie(mgr.GetConfig())
-	r.cachedDiscoveryClient = cacheddiscovery.NewMemCacheClient(clientset.Discovery())
-
-	go r.periodicGVRCachesClean()
+	r.gvrHelper = util.NewGVRHelper(ctx, clientset.DiscoveryClient)
 
 	r.aggregatedAPIResourcesClient, err = client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme()})
 	if err != nil {
@@ -392,7 +385,7 @@ func (r *ClusterBootstrapReconciler) createOrPatchClusterBootstrapFromTemplate(c
 	}
 
 	clusterBootstrapHelper := clusterbootstrapclone.NewHelper(
-		r.context, r.Client, r.aggregatedAPIResourcesClient, r.dynamicClient, r.cachedDiscoveryClient, r.Log)
+		r.context, r.Client, r.aggregatedAPIResourcesClient, r.dynamicClient, r.gvrHelper, r.Log)
 	if clusterBootstrap.UID == "" {
 		log.Info("ClusterBootstrap for cluster does not exist, cloning from template")
 		return clusterBootstrapHelper.CreateClusterBootstrapFromTemplate(clusterBootstrapTemplate, cluster, tkrName)
@@ -967,7 +960,7 @@ func (r *ClusterBootstrapReconciler) createOrPatchPackageInstallSecret(cluster *
 			return err
 		}
 		if infraRef == tkgconstants.InfrastructureProviderVSphere {
-			ok, err := util.IsTKGSCluster(r.context, r.dynamicClient, r.cachedDiscoveryClient, cluster)
+			ok, err := util.IsTKGSCluster(r.context, r.dynamicClient, r.gvrHelper.GetDiscoveryClient(), cluster)
 			if err != nil {
 				return err
 			}
@@ -1028,34 +1021,6 @@ func patchSecretWithLabels(secret *corev1.Secret, pkgName, clusterName string) b
 	return updateLabels
 }
 
-// getGVR returns a GroupVersionResource for a GroupKind
-func (r *ClusterBootstrapReconciler) getGVR(gk schema.GroupKind) (*schema.GroupVersionResource, error) {
-	if gvr, ok := r.providerGVR[gk]; ok {
-		return gvr, nil
-	}
-	gvr, err := util.GetGVRForGroupKind(gk, r.cachedDiscoveryClient)
-	if err != nil {
-		return nil, err
-	}
-	r.providerGVR[gk] = gvr
-	return nil, fmt.Errorf("unable to find server preferred resource %s/%s", gk.Group, gk.Kind)
-}
-
-// periodicGVRCachesClean invalidates caches used for GVR lookup
-func (r *ClusterBootstrapReconciler) periodicGVRCachesClean() {
-	ticker := time.NewTicker(constants.DiscoveryCacheInvalidateInterval)
-	for {
-		select {
-		case <-r.context.Done():
-			ticker.Stop()
-			return
-		case <-ticker.C:
-			r.cachedDiscoveryClient.Invalidate()
-			r.providerGVR = make(map[schema.GroupKind]*schema.GroupVersionResource)
-		}
-	}
-}
-
 // watchProvider will set a watch on the Type indicated by providerRef if not already watching
 func (r *ClusterBootstrapReconciler) watchProvider(providerRef *corev1.TypedLocalObjectReference, namespace string, log logr.Logger) error {
 	if providerRef == nil {
@@ -1067,7 +1032,7 @@ func (r *ClusterBootstrapReconciler) watchProvider(providerRef *corev1.TypedLoca
 		return nil
 	}
 
-	gvr, err := r.getGVR(schema.GroupKind{Group: *providerRef.APIGroup, Kind: providerRef.Kind})
+	gvr, err := r.gvrHelper.GetGVR(schema.GroupKind{Group: *providerRef.APIGroup, Kind: providerRef.Kind})
 	if err != nil {
 		log.Error(err, "failed to getGVR")
 		return err
@@ -1132,7 +1097,7 @@ func (r *ClusterBootstrapReconciler) GetDataValueSecretNameFromBootstrapPackage(
 		}
 
 		if cbPkg.ValuesFrom.ProviderRef != nil {
-			gvr, err := r.getGVR(schema.GroupKind{Group: *cbPkg.ValuesFrom.ProviderRef.APIGroup, Kind: cbPkg.ValuesFrom.ProviderRef.Kind})
+			gvr, err := r.gvrHelper.GetGVR(schema.GroupKind{Group: *cbPkg.ValuesFrom.ProviderRef.APIGroup, Kind: cbPkg.ValuesFrom.ProviderRef.Kind})
 			if err != nil {
 				r.Log.Error(err, "unable to get GVR")
 				return "", err
@@ -1162,7 +1127,7 @@ func (r *ClusterBootstrapReconciler) GetDataValueSecretNameFromBootstrapPackage(
 			return "", err
 		}
 		if infraRef == tkgconstants.InfrastructureProviderVSphere {
-			ok, err := util.IsTKGSCluster(r.context, r.dynamicClient, r.cachedDiscoveryClient, cluster)
+			ok, err := util.IsTKGSCluster(r.context, r.dynamicClient, r.gvrHelper.GetDiscoveryClient(), cluster)
 			if err != nil {
 				return "", err
 			}

--- a/addons/controllers/testdata/test-cluster-bootstrap-2.yaml
+++ b/addons/controllers/testdata/test-cluster-bootstrap-2.yaml
@@ -8,7 +8,7 @@ apiVersion: vmoperator.vmware.com/v1alpha1
 kind: VirtualMachine
 metadata:
   name: test-tkgs-virtual-machine
-  namespace: tkg-system
+  namespace: cluster-namespace-2
   labels:
     capv.vmware.com/cluster.name: test-cluster-tcbt-2
 spec:

--- a/addons/pkg/util/cluster_util.go
+++ b/addons/pkg/util/cluster_util.go
@@ -221,7 +221,7 @@ func IsTKGSCluster(ctx context.Context, dynamicClient dynamic.Interface, discove
 		listOptions := metav1.ListOptions{
 			LabelSelector: tkgconstants.CAPVClusterSelectorKey + "=" + cluster.Name,
 		}
-		virtualMachineList, err := dynamicClient.Resource(virtualMachineGVR).List(ctx, listOptions)
+		virtualMachineList, err := dynamicClient.Resource(virtualMachineGVR).Namespace(cluster.Namespace).List(ctx, listOptions)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return false, nil

--- a/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
+++ b/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
@@ -18,7 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
@@ -38,14 +37,14 @@ type Helper struct {
 	K8sClient                   client.Client
 	AggregateAPIResourcesClient client.Client
 	DynamicClient               dynamic.Interface
-	DiscoveryClient             discovery.DiscoveryInterface
+	GVRHelper                   util.GVRHelper
 	Logger                      logr.Logger
 }
 
 // NewHelper instantiates a new helper instance
 func NewHelper(ctx context.Context, k8sClient client.Client, aggregateAPIResourcesClient client.Client,
 	dynamicClient dynamic.Interface,
-	cachedDiscoveryClient discovery.CachedDiscoveryInterface,
+	gvrHelper util.GVRHelper,
 	logger logr.Logger) *Helper {
 
 	return &Helper{
@@ -53,7 +52,7 @@ func NewHelper(ctx context.Context, k8sClient client.Client, aggregateAPIResourc
 		K8sClient:                   k8sClient,
 		AggregateAPIResourcesClient: aggregateAPIResourcesClient,
 		DynamicClient:               dynamicClient,
-		DiscoveryClient:             cachedDiscoveryClient,
+		GVRHelper:                   gvrHelper,
 		Logger:                      logger,
 	}
 }
@@ -433,7 +432,7 @@ func (h *Helper) cloneProviderRef(
 
 	var newProvider *unstructured.Unstructured
 	var createdOrUpdatedProvider *unstructured.Unstructured
-	gvr, err := util.GetGVRForGroupKind(schema.GroupKind{Group: *cbPkg.ValuesFrom.ProviderRef.APIGroup, Kind: cbPkg.ValuesFrom.ProviderRef.Kind}, h.DiscoveryClient)
+	gvr, err := h.GVRHelper.GetGVR(schema.GroupKind{Group: *cbPkg.ValuesFrom.ProviderRef.APIGroup, Kind: cbPkg.ValuesFrom.ProviderRef.Kind})
 	if err != nil {
 		h.Logger.Error(err, "failed to getGVR")
 		return nil, err
@@ -519,7 +518,7 @@ func (h *Helper) cloneEmbeddedLocalObjectRef(cluster *clusterapiv1beta1.Cluster,
 	h.Logger.Info(fmt.Sprintf("cloning the embedded local object references within provider: %s with name: %s from"+
 		" %s namespace to %s namespace", provider.GroupVersionKind().String(), provider.GetName(), provider.GetNamespace(), cluster.Namespace))
 	for groupKind, resourceNames := range groupKindNamesMap {
-		gvr, err := util.GetGVRForGroupKind(groupKind, h.DiscoveryClient)
+		gvr, err := h.GVRHelper.GetGVR(groupKind)
 		if err != nil {
 			// error has been logged within getGVR()
 			return err
@@ -604,7 +603,7 @@ func (h *Helper) EnsureOwnerRef(clusterBootstrap *runtanzuv1alpha3.ClusterBootst
 		}
 	}
 	for _, provider := range providers {
-		gvr, err := util.GetGVRForGroupKind(provider.GroupVersionKind().GroupKind(), h.DiscoveryClient)
+		gvr, err := h.GVRHelper.GetGVR(provider.GroupVersionKind().GroupKind())
 		if err != nil {
 			h.Logger.Error(err, fmt.Sprintf("unable to get GVR of provider %s/%s", provider.GetNamespace(), provider.GetName()))
 			return err

--- a/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone_test.go
+++ b/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone_test.go
@@ -6,9 +6,9 @@ package clusterbootstrapclone
 import (
 	"context"
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone_test.go
+++ b/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone_test.go
@@ -6,17 +6,8 @@ package clusterbootstrapclone
 import (
 	"context"
 	"fmt"
-
-	openapiv2 "github.com/googleapis/gnostic/openapiv2"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	kapppkgv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
-	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
-	addontypes "github.com/vmware-tanzu/tanzu-framework/addons/pkg/types"
-	antreaconfigv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cni/v1alpha1"
-	vspherecpiv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cpi/v1alpha1"
-	"github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -24,16 +15,21 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
-	"k8s.io/apimachinery/pkg/version"
-	clientgodiscovery "k8s.io/client-go/discovery"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/rest"
 	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	controllreruntimefake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	k8syaml "sigs.k8s.io/yaml"
+
+	kapppkgv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
+	addontypes "github.com/vmware-tanzu/tanzu-framework/addons/pkg/types"
+	"github.com/vmware-tanzu/tanzu-framework/addons/test/testutil"
+	antreaconfigv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cni/v1alpha1"
+	vspherecpiv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cpi/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
 )
 
 var (
@@ -49,7 +45,7 @@ var _ = Describe("ClusterbootstrapClone", func() {
 		fakeClient                    client.Client
 		fakeClientSet                 *k8sfake.Clientset
 		fakeDynamicClient             *dynamicfake.FakeDynamicClient
-		fakeDiscovery                 *ClusterbootstrapFakeDiscovery
+		fakeDiscovery                 *testutil.FakeDiscovery
 		scheme                        *runtime.Scheme
 		cluster                       *clusterapiv1beta1.Cluster
 		antreaClusterbootstrapPackage *v1alpha3.ClusterBootstrapPackage
@@ -66,9 +62,9 @@ var _ = Describe("ClusterbootstrapClone", func() {
 
 		fakeClient = controllreruntimefake.NewClientBuilder().WithScheme(scheme).Build()
 		fakeClientSet = k8sfake.NewSimpleClientset()
-		fakeDiscovery = &ClusterbootstrapFakeDiscovery{
-			fakeClientSet.Discovery(),
-			[]*metav1.APIResourceList{
+		fakeDiscovery = &testutil.FakeDiscovery{
+			FakeDiscovery: fakeClientSet.Discovery(),
+			Resources: []*metav1.APIResourceList{
 				{
 					GroupVersion: corev1.SchemeGroupVersion.String(),
 					APIResources: []metav1.APIResource{
@@ -89,12 +85,13 @@ var _ = Describe("ClusterbootstrapClone", func() {
 				},
 			},
 		}
+		gvrHelper := &testutil.FakeGVRHelper{DiscoveryClient: fakeDiscovery}
 		helper = &Helper{
 			Ctx:                         context.TODO(),
 			K8sClient:                   fakeClient,
 			AggregateAPIResourcesClient: fakeClient,
 			DynamicClient:               fakeDynamicClient,
-			DiscoveryClient:             fakeDiscovery,
+			GVRHelper:                   gvrHelper,
 			Logger:                      ctrl.Log.WithName("clusterbootstrap_test"),
 		}
 	})
@@ -752,56 +749,4 @@ func assertTwoMapsShouldEqual(left, right map[string]interface{}) {
 		Expect(exist).To(BeTrue())
 		Expect(valueFromLeft).To(Equal(valueFromRight))
 	}
-}
-
-// ClusterbootstrapFakeDiscovery customize the behavior of fake client-go FakeDiscovery.ServerPreferredResources to return
-// a customized APIResourceList.
-// The client-go FakeDiscovery.ServerPreferredResources is hardcoded to return nil.
-// https://github.com/kubernetes/client-go/blob/master/discovery/fake/discovery.go#L85
-type ClusterbootstrapFakeDiscovery struct {
-	fakeDiscovery clientgodiscovery.DiscoveryInterface
-	resources     []*metav1.APIResourceList
-}
-
-func (c ClusterbootstrapFakeDiscovery) RESTClient() rest.Interface {
-	return c.fakeDiscovery.RESTClient()
-}
-
-func (c ClusterbootstrapFakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
-	return c.fakeDiscovery.ServerGroups()
-}
-
-func (c ClusterbootstrapFakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
-	return c.fakeDiscovery.ServerGroupsAndResources()
-}
-
-func (c ClusterbootstrapFakeDiscovery) ServerVersion() (*version.Info, error) {
-	return c.fakeDiscovery.ServerVersion()
-}
-
-func (c ClusterbootstrapFakeDiscovery) OpenAPISchema() (*openapiv2.Document, error) {
-	return c.fakeDiscovery.OpenAPISchema()
-}
-
-func (c ClusterbootstrapFakeDiscovery) getFakeServerPreferredResources() []*metav1.APIResourceList {
-	return c.resources
-}
-
-func (c ClusterbootstrapFakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
-	return c.fakeDiscovery.ServerResourcesForGroupVersion(groupVersion)
-}
-
-// Having nolint below to get rid of the complaining on the deprecation of ServerResources. We have to have the following
-// function to customize the DiscoveryInterface
-//nolint:staticcheck
-func (c ClusterbootstrapFakeDiscovery) ServerResources() ([]*metav1.APIResourceList, error) {
-	return c.fakeDiscovery.ServerResources()
-}
-
-func (c ClusterbootstrapFakeDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
-	return c.getFakeServerPreferredResources(), nil
-}
-
-func (c ClusterbootstrapFakeDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
-	return c.fakeDiscovery.ServerPreferredNamespacedResources()
 }

--- a/addons/pkg/util/gvr_helper.go
+++ b/addons/pkg/util/gvr_helper.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
+
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
 )
 
 type GVRHelper interface {

--- a/addons/pkg/util/gvr_helper.go
+++ b/addons/pkg/util/gvr_helper.go
@@ -1,0 +1,87 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
+)
+
+type GVRHelper interface {
+	GetGVR(gk schema.GroupKind) (*schema.GroupVersionResource, error)
+	GetDiscoveryClient() discovery.DiscoveryInterface
+}
+
+type gvrHelper struct {
+	cachedDiscoveryClient discovery.CachedDiscoveryInterface
+	cachedLookups         map[schema.GroupKind]*schema.GroupVersionResource
+	context               context.Context
+}
+
+func NewGVRHelper(ctx context.Context, discoveryClient discovery.DiscoveryInterface) GVRHelper {
+	cachedDiscoveryClient := cacheddiscovery.NewMemCacheClient(discoveryClient)
+	helper := &gvrHelper{
+		cachedDiscoveryClient: cachedDiscoveryClient,
+		cachedLookups:         make(map[schema.GroupKind]*schema.GroupVersionResource),
+		context:               ctx,
+	}
+	go helper.periodicGVRCachesClean()
+	return helper
+}
+
+// GetGVR returns a GroupVersionResource for a GroupKind
+func (g *gvrHelper) GetGVR(gk schema.GroupKind) (*schema.GroupVersionResource, error) {
+	if gvr, ok := g.cachedLookups[gk]; ok {
+		return gvr, nil
+	}
+	gvr, err := g.gvrForGroupKind(gk)
+	if err != nil {
+		return nil, err
+	}
+	g.cachedLookups[gk] = gvr
+	return gvr, nil
+}
+
+func (g *gvrHelper) GetDiscoveryClient() discovery.DiscoveryInterface {
+	return g.cachedDiscoveryClient
+}
+
+// periodicGVRCachesClean invalidates caches used for GVR lookup
+func (g *gvrHelper) periodicGVRCachesClean() {
+	ticker := time.NewTicker(constants.DiscoveryCacheInvalidateInterval)
+	for {
+		select {
+		case <-g.context.Done():
+			ticker.Stop()
+			return
+		case <-ticker.C:
+			g.cachedDiscoveryClient.Invalidate()
+			g.cachedLookups = make(map[schema.GroupKind]*schema.GroupVersionResource)
+		}
+	}
+}
+
+func (g *gvrHelper) gvrForGroupKind(gk schema.GroupKind) (*schema.GroupVersionResource, error) {
+	apiResourceList, err := g.cachedDiscoveryClient.ServerPreferredResources()
+	if err != nil {
+		return nil, err
+	}
+	for _, apiResource := range apiResourceList {
+		gv, err := schema.ParseGroupVersion(apiResource.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+		if gv.Group == gk.Group {
+			for i := 0; i < len(apiResource.APIResources); i++ {
+				if apiResource.APIResources[i].Kind == gk.Kind {
+					return &schema.GroupVersionResource{Group: gv.Group, Resource: apiResource.APIResources[i].Name, Version: gv.Version}, nil
+				}
+			}
+		}
+	}
+	return nil, fmt.Errorf("unable to find server preferred resource %s/%s", gk.Group, gk.Kind)
+}

--- a/addons/pkg/util/gvr_helper_test.go
+++ b/addons/pkg/util/gvr_helper_test.go
@@ -2,6 +2,7 @@ package util_test
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"

--- a/addons/pkg/util/gvr_helper_test.go
+++ b/addons/pkg/util/gvr_helper_test.go
@@ -1,0 +1,112 @@
+package util_test
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	kapppkgv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
+	"github.com/vmware-tanzu/tanzu-framework/addons/test/testutil"
+	antreaconfigv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cni/v1alpha1"
+	vspherecpiv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cpi/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+)
+
+var _ = Describe("GVRHelper", func() {
+
+	var (
+		fakeClientSet *k8sfake.Clientset
+
+		fakeDiscovery *testutil.FakeDiscovery
+		scheme        *runtime.Scheme
+		gvrHelper     util.GVRHelper
+	)
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		_ = corev1.AddToScheme(scheme)
+		_ = antreaconfigv1alpha1.AddToScheme(scheme)
+		_ = kapppkgv1alpha1.AddToScheme(scheme)
+		_ = v1alpha3.AddToScheme(scheme)
+
+		fakeClientSet = k8sfake.NewSimpleClientset()
+		fakeDiscovery = &testutil.FakeDiscovery{
+			FakeDiscovery: fakeClientSet.Discovery(),
+			Resources: []*metav1.APIResourceList{
+				{
+					GroupVersion: corev1.SchemeGroupVersion.String(),
+					APIResources: []metav1.APIResource{
+						{Name: "secrets", Namespaced: true, Kind: "Secret"},
+					},
+				},
+				{
+					GroupVersion: antreaconfigv1alpha1.GroupVersion.String(),
+					APIResources: []metav1.APIResource{
+						{Name: "antreaconfigs", Namespaced: true, Kind: "AntreaConfig"},
+					},
+				},
+				{
+					GroupVersion: vspherecpiv1alpha1.GroupVersion.String(),
+					APIResources: []metav1.APIResource{
+						{Name: "vspherecpiconfigs", Namespaced: true, Kind: "VSphereCPIConfig"},
+					},
+				},
+			},
+			APIGroups: &metav1.APIGroupList{
+				Groups: []metav1.APIGroup{
+					{
+						Name: "cni.tanzu.vmware.com",
+						Versions: []metav1.GroupVersionForDiscovery{
+							{
+								GroupVersion: "cni.tanzu.vmware.com/v1alpha1",
+								Version:      "v1alpha1",
+							},
+						},
+						PreferredVersion: metav1.GroupVersionForDiscovery{
+							GroupVersion: "cni.tanzu.vmware.com/v1alpha1",
+							Version:      "v1alpha1",
+						},
+					},
+				},
+			},
+		}
+		gvrHelper = util.NewGVRHelper(context.TODO(), fakeDiscovery)
+
+	})
+
+	Context("when an existing API server resource is looked up", func() {
+
+		It("should return a result with correct group version resource", func() {
+			group := "cni.tanzu.vmware.com"
+			version := "v1alpha1"
+			resource := "antreaconfigs"
+			antreaGVR := schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
+
+			found, err := gvrHelper.GetGVR(schema.GroupKind{Group: "cni.tanzu.vmware.com", Kind: "AntreaConfig"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(*found).To(Equal(antreaGVR))
+
+		})
+	})
+
+	Context("when an API server resource that does not exist is looked up", func() {
+
+		It("should return an error", func() {
+			_, err := gvrHelper.GetGVR(schema.GroupKind{Group: "foo.tanzu.vmware.com", Kind: "FooBar"})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("GetDiscoveryClient", func() {
+
+		It("should not be nil", func() {
+			Expect(gvrHelper.GetDiscoveryClient()).ShouldNot(BeNil())
+		})
+	})
+})

--- a/addons/pkg/util/provider_util.go
+++ b/addons/pkg/util/provider_util.go
@@ -66,7 +66,7 @@ func isValidLocalObjectRef(localObjRef map[string]interface{}) bool {
 }
 
 // GetGVRForGroupKind returns a GroupVersionResource for a GroupKind
-func GetGVRForGroupKind(gk schema.GroupKind, discoveryClient discovery.DiscoveryInterface) (*schema.GroupVersionResource, error) {
+func GetGVRForGroupKind(gk schema.GroupKind, discoveryClient discovery.CachedDiscoveryInterface) (*schema.GroupVersionResource, error) {
 	apiResourceList, err := discoveryClient.ServerPreferredResources()
 	if err != nil {
 		return nil, err

--- a/addons/test/testutil/test_fake_helpers.go
+++ b/addons/test/testutil/test_fake_helpers.go
@@ -1,0 +1,101 @@
+package testutil
+
+import (
+	"fmt"
+
+	openapiv2 "github.com/googleapis/gnostic/openapiv2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// FakeDiscovery customize the behavior of fake client-go FakeDiscovery.ServerPreferredResources to return
+// a customized APIResourceList.
+// The client-go FakeDiscovery.ServerPreferredResources is hardcoded to return nil.
+// https://github.com/kubernetes/client-go/blob/master/discovery/fake/discovery.go#L85
+type FakeDiscovery struct {
+	FakeDiscovery discovery.DiscoveryInterface
+	Resources     []*metav1.APIResourceList
+	APIGroups     *metav1.APIGroupList
+}
+
+var _ discovery.DiscoveryInterface = &FakeDiscovery{}
+
+func (c FakeDiscovery) RESTClient() rest.Interface {
+	return c.FakeDiscovery.RESTClient()
+}
+
+func (c FakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	return c.APIGroups, nil
+}
+
+func (c FakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return c.FakeDiscovery.ServerGroupsAndResources()
+}
+
+func (c FakeDiscovery) ServerVersion() (*version.Info, error) {
+	return c.FakeDiscovery.ServerVersion()
+}
+
+func (c FakeDiscovery) OpenAPISchema() (*openapiv2.Document, error) {
+	return c.FakeDiscovery.OpenAPISchema()
+}
+
+func (c FakeDiscovery) getFakeServerPreferredResources() []*metav1.APIResourceList {
+	return c.Resources
+}
+
+func (c FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	for _, res := range c.Resources {
+		if res.GroupVersion == groupVersion {
+			return res, nil
+		}
+	}
+	return nil, fmt.Errorf("no matching resources")
+}
+
+// Having nolint below to get rid of the complaining on the deprecation of ServerResources. We have to have the following
+// function to customize the DiscoveryInterface
+//nolint:staticcheck
+func (c FakeDiscovery) ServerResources() ([]*metav1.APIResourceList, error) {
+	return c.FakeDiscovery.ServerResources()
+}
+
+func (c FakeDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return c.getFakeServerPreferredResources(), nil
+}
+
+func (c FakeDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return c.FakeDiscovery.ServerPreferredNamespacedResources()
+}
+
+type FakeGVRHelper struct {
+	DiscoveryClient discovery.DiscoveryInterface
+}
+
+func (f *FakeGVRHelper) GetGVR(gk schema.GroupKind) (*schema.GroupVersionResource, error) {
+	apiResourceList, err := f.DiscoveryClient.ServerPreferredResources()
+	if err != nil {
+		return nil, err
+	}
+	for _, apiResource := range apiResourceList {
+		gv, err := schema.ParseGroupVersion(apiResource.GroupVersion)
+		if err != nil {
+			return nil, err
+		}
+		if gv.Group == gk.Group {
+			for i := 0; i < len(apiResource.APIResources); i++ {
+				if apiResource.APIResources[i].Kind == gk.Kind {
+					return &schema.GroupVersionResource{Group: gv.Group, Resource: apiResource.APIResources[i].Name, Version: gv.Version}, nil
+				}
+			}
+		}
+	}
+	return nil, fmt.Errorf("unable to find server preferred resource %s/%s", gk.Group, gk.Kind)
+}
+
+func (f *FakeGVRHelper) GetDiscoveryClient() discovery.DiscoveryInterface {
+	return f.DiscoveryClient
+}


### PR DESCRIPTION
Fix GVR lookup errors seen in Kind cluster during mgmt cluster bootstrap

Signed-off-by: Vijay Katam <vkatam@vmware.com>

### What this PR does / why we need it

Fixes an issue where a kind cluster used for bootstrapping mgmt cluster is
encountering issues with GVR lookup during provider ref cloning by moving
GVR lookup to a centralized helper so that clone helper can reuse caching. No errors
from controller which has a map for caching prev results.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2708

### Describe testing done for PR
1. Added unit tests
2. Tested on supervisor cluster
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Fix GVR lookup errors seen in Kind cluster during mgmt cluster bootstrap
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


