### PR TITLE
Add envvar option to exclude CC-related files during build

### DIFF
--- a/pkg/v1/providers/Makefile
+++ b/pkg/v1/providers/Makefile
@@ -28,7 +28,12 @@ IMAGE_REPO ?= vmware.io
 PROVIDER_TEMPLATE_IMG_TAG ?= latest
 
 
-FILES_TO_IGNORE='.env\|.idea\|.git\|.github\|hack\|.yamllint\|.gitlab\|Makefile\|provider-bundle\|tests\|README.md\|client\|go.mod\|go.sum\|providers.sha256sum|\Dockerfile.templates'
+FILES_TO_IGNORE?=.env .idea .git .github hack .yamllint .gitlab Makefile provider-bundle tests README.md client go.mod go.sum providers.sha256sum Dockerfile.templates
+ifeq ($(EXCLUDE_CLUSTER_CLASS_FILES), true)
+FILES_TO_IGNORE+=yttcc yttcb cconly cc.yaml
+endif
+FILES_TO_IGNORE_REGEX=$(subst $(space) ,\|,$(FILES_TO_IGNORE))
+
 
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
@@ -62,7 +67,7 @@ clean-providers: ## cleans provider-bundle
 
 setup-provider-for-generation: clean-providers
 	# using temporary directory to extract all files which needs to bundle
-	find . -type f | grep -v ${FILES_TO_IGNORE} | xargs tar cf - -T - | tar -C ${PROVIDER_BUNDLE_DIR} -x
+	find . -type f | grep -v "${FILES_TO_IGNORE_REGEX}" | xargs tar cf - -T - | tar -C ${PROVIDER_BUNDLE_DIR} -x
 
 .PHONY: generate-provider-bundle-zip
 generate-provider-bundle-zip: setup-provider-for-generation ## generates provider zip bundle


### PR DESCRIPTION
### What this PR does / why we need it

For builds not leveraging the clusterclass-related overlays, provide an
envvar EXCLUDE_CLUSTER_CLASS_FILES to exclude them fromo the providers file set.

Signed-off-by: Vui Lam <vui@vmware.com>

### Which issue(s) this PR fixes

Fixes: #2927

### Describe testing done for PR

    - cd pkg/v1/providers
    - EXCLUDE_CLUSTER_CLASS_FILES=true make setup-provider-for-generation
    - verified absence of cc-related contents in provider-bundle/providers/

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
None
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- x Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- x Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- x Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

