### PR TITLE
Update Scale API to support ClusterClass clusters

### DIFF
--- a/pkg/v1/tkg/test/tkgctl/aws_cc/aws_cc_scale_test.go
+++ b/pkg/v1/tkg/test/tkgctl/aws_cc/aws_cc_scale_test.go
@@ -1,0 +1,22 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package aws_cc
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+
+	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/test/tkgctl/shared"
+)
+
+var _ = Describe("Scale tests for aws clusters", func() {
+	E2EScaleSpec(context.TODO(), func() E2EScaleSpecInput {
+		return E2EScaleSpecInput{
+			E2EConfig:       e2eConfig,
+			ArtifactsFolder: artifactsFolder,
+			Cni:             "antrea",
+		}
+	})
+})


### PR DESCRIPTION
Adds a new DoScaleCCCluster function to handle scaling the control plane
and worker nodes of a clusterclass based cluster. Operates like the
legacy API when passing in a node pool name. Scales the mds in a round
robin fashion when no node pool name is given.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Updates scale API to support clusterclass based clusters.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
