### PR TITLE
validate workload cluster existence

### DIFF
--- a/pkg/v1/tkg/client/cluster.go
+++ b/pkg/v1/tkg/client/cluster.go
@@ -170,17 +170,6 @@ func (c *TkgClient) CreateCluster(options *CreateClusterOptions, waitForCluster 
 		}
 	}
 
-	clusters, err := regionalClusterClient.ListClusters("")
-	if err != nil {
-		return false, errors.Wrap(err, "unable to get list of workload clusters managed by current management cluster")
-	}
-
-	for i := range clusters {
-		if clusters[i].Name == options.ClusterName {
-			return false, errors.Errorf("cluster with name %s already exists, please specify another name", options.ClusterName)
-		}
-	}
-
 	log.Infof("Creating workload cluster '%s'...", options.ClusterName)
 	err = c.DoCreateCluster(regionalClusterClient, options.ClusterName, options.TargetNamespace, string(bytes))
 	if err != nil {

--- a/pkg/v1/tkg/constants/cluster_internal.go
+++ b/pkg/v1/tkg/constants/cluster_internal.go
@@ -6,16 +6,19 @@ package constants
 
 // cluster related constants used internally
 const (
-	KindCluster                     = "Cluster"
-	KindTanzuKubernetesCluster      = "TanzuKubernetesCluster"
-	KindClusterClass                = "ClusterClass"
-	ClusterClassFeature             = "vmware-system-tkg-clusterclass"
-	TKCAPIFeature                   = "vmware-system-tkg-tkc-api"
-	TKGSClusterClassNamespace       = "vmware-system-tkg"
-	TKGSTKCAPINamespace             = "vmware-system-tkg"
-	TKGStkcapiNamespace             = "vmware-system-tkg"
+	KindCluster                = "Cluster"
+	KindTanzuKubernetesCluster = "TanzuKubernetesCluster"
+	KindClusterClass           = "ClusterClass"
+	ClusterClassFeature        = "vmware-system-tkg-clusterclass"
+	TKCAPIFeature              = "vmware-system-tkg-tkc-api"
+	TKGSClusterClassNamespace  = "vmware-system-tkg"
+	TKGSTKCAPINamespace        = "vmware-system-tkg"
+	TKGStkcapiNamespace        = "vmware-system-tkg"
+
 	ErrorMsgFeatureGateNotActivated = "vSphere with Tanzu environment detected, however, the feature '%v' is not activated in '%v' namespace"
 	ErrorMsgFeatureGateStatus       = "error while checking feature '%v' status in namespace '%v'"
+	ErrorMsgClusterExistsAlready    = "cluster with name %s already exists, please specify another name"
+	ErrorMsgClusterListError        = "unable to get list of workload clusters managed by current management cluster"
 
 	ErrorMsgCClassInputFeatureFlagDisabled = "Input file is cluster class based but CLI feature flag '%v' is disabled, make sure its enabled to create cluster class based cluster"
 

--- a/pkg/v1/tkg/tkgctl/create_cluster.go
+++ b/pkg/v1/tkg/tkgctl/create_cluster.go
@@ -63,7 +63,6 @@ func (t *tkgctl) CreateCluster(cc CreateClusterOptions) error {
 	if err != nil {
 		return err
 	}
-
 	if cc.GenerateOnly && isInputFileClusterClassBased {
 		if config, err := os.ReadFile(cc.ClusterConfigFile); err == nil {
 			_, err = os.Stdout.Write(config)
@@ -84,6 +83,14 @@ func (t *tkgctl) CreateCluster(cc CreateClusterOptions) error {
 	// configures missing create cluster options from config file variables
 	if err := t.configureCreateClusterOptionsFromConfigFile(&cc); err != nil {
 		return err
+	}
+
+	isClusterExists := false
+	isClusterExists, err = t.IsClusterExists(cc.ClusterName, cc.Namespace)
+	if err != nil {
+		return errors.Wrap(err, constants.ErrorMsgClusterListError)
+	} else if isClusterExists {
+		return fmt.Errorf(constants.ErrorMsgClusterExistsAlready, cc.ClusterName)
 	}
 
 	if logPath, err := t.getAuditLogPath(cc.ClusterName); err == nil {

--- a/pkg/v1/tkg/tkgctl/get_cluster.go
+++ b/pkg/v1/tkg/tkgctl/get_cluster.go
@@ -57,3 +57,19 @@ func (t *tkgctl) GetClusters(options ListTKGClustersOptions) ([]client.ClusterIn
 
 	return clusters, nil
 }
+
+func (t *tkgctl) IsClusterExists(clustername, namespace string) (bool, error) {
+	clusters, err := t.GetClusters(ListTKGClustersOptions{
+		Namespace: namespace,
+		IncludeMC: true,
+	})
+	if err != nil {
+		return false, err
+	}
+	for _, cluster := range clusters {
+		if cluster.Name == clustername && cluster.Namespace == namespace {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
### What this PR does / why we need it
For CLI command `tanzu cluster create`, validates whether the given input workload cluster name already exists or not, if exists then throws error

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2988 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

- Unit Test cases
- Tested to create tkgs workload cluster which already exists
- Tested to create tkgs workload cluster which is already not exists

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixes to validate workload cluster existence and throws an error if exists
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
