### PR TITLE
Make the TKR Resolver webhook to always set Cluster topology version

### DIFF
--- a/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster_test.go
+++ b/pkg/v2/tkr/webhook/cluster/tkr-resolver/cluster/cluster_test.go
@@ -398,6 +398,7 @@ var _ = Describe("cluster.Webhook", func() {
 
 					It("should not resolve the ControlPlane", func() {
 						clusterTopology0 := cluster.Spec.Topology.DeepCopy()
+						clusterTopology0.Version = tkr.Spec.Kubernetes.Version // expect topology.version == the TKR Kubernetes version
 						err := cw.ResolveAndSetMetadata(cluster, clusterClass)
 						Expect(err).ToNot(HaveOccurred())
 						Expect(cluster.Spec.Topology).To(Equal(clusterTopology0))
@@ -412,6 +413,20 @@ var _ = Describe("cluster.Webhook", func() {
 							err := cw.ResolveAndSetMetadata(cluster, clusterClass)
 							Expect(err).ToNot(HaveOccurred())
 							Expect(cluster.Spec.Topology.Version).To(Equal(tkr.Spec.Kubernetes.Version))
+						})
+					})
+
+					When("a prefix of the K8s version is specified in Cluster topology.version", func() {
+						BeforeEach(func() {
+							cluster.Spec.Topology.Version = k8sVersionPrefix
+						})
+
+						repeat(100, func() { // make sure we hit a prefix shorter than the version
+							It("should replace the value in Cluster topology.version with TKR k8s version", func() {
+								err := cw.ResolveAndSetMetadata(cluster, clusterClass)
+								Expect(err).ToNot(HaveOccurred())
+								Expect(cluster.Spec.Topology.Version).To(Equal(tkr.Spec.Kubernetes.Version))
+							})
 						})
 					})
 				})


### PR DESCRIPTION
### What this PR does / why we need it

Always set Cluster `topology.version` to TKR Kubernetes version regardless of whether the TKR Resolver needs to resolve the Cluster.

This is necessary to make sure that when a user sets `topology.version` to a prefix of the currently resolved Kubernetes version or to the currently resolved TKR version, the field is re-set back to the resolved Kubernetes version.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

N/A

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
