### PR TITLE
Automate Custom Cluster Bootstrap for Antrea parameters for CC Guest cluster on supervisor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 	github.com/vmware-tanzu/carvel-secretgen-controller v0.5.0
 	github.com/vmware-tanzu/carvel-vendir v0.26.0
 	github.com/vmware-tanzu/carvel-ytt v0.40.0
+	github.com/vmware-tanzu/tanzu-framework/apis/cni v0.0.0-00010101000000-000000000000
 	github.com/vmware/govmomi v0.27.1
 	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0
 	go.uber.org/multierr v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -2718,6 +2718,7 @@ k8s.io/apiextensions-apiserver v0.21.1/go.mod h1:KESQFCGjqVcVsZ9g0xX5bacMjyX5emu
 k8s.io/apiextensions-apiserver v0.22.2/go.mod h1:2E0Ve/isxNl7tWLSUDgi6+cmwHi5fQRdwGVCxbC+KFA=
 k8s.io/apiextensions-apiserver v0.22.5/go.mod h1:tIXeZ0BrDxUb1PoAz+tgOz43Zi1Bp4BEEqVtUccMJbE=
 k8s.io/apiextensions-apiserver v0.23.0-alpha.4/go.mod h1:kigfmoeWZRvDkUtNCLd4vEVmVHU2jhi/8ISvK2v724c=
+k8s.io/apiextensions-apiserver v0.23.0/go.mod h1:xIFAEEDlAZgpVBl/1VSjGDmLoXAWRG40+GsWhKhAxY4=
 k8s.io/apiextensions-apiserver v0.23.4/go.mod h1:TWYAKymJx7nLMxWCgWm2RYGXHrGlVZnxIlGnvtfYu+g=
 k8s.io/apiextensions-apiserver v0.23.5 h1:5SKzdXyvIJKu+zbfPc3kCbWpbxi+O+zdmAJBm26UJqI=
 k8s.io/apiextensions-apiserver v0.23.5/go.mod h1:ntcPWNXS8ZPKN+zTXuzYMeg731CP0heCTl6gYBxLcuQ=
@@ -2758,6 +2759,7 @@ k8s.io/apiserver v0.22.2/go.mod h1:vrpMmbyjWrgdyOvZTSpsusQq5iigKNWv9o9KlDAbBHI=
 k8s.io/apiserver v0.22.4/go.mod h1:38WmcUZiiy41A7Aty8/VorWRa8vDGqoUzDf2XYlku0E=
 k8s.io/apiserver v0.22.5/go.mod h1:s2WbtgZAkTKt679sYtSudEQrTGWUSQAPe6MupLnlmaQ=
 k8s.io/apiserver v0.23.0-alpha.4/go.mod h1:filg3J7fRj+AuwLTFXNcH566LHC8mLkQrD0H2zUVpJk=
+k8s.io/apiserver v0.23.0/go.mod h1:Cec35u/9zAepDPPFyT+UMrgqOCjgJ5qtfVJDxjZYmt4=
 k8s.io/apiserver v0.23.4/go.mod h1:A6l/ZcNtxGfPSqbFDoxxOjEjSKBaQmE+UTveOmMkpNc=
 k8s.io/apiserver v0.23.5 h1:2Ly8oUjz5cnZRn1YwYr+aFgDZzUmEVL9RscXbnIeDSE=
 k8s.io/apiserver v0.23.5/go.mod h1:7wvMtGJ42VRxzgVI7jkbKvMbuCbVbgsWFT7RyXiRNTw=
@@ -2922,6 +2924,7 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.14/go.mod h1:LEScyz
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.15/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.23/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
+sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.25/go.mod h1:Mlj9PNLmG9bZ6BHFwFKDo5afkpWyUISkb9Me0GnK66I=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.27/go.mod h1:tq2nT0Kx7W+/f2JVE+zxYtUhdjuELJkVpNz+x/QN5R4=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.30/go.mod h1:fEO7lRTdivWO2qYVCVG7dEADOMo/MLDCVr8So2g88Uw=
 sigs.k8s.io/aws-iam-authenticator v0.5.3/go.mod h1:DIq7gy0lvnyaG88AgFyJzUVeix+ia5msHEp4RL0102I=
@@ -2942,6 +2945,7 @@ sigs.k8s.io/controller-runtime v0.7.0/go.mod h1:pJ3YBrJiAqMAZKi6UVGuE98ZrroV1p+p
 sigs.k8s.io/controller-runtime v0.9.0/go.mod h1:TgkfvrhhEw3PlI0BRL/5xM+89y3/yc0ZDfdbTl84si8=
 sigs.k8s.io/controller-runtime v0.10.3/go.mod h1:CQp8eyUQZ/Q7PJvnIrB6/hgfTC1kBkGylwsLgOQi1WY=
 sigs.k8s.io/controller-runtime v0.11.0-beta.0.0.20211110210527-619e6b92dab9/go.mod h1:zbtXsL/EF7Jejm73ivV4QOuyM2kg13WCz3Up+Agc1gE=
