### PR TITLE
Node affinity for KCP controller manager

### DIFF
--- a/hack/providers-sync-tools/cluster-api-control-plane-kubeadm/overlay/set-pod-affinity.yaml
+++ b/hack/providers-sync-tools/cluster-api-control-plane-kubeadm/overlay/set-pod-affinity.yaml
@@ -1,0 +1,16 @@
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind":"Deployment", "metadata": {"name": "capi-kubeadm-control-plane-controller-manager"}})
+---
+spec:
+  template:
+    spec:
+      #@overlay/match missing_ok=True
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
+            weight: 100

--- a/pkg/v1/providers/control-plane-kubeadm/v1.1.3/control-plane-components.yaml
+++ b/pkg/v1/providers/control-plane-kubeadm/v1.1.3/control-plane-components.yaml
@@ -4311,6 +4311,14 @@ spec:
       - name: cert
         secret:
           secretName: capi-kubeadm-control-plane-webhook-service-cert
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: DoesNotExist
+            weight: 100
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate


### PR DESCRIPTION
### What this PR does / why we need it
Adds a node affinity preference to target worker nodes for KCP controller manager pod scheduling. This doesn't completely mitigate the chance that the pod could be scheduled on a controller node and experience the problems detailed in #2776 but it will help reduce the frequency while still maintaining the ability to deploy the controller if a worker node is not available.

### Which issue(s) this PR fixes
Fixes #2776 

### Describe testing done for PR
An older version of the framework was first deployed then the KCP controller manager deployment patched to include the pod affinity. Once the pod was redeployed it was observed that etcd member health checks no longer failed and successful scaling of the KCP using a new AzureMachineTemplate could be completed.

### Release note
```release-note
A node affinity was added to the Kubeadm Control Plane Controller Manager deployment to reduce cluster lifecycle interruptions in certain deployment scenarios.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
