### PR TITLE
cc_cluster lifecycle test - upgrade

### DIFF
--- a/pkg/v1/tkg/test/tkgctl/tkgs_cc/tkgs_cc_workload_cluster_test.go
+++ b/pkg/v1/tkg/test/tkgctl/tkgs_cc/tkgs_cc_workload_cluster_test.go
@@ -62,6 +62,11 @@ var _ = Describe("TKGS ClusterClass based workload cluster tests", func() {
 		It("should successfully create a cluster", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("should successfully upgrade a cluster", func() {
+			Expect(err).ToNot(HaveOccurred())
+			shared.TestClusterUpgrade(tkgctlClient, clusterName, namespace)
+		})
 	})
 
 	Context("when input file is cluster class based with CNI Calico", func() {
@@ -88,6 +93,10 @@ var _ = Describe("TKGS ClusterClass based workload cluster tests", func() {
 
 		It("should successfully create a cluster", func() {
 			Expect(err).ToNot(HaveOccurred())
+		})
+		It("should successfully upgrade a cluster", func() {
+			Expect(err).ToNot(HaveOccurred())
+			shared.TestClusterUpgrade(tkgctlClient, clusterName, namespace)
 		})
 	})
 


### PR DESCRIPTION
cc_cluster lifecycle upgrade test - upgrade
    
    adds the required code to execute an upgrade test on a cluster


### What this PR does / why we need it
Adds logic to verify class cluster upgrade for integration tests. 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2450 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
adds cluster upgrade integration test for tkgs
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->

Tested the following locally: 
```
commit 538efb762a05bc9f9e7590967cd729d168abab87 (HEAD -> cc_lifecycle_test, adduarte/cc_lifecycle_test)
Author: Adolfo Duarte <aduarte@vmware.com>
Date:   Mon Jul 25 12:03:50 2022 -0700

    cc_cluster lifecycle upgrade test - upgrade
    
    adds the required code to execute an upgrade test on a cluster

```

used command: 
```
  E2E_CONFIG=/Users/aduarte/testing/tanzu-framework/trash/tkgs.yaml hack/tools/bin/ginkgo -v -trace --focus='when input file is cluster class based with CNI Antrea.*upgrade.*' pkg/v1/tkg/test/tkgctl/tkgs_cc


```
results:
```
STEP: Upgrade workload cluster "classy" in namespace "cctest"

Workload cluster 'classy' created

timeout duration of at least 15 minutes is required, using default timeout 30m0s
Creating management cluster client...
Upgrading kubernetes cluster to `v1.23.8+vmware.2-tkg.1-zshippable` version
......
worker nodes are still being upgraded for MachineDeployment 'classy-node-pool-1-h5slw', DesiredReplicas=1 Replicas=2 ReadyReplicas=2 UpdatedReplicas=1, retrying
Cluster 'classy' successfully upgraded to kubernetes version 'v1.23.8+vmware.2-tkg.1-zshippable'
Workload cluster 'classy' is being deleted 

• [SLOW TEST:1205.266 seconds]
TKGS ClusterClass based workload cluster tests
/Users/aduarte/testing/tanzu-framework/pkg/v1/tkg/test/tkgctl/tkgs_cc/tkgs_cc_workload_cluster_test.go:24
  when input file is cluster class based with CNI Antrea
  /Users/aduarte/testing/tanzu-framework/pkg/v1/tkg/test/tkgctl/tkgs_cc/tkgs_cc_workload_cluster_test.go:40
    should successfully create a cluster
    /Users/aduarte/testing/tanzu-framework/pkg/v1/tkg/test/tkgctl/tkgs_cc/tkgs_cc_workload_cluster_test.go:56
------------------------------
SSSS
JUnit report was created: /var/folders/3y/xfxl51_563q457kydkzw10yc0000gq/T/artifacts/junit/junit.e2e_suite.1.xml

Ran 1 of 5 Specs in 1206.075 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 4 Skipped
```
