### PR TITLE
Ability to generate default capabilities secret with user-specified PSPs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -637,7 +637,7 @@ generate-package-secret: ## Generate the default package values secret. Usage: m
 	@if [ $(PACKAGE) == 'pinniped' ]; then \
 	  ./addons/pinniped/tanzu-auth-controller-manager/hack/generate-package-secret.sh -v tkr=${tkr} -v infrastructure_provider=${iaas} ;\
 	elif [ $(PACKAGE) == 'capabilities' ]; then \
-	  ./pkg/v1/sdk/capabilities/hack/generate-package-secret.sh -v tkr=${tkr} ;\
+	  ./pkg/v1/sdk/capabilities/hack/generate-package-secret.sh -v tkr=${tkr} --data-value-yaml 'rbac.podSecurityPolicyNames=[${psp}]';\
 	else \
 	  echo "invalid PACKAGE: $(PACKAGE)" ;\
 	  exit 1 ;\

--- a/pkg/v1/sdk/capabilities/hack/generate-package-secret.test.sh
+++ b/pkg/v1/sdk/capabilities/hack/generate-package-secret.test.sh
@@ -16,7 +16,7 @@ TEST_RESULT_1=$(./hack/generate-package-secret.sh)
 EXPECTED_1="apiVersion: v1
 kind: Secret
 metadata:
-  name: default-capabilities-config-v0.0.0
+  name: default-capabilities-package-config-v0.0.0
 stringData:
   values.yaml: |
     namespace: tkg-system
@@ -36,11 +36,11 @@ then
 fi
 
 # test with provided args
-TEST_RESULT_2=$(./hack/generate-package-secret.sh -v tkr=foo)
+TEST_RESULT_2=$(./hack/generate-package-secret.sh -v tkr=foo --data-value-yaml 'rbac.podSecurityPolicyNames=[test-psp,test-psp-two]')
 EXPECTED_2="apiVersion: v1
 kind: Secret
 metadata:
-  name: default-capabilities-config-foo
+  name: default-capabilities-package-config-foo
 stringData:
   values.yaml: |
     namespace: tkg-system
@@ -49,7 +49,9 @@ stringData:
       nodeSelector: {}
       tolerations: []
     rbac:
-      podSecurityPolicyNames: []"
+      podSecurityPolicyNames:
+      - test-psp
+      - test-psp-two"
 
 if [[ "${TEST_RESULT_2}" != "${EXPECTED_2}" ]]
 then


### PR DESCRIPTION
### What this PR does / why we need it
Ability to generate default capabilities secret with user-specified PSPs

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #3015.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3015

### Describe testing done for PR

```
kosarajud-a02:tanzu-framework kosarajud$ make generate-package-secret PACKAGE=capabilities tkr=random psp=vmware-system-privileged
apiVersion: v1
kind: Secret
metadata:
  name: default-capabilities-package-config-random
stringData:
  values.yaml: |
    namespace: tkg-system
    deployment:
      hostNetwork: true
      nodeSelector: {}
      tolerations: []
    rbac:
      podSecurityPolicyNames:
      - vmware-system-privileged
kosarajud-a02:tanzu-framework kosarajud$ make generate-package-secret PACKAGE=capabilities tkr=random
apiVersion: v1
kind: Secret
metadata:
  name: default-capabilities-package-config-random
stringData:
  values.yaml: |
    namespace: tkg-system
    deployment:
      hostNetwork: true
      nodeSelector: {}
      tolerations: []
    rbac:
      podSecurityPolicyNames: []
kosarajud-a02:tanzu-framework kosarajud$ make generate-package-secret PACKAGE=pinniped tkr=random iaas=vsphere
apiVersion: v1
kind: Secret
metadata:
  name: default-pinniped-config-random
stringData:
  values.yaml: |
    infrastructure_provider: vsphere
    identity_management_type: none
    tkg_cluster_role: workload
```
Fixed the tests
```
kosarajud-a02:hack kosarajud$ ./generate-package-secret.test.sh 
kosarajud-a02:hack kosarajud$ 
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer
After this change, we need changes in the `bolt-cli` to pass the default `tkgs` PSP during the `tkr-bom` build
<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
