### PR TITLE
Fix stuck addons finalizer on deleted clusters

### DIFF
--- a/addons/controllers/machine_controller.go
+++ b/addons/controllers/machine_controller.go
@@ -37,7 +37,7 @@ type MachineReconciler struct {
 	ctx        context.Context
 }
 
-const PreTerminateAddonsAnnotationPrefix = clusterapiv1beta1.PreTerminateDeleteHookAnnotationPrefix + "tkg.tanzu.vmware.com/addons"
+const PreTerminateAddonsAnnotationPrefix = clusterapiv1beta1.PreTerminateDeleteHookAnnotationPrefix + "/tkg.tanzu.vmware.com"
 const PreTerminateAddonsAnnotationValue = "tkg.tanzu.vmware.com/addons"
 const requestRequeTime = time.Second * 5
 

--- a/addons/webhooks/clusterbootstrap_webhook.go
+++ b/addons/webhooks/clusterbootstrap_webhook.go
@@ -342,6 +342,13 @@ func (wh *ClusterBootstrap) ValidateUpdate(ctx context.Context, oldObj, newObj r
 	if !ok {
 		return apierrors.NewBadRequest(fmt.Sprintf("expected a ClusterBootstrap but got a %T", oldObj))
 	}
+
+	//don't validate object if being deleted
+	if !oldClusterBootstrap.GetDeletionTimestamp().IsZero() {
+		clusterbootstraplog.Info("object being deleted, ignore validation", "name", oldClusterBootstrap.Name)
+		return nil
+	}
+
 	clusterbootstraplog.Info("validate update", "name", newClusterBootstrap.Name)
 
 	var allErrs field.ErrorList


### PR DESCRIPTION
### What this PR does / why we need it

Fix stuck addons finalizer on deleted clusters
    
1. Use patch for removing finalizer as update was silently failing
2. Ignore validation in clusterbootstrap webhook for objects being deleted
3. [Drive-by]: Pick up fix from https://github.com/vmware-tanzu/tanzu-framework/pull/2779
    
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2847

### Describe testing done for PR

Tested on supervisor cluster and verified all existing clusters stuck deleting are gone.

```
root@4226deac0f1f1eb6ccb45c50eec5c727 [ ~ ]# k get clusters -A
NAMESPACE                NAME                        PHASE         AGE     VERSION
cc-antrea-ns1            cc-antrea-ns1-cluster1      Deleting      6d18h   v1.22.8+vmware.1
cc-antrea-ns3            cc-antrea-ns3-bigcluster3   Deleting      6d13h   v1.22.8+vmware.1
cc-antrea-ns4            cc-antrea-ns4-cluster4      Deleting      6d12h   v1.22.8+vmware.1
multidisk-v1a3-vds-ns1   multidisk-v1a3-vds-ns1-c1   Provisioned   5d17h   v1.22.8+vmware.1
v1a3-antrea-22-8-ns10    v1a3-antrea-22-8-ns10-c10   Deleting      5d11h   v1.22.8+vmware.1
v1a3-antrea-22-8-ns13    v1a3-antrea-22-8-ns13-c13   Deleting      5d11h   v1.22.8+vmware.1
v1a3-antrea-22-8-ns17    v1a3-antrea-22-8-ns17-c17   Deleting      5d10h   v1.22.8+vmware.1
v1a3-antrea-22-8-ns23    v1a3-antrea-22-8-ns23-c23   Deleting      5d10h   v1.22.8+vmware.1
v1a3-antrea-22-8-ns29    v1a3-antrea-22-8-ns29-c29   Deleting      5d9h    v1.22.8+vmware.1
v1a3-antrea-22-8-ns3     v1a3-antrea-22-8-ns3-c3     Deleting      5d12h   v1.22.8+vmware.1
v1a3-antrea-22-8-ns37    v1a3-antrea-22-8-ns37-c37   Deleting      5d6h    v1.22.8+vmware.1
v1a3-antrea-22-8-ns50    v1a3-antrea-22-8-ns50-c50   Deleting      5d4h    v1.22.8+vmware.1
v1a3-antrea-22-8-ns57    v1a3-antrea-22-8-ns57-c57   Deleting      5d3h    v1.22.8+vmware.1
v1a3-antrea-22-8-ns59    v1a3-antrea-22-8-ns59-c59   Deleting      5d2h    v1.22.8+vmware.1
v1a3-antrea-22-8-ns6     v1a3-antrea-22-8-ns6-c6     Deleting      5d11h   v1.22.8+vmware.1
v1a3-antrea-22-8-ns9     v1a3-antrea-22-8-ns9-c9     Deleting      5d11h   v1.22.8+vmware.1
v1a3-vds-ns2             v1a3-vds-ns2-c2             Deleting      5d19h   v1.22.8+vmware.1
v1alpha3-vds-ns10        v1alpha3-vds-ns10-c10       Provisioned   2d12h   v1.22.8+vmware.1
v1alpha3-vds-ns11        v1alpha3-vds-ns11-c11       Provisioned   2d12h   v1.22.8+vmware.1
v1alpha3-vds-ns12        v1alpha3-vds-ns12-c12       Provisioned   2d12h   v1.22.8+vmware.1
v1alpha3-vds-ns13        v1alpha3-vds-ns13-c13       Provisioned   2d12h   v1.22.8+vmware.1
v1alpha3-vds-ns14        v1alpha3-vds-ns14-c14       Provisioned   2d12h   v1.22.8+vmware.1
v1alpha3-vds-ns15        v1alpha3-vds-ns15-c15       Provisioned   2d12h   v1.22.8+vmware.1
v1alpha3-vds-ns5         v1alpha3-vds-ns5-c5         Provisioned   2d14h   v1.22.8+vmware.1
v1alpha3-vds-ns6         v1alpha3-vds-ns6-c6         Provisioned   2d13h   v1.22.8+vmware.1
v1alpha3-vds-ns7         v1alpha3-vds-ns7-c7         Provisioned   2d13h   v1.22.8+vmware.1
v1alpha3-vds-ns8         v1alpha3-vds-ns8-c8         Provisioned   2d13h   v1.22.8+vmware.1
v1alpha3-vds-ns9         v1alpha3-vds-ns9-c9         Provisioned   2d13h   v1.22.8+vmware.1
```
```
root@4226deac0f1f1eb6ccb45c50eec5c727 [ ~ ]# k get clusters -A
NAMESPACE                NAME                        PHASE         AGE     VERSION
multidisk-v1a3-vds-ns1   multidisk-v1a3-vds-ns1-c1   Provisioned   5d17h   v1.22.8+vmware.1
v1alpha3-vds-ns10        v1alpha3-vds-ns10-c10       Provisioned   2d13h   v1.22.8+vmware.1
v1alpha3-vds-ns11        v1alpha3-vds-ns11-c11       Provisioned   2d12h   v1.22.8+vmware.1
v1alpha3-vds-ns12        v1alpha3-vds-ns12-c12       Provisioned   2d12h   v1.22.8+vmware.1
v1alpha3-vds-ns13        v1alpha3-vds-ns13-c13       Provisioned   2d12h   v1.22.8+vmware.1
v1alpha3-vds-ns14        v1alpha3-vds-ns14-c14       Provisioned   2d12h   v1.22.8+vmware.1
v1alpha3-vds-ns15        v1alpha3-vds-ns15-c15       Provisioned   2d12h   v1.22.8+vmware.1
v1alpha3-vds-ns5         v1alpha3-vds-ns5-c5         Provisioned   2d14h   v1.22.8+vmware.1
v1alpha3-vds-ns6         v1alpha3-vds-ns6-c6         Provisioned   2d13h   v1.22.8+vmware.1
v1alpha3-vds-ns7         v1alpha3-vds-ns7-c7         Provisioned   2d13h   v1.22.8+vmware.1
v1alpha3-vds-ns8         v1alpha3-vds-ns8-c8         Provisioned   2d13h   v1.22.8+vmware.1
v1alpha3-vds-ns9         v1alpha3-vds-ns9-c9         Provisioned   2d13h   v1.22.8+vmware.1
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Fix stuck addons finalizer on deleted clusters
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ x] Ensure PR contains terms all contributors can understand and links all contributors can access


