### PR TITLE
Adding namespace watch to Namespace controller

### DIFF
--- a/pkg/v1/sdk/features/controllers/featuregate_controller.go
+++ b/pkg/v1/sdk/features/controllers/featuregate_controller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -73,11 +74,16 @@ func (r *FeatureGateReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 func (r *FeatureGateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&configv1alpha1.FeatureGate{}).
-		Watches(&source.Kind{Type: &configv1alpha1.Feature{}}, handler.EnqueueRequestsFromMapFunc(r.featureToFeatureGates)).
+		Watches(
+			&source.Kind{Type: &configv1alpha1.Feature{}},
+			handler.EnqueueRequestsFromMapFunc(r.toFeatureGateRequests)).
+		Watches(
+			&source.Kind{Type: &corev1.Namespace{}},
+			handler.EnqueueRequestsFromMapFunc(r.toFeatureGateRequests)).
 		Complete(r)
 }
 
-func (r *FeatureGateReconciler) featureToFeatureGates(o client.Object) []reconcile.Request {
+func (r *FeatureGateReconciler) toFeatureGateRequests(o client.Object) []reconcile.Request {
 	var requests []reconcile.Request
 
 	featuregates := &configv1alpha1.FeatureGateList{}


### PR DESCRIPTION
### What this PR does / why we need it
The `featuregates` controller does not watch namespace resource. Hence, if a namespace is added/removed, it will not get reconciled till a new feature is added. Queries targeted at the new, un-reconciled namespaces will fail. So, watch needs to be added on Namespaces.

### Which issue(s) this PR fixes

Fixes #2961 

### Describe testing done for PR

Added watcher to the Namespaces Kind

### Release note
```release-note
Featuregates controller reconciles on Namespace resource changes.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Testing
**featuregate.yaml**
```
apiVersion: config.tanzu.vmware.com/v1alpha1
kind: FeatureGate
metadata:
  name: featuregate1
  namespace: tkg-system
spec:
  namespaceSelector: 
    matchExpressions:
      - key: kubernetes.io/metadata.name
        operator: In
        values:
          - test1
          - test2
---
apiVersion: config.tanzu.vmware.com/v1alpha1
kind: FeatureGate
metadata:
  name: featuregate2
  namespace: tkg-system
spec:
  namespaceSelector:
    matchExpressions:
      - key: kubernetes.io/metadata.name
        operator: In
        values:
          - test3
          - test4
```

#### Common steps to validate
- `kubectl apply -f featuregate.yaml`
- `kubectl create ns test1`
- `kubectl create ns test2`
- `kubectl create ns test3`
- `kubectl create ns test4`
- `kubectl get featuregates -o yaml`
#### Output before the changes
```
items:
- apiVersion: config.tanzu.vmware.com/v1alpha1
  kind: FeatureGate
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"config.tanzu.vmware.com/v1alpha1","kind":"FeatureGate","metadata":{"annotations":{},"name":"featuregate1"},"spec":{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"In","values":["test1","test2"]}]}}}
    creationTimestamp: "2022-07-21T07:57:44Z"
    generation: 1
    name: featuregate1
    resourceVersion: "12356715"
    uid: 1a6a0fc2-affb-47ef-9888-6fc50fbfd4cb
  spec:
    namespaceSelector:
      matchExpressions:
      - key: kubernetes.io/metadata.name
        operator: In
        values:
        - test1
        - test2
  status: {}
- apiVersion: config.tanzu.vmware.com/v1alpha1
  kind: FeatureGate
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"config.tanzu.vmware.com/v1alpha1","kind":"FeatureGate","metadata":{"annotations":{},"name":"featuregate2"},"spec":{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"In","values":["test3","test4"]}]}}}
    creationTimestamp: "2022-07-21T07:57:47Z"
    generation: 1
    name: featuregate2
    resourceVersion: "12356727"
    uid: d8521333-8434-412c-8879-1e22d8db5ad2
  spec:
    namespaceSelector:
      matchExpressions:
      - key: kubernetes.io/metadata.name
        operator: In
        values:
        - test3
        - test4
  status: {}
kind: List
metadata:
  resourceVersion: ""
```
#### Output after the changes
```
apiVersion: v1
items:
- apiVersion: config.tanzu.vmware.com/v1alpha1
  kind: FeatureGate
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"config.tanzu.vmware.com/v1alpha1","kind":"FeatureGate","metadata":{"annotations":{},"name":"featuregate1"},"spec":{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"In","values":["test1","test2"]}]}}}
    creationTimestamp: "2022-07-21T09:15:06Z"
    generation: 1
    name: featuregate1
    resourceVersion: "12385089"
    uid: 1b02f164-87f4-45eb-9dc0-6e2084475629
  spec:
    namespaceSelector:
      matchExpressions:
      - key: kubernetes.io/metadata.name
        operator: In
        values:
        - test1
        - test2
  status:
    namespaces:
    - test1
    - test2
- apiVersion: config.tanzu.vmware.com/v1alpha1
  kind: FeatureGate
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"config.tanzu.vmware.com/v1alpha1","kind":"FeatureGate","metadata":{"annotations":{},"name":"featuregate2"},"spec":{"namespaceSelector":{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"In","values":["test3","test4"]}]}}}
    creationTimestamp: "2022-07-21T09:15:13Z"
    generation: 1
    name: featuregate2
    resourceVersion: "12385119"
    uid: b8fa4c3a-39e1-4594-a5ed-7ff767985c24
  spec:
    namespaceSelector:
      matchExpressions:
      - key: kubernetes.io/metadata.name
        operator: In
        values:
        - test3
        - test4
  status:
    namespaces:
    - test3
    - test4
kind: List
metadata:
  resourceVersion: ""
```

### Additional information
Tested this change by creating a docker image with the modified bits and deploying into a test management cluster.

#### Special notes for your reviewer

Logs from deployed controller:
```
1.658306146274512e+09	INFO	controller.featuregate	Starting EventSource	{"reconciler group": "config.tanzu.vmware.com", "reconciler kind": "FeatureGate", "source": "kind source: *v1alpha1.FeatureGate"}
1.6583061462745705e+09	INFO	controller.featuregate	Starting EventSource	{"reconciler group": "config.tanzu.vmware.com", "reconciler kind": "FeatureGate", "source": "kind source: *v1alpha1.Feature"}
1.6583061462745833e+09	INFO	controller.featuregate	Starting EventSource	{"reconciler group": "config.tanzu.vmware.com", "reconciler kind": "FeatureGate", "source": "kind source: *v1.Namespace"}
1.6583061462745943e+09	INFO	controller.featuregate	Starting Controller	{"reconciler group": "config.tanzu.vmware.com", "reconciler kind": "FeatureGate"}
1.6583061463762848e+09	INFO	controller.featuregate	Starting workers	{"reconciler group": "config.tanzu.vmware.com", "reconciler kind": "FeatureGate", "worker count": 1}
```

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
