### PR TITLE
Update clusterclass node pool support for TKGS

### DIFF
--- a/cmd/cli/plugin/cluster/delete_node_pool.go
+++ b/cmd/cli/plugin/cluster/delete_node_pool.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
 )
 
 type deleteNodePoolOptions struct {
@@ -59,5 +60,11 @@ func runDeleteNodePool(server *v1alpha1.Server, clusterName string) error {
 		Namespace:   deleteNP.namespace,
 		Name:        deleteNP.nodePoolName,
 	}
-	return tkgctlClient.DeleteMachineDeployment(options)
+
+	err = tkgctlClient.DeleteMachineDeployment(options)
+	if err == nil {
+		log.Infof("Node pool '%s' is being deleted", options.Name)
+	}
+
+	return err
 }

--- a/cmd/cli/plugin/cluster/get_node_pools.go
+++ b/cmd/cli/plugin/cluster/get_node_pools.go
@@ -4,21 +4,15 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/pkg/errors"
-	"sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/spf13/cobra"
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
-	tkgsv1alpha2 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
-	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgctl"
 )
 
 type listNodePoolOptions struct {
@@ -66,18 +60,11 @@ func listNodePoolsInternal(cmd *cobra.Command, server *v1alpha1.Server, clusterN
 		Namespace:   lnp.namespace,
 	}
 
-	isPacific, err := tkgctlClient.IsPacificRegionalCluster()
-	if err != nil {
-		return errors.Wrap(err, "error determining Tanzu Kubernetes Cluster service for vSphere management cluster ")
-	}
-	if isPacific {
-		return listPacificNodePools(cmd, tkgctlClient, mdOptions)
-	}
-
 	machineDeployments, err := tkgctlClient.GetMachineDeployments(mdOptions)
 	if err != nil {
 		return err
 	}
+
 	var t component.OutputWriter
 	if lnp.outputFormat == string(component.JSONOutputType) || lnp.outputFormat == string(component.YAMLOutputType) {
 		t = component.NewObjectWriter(cmd.OutOrStdout(), lnp.outputFormat, machineDeployments)
@@ -90,63 +77,4 @@ func listNodePoolsInternal(cmd *cobra.Command, server *v1alpha1.Server, clusterN
 	t.Render()
 
 	return nil
-}
-
-func listPacificNodePools(cmd *cobra.Command, tkgctlClient tkgctl.TKGClient, mdOptions client.GetMachineDeploymentOptions) error {
-	var tkcObj *tkgsv1alpha2.TanzuKubernetesCluster
-
-	tkcObj, err := tkgctlClient.GetPacificClusterObject(mdOptions.ClusterName, mdOptions.Namespace)
-	if err != nil {
-		return errors.Wrap(err, "unable to get Tanzu Kubernetes Cluster object")
-	}
-	machineDeployments, err := tkgctlClient.GetPacificMachineDeployments(mdOptions)
-	if err != nil {
-		return err
-	}
-	// // Pacific TKC has nodepool names, so update the MD names with nodepool names from TKC object before listing nodepools.
-	// // This is required because the user would want to use the nodepool names from the list output for nodepool set/delete operations
-	err = updateMDsWithTKCNodepoolNames(tkcObj, machineDeployments)
-	if err != nil {
-		return err
-	}
-
-	var t component.OutputWriter
-	if lnp.outputFormat == string(component.JSONOutputType) || lnp.outputFormat == string(component.YAMLOutputType) {
-		t = component.NewObjectWriter(cmd.OutOrStdout(), lnp.outputFormat, machineDeployments)
-	} else {
-		t = component.NewOutputWriter(cmd.OutOrStdout(), lnp.outputFormat, "NAME", "NAMESPACE", "PHASE", "REPLICAS", "READY", "UPDATED", "UNAVAILABLE")
-		for idx := range machineDeployments {
-			md := machineDeployments[idx]
-			t.AddRow(md.Name, md.Namespace, md.Status.Phase, md.Status.Replicas, md.Status.ReadyReplicas, md.Status.UpdatedReplicas, md.Status.UnavailableReplicas)
-		}
-	}
-	t.Render()
-
-	return nil
-}
-
-func updateMDsWithTKCNodepoolNames(tkcObj *tkgsv1alpha2.TanzuKubernetesCluster, machineDeployments []v1alpha3.MachineDeployment) error {
-	nodepools := tkcObj.Spec.Topology.NodePools
-	for mdIdx := range machineDeployments {
-		nodepoolName := getNodePoolNameFromMDName(tkcObj.Name, machineDeployments[mdIdx].Name)
-		for npIdx := range nodepools {
-			if nodepoolName == nodepools[npIdx].Name {
-				machineDeployments[mdIdx].Name = nodepools[npIdx].Name
-				break
-			}
-		}
-	}
-	return nil
-}
-
-func getNodePoolNameFromMDName(clusterName, mdName string) string {
-	// Pacific(TKGS) creates a corresponding MachineDeployment for a nodepool in
-	// the format {tkc-clustername}-{nodepool-name}-{randomstring}
-	trimmedName := strings.TrimPrefix(mdName, fmt.Sprintf("%s-", clusterName))
-	lastHypenIdx := strings.LastIndex(trimmedName, "-")
-	if lastHypenIdx == -1 {
-		return ""
-	}
-	nodepoolName := trimmedName[:lastHypenIdx]
-	return nodepoolName
 }

--- a/cmd/cli/plugin/cluster/set_node_pool.go
+++ b/cmd/cli/plugin/cluster/set_node_pool.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
 )
 
 type clusterSetNodePoolCmdOptions struct {
@@ -76,5 +77,9 @@ func SetNodePool(server *v1alpha1.Server, clusterName string) error {
 		NodePool:    nodePool,
 	}
 
-	return tkgctlClient.SetMachineDeployment(&options)
+	err = tkgctlClient.SetMachineDeployment(&options)
+	if err == nil {
+		log.Infof("Cluster update for node pool '%s' completed successfully", options.Name)
+	}
+	return err
 }

--- a/pkg/v1/tkg/client/machine_deployment.go
+++ b/pkg/v1/tkg/client/machine_deployment.go
@@ -99,20 +99,24 @@ func (c *TkgClient) SetMachineDeployment(options *SetMachineDeploymentOptions) e
 		return errors.Wrap(err, "Unable to create clusterclient")
 	}
 
