### PR TITLE
change cluster pause webhook behavior to no pause for legacy tkr

### DIFF
--- a/addons/controllers/cluster_pause_webhook_test.go
+++ b/addons/controllers/cluster_pause_webhook_test.go
@@ -19,12 +19,11 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 )
 
-const (
-	clusterpPauseWebhookManifestFile = "testdata/webhooks/cluster-pause-webhook-manifests.yaml"
-	testClusterName                  = "pause-test-cluster"
-)
-
 var _ = Describe("when cluster paused state is managed by webhook", func() {
+	var (
+		clusterpPauseWebhookManifestFile string
+		testClusterName                  string
+	)
 	JustBeforeEach(func() {
 		// Create the webhook configurations
 		f, err := os.Open(clusterpPauseWebhookManifestFile)
@@ -54,178 +53,226 @@ var _ = Describe("when cluster paused state is managed by webhook", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	Context("if the value of the cluster's TKR label changes", func() {
-		It("webhook should set pause state in cluster object", func() {
-			// Create a cluster object
-			cluster := &clusterapiv1beta1.Cluster{}
-			cluster.Name = testClusterName
-			cluster.Namespace = addonNamespace
-			cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.19.3---vmware.1"}
-			err := k8sClient.Create(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
+	When("current cluster's corresponding TKR does not have 'run.tanzu.vmware.com/legacy-tkr' label", func() {
+		BeforeEach(func() {
+			clusterpPauseWebhookManifestFile = "testdata/webhooks/cluster-pause-webhook-manifest.yaml"
+			testClusterName = "pause-test-cluster"
+		})
 
-			// It shouldn't be paused
-			key := client.ObjectKey{
-				Namespace: cluster.Namespace,
-				Name:      cluster.Name,
-			}
-			err = k8sClient.Get(ctx, key, cluster)
-			cluster = cluster.DeepCopy()
-			Expect(err).ToNot(HaveOccurred())
-			if cluster.Annotations != nil {
-				_, ok := cluster.Annotations[constants.ClusterPauseLabel]
-				Expect(ok).ToNot(BeTrue())
-			}
-			Expect(cluster.Spec.Paused).ToNot(BeTrue())
+		Context("if the value of the cluster's TKR label changes", func() {
+			It("webhook should set pause state in cluster object", func() {
+				// Create a cluster object
+				cluster := &clusterapiv1beta1.Cluster{}
+				cluster.Name = testClusterName
+				cluster.Namespace = addonNamespace
+				cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.19.3---vmware.1"}
+				err := k8sClient.Create(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
 
-			// Update cluster version
-			cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.20.5---vmware.1"}
-			err = k8sClient.Update(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
+				// It shouldn't be paused
+				key := client.ObjectKey{
+					Namespace: cluster.Namespace,
+					Name:      cluster.Name,
+				}
+				err = k8sClient.Get(ctx, key, cluster)
+				cluster = cluster.DeepCopy()
+				Expect(err).ToNot(HaveOccurred())
+				if cluster.Annotations != nil {
+					_, ok := cluster.Annotations[constants.ClusterPauseLabel]
+					Expect(ok).ToNot(BeTrue())
+				}
+				Expect(cluster.Spec.Paused).ToNot(BeTrue())
 
-			// Cluster should be paused
-			Expect(cluster.Annotations).ToNot(BeNil())
-			Expect(cluster.Annotations[constants.ClusterPauseLabel]).To(Equal(cluster.Labels[v1alpha3.LabelTKR]))
-			Expect(cluster.Spec.Paused).To(BeTrue())
+				// Update cluster version
+				cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.20.5---vmware.1"}
+				err = k8sClient.Update(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Cluster should be paused
+				Expect(cluster.Annotations).ToNot(BeNil())
+				Expect(cluster.Annotations[constants.ClusterPauseLabel]).To(Equal(cluster.Labels[v1alpha3.LabelTKR]))
+				Expect(cluster.Spec.Paused).To(BeTrue())
+			})
+		})
+
+		Context("if previously the cluster did not have any label and during an update, TKR label is set", func() {
+			It("webhook should set pause state in the cluster object", func() {
+				// Create a cluster object
+				cluster := &clusterapiv1beta1.Cluster{}
+				cluster.Name = testClusterName
+				cluster.Namespace = addonNamespace
+				err := k8sClient.Create(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				// It shouldn't be paused
+				key := client.ObjectKey{
+					Namespace: cluster.Namespace,
+					Name:      cluster.Name,
+				}
+				err = k8sClient.Get(ctx, key, cluster)
+				cluster = cluster.DeepCopy()
+				Expect(err).ToNot(HaveOccurred())
+				if cluster.Annotations != nil {
+					_, ok := cluster.Annotations[constants.ClusterPauseLabel]
+					Expect(ok).ToNot(BeTrue())
+				}
+				Expect(cluster.Spec.Paused).ToNot(BeTrue())
+
+				// Update cluster version
+				cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.19.3---vmware.1"}
+				err = k8sClient.Update(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(cluster.Annotations).ToNot(BeNil())
+				Expect(cluster.Annotations[constants.ClusterPauseLabel]).To(Equal(cluster.Labels[v1alpha3.LabelTKR]))
+				Expect(cluster.Spec.Paused).To(BeTrue())
+			})
+		})
+
+		Context("if previously the cluster did not have a TKR label and during an update, TKR label is set", func() {
+			It("webhook should set pause state in the cluster object", func() {
+				// Create a cluster object
+				cluster := &clusterapiv1beta1.Cluster{}
+				cluster.Name = testClusterName
+				cluster.Namespace = addonNamespace
+				cluster.Labels = map[string]string{"someLabel": "v1.19.3---vmware.1"}
+				err := k8sClient.Create(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				// It shouldn't be paused
+				key := client.ObjectKey{
+					Namespace: cluster.Namespace,
+					Name:      cluster.Name,
+				}
+				err = k8sClient.Get(ctx, key, cluster)
+				cluster = cluster.DeepCopy()
+				Expect(err).ToNot(HaveOccurred())
+				if cluster.Annotations != nil {
+					_, ok := cluster.Annotations[constants.ClusterPauseLabel]
+					Expect(ok).ToNot(BeTrue())
+				}
+				Expect(cluster.Spec.Paused).ToNot(BeTrue())
+
+				// Update cluster version
+				cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.19.3---vmware.1"}
+				err = k8sClient.Update(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(cluster.Annotations).ToNot(BeNil())
+				Expect(cluster.Annotations[constants.ClusterPauseLabel]).To(Equal(cluster.Labels[v1alpha3.LabelTKR]))
+				Expect(cluster.Spec.Paused).To(BeTrue())
+			})
+		})
+
+		Context("if no change in the value of the cluster's TKR label", func() {
+			It("webhook should not set pause state in the cluster object", func() {
+				// Create a cluster object
+				cluster := &clusterapiv1beta1.Cluster{}
+				cluster.Name = testClusterName
+				cluster.Namespace = addonNamespace
+				cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.19.3---vmware.1"}
+				err := k8sClient.Create(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				// It shouldn't be paused
+				key := client.ObjectKey{
+					Namespace: cluster.Namespace,
+					Name:      cluster.Name,
+				}
+				err = k8sClient.Get(ctx, key, cluster)
+				cluster = cluster.DeepCopy()
+				Expect(err).ToNot(HaveOccurred())
+				if cluster.Annotations != nil {
+					_, ok := cluster.Annotations[constants.ClusterPauseLabel]
+					Expect(ok).ToNot(BeTrue())
+				}
+				Expect(cluster.Spec.Paused).ToNot(BeTrue())
+
+				// Update cluster version
+				cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.19.3---vmware.1"}
+				err = k8sClient.Update(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Cluster should not be paused
+				Expect(cluster.Spec.Paused).ToNot(BeTrue())
+				Expect(cluster.Annotations).To(BeNil())
+			})
+		})
+
+		Context("if cluster's TKR label is removed during update", func() {
+			It("webhook should not set pause state in the cluster object", func() {
+				// Create a cluster object
+				cluster := &clusterapiv1beta1.Cluster{}
+				cluster.Name = testClusterName
+				cluster.Namespace = addonNamespace
+				cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.19.3---vmware.1"}
+				err := k8sClient.Create(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				// It shouldn't be paused
+				key := client.ObjectKey{
+					Namespace: cluster.Namespace,
+					Name:      cluster.Name,
+				}
+				err = k8sClient.Get(ctx, key, cluster)
+				cluster = cluster.DeepCopy()
+				Expect(err).ToNot(HaveOccurred())
+				if cluster.Annotations != nil {
+					_, ok := cluster.Annotations[constants.ClusterPauseLabel]
+					Expect(ok).ToNot(BeTrue())
+				}
+				Expect(cluster.Spec.Paused).ToNot(BeTrue())
+
+				// Update cluster version
+				cluster.Labels = map[string]string{}
+				err = k8sClient.Update(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Cluster should not be paused
+				Expect(cluster.Spec.Paused).ToNot(BeTrue())
+				Expect(cluster.Annotations).To(BeNil())
+			})
 		})
 	})
 
-	Context("if previously the cluster did not have any label and during an update, TKR label is set", func() {
-		It("webhook should set pause state in the cluster object", func() {
-			// Create a cluster object
-			cluster := &clusterapiv1beta1.Cluster{}
-			cluster.Name = testClusterName
-			cluster.Namespace = addonNamespace
-			err := k8sClient.Create(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
-
-			// It shouldn't be paused
-			key := client.ObjectKey{
-				Namespace: cluster.Namespace,
-				Name:      cluster.Name,
-			}
-			err = k8sClient.Get(ctx, key, cluster)
-			cluster = cluster.DeepCopy()
-			Expect(err).ToNot(HaveOccurred())
-			if cluster.Annotations != nil {
-				_, ok := cluster.Annotations[constants.ClusterPauseLabel]
-				Expect(ok).ToNot(BeTrue())
-			}
-			Expect(cluster.Spec.Paused).ToNot(BeTrue())
-
-			// Update cluster version
-			cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.19.3---vmware.1"}
-			err = k8sClient.Update(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(cluster.Annotations).ToNot(BeNil())
-			Expect(cluster.Annotations[constants.ClusterPauseLabel]).To(Equal(cluster.Labels[v1alpha3.LabelTKR]))
-			Expect(cluster.Spec.Paused).To(BeTrue())
+	When("current cluster's corresponding TKR has 'run.tanzu.vmware.com/legacy-tkr' label", func() {
+		BeforeEach(func() {
+			clusterpPauseWebhookManifestFile = "testdata/webhooks/cluster-pause-webhook-manifest-with-legacy-tkr-label.yaml"
+			testClusterName = "no-pause-test-cluster"
 		})
-	})
 
-	Context("if previously the cluster did not have a TKR label and during an update, TKR label is set", func() {
-		It("webhook should set pause state in the cluster object", func() {
-			// Create a cluster object
-			cluster := &clusterapiv1beta1.Cluster{}
-			cluster.Name = testClusterName
-			cluster.Namespace = addonNamespace
-			cluster.Labels = map[string]string{"someLabel": "v1.19.3---vmware.1"}
-			err := k8sClient.Create(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
+		Context("if the value of the cluster's TKR label changes", func() {
+			It("webhook should not set pause state in cluster object", func() {
+				// Create a cluster object
+				cluster := &clusterapiv1beta1.Cluster{}
+				cluster.Name = testClusterName
+				cluster.Namespace = addonNamespace
+				cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.19.3---vmware.1"}
+				err := k8sClient.Create(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
 
-			// It shouldn't be paused
-			key := client.ObjectKey{
-				Namespace: cluster.Namespace,
-				Name:      cluster.Name,
-			}
-			err = k8sClient.Get(ctx, key, cluster)
-			cluster = cluster.DeepCopy()
-			Expect(err).ToNot(HaveOccurred())
-			if cluster.Annotations != nil {
-				_, ok := cluster.Annotations[constants.ClusterPauseLabel]
-				Expect(ok).ToNot(BeTrue())
-			}
-			Expect(cluster.Spec.Paused).ToNot(BeTrue())
+				// It shouldn't be paused
+				key := client.ObjectKey{
+					Namespace: cluster.Namespace,
+					Name:      cluster.Name,
+				}
+				err = k8sClient.Get(ctx, key, cluster)
+				cluster = cluster.DeepCopy()
+				Expect(err).ToNot(HaveOccurred())
+				if cluster.Annotations != nil {
+					_, ok := cluster.Annotations[constants.ClusterPauseLabel]
+					Expect(ok).ToNot(BeTrue())
+				}
+				Expect(cluster.Spec.Paused).ToNot(BeTrue())
 
-			// Update cluster version
-			cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.19.3---vmware.1"}
-			err = k8sClient.Update(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
+				// Update cluster version
+				cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.20.5---vmware.1"}
+				err = k8sClient.Update(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
 
-			Expect(cluster.Annotations).ToNot(BeNil())
-			Expect(cluster.Annotations[constants.ClusterPauseLabel]).To(Equal(cluster.Labels[v1alpha3.LabelTKR]))
-			Expect(cluster.Spec.Paused).To(BeTrue())
-		})
-	})
-
-	Context("if no change in the value of the cluster's TKR label", func() {
-		It("webhook should not set pause state in the cluster object", func() {
-			// Create a cluster object
-			cluster := &clusterapiv1beta1.Cluster{}
-			cluster.Name = testClusterName
-			cluster.Namespace = addonNamespace
-			cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.19.3---vmware.1"}
-			err := k8sClient.Create(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
-
-			// It shouldn't be paused
-			key := client.ObjectKey{
-				Namespace: cluster.Namespace,
-				Name:      cluster.Name,
-			}
-			err = k8sClient.Get(ctx, key, cluster)
-			cluster = cluster.DeepCopy()
-			Expect(err).ToNot(HaveOccurred())
-			if cluster.Annotations != nil {
-				_, ok := cluster.Annotations[constants.ClusterPauseLabel]
-				Expect(ok).ToNot(BeTrue())
-			}
-			Expect(cluster.Spec.Paused).ToNot(BeTrue())
-
-			// Update cluster version
-			cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.19.3---vmware.1"}
-			err = k8sClient.Update(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Cluster should not be paused
-			Expect(cluster.Spec.Paused).ToNot(BeTrue())
-			Expect(cluster.Annotations).To(BeNil())
-		})
-	})
-
-	Context("if cluster's TKR label is removed during update", func() {
-		It("webhook should not set pause state in the cluster object", func() {
-			// Create a cluster object
-			cluster := &clusterapiv1beta1.Cluster{}
-			cluster.Name = testClusterName
-			cluster.Namespace = addonNamespace
-			cluster.Labels = map[string]string{v1alpha3.LabelTKR: "v1.19.3---vmware.1"}
-			err := k8sClient.Create(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
-
-			// It shouldn't be paused
-			key := client.ObjectKey{
-				Namespace: cluster.Namespace,
-				Name:      cluster.Name,
-			}
-			err = k8sClient.Get(ctx, key, cluster)
-			cluster = cluster.DeepCopy()
-			Expect(err).ToNot(HaveOccurred())
-			if cluster.Annotations != nil {
-				_, ok := cluster.Annotations[constants.ClusterPauseLabel]
-				Expect(ok).ToNot(BeTrue())
-			}
-			Expect(cluster.Spec.Paused).ToNot(BeTrue())
-
-			// Update cluster version
-			cluster.Labels = map[string]string{}
-			err = k8sClient.Update(ctx, cluster)
-			Expect(err).ToNot(HaveOccurred())
-
-			// Cluster should not be paused
-			Expect(cluster.Spec.Paused).ToNot(BeTrue())
-			Expect(cluster.Annotations).To(BeNil())
+				// Cluster should not be paused
+				Expect(cluster.Annotations).To(BeNil())
+			})
 		})
 	})
 })

--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -162,8 +162,8 @@ func (r *ClusterBootstrapReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	if _, labelFound := tkr.Labels[constants.TKRLabelClassyClusters]; labelFound {
-		log.Info("Skipping reconciling due to tkr label", "name", tkrName, "label", constants.TKRLabelClassyClusters)
+	if _, labelFound := tkr.Labels[constants.TKRLabelLegacyClusters]; labelFound {
+		log.Info("Skipping reconciling due to tkr label", "name", tkrName, "label", constants.TKRLabelLegacyClusters)
 		return ctrl.Result{}, nil
 	}
 

--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -162,8 +162,8 @@ func (r *ClusterBootstrapReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	if _, labelFound := tkr.Labels[constants.TKRLableLegacyClusters]; labelFound {
-		log.Info("Skipping reconciling due to tkr label", "name", tkrName, "label", constants.TKRLableLegacyClusters)
+	if _, labelFound := tkr.Labels[constants.TKRLabelClassyClusters]; labelFound {
+		log.Info("Skipping reconciling due to tkr label", "name", tkrName, "label", constants.TKRLabelClassyClusters)
 		return ctrl.Result{}, nil
 	}
 

--- a/addons/controllers/testdata/webhooks/cluster-pause-webhook-manifest-with-legacy-tkr-label.yaml
+++ b/addons/controllers/testdata/webhooks/cluster-pause-webhook-manifest-with-legacy-tkr-label.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: TanzuKubernetesRelease
+metadata:
+  name: v1.20.1---vmware.1
+  labels:
+    run.tanzu.vmware.com/legacy-tkr: ""
+spec:
+  version: v1.20.1+vmware.1
+  kubernetes:
+    version: v1.20.1+vmware.1
+    imageRepository: foo
+  osImages: [ ]
+  bootstrapPackages: [ ]

--- a/addons/controllers/testdata/webhooks/cluster-pause-webhook-manifest.yaml
+++ b/addons/controllers/testdata/webhooks/cluster-pause-webhook-manifest.yaml
@@ -30,3 +30,15 @@ webhooks:
           - clusters
     sideEffects: None
     timeoutSeconds: 10
+---
+  apiVersion: run.tanzu.vmware.com/v1alpha3
+  kind: TanzuKubernetesRelease
+  metadata:
+    name: v1.19.3---vmware.1
+  spec:
+    version: v1.19.3+vmware.1
+    kubernetes:
+      version: v1.19.3+vmware.1
+      imageRepository: foo
+    osImages: [ ]
+    bootstrapPackages: [ ]

--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -45,7 +45,7 @@ const (
 	TKRLabelClassyClusters = "run.tanzu.vmware.com/tkr"
 
 	// TKRLabelLegacyClusters is the TKR label for legacy clusters
-	TKRLableLegacyClusters = "run.tanzu.vmware.com/legacy-tkr"
+	TKRLabelLegacyClusters = "run.tanzu.vmware.com/legacy-tkr"
 
 	// TKGAnnotationTemplateConfig is the TKG annotation for addon config CRs used by ClusterBootstrapTemplate
 	TKGAnnotationTemplateConfig = "tkg.tanzu.vmware.com/template-config"

--- a/addons/webhooks/cluster_pause_webhook.go
+++ b/addons/webhooks/cluster_pause_webhook.go
@@ -86,7 +86,7 @@ func (wh *ClusterPause) Default(ctx context.Context, obj runtime.Object) error {
 			return err
 		}
 		if currentTKR != nil && currentTKR.Labels != nil {
-			if _, ok := currentTKR.Labels[constants.TKRLableLegacyClusters]; ok {
+			if _, ok := currentTKR.Labels[constants.TKRLabelClassyClusters]; ok {
 				return nil
 			}
 		}

--- a/addons/webhooks/cluster_pause_webhook.go
+++ b/addons/webhooks/cluster_pause_webhook.go
@@ -86,7 +86,7 @@ func (wh *ClusterPause) Default(ctx context.Context, obj runtime.Object) error {
 			return err
 		}
 		if currentTKR != nil && currentTKR.Labels != nil {
-			if _, ok := currentTKR.Labels[constants.TKRLabelClassyClusters]; ok {
+			if _, ok := currentTKR.Labels[constants.TKRLabelLegacyClusters]; ok {
 				return nil
 			}
 		}

--- a/addons/webhooks/cluster_pause_webhook_test.go
+++ b/addons/webhooks/cluster_pause_webhook_test.go
@@ -214,7 +214,7 @@ var _ = Describe("ClusterPause Webhook", func() {
 					TypeMeta:   metav1.TypeMeta{Kind: "Cluster"},
 					ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testNamespace, Labels: map[string]string{v1alpha3.LabelTKR: "1.23.5"}},
 				}
-				currentTKR.Labels = map[string]string{constants.TKRLabelClassyClusters: ""}
+				currentTKR.Labels = map[string]string{constants.TKRLabelLegacyClusters: ""}
 				crtCtl = &fakes.CRTClusterClient{}
 				wh = &ClusterPause{Client: crtCtl}
 				err = wh.Default(ctx, input)
@@ -233,7 +233,7 @@ var _ = Describe("ClusterPause Webhook", func() {
 					TypeMeta:   metav1.TypeMeta{Kind: "Cluster"},
 					ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testNamespace, Labels: map[string]string{v1alpha3.LabelTKR: "1.23.5"}},
 				}
-				currentTKR.Labels = map[string]string{constants.TKRLabelClassyClusters: ""}
+				currentTKR.Labels = map[string]string{constants.TKRLabelLegacyClusters: ""}
 				currentTKR.Name = testTKRName
 				crtCtl = &fakes.CRTClusterClient{}
 				crtCtl.GetReturns(apierrors.NewNotFound(schema.GroupResource{Resource: "TanzuKubernetesRelease"}, testClusterName))
@@ -254,7 +254,7 @@ var _ = Describe("ClusterPause Webhook", func() {
 					TypeMeta:   metav1.TypeMeta{Kind: "Cluster"},
 					ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testNamespace, Labels: map[string]string{v1alpha3.LabelTKR: "1.23.5"}},
 				}
-				currentTKR.Labels = map[string]string{constants.TKRLabelClassyClusters: ""}
+				currentTKR.Labels = map[string]string{constants.TKRLabelLegacyClusters: ""}
 				currentTKR.Name = testTKRName
 				crtCtl = &fakes.CRTClusterClient{}
 				crtCtl.GetReturns(errors.New("some error"))

--- a/addons/webhooks/cluster_pause_webhook_test.go
+++ b/addons/webhooks/cluster_pause_webhook_test.go
@@ -214,7 +214,7 @@ var _ = Describe("ClusterPause Webhook", func() {
 					TypeMeta:   metav1.TypeMeta{Kind: "Cluster"},
 					ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testNamespace, Labels: map[string]string{v1alpha3.LabelTKR: "1.23.5"}},
 				}
-				currentTKR.Labels = map[string]string{constants.TKRLableLegacyClusters: ""}
+				currentTKR.Labels = map[string]string{constants.TKRLabelClassyClusters: ""}
 				crtCtl = &fakes.CRTClusterClient{}
 				wh = &ClusterPause{Client: crtCtl}
 				err = wh.Default(ctx, input)
@@ -233,7 +233,7 @@ var _ = Describe("ClusterPause Webhook", func() {
 					TypeMeta:   metav1.TypeMeta{Kind: "Cluster"},
 					ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testNamespace, Labels: map[string]string{v1alpha3.LabelTKR: "1.23.5"}},
 				}
-				currentTKR.Labels = map[string]string{constants.TKRLableLegacyClusters: ""}
+				currentTKR.Labels = map[string]string{constants.TKRLabelClassyClusters: ""}
 				currentTKR.Name = testTKRName
 				crtCtl = &fakes.CRTClusterClient{}
 				crtCtl.GetReturns(apierrors.NewNotFound(schema.GroupResource{Resource: "TanzuKubernetesRelease"}, testClusterName))
@@ -254,7 +254,7 @@ var _ = Describe("ClusterPause Webhook", func() {
 					TypeMeta:   metav1.TypeMeta{Kind: "Cluster"},
 					ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testNamespace, Labels: map[string]string{v1alpha3.LabelTKR: "1.23.5"}},
 				}
-				currentTKR.Labels = map[string]string{constants.TKRLableLegacyClusters: ""}
+				currentTKR.Labels = map[string]string{constants.TKRLabelClassyClusters: ""}
 				currentTKR.Name = testTKRName
 				crtCtl = &fakes.CRTClusterClient{}
 				crtCtl.GetReturns(errors.New("some error"))

--- a/addons/webhooks/cluster_pause_webhook_test.go
+++ b/addons/webhooks/cluster_pause_webhook_test.go
@@ -8,6 +8,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
+	tkgconstants "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +26,7 @@ import (
 const (
 	testClusterName = "test-cluster"
 	testNamespace   = "test-namespace"
+	testTKRName     = "test-tkr"
 )
 
 var _ = Describe("ClusterPause Webhook", func() {
@@ -56,6 +61,7 @@ var _ = Describe("ClusterPause Webhook", func() {
 			})
 			It("should succeed", func() {
 				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cluster.GetAnnotations()).To(BeNil())
 			})
 		})
 
@@ -69,6 +75,7 @@ var _ = Describe("ClusterPause Webhook", func() {
 			})
 			It("should succeed", func() {
 				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cluster.GetAnnotations()).To(BeNil())
 			})
 		})
 
@@ -103,11 +110,12 @@ var _ = Describe("ClusterPause Webhook", func() {
 			})
 			It("should succeed", func() {
 				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cluster.GetAnnotations()).To(HaveKey(tkgconstants.ClusterPauseLabel))
 				Expect(cluster.GetAnnotations()).To(ContainElements("1.21.2"))
 			})
 		})
 
-		When("the currentCluster's labels does not include v1alpha3.LabelTKR", func() {
+		When("the currentCluster's labels does not include 'run.tanzu.vmware.com/tkr'", func() {
 			BeforeEach(func() {
 				currentCluster.Labels = map[string]string{}
 				input = &clusterv1.Cluster{
@@ -120,6 +128,25 @@ var _ = Describe("ClusterPause Webhook", func() {
 			})
 			It("should succeed", func() {
 				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cluster.GetAnnotations()).To(HaveKey(tkgconstants.ClusterPauseLabel))
+				Expect(cluster.GetAnnotations()).To(ContainElements("1.21.2"))
+			})
+		})
+
+		When("the currentCluster's labels include 'run.tanzu.vmware.com/tkr' but with empty value", func() {
+			BeforeEach(func() {
+				currentCluster.Labels = map[string]string{v1alpha3.LabelTKR: ""}
+				input = &clusterv1.Cluster{
+					TypeMeta:   metav1.TypeMeta{Kind: "Cluster"},
+					ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testNamespace, Labels: map[string]string{v1alpha3.LabelTKR: "1.21.2"}},
+				}
+				crtCtl = &fakes.CRTClusterClient{}
+				wh = &ClusterPause{Client: crtCtl}
+				err = wh.Default(ctx, input)
+			})
+			It("should succeed", func() {
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cluster.GetAnnotations()).To(HaveKey(tkgconstants.ClusterPauseLabel))
 				Expect(cluster.GetAnnotations()).To(ContainElements("1.21.2"))
 			})
 		})
@@ -137,7 +164,108 @@ var _ = Describe("ClusterPause Webhook", func() {
 			})
 			It("should succeed", func() {
 				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cluster.GetAnnotations()).To(HaveKey(tkgconstants.ClusterPauseLabel))
 				Expect(cluster.GetAnnotations()).To(ContainElements("1.23.5"))
+			})
+		})
+
+		When("the currentCluster's corresponding TKR does not have any label", func() {
+			BeforeEach(func() {
+				currentCluster.Labels = map[string]string{v1alpha3.LabelTKR: "1.21.2"}
+				input = &clusterv1.Cluster{
+					TypeMeta:   metav1.TypeMeta{Kind: "Cluster"},
+					ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testNamespace, Labels: map[string]string{v1alpha3.LabelTKR: "1.23.5"}},
+				}
+				currentTKR.Labels = map[string]string{}
+				crtCtl = &fakes.CRTClusterClient{}
+				wh = &ClusterPause{Client: crtCtl}
+				err = wh.Default(ctx, input)
+			})
+			It("should succeed", func() {
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cluster.GetAnnotations()).To(HaveKey(tkgconstants.ClusterPauseLabel))
+				Expect(cluster.GetAnnotations()).To(ContainElements("1.23.5"))
+			})
+		})
+
+		When("the currentCluster's corresponding TKR does not have 'run.tanzu.vmware.com/legacy-tkr' label", func() {
+			BeforeEach(func() {
+				currentCluster.Labels = map[string]string{v1alpha3.LabelTKR: "1.21.2"}
+				input = &clusterv1.Cluster{
+					TypeMeta:   metav1.TypeMeta{Kind: "Cluster"},
+					ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testNamespace, Labels: map[string]string{v1alpha3.LabelTKR: "1.23.5"}},
+				}
+				currentTKR.Labels = map[string]string{"someLabel": ""}
+				crtCtl = &fakes.CRTClusterClient{}
+				wh = &ClusterPause{Client: crtCtl}
+				err = wh.Default(ctx, input)
+			})
+			It("should succeed", func() {
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cluster.GetAnnotations()).To(HaveKey(tkgconstants.ClusterPauseLabel))
+				Expect(cluster.GetAnnotations()).To(ContainElements("1.23.5"))
+			})
+		})
+
+		When("the currentCluster's corresponding TKR has 'run.tanzu.vmware.com/legacy-tkr' label", func() {
+			BeforeEach(func() {
+				currentCluster.Labels = map[string]string{v1alpha3.LabelTKR: "1.21.2"}
+				input = &clusterv1.Cluster{
+					TypeMeta:   metav1.TypeMeta{Kind: "Cluster"},
+					ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testNamespace, Labels: map[string]string{v1alpha3.LabelTKR: "1.23.5"}},
+				}
+				currentTKR.Labels = map[string]string{constants.TKRLableLegacyClusters: ""}
+				crtCtl = &fakes.CRTClusterClient{}
+				wh = &ClusterPause{Client: crtCtl}
+				err = wh.Default(ctx, input)
+			})
+			It("should succeed", func() {
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cluster.GetAnnotations()).NotTo(HaveKey(tkgconstants.ClusterPauseLabel))
+				Expect(cluster.GetAnnotations()).NotTo(ContainElements("1.23.5"))
+			})
+		})
+
+		When("the currentCluster's corresponding TKR has 'run.tanzu.vmware.com/legacy-tkr' label but TKR object is not found", func() {
+			BeforeEach(func() {
+				currentCluster.Labels = map[string]string{v1alpha3.LabelTKR: "1.21.2"}
+				input = &clusterv1.Cluster{
+					TypeMeta:   metav1.TypeMeta{Kind: "Cluster"},
+					ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testNamespace, Labels: map[string]string{v1alpha3.LabelTKR: "1.23.5"}},
+				}
+				currentTKR.Labels = map[string]string{constants.TKRLableLegacyClusters: ""}
+				currentTKR.Name = testTKRName
+				crtCtl = &fakes.CRTClusterClient{}
+				crtCtl.GetReturns(apierrors.NewNotFound(schema.GroupResource{Resource: "TanzuKubernetesRelease"}, testClusterName))
+				wh = &ClusterPause{Client: crtCtl}
+				err = wh.Default(ctx, input)
+			})
+			It("should succeed", func() {
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(cluster.GetAnnotations()).NotTo(HaveKey(tkgconstants.ClusterPauseLabel))
+				Expect(cluster.GetAnnotations()).NotTo(ContainElements("1.23.5"))
+			})
+		})
+
+		When("the currentCluster's corresponding TKR has 'run.tanzu.vmware.com/legacy-tkr' label but there was another error while fetching the TKR object", func() {
+			BeforeEach(func() {
+				currentCluster.Labels = map[string]string{v1alpha3.LabelTKR: "1.21.2"}
+				input = &clusterv1.Cluster{
+					TypeMeta:   metav1.TypeMeta{Kind: "Cluster"},
+					ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testNamespace, Labels: map[string]string{v1alpha3.LabelTKR: "1.23.5"}},
+				}
+				currentTKR.Labels = map[string]string{constants.TKRLableLegacyClusters: ""}
+				currentTKR.Name = testTKRName
+				crtCtl = &fakes.CRTClusterClient{}
+				crtCtl.GetReturns(errors.New("some error"))
+				wh = &ClusterPause{Client: crtCtl}
+				err = wh.Default(ctx, input)
+			})
+			It("should fail", func() {
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("some error"))
+				Expect(cluster.GetAnnotations()).NotTo(HaveKey(tkgconstants.ClusterPauseLabel))
+				Expect(cluster.GetAnnotations()).NotTo(ContainElements("1.23.5"))
 			})
 		})
 	})


### PR DESCRIPTION
Signed-off-by: Marjan Alavi <malavi@vmware.com>

### What this PR does / why we need it
change cluster pause webhook behavior to no pause for legacy tkr

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2934 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm:  change cluster pause webhook behavior to not pause for legacy TKGS tkr's
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [X] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [X] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [X] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
