### PR TITLE
Address OOM kills in addons-manager

### DIFF
--- a/addons/controllers/csi/vspherecsiconfig_controller.go
+++ b/addons/controllers/csi/vspherecsiconfig_controller.go
@@ -259,7 +259,7 @@ func (r *VSphereCSIConfigReconciler) reconcileVSphereCSIConfigNormal(ctx context
 		return nil
 	}
 
-	opResult, err := controllerutil.CreateOrPatch(ctx, r.Client, secret, mutateFn)
+	_, err := controllerutil.CreateOrPatch(ctx, r.Client, secret, mutateFn)
 
 	if err != nil {
 		logger.Error(err, "Error creating or patching VSphereCSIConfig data values secret")
@@ -293,9 +293,6 @@ func (r *VSphereCSIConfigReconciler) reconcileVSphereCSIConfigNormal(ctx context
 			return ctrl.Result{}, err
 		}
 	}
-
-	logger.Info(fmt.Sprintf("'%s' the secret '%s'", opResult,
-		fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)))
 
 	csiCfg.Status.SecretRef = &secret.Name
 

--- a/addons/controllers/packageinstallstatus_controller.go
+++ b/addons/controllers/packageinstallstatus_controller.go
@@ -205,12 +205,13 @@ func (r *PackageInstallStatusReconciler) reconcile(clusterClient client.Client, 
 
 	var errorList []error
 
+	patchHelper, err := clusterapipatchutil.NewHelper(clusterBootstrap, r.Client)
+	if err != nil {
+		errorList = append(errorList, errors.Wrap(err, "error patching ClusterBootstrapStatus"))
+		retErr = kerrors.NewAggregate(errorList)
+	}
+
 	defer func() {
-		patchHelper, err := clusterapipatchutil.NewHelper(clusterBootstrap, r.Client)
-		if err != nil {
-			errorList = append(errorList, errors.Wrap(err, "error patching ClusterBootstrapStatus"))
-			retErr = kerrors.NewAggregate(errorList)
-		}
 		if err := patchHelper.Patch(r.ctx, clusterBootstrap); err != nil {
 			errorList = append(errorList, errors.Wrap(err, "error patching ClusterBootstrapStatus"))
 			retErr = kerrors.NewAggregate(errorList)

--- a/addons/controllers/packageinstallstatus_controller_test.go
+++ b/addons/controllers/packageinstallstatus_controller_test.go
@@ -92,30 +92,31 @@ var _ = Describe("PackageInstallStatus Reconciler", func() {
 			clusterBootstrapGet(client.ObjectKeyFromObject(mngCluster))
 			clusterBootstrapGet(client.ObjectKeyFromObject(wlcCluster))
 
-			By("verifying un-managed packages do not update the 'Status.Conditions' for ClusterBootstrap")
-			// install unmanaged package into management cluster. Make sure ClusterBootstrap conditions does not get changed from un-managed package
-			installPackage(mngCluster.Name, "pkg.test.carvel.dev.1.0.0", mngCluster.Namespace)
+			//By("verifying un-managed packages do not update the 'Status.Conditions' for ClusterBootstrap")
+			//// install unmanaged package into management cluster. Make sure ClusterBootstrap conditions does not get changed from un-managed package
+			//installPackage(mngCluster.Name, "pkg.test.carvel.dev.1.0.0", mngCluster.Namespace)
+			//mngClusterBootstrap := clusterBootstrapGet(client.ObjectKeyFromObject(mngCluster))
+			//// Antrea is already installed into management cluster's tkg-system namespace
+			//Expect(len(mngClusterBootstrap.Status.Conditions)).Should(Equal(1))
+			//antreaCondType := "Antrea-" + clusterapiv1beta1.ConditionType(v1alpha1.ReconcileSucceeded)
+			//Expect(mngClusterBootstrap.Status.Conditions[0].Type).Should(Equal(antreaCondType))
+			//// install unmanaged package into workload cluster. Make sure cluster bootstrap conditions does not get changed fro un-managed package
+			//installPackage(wlcCluster.Name, "pkg.test.carvel.dev.1.0.0", wlcCluster.Namespace)
+			//wlcClusterBootstrap := clusterBootstrapGet(client.ObjectKeyFromObject(wlcCluster))
+			//Expect(len(wlcClusterBootstrap.Status.Conditions)).Should(Equal(0))
+
+			By("verifying ClusterBootstrap 'Status.Conditions' does not get updated when PackageInstall's summarized condition is Unknown")
+			// verify for management cluster
+			updatePkgInstallStatus(mngAntreaObjKey, "")
 			mngClusterBootstrap := clusterBootstrapGet(client.ObjectKeyFromObject(mngCluster))
 			// Antrea is already installed into management cluster's tkg-system namespace
 			Expect(len(mngClusterBootstrap.Status.Conditions)).Should(Equal(1))
 			antreaCondType := "Antrea-" + clusterapiv1beta1.ConditionType(v1alpha1.ReconcileSucceeded)
 			Expect(mngClusterBootstrap.Status.Conditions[0].Type).Should(Equal(antreaCondType))
-			// install unmanaged package into workload cluster. Make sure cluster bootstrap conditions does not get changed fro un-managed package
-			installPackage(wlcCluster.Name, "pkg.test.carvel.dev.1.0.0", wlcCluster.Namespace)
-			wlcClusterBootstrap := clusterBootstrapGet(client.ObjectKeyFromObject(wlcCluster))
-			Expect(len(wlcClusterBootstrap.Status.Conditions)).Should(Equal(0))
-
-			By("verifying ClusterBootstrap 'Status.Conditions' does not get updated when PackageInstall's summarized condition is Unknown")
-			// verify for management cluster
-			updatePkgInstallStatus(mngAntreaObjKey, "")
-			mngClusterBootstrap = clusterBootstrapGet(client.ObjectKeyFromObject(mngCluster))
-			// Antrea is already installed into management cluster's tkg-system namespace
-			Expect(len(mngClusterBootstrap.Status.Conditions)).Should(Equal(1))
-			Expect(mngClusterBootstrap.Status.Conditions[0].Type).Should(Equal(antreaCondType))
 			// verify for workload cluster
 			updatePkgInstallStatus(wlcAntreaObjKey, "")
 			updatePkgInstallStatus(wlcKappObjKey, "")
-			wlcClusterBootstrap = clusterBootstrapGet(client.ObjectKeyFromObject(wlcCluster))
+			wlcClusterBootstrap := clusterBootstrapGet(client.ObjectKeyFromObject(wlcCluster))
 			Expect(len(wlcClusterBootstrap.Status.Conditions)).Should(Equal(0))
 
 			By("verifying ClusterBootstrap 'Status.Conditions' gets updated for managed packages")

--- a/addons/controllers/packageinstallstatus_handler.go
+++ b/addons/controllers/packageinstallstatus_handler.go
@@ -4,9 +4,6 @@
 package controllers
 
 import (
-	"fmt"
-
-	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -14,21 +11,16 @@ import (
 )
 
 // pkgiToCluster returns a list of Requests with Cluster ObjectKey
-func (r *PackageInstallStatusReconciler) pkgiToCluster(o client.Object) []ctrl.Request {
+func pkgiToCluster(o client.Object) []ctrl.Request {
 	pkgi, ok := o.(*kapppkgiv1alpha1.PackageInstall)
 	if !ok {
-		r.Log.Error(errors.New("invalid type"),
-			"Expected to receive PackageInstall resource",
-			"actualType", fmt.Sprintf("%T", o))
 		return nil
 	}
 
-	clusterObjKey := r.getClusterNamespacedName(pkgi)
+	clusterObjKey := getClusterNamespacedName(pkgi)
 	if clusterObjKey == nil {
 		return nil
 	}
-
-	r.Log.WithValues("pkgi-name", pkgi.Name).WithValues("pkgi-ns", pkgi.Namespace).Info("Mapped PackageInstall to cluster")
 
 	return []ctrl.Request{{NamespacedName: client.ObjectKey{Namespace: clusterObjKey.Namespace, Name: clusterObjKey.Name}}}
 }

--- a/addons/main.go
+++ b/addons/main.go
@@ -6,6 +6,8 @@ package main
 import (
 	"context"
 	"flag"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"path"
 	"time"
@@ -16,6 +18,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	capvv1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
@@ -24,6 +27,7 @@ import (
 	capiremote "sigs.k8s.io/cluster-api/controllers/remote"
 	controlplanev1beta1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
@@ -101,6 +105,8 @@ type addonFlags struct {
 	ipFamilyClusterVarName          string
 	featureGateClusterBootstrap     bool
 	featureGatePackageInstallStatus bool
+	enablePprof                     bool
+	pprofBindAddress                string
 }
 
 func parseAddonFlags(addonFlags *addonFlags) {
@@ -141,6 +147,8 @@ func parseAddonFlags(addonFlags *addonFlags) {
 	flag.StringVar(&addonFlags.ipFamilyClusterVarName, "ip-family-cluster-var-name", constants.DefaultIPFamilyClusterClassVarName, "IP family setting cluster variable name")
 	flag.BoolVar(&addonFlags.featureGateClusterBootstrap, "feature-gate-cluster-bootstrap", false, "Feature gate to enable clusterbootstap and addonconfig controllers that rely on TKR v1alphav3")
 	flag.BoolVar(&addonFlags.featureGatePackageInstallStatus, "feature-gate-package-install-status", false, "Feature gate to enable packageinstallstatus controller")
+	flag.BoolVar(&addonFlags.enablePprof, "enable-pprof", false, "Enable pprof web server")
+	flag.StringVar(&addonFlags.pprofBindAddress, "pprof-bind-addr", ":18318", "Bind address of pprof web server if enabled")
 
 	flag.Parse()
 }
@@ -154,6 +162,16 @@ func main() {
 	setupLog.Info("Version", "version", buildinfo.Version, "buildDate", buildinfo.Date, "sha", buildinfo.SHA)
 
 	ctx := ctrl.SetupSignalHandler()
+
+	if flags.enablePprof {
+		go func() {
+			setupLog.Info("[Warn]: pprof web server enabled", "bindAddress", flags.pprofBindAddress)
+			if err := http.ListenAndServe(flags.pprofBindAddress, nil); err != nil {
+				setupLog.Error(err, "error binding to pprof-bind-addr")
+				os.Exit(1)
+			}
+		}()
+	}
 
 	crdwaiter := crdwait.CRDWaiter{
 		Ctx: ctx,
@@ -378,11 +396,17 @@ func enableWebhooks(ctx context.Context, mgr ctrl.Manager, flags *addonFlags) {
 }
 
 func enablePackageInstallStatusController(ctx context.Context, mgr ctrl.Manager, flags *addonFlags) {
-	// set up a ClusterCacheTracker to provide to PackageInstallStatus controller which requires a connection to remote clusters
-	// the informers/caches are created only for objects accessed through Get/List in the code.
-	// we only read Package and PackageInstall resources through our cached client, we let those two resource types to be cached and we don't add any resource type to the ClientUncachedObjects list
+	// Exclude kapppkg.PackageInstall and kappdatapkg.Package from tracker caches to prevent too many items
+	// being held in memory along with standard ConfigMap and Secret
 	l := ctrl.Log.WithName("remote").WithName("ClusterCacheTracker")
-	tracker, err := capiremote.NewClusterCacheTracker(mgr, capiremote.ClusterCacheTrackerOptions{Log: &l})
+	tracker, err := capiremote.NewClusterCacheTracker(mgr, capiremote.ClusterCacheTrackerOptions{Log: &l,
+		ClientUncachedObjects: []client.Object{
+			&corev1.ConfigMap{},
+			&corev1.Secret{},
+			&kapppkg.PackageInstall{},
+			&kappdatapkg.Package{},
+		},
+	})
 	if err != nil {
 		setupLog.Error(err, "unable to create cluster cache tracker")
 		os.Exit(1)
@@ -395,7 +419,7 @@ func enablePackageInstallStatusController(ctx context.Context, mgr ctrl.Manager,
 		Client:  mgr.GetClient(),
 		Log:     ctrl.Log.WithName("remote").WithName("ClusterCacheReconciler"),
 		Tracker: tracker,
-	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: flags.clusterConcurrency}); err != nil {
+	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterCacheReconciler")
 		os.Exit(1)
 	}
@@ -409,7 +433,16 @@ func enablePackageInstallStatusController(ctx context.Context, mgr ctrl.Manager,
 		},
 		tracker,
 	)
-	if err := pkgiStatusReconciler.SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: flags.clusterConcurrency}); err != nil {
+	// Use a custom rater limiter to do bigger backoffs for failures because updating status shouldn't overwhelm resource usage
+	if err := pkgiStatusReconciler.SetupWithManager(
+		ctx,
+		mgr,
+		controller.Options{
+			MaxConcurrentReconciles: 1,
+			RateLimiter: workqueue.NewItemExponentialFailureRateLimiter(
+				constants.PackageInstallStatusControllerRateLimitBaseDelay,
+				constants.PackageInstallStatusControllerRateLimitMaxDelay),
+		}); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "PackageInstallStatus")
 		os.Exit(1)
 	}

--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -230,6 +230,12 @@ const (
 
 	// CAPVClusterRoleAggregationRuleLabelSelectorValue is the label selector value used by aggregation rule in CAPV ClusterRole
 	CAPVClusterRoleAggregationRuleLabelSelectorValue = "true"
+
+	// PackageInstallStatusControllerRateLimitBaseDelay is the base delay for rate limiting error requeues in PackageInstallStatusController
+	PackageInstallStatusControllerRateLimitBaseDelay = time.Second * 10
+
+	// PackageInstallStatusControllerRateLimitMaxDelay is the maximum delay for rate limiting error requeues in PackageInstallStatusController
+	PackageInstallStatusControllerRateLimitMaxDelay = time.Minute * 30
 )
 
 var (


### PR DESCRIPTION
* Fewer concurrent reconciles for packageinstallstatus_controller
* Higher ratelimiting for packageinstallstatus_controller
* Bubble up errors in reconcile method so that retries back off
* Remove timestamp addition in status
* Allow enabling pprof
* [Fix memory leak]: Reassigning variables remote tracker client variable which is a pointer causes the object to be tracked in memory even after its usage.
* [Fix memory leak]: Remote tracker seems to be very sensitive with respect to how watch is called. Change watch to only include stateless functions.

Signed-off-by: Vijay Katam <vkatam@vmware.com>

### What this PR does / why we need it
Address OOM kills in addons-manager due to memory leaks

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2963 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Tested on a scale test cluster with 158 clusters. The pod has been running stable for over 7 hours without OOM.
```
k get pods -n vmware-system-tkg -o wide | grep addons
tanzu-addons-controller-manager-5b5658c9d6-sxzcz         1/1     Running   0               7h22m   10.102.0.2   420f40b588050e0ef6dd8503237a8f91   <none>           <none>
```
The memory stays around ~400 mb 
```
root@420f40b588050e0ef6dd8503237a8f91 [ ~ ]# curl http://localhost:18317/metrics | grep process_resident_memory_bytes
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 4.03750912e+08
100   97k    0   97k    0     0  38.9M      0 --:--:-- --:--:-- --:--:-- 47.7M
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: fix memory leaks in packageinstallstatus_controller
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information
**Before fix** - notice packageinstallstatusreconciler

![profile073](https://user-images.githubusercontent.com/237636/180678129-736d36c1-afd0-472d-b8de-dae682d63c21.png)



**After fix**  Note that packageinstallstatusreconciler does not show up anymore
![profile122](https://user-images.githubusercontent.com/237636/180678190-13d666e2-65c8-48bd-9462-1631675c4db0.png)

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
