### PR TITLE
Fix flaky CPIConfig controller test.

### DIFF
--- a/addons/controllers/testdata/test-vsphere-cpi-paravirtual-clusters-same-name.yaml
+++ b/addons/controllers/testdata/test-vsphere-cpi-paravirtual-clusters-same-name.yaml
@@ -1,7 +1,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: test-cluster-cpi-paravirtual
+  name: test-cluster-cpi-paravirtual-same-name
   namespace: default
 spec:
   infrastructureRef:
@@ -13,7 +13,7 @@ spec:
 apiVersion: cpi.tanzu.vmware.com/v1alpha1
 kind: VSphereCPIConfig
 metadata:
-  name: test-cluster-cpi-paravirtual
+  name: test-cluster-cpi-paravirtual-same-name
   namespace: default
 spec:
   vsphereCPI:
@@ -23,9 +23,9 @@ apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: test-cluster-cpi-paravirtual
+    cluster.x-k8s.io/cluster-name: test-cluster-cpi-paravirtual-same-name
     topology.cluster.x-k8s.io/owned: ""
-  name: test-cluster-cpi-paravirtual
+  name: test-cluster-cpi-paravirtual-same-name
   namespace: default
 spec:
   controlPlaneEndpoint:
@@ -41,30 +41,11 @@ apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: test-cluster-cpi-paravirtual
+    cluster.x-k8s.io/cluster-name: test-cluster-cpi-paravirtual-same-name
     topology.cluster.x-k8s.io/owned: ""
-  name: test-cluster-cpi-paravirtual
+  name: test-cluster-cpi-paravirtual-same-name
   namespace: another-ns
 spec:
   controlPlaneEndpoint:
     host: 192.168.116.2
     port: 6443
----
-apiVersion: v1
-data:
-  kubeconfig: |
-    apiVersion: v1
-    clusters:
-    - cluster:
-        certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1ETXlOVEExTkRNd01Wb1hEVE15TURNeU1qQTFORE13TVZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT25TClZOTlFzb043bExlekdxcmFpb01EOHJDeU9JSDFVVnJqT0x3YWp5UXZQeHRaYjdRdE9DRTJia282RytJcFJlQzYKZ3hIZi9aQi83VXNvTzVqaXpvcWpJUVpsdjZzSm9zR0I0c1Q4NG9hTGtIT21ISEU5a0w5U09Wa1FuT2J5ZWUzNApFaExnUHZWb1pKc05xMTRVWXJsS1R1dnBxNGhpY2pNU1Vua3ZpQmtiY3BCL0oxaUpBbXpIV2tnSkdlSk5HYTNnCk1lSXUxSzJVZ1I3NWp5bkpJSUsvdHFOMyt3VGl1TEcyNDhzZkVCY29pSWFYNTdoQ0E3d0hKR3RaZVJDQmlhNTAKc2JqbFFGd0hEblJldjBPZlNxeE4wZVE3ZVZwQ1NKWWFIQWtmc0t4ZXBSNXNTMnRrRFBVMlg4cHNmcEVQZGdwaApXUS9MN1JiYWdvbE91VkRzdkdVQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFCZmp0dFp6NDNwU3NUelM5ZVFzK0lkL3VjOVcKZkxWL2VCMXhOaUJWbXN6MUNsZldaZ1VIeWFsZ1RtRTlHdGtQVnhja2pSczNXQ0hlRUY4N1psOENobEFFMnFrZwpRcE5BVDMyM3RpOVk1TWk3bWZvOFl2OXdOL0ZPNzRwbnB2OElUVXpoRVlJaGxUZFYrd3RmWHUvTmNzN1Z0akNBCkNWNnExeU5lbG05eU9CVW51RElRNVo0L1AvYXFLRDFzSXNCSFJZZVU3SzVEaklSTGNpN3gvb2dlQ2F0ZVowNFoKeWExd2NXVXB3SnNpaGxIOCtHUkJkZ2h1RzZ4aC9ka1JhNmRLbHpYdVRManpsdVYyRUp6N29hZGthSUUybzM3RQpoazZ2aERBc1JHSCtCdnJtcFZJYjNsYTVGbDZHRkd2VElKMGFNT0pMTTVFa3pHNFlUeWpNRi9qK3Joaz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-        server: https://172.17.0.3:6773
-      name: ""
-    contexts: null
-    current-context: ""
-    kind: Config
-    preferences: {}
-    users: null
-kind: ConfigMap
-metadata:
-  name: cluster-info
-  namespace: kube-public

