### PR TITLE
Support air-gapped scenario for context-scoped plugins to allow registry override

### DIFF
--- a/pkg/v1/cli/discovery/kubernetes_test.go
+++ b/pkg/v1/cli/discovery/kubernetes_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Unit tests for kubernetes discovery", func() {
 			BeforeEach(func() {
 				currentClusterClient.VerifyCLIPluginCRDReturns(false, errors.New("fake error"))
 			})
-			It("return empty plugin list without an error", func() {
+			It("should return empty plugin list without an error", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(plugins)).To(Equal(0))
 			})
@@ -54,7 +54,7 @@ var _ = Describe("Unit tests for kubernetes discovery", func() {
 			BeforeEach(func() {
 				currentClusterClient.VerifyCLIPluginCRDReturns(false, nil)
 			})
-			It("return empty plugin list without an error", func() {
+			It("should return empty plugin list without an error", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(plugins)).To(Equal(0))
 			})
@@ -63,7 +63,7 @@ var _ = Describe("Unit tests for kubernetes discovery", func() {
 			BeforeEach(func() {
 				currentClusterClient.VerifyCLIPluginCRDReturns(true, errors.New("fake error"))
 			})
-			It("return empty plugin list without an error", func() {
+			It("should return empty plugin list without an error", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(plugins)).To(Equal(0))
 			})
@@ -74,7 +74,7 @@ var _ = Describe("Unit tests for kubernetes discovery", func() {
 				currentClusterClient.VerifyCLIPluginCRDReturns(true, nil)
 				currentClusterClient.ListCLIPluginResourcesReturns(nil, errors.New("fake error"))
 			})
-			It("return empty plugin list with an error", func() {
+			It("should return empty plugin list with an error", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(len(plugins)).To(Equal(0))
 			})
@@ -83,17 +83,73 @@ var _ = Describe("Unit tests for kubernetes discovery", func() {
 			BeforeEach(func() {
 				cliplugin1 := fakehelper.NewCLIPlugin(fakehelper.TestCLIPluginOption{Name: "plugin1", Description: "plugin1 desc", RecommendedVersion: "v0.0.1"})
 				cliplugin2 := fakehelper.NewCLIPlugin(fakehelper.TestCLIPluginOption{Name: "plugin2", Description: "plugin2 desc", RecommendedVersion: "v0.0.2"})
+				cliplugins = []v1alpha1.CLIPlugin{}
 				cliplugins = append(cliplugins, cliplugin1, cliplugin2)
 				currentClusterClient.VerifyCLIPluginCRDReturns(true, nil)
 				currentClusterClient.ListCLIPluginResourcesReturns(cliplugins, nil)
+				currentClusterClient.GetCLIPluginImageRepositoryOverrideReturns(map[string]string{}, nil)
 			})
-			It("return ordered list of plugins without error", func() {
+			It("should return ordered list of plugins without error", func() {
 				Expect(len(plugins)).To(Equal(2))
 				Expect(plugins[0].Name).To(Equal("plugin1"))
 				Expect(plugins[0].RecommendedVersion).To(Equal("v0.0.1"))
 				Expect(plugins[1].Name).To(Equal("plugin2"))
 				Expect(plugins[1].RecommendedVersion).To(Equal("v0.0.2"))
 				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("When ListCLIPluginResources list of CLIPlugin resources but GetCLIPluginImageRepositoryOverrideReturns return error", func() {
+			BeforeEach(func() {
+				cliplugin1 := fakehelper.NewCLIPlugin(fakehelper.TestCLIPluginOption{Name: "plugin1", Description: "plugin1 desc", RecommendedVersion: "v0.0.1"})
+				cliplugin2 := fakehelper.NewCLIPlugin(fakehelper.TestCLIPluginOption{Name: "plugin2", Description: "plugin2 desc", RecommendedVersion: "v0.0.2"})
+				cliplugins = []v1alpha1.CLIPlugin{}
+				cliplugins = append(cliplugins, cliplugin1, cliplugin2)
+				currentClusterClient.VerifyCLIPluginCRDReturns(true, nil)
+				currentClusterClient.ListCLIPluginResourcesReturns(cliplugins, nil)
+				currentClusterClient.GetCLIPluginImageRepositoryOverrideReturns(map[string]string{}, errors.New("fake-error-image-repo-override"))
+			})
+			It("should return ordered list of plugins without error", func() {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(plugins[0].Name).To(Equal("plugin1"))
+				Expect(plugins[0].RecommendedVersion).To(Equal("v0.0.1"))
+				Expect(plugins[1].Name).To(Equal("plugin2"))
+				Expect(plugins[1].RecommendedVersion).To(Equal("v0.0.2"))
+				artifact, errArtifact := plugins[0].Distribution.DescribeArtifact("v1.0.0", "darwin", "amd64")
+				Expect(errArtifact).NotTo(HaveOccurred())
+				Expect(artifact.Image).To(Equal("fake.image.repo.com/tkg/plugin/test-darwin-plugin:v1.4.0"))
+			})
+		})
+
+		Context("When ListCLIPluginResources list of CLIPlugin resources and GetCLIPluginImageRepositoryOverrideReturns imageRepoOverride map ", func() {
+			BeforeEach(func() {
+				cliplugin1 := fakehelper.NewCLIPlugin(fakehelper.TestCLIPluginOption{Name: "plugin1", Description: "plugin1 desc", RecommendedVersion: "v0.0.1"})
+				cliplugin2 := fakehelper.NewCLIPlugin(fakehelper.TestCLIPluginOption{Name: "plugin2", Description: "plugin2 desc", RecommendedVersion: "v0.0.2"})
+				cliplugins = []v1alpha1.CLIPlugin{}
+				cliplugins = append(cliplugins, cliplugin1, cliplugin2)
+				imageOverrideMap := map[string]string{
+					"fake.image.repo.com": "custom.repo.com",
+				}
+				currentClusterClient.VerifyCLIPluginCRDReturns(true, nil)
+				currentClusterClient.ListCLIPluginResourcesReturns(cliplugins, nil)
+				currentClusterClient.GetCLIPluginImageRepositoryOverrideReturns(imageOverrideMap, nil)
+			})
+			It("should return ordered list of plugins and image override should be done in the artifact", func() {
+				Expect(len(plugins)).To(Equal(2))
+				Expect(plugins[0].Name).To(Equal("plugin1"))
+				Expect(plugins[0].RecommendedVersion).To(Equal("v0.0.1"))
+				Expect(plugins[1].Name).To(Equal("plugin2"))
+				Expect(plugins[1].RecommendedVersion).To(Equal("v0.0.2"))
+				Expect(err).NotTo(HaveOccurred())
+				artifact, errArtifact := plugins[0].Distribution.DescribeArtifact("v1.0.0", "darwin", "amd64")
+				Expect(errArtifact).NotTo(HaveOccurred())
+				Expect(artifact.Image).To(Equal("custom.repo.com/tkg/plugin/test-darwin-plugin:v1.4.0"))
+				artifact, errArtifact = plugins[0].Distribution.DescribeArtifact("v1.0.0", "windows", "amd64")
+				Expect(errArtifact).NotTo(HaveOccurred())
+				Expect(artifact.Image).To(Equal("custom.repo.com/tkg/plugin/test-windows-plugin:v1.4.0"))
+				artifact, errArtifact = plugins[0].Distribution.DescribeArtifact("v1.0.0", "linux", "amd64")
+				Expect(errArtifact).NotTo(HaveOccurred())
+				Expect(artifact.Image).To(Equal("custom.repo.com/tkg/plugin/test-linux-plugin:v1.4.0"))
 			})
 		})
 	})

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -22,6 +22,7 @@ import (
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
 	"github.com/yalp/jsonpath"
+	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	betav1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,7 +31,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -325,6 +328,8 @@ type Client interface {
 	IsClusterClassBased(clusterName, namespace string) (bool, error)
 	// GetClusterStatusInfo returns the cluster status information
 	GetClusterStatusInfo(clusterName, namespace string, workloadClusterClient Client) ClusterStatusInfo
+	// GetCLIPluginImageRepositoryOverride returns map of image repository override
+	GetCLIPluginImageRepositoryOverride() (map[string]string, error)
 }
 
 // PollOptions is options for polling
@@ -2346,6 +2351,39 @@ func (c *client) ListCLIPluginResources() ([]cliv1alpha1.CLIPlugin, error) {
 		return nil, err
 	}
 	return cliPlugins.Items, nil
+}
+
+// GetCLIPluginImageRepositoryOverride returns map of image repository override
+func (c *client) GetCLIPluginImageRepositoryOverride() (map[string]string, error) {
+	cmList := &corev1.ConfigMapList{}
+
+	labelMatch, _ := labels.NewRequirement(constants.CLIPluginImageRepositoryOverrideLabel, selection.Exists, []string{})
+	labelSelector := labels.NewSelector()
+	labelSelector = labelSelector.Add(*labelMatch)
+
+	err := c.ListResources(cmList, &crtclient.ListOptions{Namespace: constants.TanzuCLISystemNamespace, LabelSelector: labelSelector})
+	if err != nil {
+		return nil, err
+	}
+
+	imageRepoMap := make(map[string]string)
+
+	for _, cm := range cmList.Items {
+		mapString, ok := cm.Data["imageRepoMap"]
+		if !ok {
+			continue
+		}
+		irm := make(map[string]string)
+		err = yaml.Unmarshal([]byte(mapString), &irm)
+		for k, v := range irm {
+			if _, exists := imageRepoMap[k]; exists {
+				return nil, errors.Errorf("multiple references of image repository %q found while doing image repository override", k)
+			}
+			imageRepoMap[k] = v
+		}
+	}
+
+	return imageRepoMap, nil
 }
 
 // IsClusterClassBased check whether cluster is ClusterClass based or not

--- a/pkg/v1/tkg/constants/cluster_internal.go
+++ b/pkg/v1/tkg/constants/cluster_internal.go
@@ -146,6 +146,8 @@ const (
 	ClusterPauseLabel = "tkg.tanzu.vmware.com/paused"
 	// PackageTypeLabel is the label on the PackageInstall which mentions type of the package
 	PackageTypeLabel = "tkg.tanzu.vmware.com/package-type"
+	// CLIPluginImageRepositoryOverrideLabel is the label on the configmap which specifies CLIPlugin image repository override
+	CLIPluginImageRepositoryOverrideLabel = "cli.tanzu.vmware.com/cliplugin-image-repository-override"
 )
 
 // TKG management package related constants
@@ -154,4 +156,8 @@ const (
 	TKGManagementPackageInstallName    = "tkg-pkg"
 	TKGManagementPackageRepositoryName = "tanzu-management"
 	PackageTypeManagement              = "management"
+)
+
+const (
+	TanzuCLISystemNamespace = "tanzu-cli-system"
 )

--- a/pkg/v1/tkg/fakes/clusterclient.go
+++ b/pkg/v1/tkg/fakes/clusterclient.go
@@ -202,6 +202,18 @@ type ClusterClient struct {
 		result1 v1.ConfigMap
 		result2 error
 	}
+	GetCLIPluginImageRepositoryOverrideStub        func() (map[string]string, error)
+	getCLIPluginImageRepositoryOverrideMutex       sync.RWMutex
+	getCLIPluginImageRepositoryOverrideArgsForCall []struct {
+	}
+	getCLIPluginImageRepositoryOverrideReturns struct {
+		result1 map[string]string
+		result2 error
+	}
+	getCLIPluginImageRepositoryOverrideReturnsOnCall map[int]struct {
+		result1 map[string]string
+		result2 error
+	}
 	GetClientSetStub        func() clusterclient.CrtClient
 	getClientSetMutex       sync.RWMutex
 	getClientSetArgsForCall []struct {
@@ -2074,6 +2086,62 @@ func (fake *ClusterClient) GetBomConfigMapReturnsOnCall(i int, result1 v1.Config
 	}
 	fake.getBomConfigMapReturnsOnCall[i] = struct {
 		result1 v1.ConfigMap
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ClusterClient) GetCLIPluginImageRepositoryOverride() (map[string]string, error) {
+	fake.getCLIPluginImageRepositoryOverrideMutex.Lock()
+	ret, specificReturn := fake.getCLIPluginImageRepositoryOverrideReturnsOnCall[len(fake.getCLIPluginImageRepositoryOverrideArgsForCall)]
+	fake.getCLIPluginImageRepositoryOverrideArgsForCall = append(fake.getCLIPluginImageRepositoryOverrideArgsForCall, struct {
+	}{})
+	stub := fake.GetCLIPluginImageRepositoryOverrideStub
+	fakeReturns := fake.getCLIPluginImageRepositoryOverrideReturns
+	fake.recordInvocation("GetCLIPluginImageRepositoryOverride", []interface{}{})
+	fake.getCLIPluginImageRepositoryOverrideMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ClusterClient) GetCLIPluginImageRepositoryOverrideCallCount() int {
+	fake.getCLIPluginImageRepositoryOverrideMutex.RLock()
+	defer fake.getCLIPluginImageRepositoryOverrideMutex.RUnlock()
+	return len(fake.getCLIPluginImageRepositoryOverrideArgsForCall)
+}
+
+func (fake *ClusterClient) GetCLIPluginImageRepositoryOverrideCalls(stub func() (map[string]string, error)) {
+	fake.getCLIPluginImageRepositoryOverrideMutex.Lock()
+	defer fake.getCLIPluginImageRepositoryOverrideMutex.Unlock()
+	fake.GetCLIPluginImageRepositoryOverrideStub = stub
+}
+
+func (fake *ClusterClient) GetCLIPluginImageRepositoryOverrideReturns(result1 map[string]string, result2 error) {
+	fake.getCLIPluginImageRepositoryOverrideMutex.Lock()
+	defer fake.getCLIPluginImageRepositoryOverrideMutex.Unlock()
+	fake.GetCLIPluginImageRepositoryOverrideStub = nil
+	fake.getCLIPluginImageRepositoryOverrideReturns = struct {
+		result1 map[string]string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ClusterClient) GetCLIPluginImageRepositoryOverrideReturnsOnCall(i int, result1 map[string]string, result2 error) {
+	fake.getCLIPluginImageRepositoryOverrideMutex.Lock()
+	defer fake.getCLIPluginImageRepositoryOverrideMutex.Unlock()
+	fake.GetCLIPluginImageRepositoryOverrideStub = nil
+	if fake.getCLIPluginImageRepositoryOverrideReturnsOnCall == nil {
+		fake.getCLIPluginImageRepositoryOverrideReturnsOnCall = make(map[int]struct {
+			result1 map[string]string
+			result2 error
+		})
+	}
+	fake.getCLIPluginImageRepositoryOverrideReturnsOnCall[i] = struct {
+		result1 map[string]string
 		result2 error
 	}{result1, result2}
 }
@@ -6706,6 +6774,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.getAzureCredentialsFromSecretMutex.RUnlock()
 	fake.getBomConfigMapMutex.RLock()
 	defer fake.getBomConfigMapMutex.RUnlock()
+	fake.getCLIPluginImageRepositoryOverrideMutex.RLock()
+	defer fake.getCLIPluginImageRepositoryOverrideMutex.RUnlock()
 	fake.getClientSetMutex.RLock()
 	defer fake.getClientSetMutex.RUnlock()
 	fake.getClusterInfrastructureMutex.RLock()

--- a/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
+++ b/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
@@ -586,6 +586,23 @@ func GetFakePinnipedInfo(pinnipedInfo PinnipedInfo) string {
 
 // NewCLIPlugin returns new NewCLIPlugin object
 func NewCLIPlugin(options TestCLIPluginOption) v1alpha1.CLIPlugin {
+	artifacts := []v1alpha1.Artifact{
+		{
+			Image: "fake.image.repo.com/tkg/plugin/test-darwin-plugin:v1.4.0",
+			OS:    "darwin",
+			Arch:  "amd64",
+		},
+		{
+			Image: "fake.image.repo.com/tkg/plugin/test-linux-plugin:v1.4.0",
+			OS:    "linux",
+			Arch:  "amd64",
+		},
+		{
+			Image: "fake.image.repo.com/tkg/plugin/test-windows-plugin:v1.4.0",
+			OS:    "windows",
+			Arch:  "amd64",
+		},
+	}
 	cliplugin := v1alpha1.CLIPlugin{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: options.Name,
@@ -593,6 +610,9 @@ func NewCLIPlugin(options TestCLIPluginOption) v1alpha1.CLIPlugin {
 		Spec: v1alpha1.CLIPluginSpec{
 			Description:        options.Description,
 			RecommendedVersion: options.RecommendedVersion,
+			Artifacts: map[string]v1alpha1.ArtifactList{
+				"v1.0.0": artifacts,
+			},
 		},
 	}
 	return cliplugin


### PR DESCRIPTION
### What this PR does / why we need it
- This will allow admins to create a configMap on the server to point
  the context-scoped OCI based plugins to point to different image
  registry instead of the registry mentioned as part of CLIPlugin
  resource
- To do that admin need to create a configmap on the management-cluster
  with a specific label `cli.tanzu.vmware.com/cliplugin-image-repository-override` in `tanzu-cli-system` namespace

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2936

### Describe testing done for PR
- Create CLIPlugin resource on the management-cluster which points plugins to be downloaded from `projects.registry.vmware.com/tkg` registry.
```
apiVersion: cli.tanzu.vmware.com/v1alpha1
kind: CLIPlugin
metadata:
  name: cluster
spec:
  artifacts:
    v0.0.0-build.1:
    - arch: amd64
      image: projects.registry.vmware.com/tkg/tanzu_core/tanzu-cli-plugins/cluster-darwin-amd64:v0.0.0
      os: darwin
      type: oci
    - arch: amd64
      image: projects.registry.vmware.com/tkg/tanzu_core/tanzu-cli-plugins/cluster-linux-amd64:v0.0.0
      os: linux
      type: oci
    - arch: amd64
      image: projects.registry.vmware.com/tkg/tanzu_core/tanzu-cli-plugins/cluster-windows-amd64:v0.0.0
      os: windows
      type: oci
  description: Kubernetes cluster operations
  optional: false
  recommendedVersion: v0.0.0-build.1
```

- To double check, make sure the OCI images mentioned here doesn't exists.
- Create a configmap on the supervisor cluster to do registry override
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: context-plugin-repository-override
  namespace: tanzu-cli-system
  labels:
    cli.tanzu.vmware.com/cliplugin-image-repository-override: ""
data: 
  imageRepoMap: |- 
    projects.registry.vmware.com/tkg: projects-stg.registry.vmware.com/tkg/sandbox
```
- Login to the above management-cluster
- Verify the plugins by running below commands
    - `tanzu plugin list`
    - `tanzu plugin sync`
    - `tanzu plugin install cluster` 

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support air-gapped scenario for context-scoped plugins to allow registry override
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
