### PR TITLE
Change AKO default service type to npl when cni is antrea

### DIFF
--- a/pkg/v1/providers/ytt/02_addons/avi/ako_operator_secret.yaml
+++ b/pkg/v1/providers/ytt/02_addons/avi/ako_operator_secret.yaml
@@ -3,6 +3,16 @@
 #@ load("@ytt:json", "json")
 #@ load("/lib/helpers.star", "ValuesFormatStr")
 
+#@ def avi_node_network_list():
+#@  if data.values.AVI_INGRESS_NODE_NETWORK_LIST:
+#@    return json.encode(data.values.AVI_INGRESS_NODE_NETWORK_LIST)
+#@  else:
+#@    network_pathes = data.values.VSPHERE_NETWORK.split("/")
+#@    network = network_pathes[len(network_pathes)-1]
+#@    return json.encode([{"networkName":"{}".format(network)}])
+#@  end
+#@ end
+
 #@ def ako_operator_config():
 ---
 akoOperator:
@@ -14,7 +24,7 @@ akoOperator:
     avi_ingress_default_ingress_controller: #@ data.values.AVI_INGRESS_DEFAULT_INGRESS_CONTROLLER
     avi_ingress_shard_vs_size: #@ data.values.AVI_INGRESS_SHARD_VS_SIZE
     avi_ingress_service_type: #@ data.values.AVI_INGRESS_SERVICE_TYPE
-    avi_ingress_node_network_list: #@ json.encode(data.values.AVI_INGRESS_NODE_NETWORK_LIST)
+    avi_ingress_node_network_list: #@ avi_node_network_list()
     avi_admin_credential_name: #@ data.values.AVI_ADMIN_CREDENTIAL_NAME
     avi_ca_name: #@ data.values.AVI_CA_NAME
     avi_controller: #@ data.values.AVI_CONTROLLER

--- a/pkg/v1/providers/ytt/03_customizations/02_avi/ako-deployment.lib.yaml
+++ b/pkg/v1/providers/ytt/03_customizations/02_avi/ako-deployment.lib.yaml
@@ -87,7 +87,7 @@ data:
   defaultIngController: #@ "{}".format(data.values.AVI_INGRESS_DEFAULT_INGRESS_CONTROLLER).lower()
   logLevel: "WARN"
   deleteConfig: "false"
-  serviceType:  NodePort
+  serviceType: NodePort
 #@ if data.values.AVI_NSXT_T1LR:
   nsxtT1LR: #@ data.values.AVI_NSXT_T1LR
 #@ end


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>

### What this PR does / why we need it

- Change AKO(vmware/load-balancer-and-ingress-service)'s default service type to `NodePortLocal` when cluster CNI is antrea.
- Pass `nodeNetworkList` to ako configmap since it becomes a required value when service type is not `NodePort`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2939

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Created vSphere management cluster & workload clusters verified the change.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
When cluster's CNI implementation is Antrea, AKO will use NodePortLocal routing mode by default
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
