### PR TITLE
Add ClusterClass based cluster creation validation check at runtime

### DIFF
--- a/pkg/v1/tkg/test/tkgctl/tkgs/tkgs_workload_cluster_test.go
+++ b/pkg/v1/tkg/test/tkgctl/tkgs/tkgs_workload_cluster_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/cluster-api/util"
 
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/test/framework"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/test/framework/exec"
@@ -64,7 +63,7 @@ var _ = Describe("TKGS - Create workload cluster use cases", func() {
 			AfterEach(func() {
 				defer os.Remove(clusterConfigFile)
 			})
-			When("cluster class cli feature flag (features.global.package-based-lcm-beta) set true", func() {
+			When("cluster class cli feature flag (features.global.package-based-lcm-beta) is set to true", func() {
 				BeforeEach(func() {
 					//set the cli feature flag as true -  (features.global.package-based-lcm-beta)
 					Expect(framework.SetCliConfigFlag(CLI_CLUSTERCLASS_FLAG, "true")).To(Succeed(), "error while setting CLI ClusterClass flag")
@@ -81,7 +80,7 @@ var _ = Describe("TKGS - Create workload cluster use cases", func() {
 					Expect(err).To(BeNil())
 				})
 			})
-			When("cluster class cli feature flag (features.global.package-based-lcm-beta) set false", func() {
+			When("cluster class cli feature flag (features.global.package-based-lcm-beta) is set to false", func() {
 				BeforeEach(func() {
 					//set the cli feature flag as false -  (features.global.package-based-lcm-beta)
 					Expect(framework.SetCliConfigFlag(CLI_CLUSTERCLASS_FLAG, "false")).To(Succeed(), "error while setting CLI ClusterClass flag")
@@ -109,7 +108,7 @@ var _ = Describe("TKGS - Create workload cluster use cases", func() {
 			AfterEach(func() {
 				defer os.Remove(clusterConfigFile)
 			})
-			When("cluster class cli feature flag (features.global.package-based-lcm-beta) set true", func() {
+			When("cluster class cli feature flag (features.global.package-based-lcm-beta) is set to true", func() {
 				BeforeEach(func() {
 					//set the cli feature flag as true -  (features.global.package-based-lcm-beta)
 					Expect(framework.SetCliConfigFlag(CLI_CLUSTERCLASS_FLAG, "true")).To(Succeed(), "error while setting CLI ClusterClass flag")
@@ -126,7 +125,7 @@ var _ = Describe("TKGS - Create workload cluster use cases", func() {
 					Expect(err).To(BeNil())
 				})
 			})
-			When("cluster class cli feature flag (features.global.package-based-lcm-beta) set false", func() {
+			When("cluster class cli feature flag (features.global.package-based-lcm-beta) is set to false", func() {
 				BeforeEach(func() {
 					//set the cli feature flag as false -  (features.global.package-based-lcm-beta)
 					Expect(framework.SetCliConfigFlag(CLI_CLUSTERCLASS_FLAG, "false")).To(Succeed(), "error while setting CLI ClusterClass flag")
@@ -152,7 +151,7 @@ var _ = Describe("TKGS - Create workload cluster use cases", func() {
 			Expect(cclusterFile).ToNot(BeEmpty(), fmt.Sprintf("the input cluster class based config file should not be empty, file path: %v", e2eConfig.WorkloadClusterOptions.ClusterClassFilePath))
 			clusterOptions.ClusterConfigFile = e2eConfig.WorkloadClusterOptions.ClusterClassFilePath
 		})
-		When("cluster class cli feature flag (features.global.package-based-lcm-beta) set true", func() {
+		When("cluster class cli feature flag (features.global.package-based-lcm-beta) is set to true", func() {
 			BeforeEach(func() {
 				//set the cli feature flag as true -  (features.global.package-based-lcm-beta)
 				Expect(framework.SetCliConfigFlag(CLI_CLUSTERCLASS_FLAG, "true")).To(Succeed(), "error while setting CLI feature flag")
@@ -170,17 +169,26 @@ var _ = Describe("TKGS - Create workload cluster use cases", func() {
 				Expect(err).To(BeNil())
 			})
 		})
-		When("cluster class cli feature flag (features.global.package-based-lcm-beta) set false", func() {
+		When("cluster class cli feature flag (features.global.package-based-lcm-beta) is set to false", func() {
 			BeforeEach(func() {
 				//set the cli feature flag as false -  (features.global.package-based-lcm-beta)
 				Expect(framework.SetCliConfigFlag(CLI_CLUSTERCLASS_FLAG, "false")).To(Succeed(), "error while setting CLI ClusterClass flag")
 				tkgctlClient, err = tkgctl.New(tkgctlOptions)
 				Expect(err).To(BeNil())
 			})
-			It("should return error", func() {
-				By(fmt.Sprintf("creating Cluster class based workload cluster, cli feature flag is disabled"))
-				err = tkgctlClient.CreateCluster(clusterOptions)
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(constants.ErrorMsgCClassInputFeatureFlagDisabled, config.FeatureFlagPackageBasedLCM)))
+			It("should return success or error based on the ClusterClass feature-gate status on the Supervisor", func() {
+				featureGateHelper := tkgctlClient.FeatureGateHelper()
+				isClusterClassFeatureActivated, _ := featureGateHelper.FeatureActivatedInNamespace(context.Background(), constants.ClusterClassFeature, constants.TKGSClusterClassNamespace)
+				if isClusterClassFeatureActivated {
+					By(fmt.Sprintf("creating Cluster class based workload cluster, ClusterClass feature-gate is activated"))
+					err = tkgctlClient.CreateCluster(clusterOptions)
+					Expect(err).To(BeNil())
+				} else {
+					By(fmt.Sprintf("creating Cluster class based workload cluster, ClusterClass feature-gate is deactivated"))
+					err = tkgctlClient.CreateCluster(clusterOptions)
+					Expect(err).NotTo(BeNil())
+					Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(constants.ErrorMsgFeatureGateNotActivated, constants.ClusterClassFeature, constants.TKGSClusterClassNamespace)))
+				}
 			})
 		})
 	})

--- a/pkg/v1/tkg/tkgctl/client.go
+++ b/pkg/v1/tkg/tkgctl/client.go
@@ -264,6 +264,11 @@ func (t *tkgctl) TKGConfigReaderWriter() tkgconfigreaderwriter.TKGConfigReaderWr
 	return t.tkgConfigReaderWriter
 }
 
+// FeatureGateHelper returns feature gate helper to query feature gate
+func (t *tkgctl) FeatureGateHelper() featureGateHelper {
+	return t.FeatureGateHelper()
+}
+
 func ensureConfigImages(configDir string, tkgConfigUpdater tkgconfigupdater.Client) error {
 	var err error
 

--- a/pkg/v1/tkg/tkgctl/create_cluster.go
+++ b/pkg/v1/tkg/tkgctl/create_cluster.go
@@ -158,7 +158,7 @@ func (t *tkgctl) processWorkloadClusterInputFile(cc *CreateClusterOptions, isTKG
 		return isInputFileClusterClassBased, err
 	}
 	if isInputFileClusterClassBased {
-		if !t.tkgClient.IsFeatureActivated(config.FeatureFlagPackageBasedLCM) {
+		if !isTKGSCluster && !t.tkgClient.IsFeatureActivated(config.FeatureFlagPackageBasedLCM) {
 			return isInputFileClusterClassBased, fmt.Errorf(constants.ErrorMsgCClassInputFeatureFlagDisabled, config.FeatureFlagPackageBasedLCM)
 		}
 		if isTKGSCluster {

--- a/pkg/v1/tkg/tkgctl/interface.go
+++ b/pkg/v1/tkg/tkgctl/interface.go
@@ -93,4 +93,6 @@ type TKGClient interface {
 	// GetPacificMachineDeployments gets machine deployments from a Pacific cluster
 	// Note: This would be soon deprecated after TKGS and TKGm adopt the clusterclass
 	GetPacificMachineDeployments(options client.GetMachineDeploymentOptions) ([]capiv1alpha3.MachineDeployment, error)
+	// FeatureGateHelper returns feature gate helper to query feature gate
+	FeatureGateHelper() featureGateHelper
 }


### PR DESCRIPTION
### What this PR does / why we need it
- Add ClusterClass based cluster creation validation check at runtime

<img width="433" alt="Screen Shot 2022-06-30 at 12 22 57 PM" src="https://user-images.githubusercontent.com/7102902/176760782-6af4820e-abb0-42ff-b0ab-c8129cd442d8.png">


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2802

### Describe testing done for PR
- When `package-base-lcm-beta` feature flag is not configured or set to `false`
    - `tanzu cluster create -f <legacy-aws-cluster-config-file>` -> Generates legacy cluster configuration
    - `tanzu cluster create -f <AWS-clusterclass-based-configuration>` -> Returns error saying ClusterClass based cluster creation not supported
    - `tanzu cluster create -f <TKGS-clusterclass-based-configuration>`
        - If feature-gate for ClusterClass is disabled on the supervisor cluster
            - Returns error saying ClusterClass based cluster creation not supported
        - If feature-gate for ClusterClass is enabled on the supervisor cluster
            - Creates clusterclass based cluster

- When `package-base-lcm-beta` feature flag is set to `true`
    -  Allows ClusterClass based cluster creation for AWS as well as TKGS clusters

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add ClusterClass based cluster creation validation check at runtime based on feature-flag and feature-gate
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
