### PR TITLE
Add parameters to support leader election for Addons Controller

### DIFF
--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -19,6 +19,10 @@ import (
 const (
 	/* Addon constants section */
 
+	// AddonControllerManagerLeaderElectionResourceName is the name of the resource that leader election of
+	// addons controller manager will use for holding the leader lock.
+	AddonControllerManagerLeaderElectionResourceName = "tanzu-addons-manager-leader-lock"
+
 	// CalicoAddonName is name of the Calico addon
 	CalicoAddonName = "calico"
 

--- a/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
+++ b/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
@@ -324,7 +324,11 @@ metadata:
   name: tanzu-addons-controller-manager
   namespace: #@ data.values.tanzuAddonsManager.namespace
 spec:
+  #@ if data.values.tanzuAddonsManager.deployment.leaderElection:
+  replicas: #@ data.values.tanzuAddonsManager.deployment.replicas
+  #@ else:
   replicas: 1
+  #@ end
   selector:
     matchLabels:
       app: tanzu-addons-manager

--- a/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
+++ b/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
@@ -338,7 +338,7 @@ spec:
       containers:
       - args:
         - #@ "--metrics-bind-addr={}".format(data.values.tanzuAddonsManager.deployment.metricsBindAddress)
-        - --leader-elect=false
+        - #@ "--leader-elect={}".format(data.values.tanzuAddonsManager.deployment.leaderElection)
         - #@ "--health-addr=:{}".format(data.values.tanzuAddonsManager.deployment.healthzPort)
         - #@ "--webhook-server-port={}".format(data.values.tanzuAddonsManager.deployment.webhookServerPort)
         - #@ "--addon-namespace={}".format(data.values.tanzuAddonsManager.namespace)

--- a/packages/addons-manager/bundle/config/values.yaml
+++ b/packages/addons-manager/bundle/config/values.yaml
@@ -6,6 +6,7 @@ tanzuAddonsManager:
   namespace: tkg-system
   createNamespace: true
   deployment:
+    leaderElection: false
     hostNetwork: true
     priorityClassName: null
     nodeSelector: null

--- a/packages/addons-manager/bundle/config/values.yaml
+++ b/packages/addons-manager/bundle/config/values.yaml
@@ -6,6 +6,7 @@ tanzuAddonsManager:
   namespace: tkg-system
   createNamespace: true
   deployment:
+    replicas: 2
     leaderElection: false
     hostNetwork: true
     priorityClassName: null

--- a/packages/framework/bundle/config/values.yaml
+++ b/packages/framework/bundle/config/values.yaml
@@ -26,6 +26,7 @@ addonsManagerPackageValues:
     namespace: tkg-system
     createNamespace: false
     deployment:
+      replicas: 2
       leaderElection: false
       hostNetwork: true
       priorityClassName: system-cluster-critical

--- a/packages/framework/bundle/config/values.yaml
+++ b/packages/framework/bundle/config/values.yaml
@@ -26,6 +26,7 @@ addonsManagerPackageValues:
     namespace: tkg-system
     createNamespace: false
     deployment:
+      leaderElection: false
       hostNetwork: true
       priorityClassName: system-cluster-critical
       nodeSelector: null

--- a/packages/tkg/bundle/config/values.yaml
+++ b/packages/tkg/bundle/config/values.yaml
@@ -37,6 +37,7 @@ frameworkPackage:
       namespace: tkg-system
       createNamespace: false
       deployment:
+        leaderElection: false
         hostNetwork: true
         priorityClassName: system-cluster-critical
         nodeSelector: null

--- a/packages/tkg/bundle/config/values.yaml
+++ b/packages/tkg/bundle/config/values.yaml
@@ -37,6 +37,7 @@ frameworkPackage:
       namespace: tkg-system
       createNamespace: false
       deployment:
+        replicas: 2
         leaderElection: false
         hostNetwork: true
         priorityClassName: system-cluster-critical


### PR DESCRIPTION
### What this PR does / why we need it
- Add parameters in the addons controller manager's config to support leader election
- Keep leader election option to be false by default (both in manager's config and [addons-manager package](https://github.com/vmware-tanzu/tanzu-framework/blob/main/packages/addons-manager/bundle/config/upstream/addons-manager.yaml#L341))
- Set replicas of deployment `tanzu-addons-controller-manager` to 2 when leader election is enabled

**note:** User can enable leader election by passing in data values when installing package.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2541

### Describe testing done for PR
- Passed all tests locally
- Verified deployment `tanzu-addons-controller-manager` yaml is generated correctly based on `leaderElection` setting:
```
# when leaderElection is set to true
spec:
  replicas: 2
  selector:
    matchLabels:
      app: tanzu-addons-manager
  template:
    metadata:
      labels:
        app: tanzu-addons-manager
    spec:
      containers:
      - args:
        - --metrics-bind-addr=localhost:18317
        - --leader-elect=True
        - --health-addr=:18316
        - --webhook-server-port=9865
        - --addon-namespace=tkg-system

# when leaderElection is set to false
spec:
  replicas: 1
  selector:
    matchLabels:
      app: tanzu-addons-manager
  template:
    metadata:
      labels:
        app: tanzu-addons-manager
    spec:
      containers:
      - args:
        - --metrics-bind-addr=localhost:18317
        - --leader-elect=False
        - --health-addr=:18316
        - --webhook-server-port=9865
        - --addon-namespace=tkg-system
```
- Verified the leader election of `addons-controller-manager` works correctly after enabling leader election:
```
# the ConfigMap CR used for holding the leader lock shows up 
[ ~ ]# k get configmap -n vmware-system-tkg | grep tanzu
...
tanzu-addons-manager-leader-lock               0      21s
...

# scale the addons-controller to 3 replicas
[ ~ ]# k get pod -n vmware-system-tkg -o wide | grep addons
tanzu-addons-controller-manager-556c8dddf6-cq89s         1/1     Running   0                61s     192.168.128.1   423bb2f52f8c663136f412787d2345a5   <none>           <none>
[ ~ ]# k scale deploy tanzu-addons-controller-manager -n vmware-system-tkg --replicas=3
deployment.apps/tanzu-addons-controller-manager scaled
[ ~ ]# k get pod -n vmware-system-tkg | grep add
tanzu-addons-controller-manager-556c8dddf6-72m82         1/1     Running   0                24s
tanzu-addons-controller-manager-556c8dddf6-984br         1/1     Running   0                24s
tanzu-addons-controller-manager-556c8dddf6-cq89s         1/1     Running   0                2m57s
```

Related logs of this three replicas:
```
# leader pod
[ ~ ]# k logs tanzu-addons-controller-manager-556c8dddf6-cq89s -n vmware-system-tkg --tail 10
...
I0629 18:28:56.163505       1 leaderelection.go:248] attempting to acquire leader lease vmware-system-tkg/tanzu-addons-manager-leader-lock...
...
I0629 18:28:56.419425       1 leaderelection.go:258] successfully acquired lease vmware-system-tkg/tanzu-addons-manager-leader-lock
...

# non-leader pod1
[ ~ ]# k logs tanzu-addons-controller-manager-556c8dddf6-72m82 -n vmware-system-tkg --tail 10
...
I0629 18:31:27.106252       1 leaderelection.go:248] attempting to acquire leader lease vmware-system-tkg/tanzu-addons-manager-leader-lock...

# non-leader pod2
[ ~ ]# k logs tanzu-addons-controller-manager-556c8dddf6-984br -n vmware-system-tkg --tail 10
...
I0629 18:31:31.003785       1 leaderelection.go:248] attempting to acquire leader lease vmware-system-tkg/tanzu-addons-manager-leader-lock...
```

Create a new template antreaconfig in `test-ns-1`, verify only the leader controller reconciles the request:
```
[ ~ ]# k logs tanzu-addons-controller-manager-556c8dddf6-cq89s -n vmware-system-tkg --tail 10
...
I0629 18:35:21.642188       1 antreaconfig_controller.go:53] AntreaConfigController "msg"="Start reconciliation"
I0629 18:35:21.643107       1 antreaconfig_controller.go:82] AntreaConfigController "msg"="Cluster 'v1.23.5---vmware.1-tkg.1-zshippable'not found in 'test-ns-1'" "antreaconfig"={"Namespace":"test-ns-1","Name":"v1.23.5---vmware.1-tkg.1-zshippable"}

[ ~ ]# k logs tanzu-addons-controller-manager-556c8dddf6-72m82 -n vmware-system-tkg --tail 10
...
I0629 18:31:27.106252       1 leaderelection.go:248] attempting to acquire leader lease vmware-system-tkg/tanzu-addons-manager-leader-lock...
I0629 18:35:21.612268       1 logr.go:252] antreaconfig-resource "msg"="validate create"  "name"="v1.23.5---vmware.1-tkg.1-zshippable"

[ ~ ]# k logs tanzu-addons-controller-manager-556c8dddf6-984br -n vmware-system-tkg --tail 10
...
I0629 18:31:31.003785       1 leaderelection.go:248] attempting to acquire leader lease vmware-system-tkg/tanzu-addons-manager-leader-lock...
```

Delete current lead pod, verify new leader is elected:
```
[ ~ ]# k delete pod tanzu-addons-controller-manager-556c8dddf6-cq89s -n vmware-system-tkg --force
pod "tanzu-addons-controller-manager-556c8dddf6-cq89s" deleted

[ ~ ]# k get pod -n vmware-system-tkg | grep add
tanzu-addons-controller-manager-556c8dddf6-72m82         1/1     Running   0                6m52s
tanzu-addons-controller-manager-556c8dddf6-984br         1/1     Running   0                6m52s
tanzu-addons-controller-manager-556c8dddf6-hfwqw         1/1     Running   0                81s

# new leader pod
[ ~ ]# k logs tanzu-addons-controller-manager-556c8dddf6-984br -n vmware-system-tkg
I0629 18:31:31.003785       1 leaderelection.go:248] attempting to acquire leader lease vmware-system-tkg/tanzu-addons-manager-leader-lock...
...
I0629 18:36:51.113915       1 leaderelection.go:258] successfully acquired lease vmware-system-tkg/tanzu-addons-manager-leader-lock
...

# non-leader pods
[ ~ ]# k logs tanzu-addons-controller-manager-556c8dddf6-72m82 -n vmware-system-tkg --tail 10
...
I0629 18:31:27.106252       1 leaderelection.go:248] attempting to acquire leader lease vmware-system-tkg/tanzu-addons-manager-leader-lock...

[ ~ ]# k logs tanzu-addons-controller-manager-556c8dddf6-hfwqw -n vmware-system-tkg --tail 10
...
I0629 18:37:04.260751       1 leaderelection.go:248] attempting to acquire leader lease vmware-system-tkg/tanzu-addons-manager-leader-lock...
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Enable leader election for Addons Controller
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
