### PR TITLE
Support configuring multiple default trusted registry for plugin downloads during build-time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ endif
 ifndef DEFAULT_STANDALONE_DISCOVERY_LOCAL_PATH
 DEFAULT_STANDALONE_DISCOVERY_LOCAL_PATH = "standalone"
 endif
+ifndef TANZU_PLUGINS_ALLOWED_IMAGE_REPOSITORIES
+TANZU_PLUGINS_ALLOWED_IMAGE_REPOSITORIES = "projects-stg.registry.vmware.com/tkg"
+endif
 
 # Package tooling related variables
 PACKAGE_VERSION ?= ${BUILD_VERSION}
@@ -93,6 +96,9 @@ endif
 
 ifneq ($(strip $(TKG_DEFAULT_IMAGE_REPOSITORY)),)
 LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/config.DefaultStandaloneDiscoveryRepository=$(TKG_DEFAULT_IMAGE_REPOSITORY)'
+endif
+ifneq ($(strip $(TANZU_PLUGINS_ALLOWED_IMAGE_REPOSITORIES)),)
+LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/config.DefaultAllowedPluginRepositories=$(TANZU_PLUGINS_ALLOWED_IMAGE_REPOSITORIES)'
 endif
 
 ifneq ($(strip $(ENABLE_CONTEXT_AWARE_PLUGIN_DISCOVERY)),)

--- a/pkg/v1/cli/pluginmanager/manager_test.go
+++ b/pkg/v1/cli/pluginmanager/manager_test.go
@@ -634,16 +634,24 @@ func Test_VerifyRegistry(t *testing.T) {
 	assert.Nil(err)
 	err = configureAndTestVerifyRegistry(testImage, "", "", "fake.repo.com/image,fake.repo.com")
 	assert.Nil(err)
+
+	testImage = "fake1.repo.com/image:v1.0.0"
+	err = configureAndTestVerifyRegistry(testImage, "fake.repo.com/image", "", "")
+	assert.NotNil(err)
+	err = configureAndTestVerifyRegistry(testImage, "fake.repo.com/image,fake1.repo.com/image", "", "")
+	assert.Nil(err)
+	err = configureAndTestVerifyRegistry(testImage, "fake1.repo.com/image", "", "")
+	assert.Nil(err)
 }
 
 func configureAndTestVerifyRegistry(testImage, defaultRegistry, customImageRepository, allowedRegistries string) error { //nolint:unparam
-	config.DefaultStandaloneDiscoveryRepository = defaultRegistry
+	config.DefaultAllowedPluginRepositories = defaultRegistry
 	os.Setenv(constants.ConfigVariableCustomImageRepository, customImageRepository)
 	os.Setenv(constants.AllowedRegistries, allowedRegistries)
 
 	err := verifyRegistry(testImage)
 
-	config.DefaultStandaloneDiscoveryRepository = ""
+	config.DefaultAllowedPluginRepositories = ""
 	os.Setenv(constants.ConfigVariableCustomImageRepository, "")
 	os.Setenv(constants.AllowedRegistries, "")
 	return err

--- a/pkg/v1/config/defaults.go
+++ b/pkg/v1/config/defaults.go
@@ -16,6 +16,8 @@ import (
 // Default Standalone Discovery configuration
 // Value of this variables gets assigned during build time
 var (
+	// DefaultAllowedPluginRepositories this can be comma separated list of allowed registries
+	DefaultAllowedPluginRepositories     = ""
 	DefaultStandaloneDiscoveryRepository = ""
 	DefaultStandaloneDiscoveryImagePath  = ""
 	DefaultStandaloneDiscoveryImageTag   = ""
@@ -103,9 +105,11 @@ func GetDefaultStandaloneDiscoveryLocalPath() string {
 func GetTrustedRegistries() []string {
 	var trustedRegistries []string
 
-	// Add default registry to trusted registries
-	if DefaultStandaloneDiscoveryRepository != "" {
-		trustedRegistries = append(trustedRegistries, DefaultStandaloneDiscoveryRepository)
+	// Add default allowed registries to trusted registries
+	if DefaultAllowedPluginRepositories != "" {
+		for _, r := range strings.Split(DefaultAllowedPluginRepositories, ",") {
+			trustedRegistries = append(trustedRegistries, strings.TrimSpace(r))
+		}
 	}
 
 	// If custom image repository is defined add it to the list of trusted registries


### PR DESCRIPTION
### What this PR does / why we need it
- When building the tanzu-cli, by default we used to select `TKG_DEFAULT_IMAGE_REPOSITORY` as a default registry that we should trust when downloading the plugins. Also during build time `TKG_DEFAULT_IMAGE_REPOSITORY` we can only take 1 repository.

- This change introduces more flexibility by introducing another `TANZU_PLUGINS_ALLOWED_IMAGE_REPOSITORIES` variable that can have multiple image repositories with comma separated strings.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2978

### Describe testing done for PR
- Build the tanzu-cli by configuring `TANZU_PLUGINS_ALLOWED_IMAGE_REPOSITORIES=projects.registry.vmware.com/tkg,projects.registry.vmware.com/vsphere`
- Verified that user is able to download plugins from both registries without configuring any additional environment variables

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support configuring multiple default trusted registry for plugin downloads during build-time using `TANZU_PLUGINS_ALLOWED_IMAGE_REPOSITORIES`
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
