### PR TITLE
Add Misc ClusterClass e2e test

### DIFF
--- a/pkg/v1/tkg/test/tkgctl/aws_cc/aws_cc_misc_test.go
+++ b/pkg/v1/tkg/test/tkgctl/aws_cc/aws_cc_misc_test.go
@@ -1,0 +1,25 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// nolint:typecheck,nolintlint
+package aws_cc
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+
+	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/test/tkgctl/shared"
+)
+
+var _ = Describe("Miscellaneous tests for aws clusterclass", func() {
+	E2ECCMiscSpec(context.TODO(), func() E2ECommonSpecInput {
+		return E2ECommonSpecInput{
+			E2EConfig:       e2eConfig,
+			ArtifactsFolder: artifactsFolder,
+			Cni:             "antrea",
+			Plan:            "devcc",
+			Namespace:       "default",
+		}
+	})
+})

--- a/pkg/v1/tkg/test/tkgctl/shared/cc_misc.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/cc_misc.go
@@ -1,0 +1,138 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package shared
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/cluster-api/util"
+
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/test/framework"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgctl"
+)
+
+func E2ECCMiscSpec(context context.Context, inputGetter func() E2ECommonSpecInput) {
+	var (
+		err          error
+		input        E2ECommonSpecInput
+		tkgCtlClient tkgctl.TKGClient
+		logsDir      string
+		clusterName  string
+		namespace    string
+	)
+
+	BeforeEach(func() {
+		input = inputGetter()
+		namespace = input.Namespace
+		logsDir = filepath.Join(input.ArtifactsFolder, "logs")
+
+		rand.Seed(time.Now().UnixNano())
+		clusterName = input.E2EConfig.ClusterPrefix + "wc-" + util.RandomString(4) // nolint:gomnd
+
+		tkgCtlClient, err = tkgctl.New(tkgctl.Options{
+			ConfigDir: input.E2EConfig.TkgConfigDir,
+			LogOptions: tkgctl.LoggingOptions{
+				File:      filepath.Join(logsDir, clusterName+".log"),
+				Verbosity: input.E2EConfig.TkgCliLogLevel,
+			},
+		})
+
+		Expect(err).To(BeNil())
+	})
+
+	It("should test misc clusterclass operations", func() {
+		By("Running cluster create dry-run ")
+		options := framework.CreateClusterOptions{
+			ClusterName:  clusterName,
+			Namespace:    namespace,
+			Plan:         "devcc",
+			CniType:      input.Cni,
+			GenerateOnly: true,
+		}
+
+		if input.E2EConfig.InfrastructureName == "vsphere" {
+			if endpointIP, ok := os.LookupEnv("CLUSTER_ENDPOINT_2"); ok {
+				options.VsphereControlPlaneEndpoint = endpointIP
+			}
+		}
+
+		clusterConfigFile, err := framework.GetTempClusterConfigFile(input.E2EConfig.TkgClusterConfigPath, &options)
+		Expect(err).To(BeNil())
+		defer os.Remove(clusterConfigFile)
+
+		old := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		err = tkgCtlClient.CreateCluster(tkgctl.CreateClusterOptions{
+			ClusterConfigFile: clusterConfigFile,
+			Edition:           "tkg",
+			GenerateOnly:      true,
+		})
+		Expect(err).To(BeNil())
+
+		outChan := make(chan string)
+		go func() {
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+			outChan <- buf.String()
+		}()
+
+		w.Close()
+		os.Stdout = old
+
+		out := <-outChan
+
+		var clusterclass map[string]interface{}
+		yaml.NewDecoder(bytes.NewBufferString(out)).Decode(&clusterclass)
+
+		Expect(clusterclass["kind"]).To(Equal("ClusterClass"))
+
+		if metadata, ok := clusterclass["metadata"].(map[string]interface{}); ok {
+			Expect(metadata["name"]).To(Equal(fmt.Sprintf("tkg-%s-default", input.E2EConfig.InfrastructureName)))
+		}
+
+		By("running cluster create dry-run with a cc config file")
+		ccConfig, err := os.CreateTemp("", "cc_config")
+		Expect(err).ToNot(HaveOccurred())
+		defer ccConfig.Close()
+
+		io.Copy(ccConfig, bytes.NewBufferString(out))
+
+		old = os.Stdout
+		r, w, _ = os.Pipe()
+		os.Stdout = w
+
+		err = tkgCtlClient.CreateCluster(tkgctl.CreateClusterOptions{
+			ClusterConfigFile: ccConfig.Name(),
+			Edition:           "tkg",
+			GenerateOnly:      true,
+		})
+		Expect(err).To(BeNil())
+
+		outChan = make(chan string)
+		go func() {
+			var buf bytes.Buffer
+			io.Copy(&buf, r)
+			outChan <- buf.String()
+		}()
+
+		w.Close()
+		os.Stdout = old
+
+		outAgain := <-outChan
+
+		Expect(out).To(Equal(outAgain))
+	})
+}


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds a couple tests to verify miscellaneous functionality for clusterclass based clusters. Specifically it tests the dry-run operation returns the input clusterclass file when passed such an input file. Also verifies the name of the clusterclass.  

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
Added a couple tests to verify the create cluster dry-run output when using a ccluster.yaml as input. Also fixes a bug where dry-run would error when passed a ccluster.yaml because it was expecting a legacy config file. Also adds a test to verify that the clusterclass name follows the convention `tkg-${providerName}-default`. 
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
fixes bug where passing a ccluster input file to create dry-run would error expecting a legacy config file. 
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
