### PR TITLE
Add support to list clusterclass based clusters on TKGs

### DIFF
--- a/pkg/v1/tkg/client/get_cluster.go
+++ b/pkg/v1/tkg/client/get_cluster.go
@@ -14,8 +14,9 @@ import (
 
 // ListTKGClustersOptions contains options supported by ListClusters
 type ListTKGClustersOptions struct {
-	Namespace string
-	IncludeMC bool
+	Namespace                          string
+	IncludeMC                          bool
+	IsTKGSClusterClassFeatureActivated bool
 }
 
 // ClusterInfo defines the fields of get cluster output
@@ -56,7 +57,8 @@ func (c *TkgClient) ListTKGClusters(options ListTKGClustersOptions) ([]ClusterIn
 	if err != nil {
 		return nil, errors.Wrap(err, "error determining 'Tanzu Kubernetes Cluster service for vSphere' management cluster")
 	}
-	if isPacific {
+
+	if isPacific && !options.IsTKGSClusterClassFeatureActivated {
 		return c.GetClusterObjectsForPacific(regionalClusterClient, "", listOptions)
 	}
 

--- a/pkg/v1/tkg/tkgctl/get_cluster.go
+++ b/pkg/v1/tkg/tkgctl/get_cluster.go
@@ -4,9 +4,14 @@
 package tkgctl
 
 import (
+	"context"
+	"fmt"
 	"sort"
 
+	"github.com/pkg/errors"
+
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 )
 
 // ListTKGClustersOptions ptions passed while getting a list of TKG Clusters
@@ -18,9 +23,21 @@ type ListTKGClustersOptions struct {
 
 // GetClusters returns list of cluster
 func (t *tkgctl) GetClusters(options ListTKGClustersOptions) ([]client.ClusterInfo, error) {
+	isPacific, err := t.tkgClient.IsPacificManagementCluster()
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to determine if management cluster is on vSphere with Tanzu")
+	}
+	var isTKGSClusterClassFeatureActivated bool
+	if isPacific {
+		isTKGSClusterClassFeatureActivated, err = t.featureGateHelper.FeatureActivatedInNamespace(context.Background(), constants.ClusterClassFeature, constants.TKGSClusterClassNamespace)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf(constants.ErrorMsgFeatureGateStatus, constants.ClusterClassFeature, constants.TKGSClusterClassNamespace))
+		}
+	}
 	listTKGClustersOptions := client.ListTKGClustersOptions{
-		Namespace: options.Namespace,
-		IncludeMC: options.IncludeMC,
+		Namespace:                          options.Namespace,
+		IncludeMC:                          options.IncludeMC,
+		IsTKGSClusterClassFeatureActivated: isTKGSClusterClassFeatureActivated,
 	}
 
 	clusters, err := t.tkgClient.ListTKGClusters(listTKGClustersOptions)

--- a/pkg/v1/tkg/tkgctl/get_cluster_test.go
+++ b/pkg/v1/tkg/tkgctl/get_cluster_test.go
@@ -14,9 +14,10 @@ import (
 
 var _ = Describe("Unit test for get clusters", func() {
 	var (
-		ctl       tkgctl
-		tkgClient = &fakes.Client{}
-		ops       = ListTKGClustersOptions{
+		ctl               tkgctl
+		tkgClient         = &fakes.Client{}
+		featureGateHelper = &fakes.FakeFeatureGateHelper{}
+		ops               = ListTKGClustersOptions{
 			ClusterName: "my-cluster",
 		}
 		err error
@@ -24,27 +25,80 @@ var _ = Describe("Unit test for get clusters", func() {
 
 	JustBeforeEach(func() {
 		ctl = tkgctl{
-			configDir:  testingDir,
-			tkgClient:  tkgClient,
-			kubeconfig: "./kube",
+			configDir:         testingDir,
+			tkgClient:         tkgClient,
+			kubeconfig:        "./kube",
+			featureGateHelper: featureGateHelper,
 		}
 		_, err = ctl.GetClusters(ops)
 	})
 
-	Context("when failed to list clusters", func() {
+	Context("when failed to determine the management cluster is Pacific(TKGS) supervisor cluster ", func() {
 		BeforeEach(func() {
-			tkgClient.ListTKGClustersReturns(nil, errors.New("failed to list clusters"))
+			tkgClient.IsPacificManagementClusterReturns(false, errors.New("fake-error"))
 		})
 		It("should return an error", func() {
 			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to determine if management cluster is on vSphere with Tanzu"))
 		})
 	})
-	Context("when it is able list the clusters ", func() {
+	Context("when the management cluster is not Pacific(TKGS) supervisor cluster and is able to list clusters", func() {
 		BeforeEach(func() {
+			tkgClient.IsPacificManagementClusterReturns(false, nil)
 			tkgClient.ListTKGClustersReturns([]client.ClusterInfo{{Name: "my-cluster", Namespace: "default"}, {Name: "my-cluster-2", Namespace: "my-system"}}, nil)
 		})
 		It("should not return an error", func() {
 			Expect(err).ToNot(HaveOccurred())
+			options := tkgClient.ListTKGClustersArgsForCall(0)
+			Expect(options.IsTKGSClusterClassFeatureActivated).To(BeFalse())
 		})
 	})
+	Context("when the management cluster is not Pacific(TKGS) supervisor cluster, but failed to list clusters", func() {
+		BeforeEach(func() {
+			tkgClient.IsPacificManagementClusterReturns(false, nil)
+			tkgClient.ListTKGClustersReturns(nil, errors.New("failed to list clusters"))
+		})
+		It("should return an error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to list clusters"))
+			options := tkgClient.ListTKGClustersArgsForCall(1)
+			Expect(options.IsTKGSClusterClassFeatureActivated).To(BeFalse())
+		})
+	})
+	Context("when the management cluster is Pacific(TKGS) supervisor cluster but failed to get the cluster class feature activation status", func() {
+		BeforeEach(func() {
+			tkgClient.IsPacificManagementClusterReturns(true, nil)
+			featureGateHelper.FeatureActivatedInNamespaceReturns(false, errors.New("fake-feature-gate-error"))
+		})
+		It("should return an error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("fake-feature-gate-error"))
+		})
+	})
+	Context("when the management cluster is Pacific(TKGS) supervisor cluster with cluster class feature disabled and is able to list the clusters", func() {
+		BeforeEach(func() {
+			tkgClient.IsPacificManagementClusterReturns(true, nil)
+			featureGateHelper.FeatureActivatedInNamespaceReturns(true, nil)
+			tkgClient.ListTKGClustersReturns([]client.ClusterInfo{{Name: "my-cluster", Namespace: "default"}, {Name: "my-cluster-2", Namespace: "my-system"}}, nil)
+		})
+		It("should not return an error", func() {
+			Expect(err).ToNot(HaveOccurred())
+			options := tkgClient.ListTKGClustersArgsForCall(2)
+			Expect(options.IsTKGSClusterClassFeatureActivated).To(BeTrue())
+
+		})
+	})
+	Context("when the management cluster is Pacific(TKGS) supervisor cluster with cluster class feature enabled and is able to list the clusters", func() {
+		BeforeEach(func() {
+			tkgClient.IsPacificManagementClusterReturns(true, nil)
+			featureGateHelper.FeatureActivatedInNamespaceReturns(true, nil)
+			tkgClient.ListTKGClustersReturns([]client.ClusterInfo{{Name: "my-cluster", Namespace: "default"}, {Name: "my-cluster-2", Namespace: "my-system"}}, nil)
+		})
+		It("should not return an error", func() {
+			Expect(err).ToNot(HaveOccurred())
+			options := tkgClient.ListTKGClustersArgsForCall(3)
+			Expect(options.IsTKGSClusterClassFeatureActivated).To(BeTrue())
+		})
+	})
+
 })


### PR DESCRIPTION
Signed-off-by: Prem Kumar Kalle <pkalle@vmware.com>

### What this PR does / why we need it
This PR adds supports to list clusterclass based clusters created on TKGS. It would check if the clusterclass feature is enabled on TKGS, if so, would list all the clusters(same as TKGm) which includes both TKC and classy clusters. If the clusterclass feature is not enabled it would list all the TKC clusters.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2887 

### Describe testing done for PR
Created both the TKC and ClusterClass based clusters and listed both the clusters  successfully

```
❯ k get tkc -n testns
NAME          CONTROL PLANE   WORKER   TKR NAME                              AGE    READY   TKR COMPATIBLE   UPDATES AVAILABLE
prem-tkc-01   1               1        v1.22.8---vmware.1-tkg.2-zshippable   121m   True    True             [v1.23.5+vmware.1]

❯ ~/go/bin/tanzu cluster list
  NAME         NAMESPACE  STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES   PLAN  TKR
  prem-cc01    testns     running  1/1           1/1      v1.22.8+vmware.1  <none>        v1.22.8---vmware.1-tkg.2-zshippable
  prem-tkc-01  testns     running  1/1           1/1      v1.22.8+vmware.1  <none>        v1.22.8---vmware.1-tkg.2-zshippable
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add support to list clusterclass based clusters on TKGs
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
