### PR TITLE
Use fslock to acquire lock when reading/writing the tanzu config file for update

### DIFF
--- a/cmd/cli/plugin/login/main.go
+++ b/cmd/cli/plugin/login/main.go
@@ -90,12 +90,7 @@ func main() {
 
 func login(cmd *cobra.Command, args []string) (err error) {
 	cfg, err := config.GetClientConfig()
-	if _, ok := err.(*config.ClientConfigNotExistError); ok {
-		cfg, err = config.NewClientConfig()
-		if err != nil {
-			return err
-		}
-	} else if err != nil {
+	if err != nil {
 		return err
 	}
 

--- a/pkg/v1/auth/csp/grpc.go
+++ b/pkg/v1/auth/csp/grpc.go
@@ -82,6 +82,12 @@ func (c *configSource) Token() (*oauth2.Token, error) {
 	g.GlobalOpts.Auth.AccessToken = token.AccessToken
 	g.GlobalOpts.Auth.IDToken = token.IDToken
 
+	// Acquire tanzu config lock
+	config.AcquireTanzuConfigLock()
+	defer config.ReleaseTanzuConfigLock()
+
+	// TODO: Add Read/Write locking mechanism before updating the configuration
+	// Currently we are only acquiring the lock while updating the configuration
 	if err := config.StoreClientConfig(c.ClientConfig); err != nil {
 		return nil, err
 	}

--- a/pkg/v1/cli/command/core/config.go
+++ b/pkg/v1/cli/command/core/config.go
@@ -83,6 +83,11 @@ var setConfigCmd = &cobra.Command{
 		if len(args) > 2 {
 			return errors.Errorf("only path and value are allowed")
 		}
+
+		// Acquire tanzu config lock
+		config.AcquireTanzuConfigLock()
+		defer config.ReleaseTanzuConfigLock()
+
 		cfg, err := config.GetClientConfig()
 		if err != nil {
 			return err
@@ -201,6 +206,10 @@ var initConfigCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Initialize config with defaults",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Acquire tanzu config lock
+		config.AcquireTanzuConfigLock()
+		defer config.ReleaseTanzuConfigLock()
+
 		cfg, err := config.GetClientConfig()
 		if err != nil {
 			return err
@@ -325,6 +334,11 @@ var unsetConfigCmd = &cobra.Command{
 		if len(args) > 1 {
 			return errors.Errorf("only path is allowed")
 		}
+
+		// Acquire tanzu config lock
+		config.AcquireTanzuConfigLock()
+		defer config.ReleaseTanzuConfigLock()
+
 		cfg, err := config.GetClientConfig()
 		if err != nil {
 			return err

--- a/pkg/v1/cli/command/core/discovery_source.go
+++ b/pkg/v1/cli/command/core/discovery_source.go
@@ -104,6 +104,10 @@ var addDiscoverySourceCmd = &cobra.Command{
     tanzu plugin source add --name standalone-oci --type oci --uri projects.registry.vmware.com/tkg/tanzu-plugins/standalone:latest`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Acquire tanzu config lock
+		config.AcquireTanzuConfigLock()
+		defer config.ReleaseTanzuConfigLock()
+
 		cfg, err := config.GetClientConfig()
 		if err != nil {
 			return err
@@ -143,6 +147,11 @@ var updateDiscoverySourceCmd = &cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		discoveryName := args[0]
+
+		// Acquire tanzu config lock
+		config.AcquireTanzuConfigLock()
+		defer config.ReleaseTanzuConfigLock()
+
 		cfg, err := config.GetClientConfig()
 		if err != nil {
 			return err
@@ -179,6 +188,11 @@ var deleteDiscoverySourceCmd = &cobra.Command{
     tanzu plugin discovery delete standalone-oci`,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		discoveryName := args[0]
+
+		// Acquire tanzu config lock
+		config.AcquireTanzuConfigLock()
+		defer config.ReleaseTanzuConfigLock()
+
 		cfg, err := config.GetClientConfig()
 		if err != nil {
 			return err

--- a/pkg/v1/cli/command/core/repo.go
+++ b/pkg/v1/cli/command/core/repo.go
@@ -68,6 +68,10 @@ var addRepoCmd = &cobra.Command{
 	Use:   "add",
 	Short: "Add a repository",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Acquire tanzu config lock
+		config.AcquireTanzuConfigLock()
+		defer config.ReleaseTanzuConfigLock()
+
 		cfg, err := config.GetClientConfig()
 		if err != nil {
 			return err
@@ -110,6 +114,11 @@ var updateRepoCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repoName := args[0]
+
+		// Acquire tanzu config lock
+		config.AcquireTanzuConfigLock()
+		defer config.ReleaseTanzuConfigLock()
+
 		cfg, err := config.GetClientConfig()
 		if err != nil {
 			return err
@@ -153,6 +162,11 @@ var deleteRepoCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		repoName := args[0]
+
+		// Acquire tanzu config lock
+		config.AcquireTanzuConfigLock()
+		defer config.ReleaseTanzuConfigLock()
+
 		cfg, err := config.GetClientConfig()
 		if err != nil {
 			return err

--- a/pkg/v1/cli/pluginmanager/manager_test.go
+++ b/pkg/v1/cli/pluginmanager/manager_test.go
@@ -430,7 +430,8 @@ func fakeExecCommand(command string, args ...string) *exec.Cmd {
 	cs = append(cs, args...)
 	cmd := exec.Command(os.Args[0], cs...) //nolint:gosec
 	tc := "TEST_CASE=" + testCase
-	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", tc}
+	home := "HOME=" + os.Getenv("HOME")
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", tc, home}
 	return cmd
 }
 
@@ -479,6 +480,11 @@ func setupLocalDistoForTesting() func() {
 		log.Fatal(err, "unable to create temporary directory")
 	}
 
+	tmpHomeDir, err := os.MkdirTemp(os.TempDir(), "home")
+	if err != nil {
+		log.Fatal(err, "unable to create temporary home directory")
+	}
+
 	config.DefaultStandaloneDiscoveryType = "local"
 	config.DefaultStandaloneDiscoveryLocalPath = "default"
 
@@ -488,6 +494,7 @@ func setupLocalDistoForTesting() func() {
 
 	tkgConfigFile := filepath.Join(tmpDir, "tanzu_config.yaml")
 	os.Setenv("TANZU_CONFIG", tkgConfigFile)
+	os.Setenv("HOME", tmpHomeDir)
 
 	err = copy.Copy(filepath.Join("test", "local"), common.DefaultLocalPluginDistroDir)
 	if err != nil {

--- a/pkg/v1/cli/pluginmanager/test/config.yaml
+++ b/pkg/v1/cli/pluginmanager/test/config.yaml
@@ -3,6 +3,9 @@ clientOptions:
   cli:
     discoverySources:
     - local:
+        name: default-local
+        path: default
+    - local:
         name: fake
         path: standalone
     useContextAwareDiscovery: true

--- a/pkg/v1/config/lock.go
+++ b/pkg/v1/config/lock.go
@@ -1,0 +1,70 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync"
+
+	"github.com/juju/fslock"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/utils"
+)
+
+var tanzuConfigLockFile string
+
+// tanzuConfigLock used as a static lock variable that stores fslock
+// This is used for interprocess locking of the config file
+var tanzuConfigLock *fslock.Lock
+
+// mutex is used to handle the locking behavior between concurrent calls
+// within the existing process trying to acquire the lock
+var mutex sync.Mutex
+
+// AcquireTanzuConfigLock tries to acquire lock to update tanzu config file with timeout
+func AcquireTanzuConfigLock() {
+	var err error
+
+	if tanzuConfigLockFile == "" {
+		path, err := ClientConfigPath()
+		if err != nil {
+			panic(fmt.Sprintf("cannot get config path while acquiring lock on tanzu config file, reason: %v", err))
+		}
+		tanzuConfigLockFile = filepath.Join(filepath.Dir(path), constants.LocalTanzuFileLock)
+	}
+
+	// using fslock to handle interprocess locking
+	lock, err := utils.GetFileLockWithTimeOut(tanzuConfigLockFile, utils.DefaultLockTimeout)
+	if err != nil {
+		panic(fmt.Sprintf("cannot acquire lock for tanzu config file, reason: %v", err))
+	}
+
+	// Lock the mutex to prevent concurrent calls to acquire and configure the tanzuConfigLock
+	mutex.Lock()
+	tanzuConfigLock = lock
+}
+
+// ReleaseTanzuConfigLock releases the lock if the tanzuConfigLock was acquired
+func ReleaseTanzuConfigLock() {
+	if tanzuConfigLock == nil {
+		return
+	}
+	if errUnlock := tanzuConfigLock.Unlock(); errUnlock != nil {
+		panic(fmt.Sprintf("cannot release lock for tanzu config file, reason: %v", errUnlock))
+	}
+
+	tanzuConfigLock = nil
+	// Unlock the mutex to allow other concurrent calls to acquire and configure the tanzuConfigLock
+	mutex.Unlock()
+	return
+}
+
+// IsTanzuConfigLockAcquired checks the lock status and returns
+// true if the lock is acquired by the current process or returns
+// false otherwise
+func IsTanzuConfigLockAcquired() bool {
+	return tanzuConfigLock != nil
+}

--- a/pkg/v1/tkg/test/framework/utils.go
+++ b/pkg/v1/tkg/test/framework/utils.go
@@ -160,6 +160,10 @@ func GetTempClusterConfigFile(clusterConfigFile string, options *CreateClusterOp
 
 //SetCliConfigFlag sets cli flag
 func SetCliConfigFlag(flagName string, value string) error {
+	// Acquire tanzu config lock
+	config.AcquireTanzuConfigLock()
+	defer config.ReleaseTanzuConfigLock()
+
 	cfg, err := config.GetClientConfig()
 	if err != nil {
 		return err


### PR DESCRIPTION
### What this PR does / why we need it
- Use fslock to acquire lock when reading the tanzu config file for update
- This PR implements wrapper functions `AcquireTanzuConfigLock` and `ReleaseTanzuConfigLock` using fslock.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2357

### Describe testing done for PR
- Added unit tests to read and updated the configuration file in parallel.
- Verified that the unit test fails without this locking mechanism and it is successful with this change.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Use fslock to acquire lock when reading/writing the tanzu config file for update
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