--- a/addons/controllers/testdata/test-vsphere-cpi-paravirtual-with-endpoint.yaml
+++ b/addons/controllers/testdata/test-vsphere-cpi-paravirtual-with-endpoint.yaml
@@ -1,7 +1,7 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: test-cluster-cpi-paravirtual
+  name: test-cluster-cpi-paravirtual-with-endpoint
   namespace: default
 spec:
   infrastructureRef:
@@ -13,7 +13,7 @@ spec:
 apiVersion: cpi.tanzu.vmware.com/v1alpha1
 kind: VSphereCPIConfig
 metadata:
-  name: test-cluster-cpi-paravirtual
+  name: test-cluster-cpi-paravirtual-with-endpoint
   namespace: default
 spec:
   vsphereCPI:
@@ -24,9 +24,9 @@ apiVersion: vmware.infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster
 metadata:
   labels:
-    cluster.x-k8s.io/cluster-name: test-cluster-cpi-paravirtual
+    cluster.x-k8s.io/cluster-name: test-cluster-cpi-paravirtual-with-endpoint
     topology.cluster.x-k8s.io/owned: ""
-  name: test-cluster-cpi-paravirtual-kl5tl
+  name: test-cluster-cpi-paravirtual-with-endpoint
   namespace: default
 spec:
   controlPlaneEndpoint:

--- a/addons/controllers/vspherecpiconfig_controller_test.go
+++ b/addons/controllers/vspherecpiconfig_controller_test.go
@@ -4,6 +4,7 @@
 package controllers
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"regexp"
@@ -14,6 +15,7 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	capvv1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
@@ -70,6 +72,36 @@ func newTestSupervisorLBServiceStatus() v1.ServiceStatus {
 	}
 }
 
