### PR TITLE
Remove feature-gate validation for TKGS cluster and make it based on vSphere version

### DIFF
--- a/pkg/v1/tkg/fakes/clusterclient.go
+++ b/pkg/v1/tkg/fakes/clusterclient.go
@@ -1041,6 +1041,20 @@ type ClusterClient struct {
 		result1 bool
 		result2 error
 	}
+	VerifyExistenceOfCRDStub        func(string, string) (bool, error)
+	verifyExistenceOfCRDMutex       sync.RWMutex
+	verifyExistenceOfCRDArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	verifyExistenceOfCRDReturns struct {
+		result1 bool
+		result2 error
+	}
+	verifyExistenceOfCRDReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	WaitForAVIResourceCleanUpStub        func(string, string) error
 	waitForAVIResourceCleanUpMutex       sync.RWMutex
 	waitForAVIResourceCleanUpArgsForCall []struct {
@@ -6052,6 +6066,71 @@ func (fake *ClusterClient) VerifyCLIPluginCRDReturnsOnCall(i int, result1 bool, 
 	}{result1, result2}
 }
 
+func (fake *ClusterClient) VerifyExistenceOfCRD(arg1 string, arg2 string) (bool, error) {
+	fake.verifyExistenceOfCRDMutex.Lock()
+	ret, specificReturn := fake.verifyExistenceOfCRDReturnsOnCall[len(fake.verifyExistenceOfCRDArgsForCall)]
+	fake.verifyExistenceOfCRDArgsForCall = append(fake.verifyExistenceOfCRDArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.VerifyExistenceOfCRDStub
+	fakeReturns := fake.verifyExistenceOfCRDReturns
+	fake.recordInvocation("VerifyExistenceOfCRD", []interface{}{arg1, arg2})
+	fake.verifyExistenceOfCRDMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ClusterClient) VerifyExistenceOfCRDCallCount() int {
+	fake.verifyExistenceOfCRDMutex.RLock()
+	defer fake.verifyExistenceOfCRDMutex.RUnlock()
+	return len(fake.verifyExistenceOfCRDArgsForCall)
+}
+
+func (fake *ClusterClient) VerifyExistenceOfCRDCalls(stub func(string, string) (bool, error)) {
+	fake.verifyExistenceOfCRDMutex.Lock()
+	defer fake.verifyExistenceOfCRDMutex.Unlock()
+	fake.VerifyExistenceOfCRDStub = stub
+}
+
+func (fake *ClusterClient) VerifyExistenceOfCRDArgsForCall(i int) (string, string) {
+	fake.verifyExistenceOfCRDMutex.RLock()
+	defer fake.verifyExistenceOfCRDMutex.RUnlock()
+	argsForCall := fake.verifyExistenceOfCRDArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *ClusterClient) VerifyExistenceOfCRDReturns(result1 bool, result2 error) {
+	fake.verifyExistenceOfCRDMutex.Lock()
+	defer fake.verifyExistenceOfCRDMutex.Unlock()
+	fake.VerifyExistenceOfCRDStub = nil
+	fake.verifyExistenceOfCRDReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ClusterClient) VerifyExistenceOfCRDReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.verifyExistenceOfCRDMutex.Lock()
+	defer fake.verifyExistenceOfCRDMutex.Unlock()
+	fake.VerifyExistenceOfCRDStub = nil
+	if fake.verifyExistenceOfCRDReturnsOnCall == nil {
+		fake.verifyExistenceOfCRDReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.verifyExistenceOfCRDReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *ClusterClient) WaitForAVIResourceCleanUp(arg1 string, arg2 string) error {
 	fake.waitForAVIResourceCleanUpMutex.Lock()
 	ret, specificReturn := fake.waitForAVIResourceCleanUpReturnsOnCall[len(fake.waitForAVIResourceCleanUpArgsForCall)]
@@ -6902,6 +6981,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.useContextMutex.RUnlock()
 	fake.verifyCLIPluginCRDMutex.RLock()
 	defer fake.verifyCLIPluginCRDMutex.RUnlock()
+	fake.verifyExistenceOfCRDMutex.RLock()
+	defer fake.verifyExistenceOfCRDMutex.RUnlock()
 	fake.waitForAVIResourceCleanUpMutex.RLock()
 	defer fake.waitForAVIResourceCleanUpMutex.RUnlock()
 	fake.waitForAutoscalerDeploymentMutex.RLock()


### PR DESCRIPTION
### What this PR does / why we need it

In some of the environments, (specifically TKGS clusters) devops users doesn't have ability to list featuregates and hence tanzu cluster list/create fails. This PR solves this problem in the following way.

- As both ClassyCluster feature-gate will always be enabled for vSphere8 rely on vSphere version to determine ClusterCluster support.

Signed-off-by: Anuj Chaudhari <anujc@vmware.com>

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2985

### Describe testing done for PR
- Manually tested the `tanzu cluster list` command with the devops user and was able to list the clusters successfully
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Remove feature-gate validation for TKGS cluster and make it based on vSphere version
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
