### PR TITLE
Add E2E tests for Antrea/Calico CNI on tkgs

### DIFF
--- a/pkg/v1/tkg/client/cluster.go
+++ b/pkg/v1/tkg/client/cluster.go
@@ -237,13 +237,14 @@ func (c *TkgClient) waitForClusterCreation(regionalClusterClient clusterclient.C
 
 	c.WaitForAutoscalerDeployment(regionalClusterClient, options.ClusterName, options.TargetNamespace)
 
-	workloadClusterClient, err := clusterclient.NewClient(workloadClusterKubeconfigPath, kubeContext, clusterclient.Options{OperationTimeout: 15 * time.Minute})
-	if err != nil {
-		return errors.Wrap(err, "unable to create workload cluster client")
-	}
-
 	if !isTKGSCluster {
 		log.Info("Waiting for addons installation...")
+
+		workloadClusterClient, err := clusterclient.NewClient(workloadClusterKubeconfigPath, kubeContext, clusterclient.Options{OperationTimeout: 15 * time.Minute})
+		if err != nil {
+			return errors.Wrap(err, "unable to create workload cluster client")
+		}
+
 		if err := c.WaitForAddons(waitForAddonsOptions{
 			regionalClusterClient: regionalClusterClient,
 			workloadClusterClient: workloadClusterClient,

--- a/pkg/v1/tkg/test/tkgctl/tkgs/tkgs_suite_test.go
+++ b/pkg/v1/tkg/test/tkgctl/tkgs/tkgs_suite_test.go
@@ -90,9 +90,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		Plan:       "dev",
 	}
 	tkgctlClient, err = tkgctl.New(tkgctlOptions)
-	var isTKGS bool
-	isTKGS, err = tkgctlClient.IsPacificRegionalCluster()
 	Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("failed to connect cluster with given input kube config file:%v and context:%v, reason: %v", e2eConfig.TKGSKubeconfigPath, e2eConfig.TKGSKubeconfigContext, err))
+	isTKGS, err := tkgctlClient.IsPacificRegionalCluster()
+	Expect(err).ShouldNot(HaveOccurred())
 	Expect(isTKGS).To(Equal(true), fmt.Sprintf("the input kube config file:%v with given context:%v is not TKGS cluster", e2eConfig.TKGSKubeconfigPath, e2eConfig.TKGSKubeconfigContext))
 
 	featureGateHelper := tkgctlClient.FeatureGateHelper()

--- a/pkg/v1/tkg/test/tkgctl/tkgs/tkgs_workload_cluster_test.go
+++ b/pkg/v1/tkg/test/tkgctl/tkgs/tkgs_workload_cluster_test.go
@@ -17,7 +17,11 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgctl"
 )
 
-const TKC_KIND = "kind: TanzuKubernetesCluster"
+const (
+	TKC_KIND  = "kind: TanzuKubernetesCluster"
+	cniAntrea = "antrea"
+	cniCalico = "calico"
+)
 
 var _ = Describe("TKGS - Create TKC based workload cluster tests", func() {
 	var (
@@ -46,13 +50,31 @@ var _ = Describe("TKGS - Create TKC based workload cluster tests", func() {
 		AfterEach(func() {
 			defer os.Remove(clusterOptions.ClusterConfigFile)
 		})
+
 		Context("when cluster Plan is dev", func() {
 			BeforeEach(func() {
 				e2eConfig.WorkloadClusterOptions.ClusterPlan = "dev"
 			})
-			When("create cluster is invoked", func() {
+
+			When("create cluster is invoked with CNI Antrea", func() {
+				BeforeEach(func() {
+					clusterOptions.CniType = cniAntrea
+				})
 				AfterEach(func() {
 					err = tkgctlClient.DeleteCluster(deleteClusterOptions)
+				})
+				It("should create TKC Workload Cluster and delete it", func() {
+					Expect(err).To(BeNil())
+				})
+			})
+
+			When("create cluster is invoked with CNI Calico", func() {
+				BeforeEach(func() {
+					clusterOptions.CniType = cniCalico
+				})
+				AfterEach(func() {
+					err = tkgctlClient.DeleteCluster(deleteClusterOptions)
+					clusterOptions.CniType = cniAntrea
 				})
 				It("should create TKC Workload Cluster and delete it", func() {
 					Expect(err).To(BeNil())
@@ -82,15 +104,32 @@ var _ = Describe("TKGS - Create TKC based workload cluster tests", func() {
 				})
 			})
 		})
+
 		Context("when cluster Plan is prod", func() {
 			BeforeEach(func() {
 				clusterOptions.Plan = "prod"
 				clusterOptions.GenerateOnly = false
 			})
 
-			When("create cluster is invoked", func() {
+			When("create cluster is invoked with CNI Antrea", func() {
+				BeforeEach(func() {
+					clusterOptions.CniType = cniAntrea
+				})
 				AfterEach(func() {
 					err = tkgctlClient.DeleteCluster(deleteClusterOptions)
+				})
+				It("should create TKC Workload Cluster and delete it", func() {
+					Expect(err).To(BeNil())
+				})
+			})
+
+			When("create cluster is invoked with CNI Calico", func() {
+				BeforeEach(func() {
+					clusterOptions.CniType = cniCalico
+				})
+				AfterEach(func() {
+					err = tkgctlClient.DeleteCluster(deleteClusterOptions)
+					clusterOptions.CniType = cniAntrea
 				})
 				It("should create TKC Workload Cluster and delete it", func() {
 					Expect(err).To(BeNil())

--- a/pkg/v1/tkg/test/tkgctl/tkgs_cc/tkgs_cc_suite_test.go
+++ b/pkg/v1/tkg/test/tkgctl/tkgs_cc/tkgs_cc_suite_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/cluster-api/util"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/test/framework"
@@ -90,9 +91,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		Plan:       "dev",
 	}
 	tkgctlClient, err = tkgctl.New(tkgctlOptions)
-	var isTKGS bool
-	isTKGS, err = tkgctlClient.IsPacificRegionalCluster()
 	Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("failed to connect cluster with given input kube config file:%v and context:%v, reason: %v", e2eConfig.TKGSKubeconfigPath, e2eConfig.TKGSKubeconfigContext, err))
+	isTKGS, err := tkgctlClient.IsPacificRegionalCluster()
+	Expect(err).ShouldNot(HaveOccurred())
 	Expect(isTKGS).To(Equal(true), fmt.Sprintf("the input kube config file:%v with given context:%v is not TKGS cluster", e2eConfig.TKGSKubeconfigPath, e2eConfig.TKGSKubeconfigContext))
 
 	featureGateHelper := tkgctlClient.FeatureGateHelper()
@@ -155,4 +156,28 @@ func createClusterConfigFile(e2eConfig *framework.E2EConfig) string {
 	err = e2eConfig.SaveWorkloadClusterOptions(clusterConfigFile)
 	Expect(err).To(BeNil())
 	return clusterConfigFile
+}
+
+// getCalicoCNIClusterClassFile return temporary Cluster Class config file with Calico CNI
+func getCalicoCNIClusterClassFile(e2eConfig *framework.E2EConfig) string {
+	clusterConfigFile := e2eConfig.WorkloadClusterOptions.ClusterClassFilePath
+
+	_, err := os.Stat(clusterConfigFile)
+	Expect(err).To(BeNil())
+
+	yamlFile, err := os.ReadFile(clusterConfigFile)
+	Expect(err).To(BeNil())
+
+	f, err := os.CreateTemp("", "temp_calico_cni_cluster_config_"+util.RandomString(4)+".yaml") // nolint:gomnd
+	Expect(err).To(BeNil())
+
+	_, err = f.Write([]byte(fmt.Sprintf(cniCalicoCBResource, e2eConfig.WorkloadClusterOptions.ClusterName,
+		e2eConfig.WorkloadClusterOptions.Namespace, e2eConfig.TkrVersion, e2eConfig.WorkloadClusterOptions.ClusterName,
+		e2eConfig.WorkloadClusterOptions.Namespace, e2eConfig.WorkloadClusterOptions.ClusterName) + string(yamlFile)))
+	Expect(err).To(BeNil())
+
+	calicoCNIClusterConfigFile, err := filepath.Abs(f.Name())
+	Expect(err).To(BeNil())
+
+	return calicoCNIClusterConfigFile
 }

--- a/pkg/v1/tkg/test/tkgctl/tkgs_cc/utils.go
+++ b/pkg/v1/tkg/test/tkgctl/tkgs_cc/utils.go
@@ -1,0 +1,38 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package tkgs_cc
+
+// cniCalicoCBResource declares resources required along with the classy cluster
+// to deploy a workload cluster with CNI Calico
+const cniCalicoCBResource = `apiVersion: cni.tanzu.vmware.com/v1alpha1
+kind: CalicoConfig
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  calico:
+    config:
+      vethMTU: 0
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: ClusterBootstrap
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/add-missing-fields-from-tkr: %s
+  name: %s
+  namespace: %s
+spec:
+  additionalPackages:
+  - refName: metrics-server*
+  - refName: secretgen-controller*
+  - refName: pinniped*
+  cni:
+    refName: calico*
+    valuesFrom:
+      providerRef:
+        apiGroup: cni.tanzu.vmware.com
+        kind: CalicoConfig
+        name: %s
+---
+`


### PR DESCRIPTION
### What this PR does / why we need it
- Add E2E tests for Antrea/Calico CNI on tkgs
*note: two branches [here](https://github.com/vmware-tanzu/tanzu-framework/blob/release-0.24/pkg/v1/tkg/client/cluster.go#L466) for both legacy cluster (`WaitForPacificCluster`) and classy cluster (`waitForClusterCreation`) will check whether the cluster is ready within timeout. And CNI should be deployed successfully before the cluster is ready.
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2453

### Describe testing done for PR
- Manually verified that Antrea/Calico CNI and other addons are deployed successfully on the newly created workload cluster.
```
[ ~ ]# k --kubeconfig /tmp/kube-config get packageinstall -A
NAMESPACE           NAME                                      PACKAGE NAME                                  PACKAGE VERSION                    DESCRIPTION           AGE
vmware-system-tkg   tkc-e2e-mtpt-calico                       calico.tanzu.vmware.com                       3.22.1+vmware.1-tkg.1-zshippable   Reconcile succeeded   3m51s
vmware-system-tkg   tkc-e2e-mtpt-capabilities                 capabilities.tanzu.vmware.com                 0.25.0-dev-12-g9305a725+vmware.1   Reconciling           3m44s
vmware-system-tkg   tkc-e2e-mtpt-guest-cluster-auth-service   guest-cluster-auth-service.tanzu.vmware.com   1.0.0+tkg.1-zshippable             Reconcile succeeded   3m48s
vmware-system-tkg   tkc-e2e-mtpt-metrics-server               metrics-server.tanzu.vmware.com               0.6.1+vmware.1-tkg.1-zshippable    Reconcile succeeded   3m47s
vmware-system-tkg   tkc-e2e-mtpt-pinniped                     pinniped.tanzu.vmware.com                     0.12.1+vmware.1-tkg.1-zshippable   Reconcile succeeded   3m45s
vmware-system-tkg   tkc-e2e-mtpt-secretgen-controller         secretgen-controller.tanzu.vmware.com         0.9.1+vmware.1-tkg.1-zshippable    Reconcile succeeded   3m46s
vmware-system-tkg   tkc-e2e-mtpt-vsphere-cpi                  vsphere-cpi.tanzu.vmware.com                  1.23.1+vmware.1-tkg.1-zshippable   Reconcile succeeded   3m50s
vmware-system-tkg   tkc-e2e-mtpt-vsphere-pv-csi               vsphere-pv-csi.tanzu.vmware.com               2.4.0+vmware.1-tkg.1-zshippable    Reconcile succeeded   3m49s
```
- Tests passed locally for legacy clusters:
```
[~] hack/tools/bin/ginkgo -v -trace --focus="when input file is legacy config file" pkg/v1/tkg/test/tkgctl/tkgs
...
Ran 10 of 14 Specs in 4874.388 seconds
SUCCESS! -- 10 Passed | 0 Failed | 0 Pending | 4 Skipped
```
- Tests passed locally for classy clusters (can only run 1 test each time for classy clusters due to bug https://github.com/vmware-tanzu/tanzu-framework/issues/2990):
```
[~] hack/tools/bin/ginkgo -v -trace --focus="when input file is cluster class based" pkg/v1/tkg/test/tkgctl/tkgs_cc
...
Ran 1 of 11 Specs in 477.064 seconds
SUCCESS! -- 1 Passed | 0 Failed | 2 Pending | 8 Skipped
PASS
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add TKGS E2E tests to verify the workload cluster is created successfully with Calico CNI
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access


### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->
