### PR TITLE
Addons-controller init should not wait on availabilityzones resource

### DIFF
--- a/addons/controllers/addon_controller.go
+++ b/addons/controllers/addon_controller.go
@@ -39,7 +39,6 @@ import (
 	addonpredicates "github.com/vmware-tanzu/tanzu-framework/addons/predicates"
 	runtanzuv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
 	bomtypes "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/types"
-	topologyv1alpha1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 )
 
 const (
@@ -571,9 +570,6 @@ func GetExternalCRDs() map[schema.GroupVersion]*sets.String {
 
 	kapppkgv1alpha1Resources := sets.NewString("packageinstalls", "packagerepositories")
 	crds[kapppkg.SchemeGroupVersion] = &kapppkgv1alpha1Resources
-
-	topologyv1alpha1Resources := sets.NewString("availabilityzones")
-	crds[topologyv1alpha1.GroupVersion] = &topologyv1alpha1Resources
 
 	return crds
 }

--- a/addons/controllers/csi/vspherecsiconfig_controller.go
+++ b/addons/controllers/csi/vspherecsiconfig_controller.go
@@ -123,6 +123,9 @@ func (r *VSphereCSIConfigReconciler) SetupWithManager(_ context.Context, mgr ctr
 			VSphereCSIFeatureStateConfigMapName)
 	}
 
+	// (deliberate decision): There is no watch on AvailabilityZone in vspherecsiconfig_controller so any change to it will not trigger reconcile
+	// of resources. Based on discussions with TKGS team, availability zone is created at supervisor cluster init time
+	// and does not really change after that.
 	return nil
 }
 

--- a/addons/test/testutil/test_helpers.go
+++ b/addons/test/testutil/test_helpers.go
@@ -13,8 +13,6 @@ import (
 	"path/filepath"
 	"time"
 
-	topologyv1alpha1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
-
 	"golang.org/x/tools/go/packages"
 
 	"github.com/onsi/ginkgo"
@@ -341,17 +339,4 @@ func SetupWebhookCertificates(ctx context.Context, k8sClient client.Client, k8sC
 		}
 	}
 	return nil
-}
-
-func CreateAvailabilityZones(ctx context.Context, k8sClient client.Client, availabilityzoneName string) {
-	// Create availability zones
-	availabilityzones := &topologyv1alpha1.AvailabilityZone{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: availabilityzoneName,
-		},
-		Spec:   topologyv1alpha1.AvailabilityZoneSpec{},
-		Status: topologyv1alpha1.AvailabilityZoneStatus{},
-	}
-	k8sClient.Create(ctx, availabilityzones)
 }


### PR DESCRIPTION
### What this PR does / why we need it

Addon controller should not wait on crds in github.com/vmware-tanzu/vm-operator/external/tanzu-topology

External crds that are infra specific are not required for controller initialization

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2973

### Describe testing done for PR

Trigger downstream e2e test

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Bug fix for regression caused by https://github.com/vmware-tanzu/tanzu-framework/pull/2926/
```

### PR Checklist

<!-- Please acknowledge by checking that they are being followed -->

- [x] Squash the commits into one or a small number of logical commits
      <!--
      This repository adopts a linear git history model where no merge commits are necessary. To
      keep the commit history tidy, it is recommended that authors be responsible for the decision
      whether to squash the PR's changes into a single commit (and tidy up the commit message in the
      process) or organizing them into a small number of self-contained and meaningful ones.
      -->
- [x] Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
- [x] Ensure PR contains terms all contributors can understand and links all contributors can access



