### PR TITLE
Change default AVI_CONTROLLER_VERSION to 20.1.3.

### DIFF
--- a/pkg/v1/providers/config_default.yaml
+++ b/pkg/v1/providers/config_default.yaml
@@ -550,7 +550,7 @@ AVI_CONTROL_PLANE_HA_PROVIDER: false
 
 #! Avi aka. NSX Advanced Loader Balancer's controller ip or FQDN
 AVI_CONTROLLER:
-AVI_CONTROLLER_VERSION: 20.1.7
+AVI_CONTROLLER_VERSION: 20.1.3
 AVI_USERNAME: ""
 AVI_PASSWORD: ""
 #! The cerficiate used to access Avi aka. NSX Advanced Loader Balancer's controller, need to be base64 encoded


### PR DESCRIPTION
### What this PR does / why we need it

We cannot use the newer 20.1.7 Avi controller version yet since the downstream testbed is still using the older version 20.1.3. This version mismatch will cause the applied ADC to be rejected by its admission webhook since the ako-operator cannot talk to the Avi controller (400 invalid version).

It reverts the changes by https://github.com/vmware-tanzu/tanzu-framework/pull/2827/files here.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes # https://github.com/vmware-tanzu/tanzu-framework/issues/2932

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Change default AVI_CONTROLLER_VERSION to 20.1.3.
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
