### PR TITLE
Add nodeselector, deployment and daemonset options to kapp-controller data-values

### DIFF
--- a/pkg/v1/providers/kapp-controller-values/kapp-controller_data.lib.yaml
+++ b/pkg/v1/providers/kapp-controller-values/kapp-controller_data.lib.yaml
@@ -6,6 +6,14 @@
 #@ def kappcontrollerdatavalues():
 ---
 namespace: tkg-system
+nodeSelector: null
+deployment:
+  updateStrategy: null
+  rollingUpdate:
+    maxUnavailable: null
+    maxSurge: null
+daemonset:
+  updateStrategy: null
 kappController:
   namespace: tkg-system
   createNamespace: true

--- a/pkg/v1/tkg/client/test/kapp-controller-values/testcase1/output.yaml
+++ b/pkg/v1/tkg/client/test/kapp-controller-values/testcase1/output.yaml
@@ -3,6 +3,14 @@
 #@overlay/replace
 ---
 namespace: tkg-system
+nodeSelector: null
+deployment:
+  updateStrategy: null
+  rollingUpdate:
+    maxUnavailable: null
+    maxSurge: null
+daemonset:
+  updateStrategy: null
 kappController:
   namespace: tkg-system
   createNamespace: true

--- a/pkg/v1/tkg/client/test/kapp-controller-values/testcase2/output.yaml
+++ b/pkg/v1/tkg/client/test/kapp-controller-values/testcase2/output.yaml
@@ -3,6 +3,14 @@
 #@overlay/replace
 ---
 namespace: tkg-system
+nodeSelector: null
+deployment:
+  updateStrategy: null
+  rollingUpdate:
+    maxUnavailable: null
+    maxSurge: null
+daemonset:
+  updateStrategy: null
 kappController:
   namespace: tkg-system
   createNamespace: true

--- a/pkg/v1/tkg/client/test/kapp-controller-values/testcase3/output.yaml
+++ b/pkg/v1/tkg/client/test/kapp-controller-values/testcase3/output.yaml
@@ -3,6 +3,14 @@
 #@overlay/replace
 ---
 namespace: tkg-system
+nodeSelector: null
+deployment:
+  updateStrategy: null
+  rollingUpdate:
+    maxUnavailable: null
+    maxSurge: null
+daemonset:
+  updateStrategy: null
 kappController:
   namespace: tkg-system
   createNamespace: true


### PR DESCRIPTION
Signed-off-by: Shyaam Nagarajan <nagarajans@vmware.com>

### What this PR does / why we need it
Recently to kapp-controller package a change was introduced to add node-selector, deployment and daemonset options. But these options were not added kapp-controller data-values in tanzu-framework. This causes installation issues for kapp-controller
 
### Which issue(s) this PR fixes
Fixes #2758

### Describe testing done for PR
ytt rendered the kapp-controller-data-values file with kapp-controller package

### Release note
```release-note
package-based-lcm: Add nodeselector, deployment and daemonset options to kapp-controller data-values to fix kapp-controller ytt template not being rendered and causing installation failure
```

### PR Checklist
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer
