### PR TITLE
Add telemetry plugin to standalone plugins kbld config

### DIFF
--- a/packages/standalone-plugins/kbld-config.yaml
+++ b/packages/standalone-plugins/kbld-config.yaml
@@ -12,6 +12,8 @@ overrides:
   newImage: ""
 - image: tanzu-cli-plugins/secret-linux-amd64:latest
   newImage: ""
+- image: tanzu-cli-plugins/telemetry-linux-amd64:latest
+  newImage: ""
 #! tanzu-cliplugins darwin-amd64
 - image: tanzu-cli-plugins/login-darwin-amd64:latest
   newImage: ""
@@ -23,6 +25,8 @@ overrides:
   newImage: ""
 - image: tanzu-cli-plugins/secret-darwin-amd64:latest
   newImage: ""
+- image: tanzu-cli-plugins/telemetry-darwin-amd64:latest
+  newImage: ""
 #! tanzu-cliplugins windows-amd64
 - image: tanzu-cli-plugins/login-windows-amd64:latest
   newImage: ""
@@ -33,4 +37,6 @@ overrides:
 - image: tanzu-cli-plugins/pinniped-auth-windows-amd64:latest
   newImage: ""
 - image: tanzu-cli-plugins/secret-windows-amd64:latest
+  newImage: ""
+- image: tanzu-cli-plugins/telemetry-windows-amd64:latest
   newImage: ""


### PR DESCRIPTION
### What this PR does / why we need it

Previous PR adding the telemetry plugin needed to add these bits, currently causing a bug when users try to build all images for the CLI.

```
> make docker-all
 [iad.ocir.io/odx-mockcustomer/tanzu-cli-plugins/telemetry-darwin-amd64:latest](http://iad.ocir.io/odx-mockcustomer/tanzu-cli-plugins/telemetry-darwin-amd64:latest)
2022/07/01 10:36:18 image "tanzu-cli-plugins/telemetry-darwin-amd64:latest" not found in kbld config
exit status 1
make[2]: *** [Makefile:46: kbld-image-replace-telemetry_darwin-amd64_standalone-plugins] Error 1
```

Which issue(s) this PR fixes
Fixes #2810

### Describe testing done for PR
No tests for this particular change, manually running existing tests to make sure it didn't break anything.

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
