### PR TITLE
Exposes addons-manager cluster-delete-timeout as template parameter

### DIFF
--- a/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
+++ b/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
@@ -347,6 +347,7 @@ spec:
         - #@ "--metrics-bind-addr={}".format(data.values.tanzuAddonsManager.deployment.metricsBindAddress)
         - #@ "--leader-elect={}".format(data.values.tanzuAddonsManager.deployment.leaderElection)
         - #@ "--health-addr=:{}".format(data.values.tanzuAddonsManager.deployment.healthzPort)
+        - #@ "--cluster-delete-timeout={}".format(data.values.tanzuAddonsManager.deployment.clusterDeleteTimeout)
         - #@ "--webhook-server-port={}".format(data.values.tanzuAddonsManager.deployment.webhookServerPort)
         - #@ "--addon-namespace={}".format(data.values.tanzuAddonsManager.namespace)
         #@ if/end data.values.tanzuAddonsManager.featureGates.clusterBootstrapController:

--- a/packages/addons-manager/bundle/config/values.yaml
+++ b/packages/addons-manager/bundle/config/values.yaml
@@ -14,6 +14,7 @@ tanzuAddonsManager:
     tolerations: []
     webhookServerPort: 9865
     healthzPort: 18316
+    clusterDeleteTimeout: "10m"
     metricsBindAddress: "localhost:18317"
   featureGates:
     clusterBootstrapController: false

--- a/packages/framework/bundle/config/values.yaml
+++ b/packages/framework/bundle/config/values.yaml
@@ -34,6 +34,7 @@ addonsManagerPackageValues:
       tolerations: []
       webhookServerPort: 9865
       healthzPort: 18316
+      clusterDeleteTimeout: "10m"
       metricsBindAddress: "localhost:18317"
     featureGates:
       clusterBootstrapController: false

--- a/packages/tkg/bundle/config/values.yaml
+++ b/packages/tkg/bundle/config/values.yaml
@@ -45,6 +45,7 @@ frameworkPackage:
         tolerations: []
         webhookServerPort: 9865
         healthzPort: 18316
+        clusterDeleteTimeout: "10m"
         metricsBindAddress: "localhost:18317"
       featureGates:
         clusterBootstrapController: false


### PR DESCRIPTION
cluster-delete-timeout controls how log the addons-manager
waits before timing out a cluster deletion. Once the timeout
is reached, the cluster is deleted unconditionally.

The variable is exposed as tanzuAddonsManager.deployment.clusterDeleteTimeout

Fixes #2991



### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Deployed tkg cluster on vsphere.
Created addons-manager package and pushed to OCI registry. 
Edited the Package:  kubectl edit package -n vmware-system-pkgs   addons-manager.tanzu.vmware.com.0.25.0-dev-11-g87115377+vmware.1 

Verified new deployment is  created with new --cluster-delete-timeout=10m

Verify tanzu-addons-controller-manager-#### starts and logs. 


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
addons-manager "--cluster-delete-timeout" is exposed to templates as tanzuAddonsManager.deployment.clusterDeleteTimeout
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
