### PR TITLE
OPC should remove ownerReferences from propagated objects

### DIFF
--- a/pkg/v2/object-propagation/propagation/reconciler.go
+++ b/pkg/v2/object-propagation/propagation/reconciler.go
@@ -221,6 +221,8 @@ func (r *Reconciler) overwrite(targetObj, sourceObj client.Object) error {
 	}
 	restoreMeta(targetObj, orig)
 
+	targetObj.SetOwnerReferences(nil)
+
 	return nil
 }
 


### PR DESCRIPTION
### What this PR does / why we need it

Without this change, the OPC (Object-Propagation Controller) copies ClusterClass-related resources to other namespaces, but because they have an ownerReference with UID from the original ClusterClass (in the source namespace), Kubernetes immediately deletes them (as the original ClusterClass is not present in the target namespace, only a propagated copy of it).

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

N/A

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Added unit tests covering the fix.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
