### PR TITLE
Add AWS EBS and AzureDisk CSI Drivers

### DIFF
--- a/pkg/v1/providers/ytt/02_addons/public-cloud-csi/add_aws_csi_driver.yaml
+++ b/pkg/v1/providers/ytt/02_addons/public-cloud-csi/add_aws_csi_driver.yaml
@@ -1,0 +1,24 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("/lib/helpers.star", "ValuesFormatStr")
+#@ load("ebs/aws-ebs-csi-driver_data.lib.yaml", "ebsdatavalues")
+
+#@ if data.values.PROVIDER_TYPE == "aws" and not data.values.IS_WINDOWS_WORKLOAD_CLUSTER:
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #@ "{}-aws-ebs-csi-driver-addon".format(data.values.CLUSTER_NAME)
+  namespace: #@ data.values.NAMESPACE
+  labels:
+    tkg.tanzu.vmware.com/addon-name: "aws-ebs-csi-driver"
+    tkg.tanzu.vmware.com/cluster-name: #@ data.values.CLUSTER_NAME
+    #@ if data.values.TKG_CLUSTER_ROLE != "workload":
+    clusterctl.cluster.x-k8s.io/move: ""
+    #@ end
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: "csi/aws-ebs-csi-driver"
+type: tkg.tanzu.vmware.com/addon
+stringData:
+  values.yaml: #@ ValuesFormatStr.format(yaml.encode(ebsdatavalues()))
+#@ end

--- a/pkg/v1/providers/ytt/02_addons/public-cloud-csi/add_azure_csi_driver.yaml
+++ b/pkg/v1/providers/ytt/02_addons/public-cloud-csi/add_azure_csi_driver.yaml
@@ -1,0 +1,24 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("/lib/helpers.star", "ValuesFormatStr")
+#@ load("disk/azuredisk-csi-driver_data.lib.yaml", "diskdatavalues")
+
+#@ if data.values.PROVIDER_TYPE == "azure" and not data.values.IS_WINDOWS_WORKLOAD_CLUSTER:
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: #@ "{}-azuredisk-csi-driver-addon".format(data.values.CLUSTER_NAME)
+  namespace: #@ data.values.NAMESPACE
+  labels:
+    tkg.tanzu.vmware.com/addon-name: "azuredisk-csi-driver"
+    tkg.tanzu.vmware.com/cluster-name: #@ data.values.CLUSTER_NAME
+    #@ if data.values.TKG_CLUSTER_ROLE != "workload":
+    clusterctl.cluster.x-k8s.io/move: ""
+    #@ end
+  annotations:
+    tkg.tanzu.vmware.com/addon-type: "csi/azuredisk-csi-driver"
+type: tkg.tanzu.vmware.com/addon
+stringData:
+  values.yaml: #@ ValuesFormatStr.format(yaml.encode(diskdatavalues()))
+#@ end

--- a/pkg/v1/providers/ytt/02_addons/public-cloud-csi/disk/azuredisk-csi-driver_data.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/public-cloud-csi/disk/azuredisk-csi-driver_data.lib.yaml
@@ -1,0 +1,16 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("/lib/helpers.star", "get_no_proxy")
+
+#@ def diskdatavalues():
+azureDiskCSIDriver:
+  namespace: kube-system
+  http_proxy: #@ data.values.TKG_HTTP_PROXY
+  https_proxy: #@ data.values.TKG_HTTPS_PROXY
+  no_proxy: #@ get_no_proxy()
+  #@ if data.values.CLUSTER_PLAN == "dev":
+  deployment_replicas: 1
+  #@ else:
+  deployment_replicas: 3
+  #@ end
+#@ end

--- a/pkg/v1/providers/ytt/02_addons/public-cloud-csi/ebs/aws-ebs-csi-driver_data.lib.yaml
+++ b/pkg/v1/providers/ytt/02_addons/public-cloud-csi/ebs/aws-ebs-csi-driver_data.lib.yaml
@@ -1,0 +1,16 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+#@ load("/lib/helpers.star", "get_no_proxy")
+
+#@ def ebsdatavalues():
+awsEBSCSIDriver:
+  namespace: kube-system
+  http_proxy: #@ data.values.TKG_HTTP_PROXY
+  https_proxy: #@ data.values.TKG_HTTPS_PROXY
+  no_proxy: #@ get_no_proxy()
+  #@ if data.values.CLUSTER_PLAN == "dev":
+  deployment_replicas: 1
+  #@ else:
+  deployment_replicas: 3
+  #@ end
+#@ end

--- a/pkg/v1/providers/ytt/03_customizations/add_sc.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/add_sc.yaml
@@ -1,6 +1,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
 #@ load("@ytt:yaml", "yaml")
+#@ load("/lib/helpers.star", "enable_csi_driver")
 
 
 #@ def aws_storage_class():
@@ -11,7 +12,11 @@ metadata:
   name: default
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
+#@ if enable_csi_driver():
+provisioner: ebs.csi.aws.com
+#@ else:
 provisioner: kubernetes.io/aws-ebs
