### PR TITLE
TKR Resolver: Custom imageRepository

### DIFF
--- a/pkg/v2/tkr/util/testdata/gendata.go
+++ b/pkg/v2/tkr/util/testdata/gendata.go
@@ -198,7 +198,14 @@ func GenTKR(osImagesByK8sVersion map[string]data.OSImages) *runv1.TanzuKubernete
 			Version:  v,
 			OSImages: OsImageRefs(RandNonEmptySubsetOfOSImages(osImagesByK8sVersion[k8sVersion])),
 			Kubernetes: runv1.KubernetesSpec{
-				Version: k8sVersion,
+				Version:         k8sVersion,
+				ImageRepository: rand.String(10),
+				Etcd: &runv1.ContainerImageInfo{
+					ImageTag: fmt.Sprintf("v1.%v.%v", rand.Intn(10), rand.Intn(10)),
+				},
+				CoreDNS: &runv1.ContainerImageInfo{
+					ImageTag: fmt.Sprintf("v1.%v.%v", rand.Intn(10), rand.Intn(10)),
+				},
 			},
 		},
 		Status: runv1.TanzuKubernetesReleaseStatus{

--- a/pkg/v2/tkr/util/topology/cluster_test.go
+++ b/pkg/v2/tkr/util/topology/cluster_test.go
@@ -24,6 +24,8 @@ func TestClusterVariables(t *testing.T) {
 const (
 	varA = "A"
 	varB = "B"
+	varC = "C"
+	varD = "D"
 )
 
 type AData struct {
@@ -47,6 +49,8 @@ var _ = Describe("Cluster variable getters and setters", func() {
 		clusterClass.Spec.Variables = []clusterv1.ClusterClassVariable{
 			{Name: varA},
 			{Name: varB},
+			{Name: varC},
+			// D does not exist
 		}
 		cluster = &clusterv1.Cluster{
 			ObjectMeta: metav1.ObjectMeta{
@@ -79,10 +83,28 @@ var _ = Describe("Cluster variable getters and setters", func() {
 							Name:  varB,
 							Value: apiextensionsv1.JSON{Raw: []byte(`{"bar":"foo"}`)},
 						},
+						// C is not set
 					},
 				},
 			},
 		}
+	})
+
+	Describe("GetVariable()", func() {
+		When("the variable is not set", func() {
+			It("should set the target var to nil", func() {
+				data := &AData{}
+				Expect(GetVariable(cluster, varC, &data)).To(Succeed())
+				Expect(data).To(BeNil())
+			})
+		})
+		When("the variable does not exist", func() {
+			It("should set the target var to nil", func() {
+				data := &AData{}
+				Expect(GetVariable(cluster, varD, &data)).To(Succeed())
+				Expect(data).To(BeNil())
+			})
+		})
 	})
 
 	Describe("SetMDVariable()", func() {

--- a/pkg/v2/tkr/webhook/cluster/tkr-resolver/main.go
+++ b/pkg/v2/tkr/webhook/cluster/tkr-resolver/main.go
@@ -38,8 +38,10 @@ func main() {
 	var webhookCertDir string
 	var metricsAddr string
 	var webhookServerPort int
+	var customImageRepositoryCCVar string
 	flag.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/", "Webhook cert directory.")
 	flag.StringVar(&metricsAddr, "metrics-bind-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&customImageRepositoryCCVar, "custom-image-repository-cc-var", "imageRepository", "Custom imageRepository ClusterClass variable")
 	flag.IntVar(&webhookServerPort, "webhook-server-port", 9443, "The port that the webhook server serves at.")
 
 	opts := zap.Options{
@@ -97,6 +99,9 @@ func main() {
 			Log:         mgr.GetLogger().WithName("handler.Cluster"),
 			TKRResolver: tkrResolver,
 			Client:      mgr.GetClient(),
+			Config: cluster.Config{
+				CustomImageRepositoryCCVar: customImageRepositoryCCVar,
+			},
 		},
 	})
 


### PR DESCRIPTION
### What this PR does / why we need it

Use custom imageRepository in TKR_DATA if it is specified in the cluster using `imageRepository` cluster variable.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

N/A

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Updated unit tests to cover added functionality.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The TKR Resolver Cluster webhook now honors the custom `imageRepository` cluster variable: 
if present, its `host` field value is written into the resolved TKR_DATA values' 
kubernetesSpec imageRepository fields.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
