### PR TITLE
Full TKR version not always replaced in Cluster `topology.version`

### DIFF
--- a/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster.go
+++ b/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster.go
@@ -151,7 +151,7 @@ func (cw *Webhook) filterOSImageQuery(tkr *runv1.TanzuKubernetesRelease, tkrData
 			if osImageName, ok := tkrDataValue.Labels[runv1.LabelOSImage]; ok {
 				if osImage := cw.TKRResolver.Get(osImageName, &runv1.OSImage{}).(*runv1.OSImage); osImage != nil {
 					// Found TKR and OSImage. Now, see if they match the provided version and selectors.
-					if version.Prefixes(version.Label(tkr.Spec.Version)).Has(version.Label(osImageQuery.K8sVersionPrefix)) &&
+					if version.Prefixes(version.Label(tkr.Spec.Kubernetes.Version)).Has(version.Label(osImageQuery.K8sVersionPrefix)) &&
 						osImageQuery.TKRSelector.Matches(labels.Set(tkr.Labels)) &&
 						osImageQuery.OSImageSelector.Matches(labels.Set(osImage.Labels)) {
 						return nil // indicating we don't need to resolve: already have matching TKR and OSImage

--- a/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster_test.go
+++ b/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster_test.go
@@ -394,7 +394,6 @@ var _ = Describe("cluster.Webhook", func() {
 						tkrData := TKRData{}
 						tkrData[tkr.Spec.Kubernetes.Version] = tkrDataValue(tkr, osImage)
 						Expect(topology.SetVariable(cluster, VarTKRData, tkrData)).To(Succeed())
-
 					})
 
 					It("should not resolve the ControlPlane", func() {
@@ -402,6 +401,18 @@ var _ = Describe("cluster.Webhook", func() {
 						err := cw.ResolveAndSetMetadata(cluster, clusterClass)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(cluster.Spec.Topology).To(Equal(clusterTopology0))
+					})
+
+					When("full TKR version is specified in Cluster topology.version", func() {
+						BeforeEach(func() {
+							cluster.Spec.Topology.Version = tkr.Spec.Version
+						})
+
+						It("should replace the value in Cluster topology.version with TKR k8s version", func() {
+							err := cw.ResolveAndSetMetadata(cluster, clusterClass)
+							Expect(err).ToNot(HaveOccurred())
+							Expect(cluster.Spec.Topology.Version).To(Equal(tkr.Spec.Kubernetes.Version))
+						})
 					})
 				})
 


### PR DESCRIPTION
### What this PR does / why we need it

Before this change, in an already resolved Cluster, when `topology.version` is set to the TKR version (not its Kubernetes version), the TKR resolver would not replace it with the Kubernetes version.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

N/A

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Added a unit test covering the described situation.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixed an edge case: in an already resolved Cluster, when `topology.version` is set to 
the TKR version (not its Kubernetes version), the TKR resolver would not replace it with 
the Kubernetes version.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