+	ccBased, err := clusterClient.IsClusterClassBased(options.ClusterName, options.Namespace)
+	if err != nil {
+		return errors.Wrap(err, "unable to determine if cluster is clusterclass based")
+	}
+	if ccBased {
+		var cluster capi.Cluster
+		if err = clusterClient.GetResource(&cluster, options.ClusterName, options.Namespace, nil, nil); err != nil {
+			return errors.Wrap(err, "Unable to retrieve cluster resource")
+		}
+		return DoSetMachineDeploymentCC(clusterClient, &cluster, options)
+	}
+
 	isPacific, err := clusterClient.IsPacificRegionalCluster()
 	if err != nil {
 		return errors.Wrap(err, "error determining Tanzu Kubernetes Cluster service for vSphere management cluster ")
 	}
 	if isPacific {
 		return c.SetNodePoolsForPacificCluster(clusterClient, options)
-	}
-
-	var cluster capi.Cluster
-	if err = clusterClient.GetResource(&cluster, options.ClusterName, options.Namespace, nil, nil); err != nil {
-		return errors.Wrap(err, "Unable to retrieve cluster resource")
-	}
-	if cluster.Spec.Topology != nil {
-		return DoSetMachineDeploymentCC(clusterClient, &cluster, options)
 	}
 
 	return DoSetMachineDeployment(clusterClient, options)
@@ -308,20 +312,24 @@ func (c *TkgClient) DeleteMachineDeployment(options DeleteMachineDeploymentOptio
 		return errors.Wrap(err, "Unable to create clusterclient")
 	}
 
+	ccBased, err := clusterClient.IsClusterClassBased(options.ClusterName, options.Namespace)
+	if err != nil {
+		return errors.Wrap(err, "unable to determine if cluster is clusterclass based")
+	}
+	if ccBased {
+		var cluster capi.Cluster
+		if err = clusterClient.GetResource(&cluster, options.ClusterName, options.Namespace, nil, nil); err != nil {
+			return errors.Wrap(err, "Unable to retrieve cluster resource")
+		}
+		return DoDeleteMachineDeploymentCC(clusterClient, &cluster, &options)
+	}
+
 	isPacific, err := clusterClient.IsPacificRegionalCluster()
 	if err != nil {
 		return errors.Wrap(err, "error determining Tanzu Kubernetes Cluster service for vSphere management cluster ")
 	}
 	if isPacific {
 		return c.DeleteNodePoolForPacificCluster(clusterClient, options)
-	}
-
-	var cluster capi.Cluster
-	if err = clusterClient.GetResource(&cluster, options.ClusterName, options.Namespace, nil, nil); err != nil {
-		return errors.Wrap(err, "Unable to retrieve cluster resource")
-	}
-	if cluster.Spec.Topology != nil {
-		return DoDeleteMachineDeploymentCC(clusterClient, &cluster, &options)
 	}
 
 	return DoDeleteMachineDeployment(clusterClient, &options)
@@ -478,12 +486,47 @@ func (c *TkgClient) GetMachineDeployments(options GetMachineDeploymentOptions) (
 		return nil, errors.Wrap(err, "Unable to create clusterclient")
 	}
 
