### PR TITLE
Fix: object-Propagation controller failing to copy resources

### DIFF
--- a/pkg/v2/object-propagation/propagation/reconciler.go
+++ b/pkg/v2/object-propagation/propagation/reconciler.go
@@ -242,6 +242,10 @@ func (r stringValueReplacer) replace(v reflect.Value) {
 		r.replace(v.Elem())
 	case reflect.Map:
 		r.replaceMap(v)
+	case reflect.Slice:
+		for i := 0; i < v.Len(); i++ {
+			r.replace(v.Index(i))
+		}
 	case reflect.Struct:
 		for i := 0; i < v.NumField(); i++ {
 			r.replace(v.Field(i))

--- a/pkg/v2/object-propagation/propagation/reconciler_test.go
+++ b/pkg/v2/object-propagation/propagation/reconciler_test.go
@@ -214,6 +214,20 @@ var _ = Describe("Reconciler", func() {
 								runv1.AnnotationResolveTKR: "",
 							}},
 						},
+						Workers: clusterv1.WorkersClass{
+							MachineDeployments: []clusterv1.MachineDeploymentClass{{
+								Template: clusterv1.MachineDeploymentClassTemplate{
+									Bootstrap: clusterv1.LocalObjectTemplate{
+										Ref: &corev1.ObjectReference{
+											Kind:       "AwesomeBootstrapTemplate",
+											Namespace:  nameNSTKGSystem,
+											Name:       "awesome-bootstrap-template",
+											APIVersion: "run.tanzu.vmware.com/v1omega3",
+										},
+									},
+								},
+							}},
+						},
 					},
 				}
 				objects = append(objects, cc0)
@@ -232,7 +246,9 @@ var _ = Describe("Reconciler", func() {
 						Expect(r.Client.Get(ctx, client.ObjectKey{Namespace: ns, Name: cc0.Name}, cc)).To(Succeed())
 
 						Expect(cc.Spec.Infrastructure.Ref.Namespace).To(Equal(ns))
-						cc.Spec.Infrastructure.Ref.Namespace = cc0.Spec.Infrastructure.Ref.Namespace
+						Expect(cc.Spec.Workers.MachineDeployments[0].Template.Bootstrap.Ref.Namespace).To(Equal(ns))
+						cc.Spec.Infrastructure.Ref.Namespace = cc0.Namespace
+						cc.Spec.Workers.MachineDeployments[0].Template.Bootstrap.Ref.Namespace = cc0.Namespace
 
 						restoreMeta(cc, cc0)
 						Expect(cc).To(Equal(cc0))
@@ -265,7 +281,9 @@ var _ = Describe("Reconciler", func() {
 						Expect(r.Client.Get(ctx, client.ObjectKey{Namespace: ns, Name: cc0.Name}, cc)).To(Succeed())
 
 						Expect(cc.Spec.Infrastructure.Ref.Namespace).To(Equal(ns))
-						cc.Spec.Infrastructure.Ref.Namespace = cc0.Spec.Infrastructure.Ref.Namespace
+						Expect(cc.Spec.Workers.MachineDeployments[0].Template.Bootstrap.Ref.Namespace).To(Equal(ns))
+						cc.Spec.Infrastructure.Ref.Namespace = cc0.Namespace
+						cc.Spec.Workers.MachineDeployments[0].Template.Bootstrap.Ref.Namespace = cc0.Namespace
 
 						restoreMeta(cc, cc0)
 						Expect(cc).To(Equal(cc0))


### PR DESCRIPTION
### What this PR does / why we need it

Without this change, the Object-Propagation Controller fails to copy
ClusterClass resources with errors like this in the log:
`spec.workers.machineDeployments[0].template.bootstrap.ref.namespace:
Invalid value: "tkg-system": template must be in the same namespace as
the ClusterClass (default)`.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

N/A

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Added a unit test to reproduce the failure. Fixed the code to make tests pass. 

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