+#@ end
 allowVolumeExpansion: true
 #@ end
 
@@ -43,7 +48,11 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
   labels:
     kubernetes.io/cluster-service: "true"
+#@ if enable_csi_driver():
+provisioner: disk.csi.azure.com
+#@ else:
 provisioner: kubernetes.io/azure-disk
+#@ end
 allowVolumeExpansion: true
 parameters:
   kind: Managed

--- a/pkg/v1/providers/ytt/lib/helpers.star
+++ b/pkg/v1/providers/ytt/lib/helpers.star
@@ -1,5 +1,6 @@
 load("@ytt:data", "data")
 load("@ytt:assert", "assert")
+load("@ytt:regexp", "regexp")
 
 TKGSProductName = "VMware Tanzu Kubernetes Grid Service for vSphere"
 TKGProductName = "VMware Tanzu Kubernetes Grid"
@@ -327,4 +328,25 @@ def get_labels_map_from_string(labelString):
     labelMap.update({kv[0]: kv[1]})
    end
    return labelMap
+end
+
+def compare_semver_versions(a, b):
+  a_array = regexp.replace("v?(\d+\.\d+\.\d+).*", a, "$1").split(".")
+  b_array = regexp.replace("v?(\d+\.\d+\.\d+).*", b, "$1").split(".")
+  for i in range(len(a_array)):
+    if int(a_array[i]) > int(b_array[i]):
+      return 1
+    elif int(a_array[i]) < int(b_array[i]):
+      return -1
+    end
+  end
+  return 0
+end
+
+def enable_csi_driver():
+  tkrVersion = get_tkr_version_from_tkr_name(data.values.KUBERNETES_RELEASE)
+  if compare_semver_versions(tkrVersion, "v1.23.0") >= 0:
+     return True
+  end
+  return False
 end

--- a/pkg/v1/tkg/aws/fixtures/cloudformation-default.yaml
+++ b/pkg/v1/tkg/aws/fixtures/cloudformation-default.yaml
@@ -288,6 +288,26 @@ Resources:
             Resource:
             - '*'
             Sid: tmccloudvmwarecom
+          - Action:
+            - ec2:AttachVolume
+            - ec2:CreateSnapshot
+            - ec2:CreateTags
+            - ec2:CreateVolume
+            - ec2:DeleteSnapshot
+            - ec2:DeleteTags
+            - ec2:DeleteVolume
+            - ec2:DescribeAvailabilityZones
+            - ec2:DescribeInstances
+            - ec2:DescribeSnapshots
+            - ec2:DescribeTags
+            - ec2:DescribeVolumes
+            - ec2:DescribeVolumesModifications
+            - ec2:DetachVolume
+            - ec2:ModifyVolume
+            Effect: Allow
+            Resource:
+            - '*'
+            Sid: tanzuebscsi
           Version: 2012-10-17
         PolicyName: tkg-cloud-vmware-com
       RoleName: control-plane.tkg.cloud.vmware.com

--- a/pkg/v1/tkg/aws/fixtures/cloudformation-tmc-disabled.yaml
+++ b/pkg/v1/tkg/aws/fixtures/cloudformation-tmc-disabled.yaml
@@ -265,6 +265,31 @@ Resources:
             Service:
             - ec2.amazonaws.com
         Version: 2012-10-17
+      Policies:
+      - PolicyDocument:
+          Statement:
+          - Action:
+            - ec2:AttachVolume
+            - ec2:CreateSnapshot
+            - ec2:CreateTags
+            - ec2:CreateVolume
+            - ec2:DeleteSnapshot
+            - ec2:DeleteTags
+            - ec2:DeleteVolume
+            - ec2:DescribeAvailabilityZones
+            - ec2:DescribeInstances
+            - ec2:DescribeSnapshots
+            - ec2:DescribeTags
+            - ec2:DescribeVolumes
+            - ec2:DescribeVolumesModifications
+            - ec2:DetachVolume
+            - ec2:ModifyVolume
+            Effect: Allow
+            Resource:
+            - '*'
+            Sid: tanzuebscsi
+          Version: 2012-10-17
+        PolicyName: tkg-cloud-vmware-com
       RoleName: control-plane.tkg.cloud.vmware.com
     Type: AWS::IAM::Role
   AWSIAMRoleControllers:


### PR DESCRIPTION
Add AWS EBS CSI Driver and AzureDisk CSI Driver

### What this PR does / why we need it
Add AWS EBS CSI Driver and AzureDisk CSI Driver for coming k8s 1.23.x release

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2889

### Describe testing done for PR

- Create AWS cluster, check ebs csi driver
- Create Azure cluster, check azure disk driver
- Check storageclass is using csi driver for 1.23.x, and using in-tree driver for 1.22.x and 1.21.x

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add AWS EBS CSI Driver and AzureDisk CSI Driver

```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

- After 1.23.x, AWS EBS and Azure Disk in-tree driver will retire
- Install CSI drivers from Tanzu 1.6
- Set default storage class to in-tree driver for 1.21.x or 1.22.x
- Set default storage class to csi driver for 1.23.x (and later version)