-	var cluster capi.Cluster
-	if err = clusterClient.GetResource(&cluster, options.ClusterName, options.Namespace, nil, nil); err != nil {
-		return nil, errors.Wrap(err, "Unable to retrieve cluster resources")
+	ccBased, err := clusterClient.IsClusterClassBased(options.ClusterName, options.Namespace)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to determine if cluster is clusterclass based")
 	}
-	if cluster.Spec.Topology != nil {
+	if ccBased {
+		var cluster capi.Cluster
+		if err = clusterClient.GetResource(&cluster, options.ClusterName, options.Namespace, nil, nil); err != nil {
+			return nil, errors.Wrap(err, "Unable to retrieve cluster resources")
+		}
 		return DoGetMachineDeploymentsCC(clusterClient, &cluster, &options)
+	}
+
+	isPacific, err := clusterClient.IsPacificRegionalCluster()
+	if err != nil {
+		return nil, errors.Wrap(err, "error determining Tanzu Kubernetes Cluster service for vSphere management cluster ")
+	}
+	if isPacific {
+		pacificMds, err := c.GetPacificMachineDeployments(options)
+		if err != nil {
+			return nil, err
+		}
+
+		var mds []capi.MachineDeployment
+		for i := range pacificMds {
+			newMd := capi.MachineDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      getNodePoolNameFromMDName(options.ClusterName, pacificMds[i].Name),
+					Namespace: pacificMds[i].Namespace,
+				},
+				Status: capi.MachineDeploymentStatus{
+					Replicas:            pacificMds[i].Status.Replicas,
+					UpdatedReplicas:     pacificMds[i].Status.UpdatedReplicas,
+					ReadyReplicas:       pacificMds[i].Status.ReadyReplicas,
+					AvailableReplicas:   pacificMds[i].Status.AvailableReplicas,
+					UnavailableReplicas: pacificMds[i].Status.UnavailableReplicas,
+					Phase:               pacificMds[i].Status.Phase,
+				},
+			}
+			mds = append(mds, newMd)
+		}
+		return mds, nil
 	}
 
 	return DoGetMachineDeployments(clusterClient, &options)
@@ -696,6 +739,18 @@ func NormalizeNodePoolName(workers []capi.MachineDeployment, clusterName string)
 	}
 
 	return workers, nil
+}
+
+func getNodePoolNameFromMDName(clusterName, mdName string) string {
+	// Pacific(TKGS) creates a corresponding MachineDeployment for a nodepool in
+	// the format {tkc-clustername}-{nodepool-name}-{randomstring}
+	trimmedName := strings.TrimPrefix(mdName, fmt.Sprintf("%s-", clusterName))
+	lastHypenIdx := strings.LastIndex(trimmedName, "-")
+	if lastHypenIdx == -1 {
+		return ""
+	}
+	nodepoolName := trimmedName[:lastHypenIdx]
+	return nodepoolName
 }
 
 func updateAzureSecret(kcTemplate *v1beta1.KubeadmConfigTemplate, machineTemplateName string) {

--- a/pkg/v1/tkg/client/machine_deployment_cc_test.go
+++ b/pkg/v1/tkg/client/machine_deployment_cc_test.go
@@ -584,20 +584,15 @@ var _ = Describe("SetMachineDeploymentCC", func() {
 						},
 					},
 				})
-				expectedLabels, _ := json.Marshal([]map[string]string{
-					{
-						"os": "ubuntu",
-					},
-					{
-						"arch": "amd64",
-					},
-				})
 				clusterInterface, _, _, _ := regionalClusterClient.UpdateResourceArgsForCall(0)
 				actual, ok := clusterInterface.(*capi.Cluster)
 				Expect(ok).To(BeTrue())
 				Expect(len(actual.Spec.Topology.Workers.MachineDeployments)).To(Equal(3))
 				Expect(len(actual.Spec.Topology.Workers.MachineDeployments[2].Variables.Overrides)).To(Equal(3))
-				Expect(actual.Spec.Topology.Workers.MachineDeployments[2].Variables.Overrides[0].Value.Raw).To(Equal(expectedLabels))
+				var actualLabels []map[string]string
+				err = json.Unmarshal(actual.Spec.Topology.Workers.MachineDeployments[2].Variables.Overrides[0].Value.Raw, &actualLabels)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(actualLabels)).To(Equal(2))
 				Expect(actual.Spec.Topology.Workers.MachineDeployments[2].Variables.Overrides[1].Value.Raw).To(Equal(expected))
 
 				expectedVcenter, _ := json.Marshal(map[string]interface{}{


### PR DESCRIPTION
### What this PR does / why we need it
This change updates the node pool operations to support the TKGs clusterclass. Specifically it adds support for the nodePoolTaints, nodePoolVolumes, vmClass, and storageClass variables found in the tkgs clusterclass.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2949 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: updates node pool API to properly support all node pool customization values, e.g vmClass, storageClass
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [ ] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [ ] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [ ] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