+sigs.k8s.io/controller-runtime v0.11.1/go.mod h1:KKwLiTooNGu+JmLZGn9Sl3Gjmfj66eMbCQznLP5zcqA=
 sigs.k8s.io/controller-runtime v0.11.2 h1:H5GTxQl0Mc9UjRJhORusqfJCIjBO8UtUxGggCwL1rLA=
 sigs.k8s.io/controller-runtime v0.11.2/go.mod h1:P6QCzrEjLaZGqHsfd+os7JQ+WFZhvB8MRFsn4dWF7O4=
 sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
@@ -2970,6 +2974,7 @@ sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK
 sigs.k8s.io/structured-merge-diff/v4 v4.0.3/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.2/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
+sigs.k8s.io/structured-merge-diff/v4 v4.2.0/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.1 h1:bKCqE9GvQ5tiVHn5rfn1r+yao3aLQEaLzkkmAkf+A6Y=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.1/go.mod h1:j/nl6xW8vLS49O8YvXW1ocPhZawJtm+Yrr7PPRQ0Vg4=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/v1/tkg/test/config/tkgs.yaml
+++ b/pkg/v1/tkg/test/config/tkgs.yaml
@@ -20,3 +20,4 @@ workload_cluster_options:
   WORKER_VM_CLASS: "best-effort-small"
   NODE_POOL_0_NAME: "workers-name-overwrite"
   CLUSTER_CLASS_FILE_PATH: /Users/clusterClass.yaml
+  CLUSTER_CLASS_CB_FILE_PATH: ../test/data/testdata/customClusterBootstrapAntrea.yaml

--- a/pkg/v1/tkg/test/data/testdata/customClusterBootstrapAntrea.yaml
+++ b/pkg/v1/tkg/test/data/testdata/customClusterBootstrapAntrea.yaml
@@ -1,8 +1,8 @@
 apiVersion: cni.tanzu.vmware.com/v1alpha1
 kind: AntreaConfig
 metadata:
-  name: cc20
-  namespace: shivaani-ns
+  name: cc20-antrea-package
+  namespace: customcb-ns
 spec:
   antrea:
     config:
@@ -24,7 +24,7 @@ metadata:
   annotations:
     tkg.tanzu.vmware.com/add-missing-fields-from-tkr: v1.23.5---vmware.1-tkg.1-zshippable
   name: cc20
-  namespace: shivaani-ns
+  namespace: customcb-ns
 spec:
   additionalPackages:
     - refName: metrics-server*
@@ -36,7 +36,7 @@ spec:
       providerRef:
         apiGroup: cni.tanzu.vmware.com
         kind: AntreaConfig
-        name: cc20
+        name: cc20-antrea-package
   kapp:
     refName: kapp-controller*
 ---
@@ -44,7 +44,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: cc20
-  namespace: shivaani-ns
+  namespace: customcb-ns
 spec:
   clusterNetwork:
     pods:

--- a/pkg/v1/tkg/test/data/testdata/customClusterBootstrapAntrea.yaml
+++ b/pkg/v1/tkg/test/data/testdata/customClusterBootstrapAntrea.yaml
@@ -1,0 +1,78 @@
+apiVersion: cni.tanzu.vmware.com/v1alpha1
+kind: AntreaConfig
+metadata:
+  name: cc20
+  namespace: shivaani-ns
+spec:
+  antrea:
+    config:
+      disableUdpTunnelOffload: false
+      featureGates:
+        AntreaPolicy: true
+        AntreaProxy: true
+        AntreaTraceflow: false
+        Egress: true
+        EndpointSlice: true
+        FlowExporter: false
+        NodePortLocal: true
+      noSNAT: false
+      trafficEncapMode: encap
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: ClusterBootstrap
+metadata:
+  annotations:
+    tkg.tanzu.vmware.com/add-missing-fields-from-tkr: v1.23.5---vmware.1-tkg.1-zshippable
+  name: cc20
+  namespace: shivaani-ns
+spec:
+  additionalPackages:
+    - refName: metrics-server*
+    - refName: secretgen-controller*
+    - refName: pinniped*
+  cni:
+    refName: antrea*
+    valuesFrom:
+      providerRef:
+        apiGroup: cni.tanzu.vmware.com
+        kind: AntreaConfig
+        name: cc20
+  kapp:
+    refName: kapp-controller*
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cc20
+  namespace: shivaani-ns
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.0.2.0/16
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+        - 198.51.100.0/12
+  topology:
+    class: tanzukubernetescluster
+    controlPlane:
+      metadata: {}
+      replicas: 1
+    variables:
+      - name: storageClasses
+        value:
+          - wcpglobalstorageprofile
+      - name: ntp
+        value: time1.vmware.com
+      - name: vmClass
+        value: best-effort-small
+      - name: storageClass
+        value: wcpglobalstorageprofile
+    version: v1.23.5+vmware.1-tkg.1-zshippable
+    workers:
+      machineDeployments:
+        - class: node-pool
+          metadata: {}
+          name: np-2
+          replicas: 1

