### PR TITLE
WIP: Use different tkg directory for legacy fallback test

### DIFF
--- a/.github/workflows/tkg_integration_tests_clusterclass.yaml
+++ b/.github/workflows/tkg_integration_tests_clusterclass.yaml
@@ -214,6 +214,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+          RUN_FULL_INTEGRATION_TESTS: "1"
           AWS_REGION: "us-west-2"
           _MANAGEMENT_PACKAGE_REPO_IMAGE: ${{ steps.set_registry.outputs.registry }}/tanzu_framework/github-actions/${{ steps.extract_reg_dir.outputs.regdir }}/management:v0.21.0
           _MANAGEMENT_PACKAGE_VERSION: "0.21.0"

--- a/pkg/v1/tkg/test/tkgctl/shared/legacy_fallback.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/legacy_fallback.go
@@ -14,6 +14,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/otiai10/copy"
 	"sigs.k8s.io/cluster-api/util"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
@@ -32,13 +33,14 @@ type E2ELegacyFallbackSpecInput struct {
 
 func E2ELegacyFallbackSpec(context context.Context, inputGetter func() E2ELegacyFallbackSpecInput) { //nolint:funlen
 	var (
-		err            error
-		input          E2ELegacyFallbackSpecInput
-		tkgCtlClient   tkgctl.TKGClient
-		logsDir        string
-		clusterName    string
-		namespace      string
-		suppressUpdate string
+		err              error
+		input            E2ELegacyFallbackSpecInput
+		tkgCtlClient     tkgctl.TKGClient
+		logsDir          string
+		clusterName      string
+		namespace        string
+		suppressUpdate   string
+		testTkgConfigDir string
 	)
 	const (
 		SuppressUpdateEnvVar = "SUPPRESS_PROVIDER_UPDATE"
@@ -46,7 +48,7 @@ func E2ELegacyFallbackSpec(context context.Context, inputGetter func() E2ELegacy
 
 	Context("When there are modifications in the provider overlays", func() {
 		BeforeEach(func() { //nolint:dupl
-			if os.Getenv("RUN_FULL_INTEG_TEST") != "1" {
+			if os.Getenv("RUN_FULL_INTEGRATION_TESTS") != "1" {
 				Skip("Skip legacy fallback creation tests")
 			}
 
@@ -56,13 +58,18 @@ func E2ELegacyFallbackSpec(context context.Context, inputGetter func() E2ELegacy
 				namespace = input.Namespace
 			}
 
+			testTkgConfigDir, err = os.MkdirTemp("/tmp", "legacy_fallback_tkgdir_*")
+			Expect(err).To(BeNil())
+			err = copy.Copy(input.E2EConfig.TkgConfigDir, testTkgConfigDir)
+			Expect(err).To(BeNil())
+
 			logsDir = filepath.Join(input.ArtifactsFolder, "logs")
 
 			rand.Seed(time.Now().UnixNano())
 			clusterName = input.E2EConfig.ClusterPrefix + "wc-" + util.RandomString(4) // nolint:gomnd
 
 			tkgCtlClient, err = tkgctl.New(tkgctl.Options{
-				ConfigDir: input.E2EConfig.TkgConfigDir,
+				ConfigDir: testTkgConfigDir,
 				LogOptions: tkgctl.LoggingOptions{
 					File:      filepath.Join(logsDir, clusterName+".log"),
 					Verbosity: input.E2EConfig.TkgCliLogLevel,
@@ -81,7 +88,7 @@ func E2ELegacyFallbackSpec(context context.Context, inputGetter func() E2ELegacy
 ---
 `
 			// simulate modifications in provider overlays
-			dummyDataValueFilePath := filepath.Join(input.E2EConfig.TkgConfigDir, "providers", "ytt", "dummy.yaml")
+			dummyDataValueFilePath := filepath.Join(testTkgConfigDir, "providers", "ytt", "dummy.yaml")
 			defer os.Remove(dummyDataValueFilePath)
 			err = os.WriteFile(dummyDataValueFilePath, []byte(fileContent), 0644)
 			Expect(err).To(BeNil())
@@ -161,6 +168,7 @@ func E2ELegacyFallbackSpec(context context.Context, inputGetter func() E2ELegacy
 
 		AfterEach(func() {
 			os.Setenv(SuppressUpdateEnvVar, suppressUpdate)
+			os.Remove(testTkgConfigDir)
 		})
 	})
 }


### PR DESCRIPTION
### What this PR does / why we need it
```
    overlay-modifying tests like the legacy creation fallback tests needs
    their own tkg directory to isolate mods from other tests not expecting
    them.
```


### Which issue(s) this PR fixes

Fixes #N/A

### Describe testing done for PR

e2e aws_cc tests locally, monitoring CI run of the same.

### Release note

```release-note
NONE
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- x Squash the commits into one or a small number of logical commits
- x Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- x Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
