### PR TITLE
Enable PackageInstallStatus feature in AddonsManager

### DIFF
--- a/pkg/v1/tkg/managementcomponents/helper.go
+++ b/pkg/v1/tkg/managementcomponents/helper.go
@@ -62,6 +62,7 @@ func GetTKGPackageConfigValuesFileFromUserConfig(managementPackageVersion string
 				TanzuAddonsManager: TanzuAddonsManager{
 					FeatureGates: AddonsFeatureGates{
 						ClusterBootstrapController: true,
+						PackageInstallStatus:       true,
 					},
 				},
 			},

--- a/pkg/v1/tkg/managementcomponents/test/output_aws.yaml
+++ b/pkg/v1/tkg/managementcomponents/test/output_aws.yaml
@@ -15,6 +15,7 @@ frameworkPackage:
         tanzuAddonsManager:
             featureGates:
                 clusterBootstrapController: true
+                packageInstallStatus: true
     tanzuAuthPackageValues:
         versionConstraints: v0.21.0
 clusterclassPackage:

--- a/pkg/v1/tkg/managementcomponents/test/output_azure.yaml
+++ b/pkg/v1/tkg/managementcomponents/test/output_azure.yaml
@@ -15,6 +15,7 @@ frameworkPackage:
         tanzuAddonsManager:
             featureGates:
                 clusterBootstrapController: true
+                packageInstallStatus: true
     tanzuAuthPackageValues:
         versionConstraints: v0.21.0
 clusterclassPackage:

--- a/pkg/v1/tkg/managementcomponents/test/output_vsphere.yaml
+++ b/pkg/v1/tkg/managementcomponents/test/output_vsphere.yaml
@@ -15,6 +15,7 @@ frameworkPackage:
         tanzuAddonsManager:
             featureGates:
                 clusterBootstrapController: true
+                packageInstallStatus: true
     tanzuAuthPackageValues:
         versionConstraints: v0.21.0
 clusterclassPackage:

--- a/pkg/v1/tkg/managementcomponents/types.go
+++ b/pkg/v1/tkg/managementcomponents/types.go
@@ -51,6 +51,7 @@ type ClusterClassPackage struct {
 
 type AddonsFeatureGates struct {
 	ClusterBootstrapController bool `yaml:"clusterBootstrapController,omitempty"`
+	PackageInstallStatus       bool `yaml:"packageInstallStatus,omitempty"`
 }
 
 type TanzuAddonsManager struct {


### PR DESCRIPTION
Signed-off-by: F. Gold <fgold@vmware.com>

### What this PR does / why we need it

The goal of this PR is to show the reconciliation status for all core/additional packages in ClusterBootstrap status conditions field. To accomplish this goal, I had to enable the PackageInstallStatus feature to addons manager. This will pass along the status of Carval package installations to the ClusterBootstrap object status conditions field.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2470 

### Describe testing done for PR

I manually,
- Created a management cluster using a cluster configuration file I had from before.
- Verified in the clusterbootstrap object a status message showing all core and additional packages have been reconciled

```bash
$ kubectl get clusterbootstrap -n tkg-system jun29-dev-dirty -o yaml
apiVersion: run.tanzu.vmware.com/v1alpha3
kind: ClusterBootstrap
[...clipped..]
spec:
  additionalPackages:
  - refName: metrics-server.tanzu.vmware.com.0.5.1+vmware.1-tkg.2-zshippable
  - refName: secretgen-controller.tanzu.vmware.com.0.9.1+vmware.1-tkg.1-zshippable
  - refName: pinniped.tanzu.vmware.com.0.12.1+vmware.1-tkg.1-zshippable
    valuesFrom:
      secretRef: jun29-dev-dirty-pinniped-package
  - refName: capabilities.tanzu.vmware.com.0.24.0-dev-76-g50594bfb+vmware.1
  - refName: tkg-storageclass.tanzu.vmware.com.0.24.0-dev-76-g50594bfb+vmware.1
  cni:
    refName: antrea.tanzu.vmware.com.1.5.2+vmware.3-tkg.1-advanced-zshippable
    valuesFrom:
      providerRef:
        apiGroup: cni.tanzu.vmware.com
        kind: AntreaConfig
        name: jun29-dev-dirty-antrea-package
  kapp:
    refName: kapp-controller.tanzu.vmware.com.0.34.0+vmware.1-tkg.1-zshippable
    valuesFrom:
      providerRef:
        apiGroup: run.tanzu.vmware.com
        kind: KappControllerConfig
        name: jun29-dev-dirty-kapp-controller-package
  paused: false
status:
  conditions:
  - lastTransitionTime: "2022-06-29T23:22:01Z"
    status: "True"
    type: Antrea-ReconcileSucceeded
  - lastTransitionTime: "2022-06-29T23:22:01Z"
    status: "True"
    type: Capabilities-ReconcileSucceeded
  - lastTransitionTime: "2022-06-29T23:22:01Z"
    status: "True"
    type: Metrics-Server-ReconcileSucceeded
  - lastTransitionTime: "2022-06-29T23:22:01Z"
    status: "True"
    type: Pinniped-ReconcileSucceeded
  - lastTransitionTime: "2022-06-29T23:22:01Z"
    status: "True"
    type: Secretgen-Controller-ReconcileSucceeded
  - lastTransitionTime: "2022-06-29T23:22:02Z"
    message: 'kapp: Error: Trying to apply empty set of resources will result in deletion
      of resources on cluster. Refusing to continue unless --dangerous-allow-empty-list-of-resources
      is specified.'
    status: "True"
    type: Tkg-Storageclass-ReconcileFailed
  resolvedTKR: v1.23.5---vmware.1-tkg.1-zshippable
```

To prove the package install status conditions were showing up due to the changes in this PR, I also did a test where I built the Tanzu CLI from the main branch which did not have my changes, and retrieved the clusterbootstrap object. Here is an excerpt from that test:

ClusterBootstrap status before changes from this PR: 

```bash
$ kubectl get clusterbootstrap -n tkg-system -o yaml jun30-main
apiVersion: run.tanzu.vmware.com/v1alpha3
kind: ClusterBootstrap
[...clipped...]
status:
  resolvedTKR: v1.23.5---vmware.1-tkg.1-zshippable
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Show core and additional package install statuses in clusterbootstrap status message field.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
