### PR TITLE
Set CAPI ClusterTopology feature accordingly during management cluster creation

### DIFF
--- a/pkg/v1/tkg/client/init.go
+++ b/pkg/v1/tkg/client/init.go
@@ -149,6 +149,8 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 		log.Infof("Using custom image repository: %s", customImageRepo)
 	}
 
+	c.ensureClusterTopologyConfiguration()
+
 	providerName, _, err := ParseProviderName(options.InfrastructureProvider)
 	if err != nil {
 		return errors.Wrap(err, "unable to parse provider name")
@@ -427,6 +429,7 @@ func (c *TkgClient) MoveObjects(fromKubeconfigPath, toKubeconfigPath, namespace 
 }
 
 func (c *TkgClient) ensureKindCluster(kubeconfig string, useExistingCluster bool, backupPath string) (string, error) {
+
 	// skip if using existing cluster
 	if useExistingCluster {
 		if kubeconfig == "" {

--- a/pkg/v1/tkg/constants/config_variables.go
+++ b/pkg/v1/tkg/constants/config_variables.go
@@ -240,6 +240,9 @@ const (
 	ConfigVariableInternalCAPZManagerImageTag     = "CAPZ_CONTROLLER_IMAGE_TAG"
 	ConfigVariableInternalNMIImageTag             = "NMI_IMAGE_TAG"
 
+	// Other variables related to provider installation
+	ConfigVariableClusterTopology = "CLUSTER_TOPOLOGY"
+
 	ConfigVariablePackageInstallTimeout = "PACKAGE_INSTALL_TIMEOUT"
 
 	// Windows specific variables


### PR DESCRIPTION
```
When installing CAPI, sets the ClusterTopology feature gate based on
whether ClusterClass-based cluster LCM is supported or not.

During creation of management cluster, the only way to override the
feature gate when CC-based LCM is not supported is to override
CLUSTER_TOPOLOGY config or env var with 'true'
```

Signed-off-by: Vui Lam <vui@vmware.com>

### What this PR does / why we need it

### Which issue(s) this PR fixes

Fixes #2993

### Describe testing done for PR

Besides unit tests, did the following:
 
with pblcm cli ff deactivated:

```
-  tanzu management-cluster create -e -v 9 -f mc_config.yaml (deactivates ClusterTopology feature gate)
-  CLUSTER_TOPOLOGY=true tanzu management-cluster create -e -v 9 -f mc_config.yaml(activates)
```

with pblcm cli ff activated:

```
- CLUSTER_TOPOLOGY=false tanzu management-cluster create -e -v 9 -f mc_config.yaml (activates)
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
```release-note
CAPI controller deployed during management cluster creation will activate ClusterTopology featuregate only if needed
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
