### PR TITLE
Add antreaNSXPodRoutingEnabled field to the CPIConfig CR.

### DIFF
--- a/addons/config/expected/cpi.tanzu.vmware.com/v1alpha1/vspherecpiconfig/tkgs.yaml
+++ b/addons/config/expected/cpi.tanzu.vmware.com/v1alpha1/vspherecpiconfig/tkgs.yaml
@@ -15,5 +15,4 @@ metadata:
 spec:
   vsphereCPI:
     mode: vsphereParavirtualCPI
-    nsxt:
-      podRoutingEnabled: true
+    antreaNSXPodRoutingEnabled: true

--- a/addons/config/templates/cpi.tanzu.vmware.com/v1alpha1/vspherecpiconfig.yaml
+++ b/addons/config/templates/cpi.tanzu.vmware.com/v1alpha1/vspherecpiconfig.yaml
@@ -18,6 +18,5 @@ metadata:
 spec:
   vsphereCPI:
     mode: vsphereParavirtualCPI
-    nsxt:
-      podRoutingEnabled: true
+    antreaNSXPodRoutingEnabled: true
 #@ end

--- a/addons/controllers/cpi/vspherecpiconfig_datavalues.go
+++ b/addons/controllers/cpi/vspherecpiconfig_datavalues.go
@@ -71,6 +71,7 @@ type VSphereCPIParaVirtDataValues struct {
 	ClusterUID                 string `yaml:"clusterUID"`
 	SupervisorMasterEndpointIP string `yaml:"supervisorMasterEndpointIP"`
 	SupervisorMasterPort       string `yaml:"supervisorMasterPort"`
+	AntreaNSXPodRoutingEnabled bool   `yaml:"antreaNSXPodRoutingEnabled"`
 }
 
 func (v *VSphereCPIParaVirtDataValues) Serialize() ([]byte, error) {

--- a/addons/controllers/cpi/vspherecpiconfig_utils.go
+++ b/addons/controllers/cpi/vspherecpiconfig_utils.go
@@ -176,7 +176,9 @@ func (r *VSphereCPIConfigReconciler) mapCPIConfigToDataValuesNonParavirtual( // 
 }
 
 // mapCPIConfigToDataValuesParavirtual generates CPI data values for paravirtual modes
-func (r *VSphereCPIConfigReconciler) mapCPIConfigToDataValuesParavirtual(ctx context.Context, _ *cpiv1alpha1.VSphereCPIConfig, cluster *clusterapiv1beta1.Cluster) (VSphereCPIDataValues, error) {
+func (r *VSphereCPIConfigReconciler) mapCPIConfigToDataValuesParavirtual(ctx context.Context, cpiConfig *cpiv1alpha1.VSphereCPIConfig, cluster *clusterapiv1beta1.Cluster) (VSphereCPIDataValues, error) {
+	c := cpiConfig.Spec.VSphereCPI.ParavirtualConfig
+
 	d := &VSphereCPIParaVirtDataValues{}
 	d.Mode = VSphereCPIParavirtualMode
 
@@ -185,6 +187,10 @@ func (r *VSphereCPIConfigReconciler) mapCPIConfigToDataValuesParavirtual(ctx con
 	d.ClusterKind = cluster.GroupVersionKind().Kind
 	d.ClusterName = cluster.ObjectMeta.Name
 	d.ClusterUID = string(cluster.ObjectMeta.UID)
+
+	if c != nil && c.AntreaNSXPodRoutingEnabled != nil {
+		d.AntreaNSXPodRoutingEnabled = *c.AntreaNSXPodRoutingEnabled
+	}
 
 	address, port, err := r.getSupervisorAPIServerAddress(ctx)
 	if err != nil {

--- a/addons/controllers/testdata/test-vsphere-cpi-paravirtual.yaml
+++ b/addons/controllers/testdata/test-vsphere-cpi-paravirtual.yaml
@@ -18,6 +18,7 @@ metadata:
 spec:
   vsphereCPI:
     mode: vsphereParavirtualCPI
+    antreaNSXPodRoutingEnabled: true
 ---
 apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster

--- a/addons/controllers/vspherecpiconfig_controller_test.go
+++ b/addons/controllers/vspherecpiconfig_controller_test.go
@@ -268,6 +268,7 @@ var _ = Describe("VSphereCPIConfig Reconciler", func() {
 				Expect(strings.Contains(secretData, "datacenter:")).Should(BeFalse())
 				Expect(strings.Contains(secretData, "server:")).Should(BeFalse())
 				Expect(strings.Contains(secretData, "nsxt:")).Should(BeFalse())
+				Expect(strings.Contains(secretData, "antreaNSXPodRoutingEnabled: true")).Should(BeTrue())
 
 				return true
 			}, waitTimeout, pollingInterval).Should(BeTrue())

--- a/apis/cpi/v1alpha1/vspherecpiconfig_types.go
+++ b/apis/cpi/v1alpha1/vspherecpiconfig_types.go
@@ -152,7 +152,10 @@ type NonParavirtualConfig struct {
 }
 
 type ParavirtualConfig struct {
-	// All configurations for paravirtual mode will be derived
+	// A flag that enables pod routing by Antrea NSX for paravirtual mode
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default:=false
+	AntreaNSXPodRoutingEnabled *bool `json:"antreaNSXPodRoutingEnabled,omitempty"`
 }
 
 type VSphereCPI struct {

--- a/config/crd/bases/cpi.tanzu.vmware.com_vspherecpiconfigs.yaml
+++ b/config/crd/bases/cpi.tanzu.vmware.com_vspherecpiconfigs.yaml
@@ -48,6 +48,11 @@ spec:
             properties:
               vsphereCPI:
                 properties:
+                  antreaNSXPodRoutingEnabled:
+                    default: false
+                    description: A flag that enables pod routing by Antrea NSX for
+                      paravirtual mode
+                    type: boolean
                   datacenter:
                     description: The datacenter in which VMs are created/located
                     type: string


### PR DESCRIPTION
### What this PR does / why we need it

Add antreaNSXPodRoutingEnabled field to the CPIConfig CR. With this PR, the cluster admin is able to deploy VSphereCPIConfig CR like this to turn on the routable pod feature.

```
apiVersion: cpi.tanzu.vmware.com/v1alpha1
kind: VSphereCPIConfig
metadata:
  name: #@ "{}-routable".format(data.values.TKR_VERSION)
  namespace: #@ data.values.GLOBAL_NAMESPACE
spec:
  vsphereCPI:
    mode: vsphereParavirtualCPI
    antreaNSXPodRoutingEnabled: true
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add antreaNSXPodRoutingEnabled field to the CPIConfig CR.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

Addon controller integration test (running)

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
