### PR TITLE
TKR Ready status condition and additional print-column

### DIFF
--- a/apis/run/v1alpha3/tanzukubernetesrelease_types.go
+++ b/apis/run/v1alpha3/tanzukubernetesrelease_types.go
@@ -12,6 +12,7 @@ import (
 const (
 	ConditionCompatible = "Compatible"
 	ConditionValid      = "Valid"
+	ConditionReady      = "Ready"
 
 	ConditionUpdatesAvailable = "UpdatesAvailable"
 
@@ -99,6 +100,7 @@ type TanzuKubernetesReleaseStatus struct {
 // +kubebuilder:resource:path=tanzukubernetesreleases,scope=Cluster,shortName=tkr
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Version",type=string,JSONPath=.spec.version
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=.status.conditions[?(@.type=='Ready')].status
 // +kubebuilder:printcolumn:name="Compatible",type=string,JSONPath=.status.conditions[?(@.type=='Compatible')].status
 // +kubebuilder:printcolumn:name="Created",type="date",JSONPath=.metadata.creationTimestamp
 type TanzuKubernetesRelease struct {

--- a/config/crd/bases/run.tanzu.vmware.com_tanzukubernetesreleases.yaml
+++ b/config/crd/bases/run.tanzu.vmware.com_tanzukubernetesreleases.yaml
@@ -361,6 +361,9 @@ spec:
     - jsonPath: .spec.version
       name: Version
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
     - jsonPath: .status.conditions[?(@.type=='Compatible')].status
       name: Compatible
       type: string

--- a/packages/tkr-service/bundle/config/upstream/tkr-crd.yaml
+++ b/packages/tkr-service/bundle/config/upstream/tkr-crd.yaml
@@ -375,6 +375,9 @@ spec:
     - jsonPath: .spec.version
       name: Version
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
     - jsonPath: .status.conditions[?(@.type=='Compatible')].status
       name: Compatible
       type: string


### PR DESCRIPTION
### What this PR does / why we need it

Users need an easy way to know that a TKR is ready for use. TKR v1alpha3 missed this functionality, and this change fixes this in the form of additional print-column 'Ready', using the newly added 'Ready' status condition as the source of the displayed value.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

N/A

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Added a unit-test covering the added logic.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Added 'Ready' status condition and a print-column with the same name, indicating if the TKR is usable for cluster creation or update.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
