### PR TITLE
Remove podcidr auto-fill when tkgs routable pod feature is enabled

### DIFF
--- a/tkg/client/validate.go
+++ b/tkg/client/validate.go
@@ -1682,7 +1682,12 @@ func (c *TkgClient) configureAndValidateIPFamilyConfiguration(clusterRole string
 		return err
 	}
 	if clusterCIDRs == "" {
-		c.TKGConfigReaderWriter().Set(constants.ConfigVariableClusterCIDR, c.defaultClusterCIDR(ipFamily))
+		routablePodEnabledString, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableEnableTKGSRoutablePod)
+		routablePodEnabled := (routablePodEnabledString == trueString)
+		//Skip auto-fill podcidr if tkgs routable pod feature is enabled
+		if routablePodEnabled != true {
+			c.TKGConfigReaderWriter().Set(constants.ConfigVariableClusterCIDR, c.defaultClusterCIDR(ipFamily))
+		}
 	} else if err := c.validateCIDRsForIPFamily(constants.ConfigVariableClusterCIDR, clusterCIDRs, ipFamily); err != nil {
 		return err
 	}

--- a/tkg/client/validate_test.go
+++ b/tkg/client/validate_test.go
@@ -254,7 +254,15 @@ var _ = Describe("Validate", func() {
 					})
 				})
 				Context("when CLUSTER_CIDR is undefined", func() {
-					It("should set the default CIDR", func() {
+					It("should not set the default CIDR if ConfigVariableEnableTKGSRoutablePod is enabled", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableEnableTKGSRoutablePod, "true")
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+						cidr, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableClusterCIDR)
+						Expect(cidr).To(Equal(""))
+					})
+
+					It("should set the default CIDR if ConfigVariableEnableTKGSRoutablePod is not enabled", func() {
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
 						Expect(validationError).NotTo(HaveOccurred())
 						cidr, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableClusterCIDR)
@@ -464,7 +472,15 @@ var _ = Describe("Validate", func() {
 					})
 				})
 				Context("when CLUSTER_CIDR is undefined", func() {
-					It("should set the default CIDR", func() {
+					It("should not set the default CIDR if ConfigVariableEnableTKGSRoutablePod is enabled", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableEnableTKGSRoutablePod, "true")
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+						cidr, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableClusterCIDR)
+						Expect(cidr).To(Equal(""))
+					})
+
+					It("should set the default CIDR if ConfigVariableEnableTKGSRoutablePod is not enabled", func() {
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
 						Expect(validationError).NotTo(HaveOccurred())
 						cidr, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableClusterCIDR)
@@ -625,7 +641,15 @@ var _ = Describe("Validate", func() {
 				})
 
 				Context("when CLUSTER_CIDR is undefined", func() {
-					It("should set the default CIDR", func() {
+					It("should not set the default CIDR if ConfigVariableEnableTKGSRoutablePod is enabled", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableEnableTKGSRoutablePod, "true")
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+						cidr, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableClusterCIDR)
+						Expect(cidr).To(Equal(""))
+					})
+
+					It("should set the default CIDR if ConfigVariableEnableTKGSRoutablePod is not enabled", func() {
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
 						Expect(validationError).NotTo(HaveOccurred())
 						cidr, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableClusterCIDR)
@@ -700,7 +724,15 @@ var _ = Describe("Validate", func() {
 				})
 
 				Context("when CLUSTER_CIDR is undefined", func() {
-					It("should set the default CIDR", func() {
+					It("should not set the default CIDR if ConfigVariableEnableTKGSRoutablePod is enabled", func() {
+						tkgConfigReaderWriter.Set(constants.ConfigVariableEnableTKGSRoutablePod, "true")
+						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
+						Expect(validationError).NotTo(HaveOccurred())
+						cidr, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableClusterCIDR)
+						Expect(cidr).To(Equal(""))
+					})
+
+					It("should set the default CIDR if ConfigVariableEnableTKGSRoutablePod is not enabled", func() {
 						validationError := tkgClient.ConfigureAndValidateManagementClusterConfiguration(initRegionOptions, true)
 						Expect(validationError).NotTo(HaveOccurred())
 						cidr, _ := tkgConfigReaderWriter.Get(constants.ConfigVariableClusterCIDR)

--- a/tkg/constants/config_variables.go
+++ b/tkg/constants/config_variables.go
@@ -288,4 +288,7 @@ const (
 	ConfigVariableKubevipLoadbalancerCIDRs    = "KUBEVIP_LOADBALANCER_CIDRS"
 	ConfigVariableKubevipLoadbalancerIPRanges = "KUBEVIP_LOADBALANCER_IP_RANGES"
 	ConfigVariableFeatureFlagPackageBasedCC   = "FEATURE_FLAG_PACKAGE_BASED_CC"
+
+	// Config variable for enabling tkgs routable pod feature
+	ConfigVariableEnableTKGSRoutablePod = "ENABLE_TKGS_ROUTABLE_POD"
 )


### PR DESCRIPTION
- It's for enabling routable pod feature when creating tkgs cluster

Signed-off-by: Chen Lin <linch@vmware.com>

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes # 

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2060

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
When users want to enable routable pod feature for tkgs, they can set global variable `ENABLE_TKGS_ROUTABLE_POD` to `TRUE`. 
Also, users need to make sure that podcidr is empty when routable pod feature is enabled
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
