### PR TITLE
package/pinniped: post-deploy job read nodes to obtain cluster-name or accept --jwtauthenticator-audience flag

### DIFF
--- a/addons/pinniped/post-deploy/go.mod
+++ b/addons/pinniped/post-deploy/go.mod
@@ -33,6 +33,7 @@ require (
 	k8s.io/apimachinery v0.24.1
 	k8s.io/client-go v0.24.1
 	k8s.io/klog/v2 v2.60.1
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/cluster-api v1.1.5
 	sigs.k8s.io/controller-runtime v0.11.2
 )
@@ -90,7 +91,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.23.5 // indirect
 	k8s.io/component-base v0.23.5 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/addons/pinniped/post-deploy/pkg/inspect/inspect.go
+++ b/addons/pinniped/post-deploy/pkg/inspect/inspect.go
@@ -49,13 +49,15 @@ type TKGMetadata struct {
 		      configmapRef:
 		        name: tkg-bom
 	*/
-	Cluster struct {
-		Name           string `yaml:"name"`
-		Type           string `yaml:"type"`
-		Infrastructure struct {
-			Provider string `yaml:"provider"`
-		} `yaml:"infrastructure"`
-	} `yaml:"cluster"`
+	Cluster TKGMetadataCluster `yaml:"cluster"`
+}
+
+type TKGMetadataCluster struct {
+	Name           string `yaml:"name"`
+	Type           string `yaml:"type"`
+	Infrastructure struct {
+		Provider string `yaml:"provider"`
+	} `yaml:"infrastructure"`
 }
 
 // ClusterInfo contains information about the cluster.


### PR DESCRIPTION
Signed-off-by: Benjamin A. Petersen <ben@benjaminapetersen.me>

- Builds on #2705 post-deploy conditionally reads tkg-metadata
- Depends on [Community Edition 4915](https://github.com/vmware-tanzu/community-edition/pull/4915)
  - Pinniped Package needs to provide RBAC to the post-deploy job first to enable the listing of nodes
  - Upstream Pinniped already has the ability to read nodes, therefore this is reasonable
- Cluster-API[ provides the cluster-name annotation](https://github.com/kubernetes-sigs/cluster-api/issues/4044) on nodes. 
- If tkg-metadata is not found, post-deploy job can fall back to the annotation on the node

### What this PR does / why we need it

The tkg-metadata configmap is not created in classy clusters. Therefore the post-deploy job needs a fallback mechanism to obtain the name of the cluster so that it can configure the pinniped concierge correctly to create the JWTAuthenticator with a viable audience. 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
