### PR TITLE
Add support to delete clusterclass based clusters on TKGs

### DIFF
--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -1522,8 +1522,12 @@ func (c *client) ListClusters(namespace string) ([]capi.Cluster, error) {
 }
 
 func (c *client) DeleteCluster(clusterName, namespace string) error {
+	isCCBasedCluster, err := c.IsClusterClassBased(clusterName, namespace)
+	if err != nil {
+		return errors.Wrap(err, "unable to determine cluster type")
+	}
 	isPacific, err := c.IsPacificRegionalCluster()
-	if err == nil && isPacific {
+	if err == nil && isPacific && !isCCBasedCluster {
 		tkcObj, err := c.GetPacificClusterObject(clusterName, namespace)
 		if err != nil {
 			errString := fmt.Sprintf("failed to get cluster object for delete: %s", err.Error())
@@ -1531,7 +1535,6 @@ func (c *client) DeleteCluster(clusterName, namespace string) error {
 		}
 		return c.DeleteResource(tkcObj)
 	}
-
 	clusterObject := &capi.Cluster{}
 	clusterObject.Name = clusterName
 	clusterObject.Namespace = namespace


### PR DESCRIPTION
Signed-off-by: Prem Kumar Kalle <pkalle@vmware.com>

### What this PR does / why we need it
This PR adds support to delete clusterclass based clusters created on TKGS
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes # #2843 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Created TKC cluster and also clusterclass bases cluster on TKGS and successfully deleted both TKC cluster and clusterclass based workload clusters.

```
❯ k get cluster -n ns01
NAME           PHASE         AGE     VERSION
cc09           Provisioned   4d7h    v1.22.8+vmware.1
prem-cc01      Provisioned   17m     v1.22.8+vmware.1
prem-tkc-01    Provisioned   3m23s   v1.22.8+vmware.1
tkc-02         Provisioned   4d11h   v1.22.8+vmware.1
tkc-05         Provisioned   4d7h    v1.22.8+vmware.1
tkc-e2e-badu   Provisioned   4d8h    v1.22.8+vmware.1
❯
❯
❯ k get tkc -n ns01
NAME           CONTROL PLANE   WORKER   TKR NAME                              AGE     READY   TKR COMPATIBLE   UPDATES AVAILABLE
cc09           1               1        v1.22.8---vmware.1-tkg.2-zshippable   4d7h    False   True             [v1.23.5+vmware.1]
prem-tkc-01    1               1        v1.22.8---vmware.1-tkg.2-zshippable   5m58s   False   True             [v1.23.5+vmware.1]
tkc-02         1               1        v1.22.8---vmware.1-tkg.2-zshippable   4d11h   False   True             [v1.23.5+vmware.1]
tkc-05         1               1        v1.22.8---vmware.1-tkg.2-zshippable   4d7h    False   True             [v1.23.5+vmware.1]
tkc-e2e-badu   1               1        v1.22.8---vmware.1-tkg.2-zshippable   4d8h    False   True             [v1.23.5+vmware.1]
❯

❯ ~/go/bin/tanzu cluster delete prem-cc01 -n ns01
Deleting workload cluster 'prem-cc01'. Are you sure? [y/N]: y
Workload cluster 'prem-cc01' is being deleted

❯ ~/go/bin/tanzu cluster delete prem-tkc-01 -n ns01
Deleting workload cluster 'prem-tkc-01'. Are you sure? [y/N]: y
Workload cluster 'prem-tkc-01' is being deleted
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
This PR adds support to delete clusterclass based clusters created on TKGS
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