--- a/pkg/v1/tkg/test/framework/e2e_config.go
+++ b/pkg/v1/tkg/test/framework/e2e_config.go
@@ -62,6 +62,7 @@ type WorkloadClusterOptions struct {
 	WorkerVMClass            string `json:"WORKER_VM_CLASS,omitempty"`
 	NodePoolName             string `json:"NODE_POOL_0_NAME,omitempty"`
 	ClusterClassFilePath     string `json:"CLUSTER_CLASS_FILE_PATH,omitempty"`
+	ClusterClassCBFilePath   string `json:"CLUSTER_CLASS_CB_FILE_PATH,omitempty"`
 }
 
 // E2EConfig represents the configuration for the e2e tests

--- a/pkg/v1/tkg/test/tkgctl/shared/e2e_common.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/e2e_common.go
@@ -154,7 +154,7 @@ func E2ECommonSpec(ctx context.Context, inputGetter func() E2ECommonSpecInput) {
 
 		var (
 			mngClient        client.Client
-			clusterResources []clusterResource
+			clusterResources []ClusterResource
 		)
 
 		// verify addons are deployed successfully in clusterclass mode
@@ -180,24 +180,24 @@ func E2ECommonSpec(ctx context.Context, inputGetter func() E2ECommonSpecInput) {
 				Expect(err).To(BeNil())
 
 				By(fmt.Sprintf("Get k8s client for management cluster %q", clusterName))
-				mngclient, mngDynamicClient, mngAggregatedAPIResourcesClient, mngDiscoveryClient, err := getClients(ctx, mngtempFilePath)
+				mngclient, mngDynamicClient, mngAggregatedAPIResourcesClient, mngDiscoveryClient, err := GetClients(ctx, mngtempFilePath)
 				Expect(err).NotTo(HaveOccurred())
 				mngClient = mngclient
 
 				By(fmt.Sprintf("Get k8s client for workload cluster %q", clusterName))
-				wlcClient, _, _, _, err := getClients(ctx, tempFilePath)
+				wlcClient, _, _, _, err := GetClients(ctx, tempFilePath)
 				Expect(err).NotTo(HaveOccurred())
 
 				By(fmt.Sprintf("Verify addon packages on management cluster %q matches clusterBootstrap info on management cluster %q", input.E2EConfig.ManagementClusterName, input.E2EConfig.ManagementClusterName))
-				err = checkClusterCB(ctx, mngclient, wlcClient, input.E2EConfig.ManagementClusterName, constants.TkgNamespace, "", "", infrastructureName, true)
+				err = CheckClusterCB(ctx, mngclient, wlcClient, input.E2EConfig.ManagementClusterName, constants.TkgNamespace, "", "", infrastructureName, true)
 				Expect(err).To(BeNil())
 
 				By(fmt.Sprintf("Verify addon packages on workload cluster %q matches clusterBootstrap info on management cluster %q", clusterName, input.E2EConfig.ManagementClusterName))
-				err = checkClusterCB(ctx, mngclient, wlcClient, input.E2EConfig.ManagementClusterName, constants.TkgNamespace, clusterName, namespace, infrastructureName, false)
+				err = CheckClusterCB(ctx, mngclient, wlcClient, input.E2EConfig.ManagementClusterName, constants.TkgNamespace, clusterName, namespace, infrastructureName, false)
 				Expect(err).To(BeNil())
 
 				By(fmt.Sprintf("Get management cluster resources created by addons-manager for workload cluster %q on management cluster %q", clusterName, input.E2EConfig.ManagementClusterName))
-				clusterResources, err = getManagementClusterResources(ctx, mngclient, mngDynamicClient, mngAggregatedAPIResourcesClient, mngDiscoveryClient, namespace, clusterName, infrastructureName)
+				clusterResources, err = GetManagementClusterResources(ctx, mngclient, mngDynamicClient, mngAggregatedAPIResourcesClient, mngDiscoveryClient, namespace, clusterName, infrastructureName)
 				Expect(err).NotTo(HaveOccurred())
 			}
 		}