+func newClusterInfoConfigMap() *v1.ConfigMap {
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controllers.ConfigMapClusterInfo,
+			Namespace: metav1.NamespacePublic,
+		},
+		Data: map[string]string{
+			"kubeconfig": `apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeU1ETXlOVEExTkRNd01Wb1hEVE15TURNeU1qQTFORE13TVZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBT25TClZOTlFzb043bExlekdxcmFpb01EOHJDeU9JSDFVVnJqT0x3YWp5UXZQeHRaYjdRdE9DRTJia282RytJcFJlQzYKZ3hIZi9aQi83VXNvTzVqaXpvcWpJUVpsdjZzSm9zR0I0c1Q4NG9hTGtIT21ISEU5a0w5U09Wa1FuT2J5ZWUzNApFaExnUHZWb1pKc05xMTRVWXJsS1R1dnBxNGhpY2pNU1Vua3ZpQmtiY3BCL0oxaUpBbXpIV2tnSkdlSk5HYTNnCk1lSXUxSzJVZ1I3NWp5bkpJSUsvdHFOMyt3VGl1TEcyNDhzZkVCY29pSWFYNTdoQ0E3d0hKR3RaZVJDQmlhNTAKc2JqbFFGd0hEblJldjBPZlNxeE4wZVE3ZVZwQ1NKWWFIQWtmc0t4ZXBSNXNTMnRrRFBVMlg4cHNmcEVQZGdwaApXUS9MN1JiYWdvbE91VkRzdkdVQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFCZmp0dFp6NDNwU3NUelM5ZVFzK0lkL3VjOVcKZkxWL2VCMXhOaUJWbXN6MUNsZldaZ1VIeWFsZ1RtRTlHdGtQVnhja2pSczNXQ0hlRUY4N1psOENobEFFMnFrZwpRcE5BVDMyM3RpOVk1TWk3bWZvOFl2OXdOL0ZPNzRwbnB2OElUVXpoRVlJaGxUZFYrd3RmWHUvTmNzN1Z0akNBCkNWNnExeU5lbG05eU9CVW51RElRNVo0L1AvYXFLRDFzSXNCSFJZZVU3SzVEaklSTGNpN3gvb2dlQ2F0ZVowNFoKeWExd2NXVXB3SnNpaGxIOCtHUkJkZ2h1RzZ4aC9ka1JhNmRLbHpYdVRManpsdVYyRUp6N29hZGthSUUybzM3RQpoazZ2aERBc1JHSCtCdnJtcFZJYjNsYTVGbDZHRkd2VElKMGFNT0pMTTVFa3pHNFlUeWpNRi9qK3Joaz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    server: https://172.17.0.3:6773
+  name: ""
+contexts: null
+current-context: ""
+kind: Config
+preferences: {}
+users: null`,
+		},
+	}
+}
+
+func tryCreateIfNotExists(ctx context.Context, client client.Client, object client.Object) error {
+	err := client.Create(ctx, object)
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}
+
 func getSecretDataValuesForCluster(clusterName string) (string, error) {
 	secret := &v1.Secret{}
 	secretKey := client.ObjectKey{
@@ -118,7 +150,6 @@ var _ = Describe("VSphereCPIConfig Reconciler", func() {
 	Context("reconcile VSphereCPIConfig manifests in non-paravirtual mode", func() {
 		BeforeEach(func() {
 			clusterName = "test-cluster-cpi"
-			vsphereClusterName = "test-cluster-cpi-paravirtual-kl5tl"
 			clusterResourceFilePath = "testdata/test-vsphere-cpi-non-paravirtual.yaml"
 		})
 
@@ -241,8 +272,11 @@ var _ = Describe("VSphereCPIConfig Reconciler", func() {
 		BeforeEach(func() {
 			clusterName = "test-cluster-cpi-paravirtual"
 			clusterResourceFilePath = "testdata/test-vsphere-cpi-paravirtual.yaml"
+
+			Expect(tryCreateIfNotExists(ctx, k8sClient, newClusterInfoConfigMap())).Should(Succeed())
 		})
-		It("Should reconcile VSphereCPIConfig and create data values secret for VSphereCPIConfig on management cluster", func() {
+		It("Should reconcile VSphereCPIConfig", func() {
+			By("create data values secret for VSphereCPIConfig on management cluster")
 			// the data values secret should be generated
 			Eventually(func() bool {
 				secretData, err := getSecretDataValuesForCluster(clusterName)
@@ -282,9 +316,8 @@ var _ = Describe("VSphereCPIConfig Reconciler", func() {
 				Expect(config.Status.SecretRef).To(Equal(fmt.Sprintf("%s-%s-data-values", clusterName, constants.CPIAddonName)))
 				return true
 			})
-		})
 
-		It("Should reconcile ProviderServiceAccount", func() {
+			By("create ProviderServiceAccount")
 			serviceAccount := &capvvmwarev1beta1.ProviderServiceAccount{}
 			Eventually(func() bool {
 				serviceAccountKey := client.ObjectKey{
@@ -301,9 +334,8 @@ var _ = Describe("VSphereCPIConfig Reconciler", func() {
 				Expect(serviceAccount.Spec.TargetSecretName).To(Equal("cloud-provider-creds"))
 				return true
 			})
-		})
 
-		It("Should reconcile aggregated cluster role", func() {
+			By("create aggregated cluster role")
 			clusterRole := &rbacv1.ClusterRole{}
 			Eventually(func() bool {
 				key := client.ObjectKey{
@@ -319,34 +351,55 @@ var _ = Describe("VSphereCPIConfig Reconciler", func() {
 				return true
 			})
 		})
+	})
+})
 
-		When("Headless service and endpoints already exists", func() {
-			var svc *v1.Service
-			BeforeEach(func() {
-				svc = newTestSupervisorLBService()
-				Expect(k8sClient.Create(ctx, svc)).To(Succeed())
-				svc.Status = newTestSupervisorLBServiceStatus()
-				Expect(k8sClient.Status().Update(ctx, svc)).To(Succeed())
-			})
+var _ = Describe("VSphereCPIConfig Reconciler with existing endpoint from LB service", func() {
+	var (
+		clusterName             string
+		clusterResourceFilePath string
+	)
 
-			AfterEach(func() {
-				Expect(k8sClient.Delete(ctx, svc)).To(Succeed())
-			})
+	JustBeforeEach(func() {
+		By("Creating cluster and VSphereCPIConfig resources")
+		f, err := os.Open(clusterResourceFilePath)
+		Expect(err).ToNot(HaveOccurred())
+		defer f.Close()
+		err = testutil.CreateResources(f, cfg, dynamicClient)
+		Expect(err).ToNot(HaveOccurred())
+	})
 
-			It("Should use headless service's endpoints", func() {
-				Eventually(func() bool {
-					secretData, err := getSecretDataValuesForCluster(clusterName)
-					// allow some time for data value secret to be generated
-					if err != nil {
-						return false
-					}
-					Expect(strings.Contains(secretData, "supervisorMasterEndpointIP: "+testSupervisorAPIServerVIP)).Should(BeTrue())
-					Expect(strings.Contains(secretData, "supervisorMasterPort: \""+strconv.Itoa(testSupervisorAPIServerPort)+"\"")).Should(BeTrue())
-					return true
-				}).Should(BeTrue())
-			})
+	Context("reconcile VSphereCPIConfig manifests in paravirtual mode, with existing endpoint", func() {
+		var svc *v1.Service
+
+		BeforeEach(func() {
+			clusterName = "test-cluster-cpi-paravirtual-with-endpoint"
+			clusterResourceFilePath = "testdata/test-vsphere-cpi-paravirtual-with-endpoint.yaml"
+
+			svc = newTestSupervisorLBService()
+			Expect(k8sClient.Create(ctx, svc)).To(Succeed())
+			svc.Status = newTestSupervisorLBServiceStatus()
+			Expect(k8sClient.Status().Update(ctx, svc)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Delete(ctx, svc)).To(Succeed())
+		})
+
+		It("uses headless service's endpoints", func() {
+			Eventually(func() bool {
+				secretData, err := getSecretDataValuesForCluster(clusterName)
+				// allow some time for data value secret to be generated
+				if err != nil {
+					return false
+				}
+				Expect(strings.Contains(secretData, "supervisorMasterEndpointIP: "+testSupervisorAPIServerVIP)).Should(BeTrue())
+				Expect(strings.Contains(secretData, "supervisorMasterPort: \""+strconv.Itoa(testSupervisorAPIServerPort)+"\"")).Should(BeTrue())
+				return true
+			}).Should(BeTrue())
 		})
 	})
+
 })
 
 var _ = Describe("VSphereCPIConfig Reconciler multi clusters", func() {
@@ -370,8 +423,10 @@ var _ = Describe("VSphereCPIConfig Reconciler multi clusters", func() {
 		// covers the issue https://github.com/vmware-tanzu/tanzu-framework/issues/2714
 		// it was triggered when two clusters with the same name, but under different namespaces
 		BeforeEach(func() {
-			clusterName = "test-cluster-cpi-paravirtual"
+			clusterName = "test-cluster-cpi-paravirtual-same-name"
 			clusterResourceFilePath = "testdata/test-vsphere-cpi-paravirtual-clusters-same-name.yaml"
+
+			Expect(tryCreateIfNotExists(ctx, k8sClient, newClusterInfoConfigMap())).Should(Succeed())
 		})
 
 		It("should select vSphereCluster with right namespace", func() {


### PR DESCRIPTION
### What this PR does / why we need it

Fix flaky CPIConfig controller test caused by the cluster object still being deleted, when the next test case tries to recreate it.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes # https://github.com/vmware-tanzu/tanzu-framework/issues/2769

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix flaky CPIConfig controller test.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