--- a/pkg/v1/tkg/test/tkgctl/shared/package.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/package.go
@@ -140,16 +140,9 @@ func getPackagesFromCB(ctx context.Context, clusterBootstrap *runtanzuv1alpha3.C
 	packages = append(packages, kapppkgv1alpha1.Package{ObjectMeta: metav1.ObjectMeta{Name: cniPkgShortName, Namespace: systemNamespace},
 		Spec: kapppkgv1alpha1.PackageSpec{RefName: cniPkgName, Version: cniPkgVersion}})
 
-	// for tkgs, kapp controller is in the Supervisor cluster. For other infrastructure, it is in the workload cluster
-	if (infrastructureName == "tkgs" && isManagementCluster) || (infrastructureName != "tkgs" && !isManagementCluster) {
-		var kappPkgNamespace string
-		if isManagementCluster {
-			kappPkgNamespace = mcClusterNamespace
-		} else {
-			kappPkgNamespace = wcClusterNamespace
-		}
+	if !isManagementCluster {
 		kappPkgShortName, kappPkgName, kappPkgVersion := getPackageDetailsFromCBS(clusterBootstrap.Spec.Kapp.RefName)
-		packages = append(packages, kapppkgv1alpha1.Package{ObjectMeta: metav1.ObjectMeta{Name: kappPkgShortName, Namespace: kappPkgNamespace},
+		packages = append(packages, kapppkgv1alpha1.Package{ObjectMeta: metav1.ObjectMeta{Name: kappPkgShortName, Namespace: wcClusterNamespace},
 			Spec: kapppkgv1alpha1.PackageSpec{RefName: kappPkgName, Version: kappPkgVersion}})
 	}
 

--- a/pkg/v1/tkg/test/tkgctl/tkgs/tkgs_suite_test.go
+++ b/pkg/v1/tkg/test/tkgctl/tkgs/tkgs_suite_test.go
@@ -132,7 +132,7 @@ func ValidateClusterClassConfigFile(clusterclassConfigFilePath string) (string, 
 	cclusterFile, err := os.ReadFile(clusterclassConfigFilePath)
 	Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("failed to read the input cluster class based config file from: %v", clusterclassConfigFilePath))
 	Expect(cclusterFile).ToNot(BeEmpty(), fmt.Sprintf("the input cluster class based config file should not be empty, file path: %v", clusterclassConfigFilePath))
-	isCC, ccObject, err := tkgctl.CheckIfInputFileIsClusterClassBased(e2eConfig.WorkloadClusterOptions.ClusterClassFilePath)
+	isCC, ccObject, err := tkgctl.CheckIfInputFileIsClusterClassBased(clusterclassConfigFilePath)
 	Expect(err).ShouldNot(HaveOccurred(), fmt.Sprintf("failed to process cluster class input config file, reason: %v", err))
 	Expect(isCC).To(Equal(true), fmt.Sprintf("input cluster class based config file is not cluster class based, does not have Cluster object."))
 	return ccObject.GetName(), ccObject.GetNamespace()


### PR DESCRIPTION
### What this PR does / why we need it
Automate Custom Cluster Bootstrap for Antrea parameters for CC Guest cluster on supervisor
- Modified the helper function library (package.go) to work for TKGS and TKGm. 
- Created test case for custom bootstrap. Used the modified helper functions to validate custom bootstrap and packages
- Added test case for custom Antrea package

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2451 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

1. Verified by creating a classy cluster
2. Verified AntreaConfig object and output as follows:
```
apiVersion: cni.tanzu.vmware.com/v1alpha1
  kind: AntreaConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"cni.tanzu.vmware.com/v1alpha1","kind":"AntreaConfig","metadata":{"annotations":{},"name":"cc20","namespace":"shivaani-ns"},"spec":{"antrea":{"config":{"disableUdpTunnelOffload":false,"featureGates":{"AntreaPolicy":true,"AntreaProxy":true,"AntreaTraceflow":false,"Egress":true,"EndpointSlice":true,"FlowExporter":false,"NodePortLocal":true},"noSNAT":false,"trafficEncapMode":"encap"}}}}
    creationTimestamp: "2022-07-22T15:57:45Z"
    generation: 1
    name: cc20
    namespace: shivaani-ns
    resourceVersion: "19293942"
    selfLink: /apis/cni.tanzu.vmware.com/v1alpha1/namespaces/shivaani-ns/antreaconfigs/cc20
    uid: 5562d65e-e9f7-4789-bde4-e59983cf4785
  spec:
    antrea:
      config:
        defaultMTU: ""
        disableUdpTunnelOffload: false
        featureGates:
          AntreaPolicy: true
          AntreaProxy: true
          AntreaTraceflow: false
          Egress: true
          EndpointSlice: true
          FlowExporter: false
          NetworkPolicyStats: false
          NodePortLocal: true
        noSNAT: false
        tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
        trafficEncapMode: encap
```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
