### PR TITLE
monitor cluster class based workload cluster core packages installation

### DIFF
--- a/pkg/v1/tkg/client/cluster.go
+++ b/pkg/v1/tkg/client/cluster.go
@@ -57,6 +57,7 @@ type waitForAddonsOptions struct {
 	clusterName           string
 	namespace             string
 	waitForCNI            bool
+	isTKGSCluster         bool
 }
 
 // TKGSupportedClusterOptions is the comma separated list of cluster options that could be enabled by user
@@ -170,7 +171,7 @@ func (c *TkgClient) CreateCluster(options *CreateClusterOptions, waitForCluster 
 		}
 	}
 
-	log.Infof("Creating workload cluster '%s'...", options.ClusterName)
+	log.Infof("creating workload cluster '%s'...", options.ClusterName)
 	err = c.DoCreateCluster(regionalClusterClient, options.ClusterName, options.TargetNamespace, string(bytes))
 	if err != nil {
 		return false, errors.Wrap(err, "unable to create cluster")
@@ -179,7 +180,7 @@ func (c *TkgClient) CreateCluster(options *CreateClusterOptions, waitForCluster 
 	if !waitForCluster {
 		return false, nil
 	}
-	return true, c.waitForClusterCreation(regionalClusterClient, options, isPacific)
+	return true, c.waitForClusterCreation(regionalClusterClient, options)
 }
 
 // getClusterConfigurationBytes returns cluster configuration by taking into consideration of legacy vs clusterclass based cluster creation
@@ -205,13 +206,13 @@ func (c *TkgClient) getClusterConfigurationBytes(options *ClusterConfigOptions, 
 func getContentFromInputFile(fileName string) ([]byte, error) {
 	content, err := os.ReadFile(fileName)
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("Error while reading input file %v : ", fileName))
+		return nil, errors.Wrap(err, fmt.Sprintf("error while reading input file %v : ", fileName))
 	}
 	return content, nil
 }
 
-func (c *TkgClient) waitForClusterCreation(regionalClusterClient clusterclient.Client, options *CreateClusterOptions, isTKGSCluster bool) error {
-	log.Info("Waiting for cluster to be initialized...")
+func (c *TkgClient) waitForClusterCreation(regionalClusterClient clusterclient.Client, options *CreateClusterOptions) error {
+	log.Info("waiting for cluster to be initialized...")
 	kubeConfigBytes, err := c.WaitForClusterInitializedAndGetKubeConfig(regionalClusterClient, options.ClusterName, options.TargetNamespace)
 	if err != nil {
 		return errors.Wrap(err, "unable to wait for cluster and get the cluster kubeconfig")
@@ -230,21 +231,39 @@ func (c *TkgClient) waitForClusterCreation(regionalClusterClient clusterclient.C
 		return errors.Wrap(err, "unable to save management cluster kubeconfig to TKG managed kubeconfig")
 	}
 
-	log.Info("Waiting for cluster nodes to be available...")
+	log.Info("waiting for cluster nodes to be available...")
 	if err := c.WaitForClusterReadyAfterCreate(regionalClusterClient, options.ClusterName, options.TargetNamespace); err != nil {
 		return errors.Wrap(err, "unable to wait for cluster nodes to be available")
 	}
 
 	c.WaitForAutoscalerDeployment(regionalClusterClient, options.ClusterName, options.TargetNamespace)
+	workloadClusterClient, err := clusterclient.NewClient(workloadClusterKubeconfigPath, kubeContext, clusterclient.Options{OperationTimeout: 15 * time.Minute})
+	if err != nil {
+		return errors.Wrap(err, "unable to create workload cluster client")
+	}
 
-	if !isTKGSCluster {
-		log.Info("Waiting for addons installation...")
-
-		workloadClusterClient, err := clusterclient.NewClient(workloadClusterKubeconfigPath, kubeContext, clusterclient.Options{OperationTimeout: 15 * time.Minute})
-		if err != nil {
-			return errors.Wrap(err, "unable to create workload cluster client")
+	isClusterClassBased, err := regionalClusterClient.IsClusterClassBased(options.ClusterName, options.TargetNamespace)
+	if err != nil {
+		return errors.Wrap(err, "error while checking workload cluster type")
+	}
+	isTKGSCluster, err := regionalClusterClient.IsPacificRegionalCluster()
+	if err != nil {
+		return errors.Wrap(err, constants.ErrorMsgIsTKGSCluster)
+	}
+	if isClusterClassBased {
+		log.Info("waiting for addons core packages installation...")
+		if err := c.WaitForAddonsCorePackagesInstallation(waitForAddonsOptions{
+			regionalClusterClient: regionalClusterClient,
+			workloadClusterClient: workloadClusterClient,
+			clusterName:           options.ClusterName,
+			namespace:             options.TargetNamespace,
+			waitForCNI:            true,
+			isTKGSCluster:         isTKGSCluster,
+		}); err != nil {
+			return errors.Wrap(err, "error waiting for addons to get installed")
 		}
-
+	} else {
+		log.Info("waiting for addons installation...")
 		if err := c.WaitForAddons(waitForAddonsOptions{
 			regionalClusterClient: regionalClusterClient,
 			workloadClusterClient: workloadClusterClient,
@@ -254,9 +273,9 @@ func (c *TkgClient) waitForClusterCreation(regionalClusterClient clusterclient.C
 		}); err != nil {
 			return errors.Wrap(err, "error waiting for addons to get installed")
 		}
-		log.Info("Waiting for packages to be up and running...")
+		log.Info("waiting for packages to be up and running...")
 		if err := c.WaitForPackages(regionalClusterClient, workloadClusterClient, options.ClusterName, options.TargetNamespace, false); err != nil {
-			log.Warningf("Warning: Cluster is created successfully, but some packages are failing. %v", err)
+			log.Warningf("warning: Cluster is created successfully, but some packages are failing. %v", err)
 		}
 	}
 	return nil
@@ -273,7 +292,7 @@ func (c *TkgClient) getValueForAutoscalerDeploymentConfig() bool {
 	}
 
 	if isEnabled, err = strconv.ParseBool(autoscalerEnabled); err != nil {
-		log.Warningf("Unable to parse the value of config variable %q. reason: %v", constants.ConfigVariableEnableAutoscaler, err)
+		log.Warningf("unable to parse the value of config variable %q. reason: %v", constants.ConfigVariableEnableAutoscaler, err)
 		return false
 	}
 
@@ -405,7 +424,24 @@ func (c *TkgClient) waitForCRS(options waitForAddonsOptions) error {
 	if err != nil {
 		return errors.Wrap(err, "error waiting for ClusterResourceSet object to be applied for the cluster")
 	}
+
 	return nil
+}
+
+// WaitForAddonsCorePackagesInstallation gets ClusterBootstrap and collects list of addons core packages, and monitors the kapp controller package installation in management cluster and rest of core packages installation in workload cluster
+func (c *TkgClient) WaitForAddonsCorePackagesInstallation(options waitForAddonsOptions) error {
+	clusterBootstrap, err := GetClusterBootstrap(options.regionalClusterClient, options.clusterName, options.namespace)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error while getting ClusterBootstrap object for workload cluster: %v", options.clusterName))
+	}
+	var corePackagesNamespace string
+	if options.isTKGSCluster {
+		corePackagesNamespace = constants.CorePackagesNamespaceInTKGS
+	} else {
+		corePackagesNamespace = constants.CorePackagesNamespaceInTKGM
+	}
+	packages := GetCorePackagesFromClusterBootstrap(clusterBootstrap, corePackagesNamespace)
+	return MonitorAddonsCorePackageInstallation(options.regionalClusterClient, options.workloadClusterClient, packages, c.getPackageInstallTimeoutFromConfig())
 }
 
 func (c *TkgClient) createPacificCluster(options *CreateClusterOptions, waitForCluster bool) (err error) {
@@ -454,7 +490,7 @@ func (c *TkgClient) createPacificCluster(options *CreateClusterOptions, waitForC
 
 	log.V(3).Infof("Waiting for the Tanzu Kubernetes Cluster service for vSphere workload cluster\n")
 	if options.IsInputFileClusterClassBased {
-		err = c.waitForClusterCreation(clusterClient, options, options.IsInputFileClusterClassBased)
+		err = c.waitForClusterCreation(clusterClient, options)
 	} else {
 		err = clusterClient.WaitForPacificCluster(clusterName, namespace)
 	}

--- a/pkg/v1/tkg/client/package_helper.go
+++ b/pkg/v1/tkg/client/package_helper.go
@@ -1,0 +1,101 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kapppkgv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
+	runtanzuv1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/clusterclient"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
+)
+
+// GetClusterBootstrap returns ClusterBootstrap object for the given clustername in the management cluster
+func GetClusterBootstrap(managementClusterClient clusterclient.Client, clusterName, namespace string) (*runtanzuv1alpha3.ClusterBootstrap, error) {
+	log.V(3).Infof("getting ClusterBootstrap object for cluster: %v", clusterName)
+	clusterBootstrap := &runtanzuv1alpha3.ClusterBootstrap{}
+	err := managementClusterClient.GetResource(clusterBootstrap, clusterName, namespace, nil, &clusterclient.PollOptions{Interval: clusterclient.CheckResourceInterval, Timeout: clusterclient.PackageInstallTimeout})
+	return clusterBootstrap, err
+}
+
+// GetCorePackagesFromClusterBootstrap returns addon's core packages details from the given ClsuterBootstrap object
+func GetCorePackagesFromClusterBootstrap(clusterBootstrap *runtanzuv1alpha3.ClusterBootstrap, corePackagesNamespace string) []kapppkgv1alpha1.Package {
+	var packages []kapppkgv1alpha1.Package
+	suffixStr := "-package"
+	// kapp package is installed in namespace in which workload cluster created
+	if clusterBootstrap.Spec.Kapp != nil && clusterBootstrap.Spec.Kapp.ValuesFrom != nil && clusterBootstrap.Spec.Kapp.ValuesFrom.ProviderRef != nil {
+		name := strings.TrimSuffix(clusterBootstrap.Spec.Kapp.ValuesFrom.ProviderRef.Name, suffixStr)
+		packages = append(packages, kapppkgv1alpha1.Package{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: clusterBootstrap.ObjectMeta.Namespace}})
+	}
+	// Core packages CNI, CSI and CPI (other than Kapp) installed in tkg-system namespace in case of tkgm, and in case of tkgs installed in vmware-system-tkg namespace
+	if clusterBootstrap.Spec.CNI != nil && clusterBootstrap.Spec.CNI.ValuesFrom != nil && clusterBootstrap.Spec.CNI.ValuesFrom.ProviderRef != nil {
+		name := strings.TrimSuffix(clusterBootstrap.Spec.CNI.ValuesFrom.ProviderRef.Name, suffixStr)
+		packages = append(packages, kapppkgv1alpha1.Package{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: corePackagesNamespace}})
+	}
+	if clusterBootstrap.Spec.CSI != nil && clusterBootstrap.Spec.CSI.ValuesFrom != nil && clusterBootstrap.Spec.CSI.ValuesFrom.ProviderRef != nil {
+		name := strings.TrimSuffix(clusterBootstrap.Spec.CSI.ValuesFrom.ProviderRef.Name, suffixStr)
+		packages = append(packages, kapppkgv1alpha1.Package{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: corePackagesNamespace}})
+	}
+	if clusterBootstrap.Spec.CPI != nil && clusterBootstrap.Spec.CPI.ValuesFrom != nil && clusterBootstrap.Spec.CPI.ValuesFrom.ProviderRef != nil {
+		name := strings.TrimSuffix(clusterBootstrap.Spec.CPI.ValuesFrom.ProviderRef.Name, suffixStr)
+		packages = append(packages, kapppkgv1alpha1.Package{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: corePackagesNamespace}})
+	}
+	return packages
+}
+
+// MonitorAddonsCorePackageInstallation monitors addon's core packages (kapp, cni, csi and cpi) and returns error if any while monitoring packages or any packages are not installed successfully. First it monitors kapp package in management cluster then it monitors other core packages in workload cluster.
+func MonitorAddonsCorePackageInstallation(regionalClusterClient clusterclient.Client, workloadClusterClient clusterclient.Client, packages []kapppkgv1alpha1.Package, packageInstallTimeout time.Duration) error {
+	if len(packages) == 0 {
+		return nil
+	}
+	var corePackagesOnWorkloadCluster, corePackagesOnManagementCluster []kapppkgv1alpha1.Package
+	for _, currentPackage := range packages {
+		if strings.Contains(currentPackage.ObjectMeta.Name, "kapp-controller") {
+			corePackagesOnManagementCluster = append(corePackagesOnManagementCluster, currentPackage)
+		} else {
+			corePackagesOnWorkloadCluster = append(corePackagesOnWorkloadCluster, currentPackage)
+		}
+	}
+	err := WaitForPackagesInstallation(regionalClusterClient, corePackagesOnManagementCluster, packageInstallTimeout)
+	if err != nil {
+		return err
+	}
+	return WaitForPackagesInstallation(workloadClusterClient, corePackagesOnWorkloadCluster, packageInstallTimeout)
+}
+
+func WaitForPackagesInstallation(clusterClient clusterclient.Client, packages []kapppkgv1alpha1.Package, packageInstallTimeout time.Duration) error {
+	// Start waiting for all packages in parallel using group.Wait
+	// Note: As PackageInstall resources are created in the cluster itself
+	// we are using currentClusterClient which will point to correct cluster
+	group, _ := errgroup.WithContext(context.Background())
+
+	for _, currentPackage := range packages {
+		pn := currentPackage.ObjectMeta.Name
+		ns := currentPackage.ObjectMeta.Namespace
+		log.V(3).Warningf("waiting for package: '%s'", pn)
+		group.Go(
+			func() error {
+				err := clusterClient.WaitForPackageInstall(pn, ns, packageInstallTimeout)
+				if err != nil {
+					log.V(3).Warningf("failure while waiting for package: '%s' in namespace: '%s'", pn, ns)
+				} else {
+					log.V(3).Infof("successfully reconciled package: '%s' in namespace: '%s'", pn, ns)
+				}
+				return err
+			})
+	}
+
+	err := group.Wait()
+	if err != nil {
+		return errors.Wrap(err, "failure while waiting for packages to be installed")
+	}
+	return nil
+}

--- a/pkg/v1/tkg/client/package_helper_test.go
+++ b/pkg/v1/tkg/client/package_helper_test.go
@@ -1,0 +1,109 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client_test
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+
+	"sigs.k8s.io/yaml"
+
+	runtanzuv1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+	. "github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/fakes"
+)
+
+const bootstrapObject = "../fakes/config/clusterbootstrap.yaml"
+
+var (
+	fakeMgtClusterClient *fakes.ClusterClient
+	fakeWcClusterClient  *fakes.ClusterClient
+	timeout              time.Duration
+	clusterBootstrap     *runtanzuv1alpha3.ClusterBootstrap
+)
+
+func init() {
+	fakeMgtClusterClient = &fakes.ClusterClient{}
+	fakeWcClusterClient = &fakes.ClusterClient{}
+	timeout = time.Duration(1)
+
+}
+
+var _ = Describe("unit tests for monitor addon's packages installation", func() {
+	Context("get bootstrap object for workload cluster", func() {
+		When("bootstrap object exists should not return any error", func() {
+			BeforeEach(func() {
+				fakeMgtClusterClient.GetResourceReturns(nil)
+			})
+			It("should not return error", func() {
+				_, err := GetClusterBootstrap(fakeMgtClusterClient, "cluster1", "namespace1")
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		When("bootstrap object not exists should return an error", func() {
+			resourceNotExists := "resource not exists"
+			BeforeEach(func() {
+				fakeMgtClusterClient.GetResourceReturns(errors.New(resourceNotExists))
+			})
+			It("should return error", func() {
+				_, err := GetClusterBootstrap(fakeMgtClusterClient, "cluster1", "namespace1")
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+	Context("get packages from bootstrap object and monitor packages installation", func() {
+		BeforeEach(func() {
+			bs, _ := os.ReadFile(bootstrapObject)
+			clusterBootstrap = &runtanzuv1alpha3.ClusterBootstrap{}
+			Expect(yaml.Unmarshal(bs, clusterBootstrap)).To(Succeed(), "Failed to convert the cluster bootstrap input file to yaml")
+		})
+		When("package installation successful should not return error", func() {
+			BeforeEach(func() {
+				fakeMgtClusterClient.WaitForPackageInstallReturns(nil)
+				fakeWcClusterClient.WaitForPackageInstallReturns(nil)
+			})
+			It("should not return error", func() {
+				packages := GetCorePackagesFromClusterBootstrap(clusterBootstrap, constants.CorePackagesNamespaceInTKGM)
+				err := MonitorAddonsCorePackageInstallation(fakeMgtClusterClient, fakeWcClusterClient, packages, timeout)
+				pkg, ns, _ := fakeMgtClusterClient.WaitForPackageInstallArgsForCall(0)
+				Expect(pkg).To(Equal(packages[0].ObjectMeta.Name))
+				Expect(ns).To(Equal(packages[0].ObjectMeta.Namespace))
+				pkg, ns, _ = fakeWcClusterClient.WaitForPackageInstallArgsForCall(0)
+				Expect([]string{packages[1].ObjectMeta.Name, packages[2].ObjectMeta.Name, packages[3].ObjectMeta.Name}).Should(ContainElements(pkg))
+				Expect(ns).To(Equal(packages[1].ObjectMeta.Namespace))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		When("package installation not successful because of MC packages error, should return error", func() {
+			packageNotFound := "package not found"
+			BeforeEach(func() {
+				fakeMgtClusterClient.WaitForPackageInstallReturns(errors.New(packageNotFound))
+			})
+			It("should return error", func() {
+				packages := GetCorePackagesFromClusterBootstrap(clusterBootstrap, constants.CorePackagesNamespaceInTKGM)
+				err := MonitorAddonsCorePackageInstallation(fakeMgtClusterClient, fakeWcClusterClient, packages, timeout)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(packageNotFound))
+			})
+		})
+		When("package installation not successful because of WC packages error, should return error", func() {
+			packageNotFound := "package not found"
+			BeforeEach(func() {
+				fakeWcClusterClient.WaitForPackageInstallReturns(errors.New(packageNotFound))
+			})
+			It("should return error", func() {
+				packages := GetCorePackagesFromClusterBootstrap(clusterBootstrap, constants.CorePackagesNamespaceInTKGM)
+				err := MonitorAddonsCorePackageInstallation(fakeMgtClusterClient, fakeWcClusterClient, packages, timeout)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring(packageNotFound))
+			})
+		})
+	})
+
+})

--- a/pkg/v1/tkg/client/workload_cluster.go
+++ b/pkg/v1/tkg/client/workload_cluster.go
@@ -196,6 +196,6 @@ func deleteCRSObjectsIfPresent(clusterClient clusterclient.Client, clusterName, 
 		return kerrors.NewAggregate(errorList)
 	}
 
-	log.V(3).Infof("Successfully deleted ClusterResourceSet objects associated with cluster '%s'", clusterName)
+	log.V(3).Infof("successfully deleted ClusterResourceSet objects associated with cluster '%s'", clusterName)
 	return nil
 }

--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -633,7 +633,7 @@ func (c *client) WaitForResourceDeletion(resourceReference interface{}, resource
 		return err
 	}
 
-	log.V(4).Infof("Waiting for %s resource of type %s to be deleted", resourceName, reflect.TypeOf(resourceReference))
+	log.V(4).Infof("waiting for %s resource of type %s to be deleted", resourceName, reflect.TypeOf(resourceReference))
 	_, err = c.poller.PollImmediateWithGetter(pollOptions.Interval, pollOptions.Timeout, func() (interface{}, error) {
 		getErr := c.get(resourceName, namespace, obj, postVerify)
 		if getErr != nil {
@@ -1197,7 +1197,7 @@ func (c *client) GetResource(resourceReference interface{}, resourceName, namesp
 	// if pollOptions are provided use the polling and wait for the result/error/timeout
 	// else use normal get
 	if pollOptions != nil {
-		log.V(4).Infof("Waiting for resource %s of type %s to be up and running", resourceName, reflect.TypeOf(resourceReference))
+		log.V(4).Infof("waiting for resource %s of type %s to be up and running", resourceName, reflect.TypeOf(resourceReference))
 		_, err = c.poller.PollImmediateWithGetter(pollOptions.Interval, pollOptions.Timeout, func() (interface{}, error) {
 			return nil, c.get(resourceName, namespace, obj, postVerify)
 		})
@@ -1231,7 +1231,7 @@ func (c *client) GetResourceList(resourceReference interface{}, clusterName, nam
 	// if pollOptions are provided use the polling and wait for the result/error/timeout
 	// else use normal list
 	if pollOptions != nil {
-		log.V(4).Infof("Waiting for resources type %s to be up and running", reflect.TypeOf(resourceReference))
+		log.V(4).Infof("waiting for resources type %s to be up and running", reflect.TypeOf(resourceReference))
 		_, err = c.poller.PollImmediateWithGetter(pollOptions.Interval, pollOptions.Timeout, func() (interface{}, error) {
 			return nil, c.list(clusterName, namespace, obj, postVerify)
 		})
@@ -1349,7 +1349,7 @@ func (c *client) GetSecretValue(secretName, key, namespace string, pollOptions *
 }
 
 func (c *client) GetKubeConfigForCluster(clusterName, namespace string, pollOptions *PollOptions) ([]byte, error) {
-	log.V(4).Info("Getting secret for cluster")
+	log.V(4).Info("getting secret for cluster")
 	clusterSecretName := fmt.Sprintf("%s-%s", clusterName, kubeConfigSecretSuffix)
 	kubeConfigBytes, err := c.GetSecretValue(clusterSecretName, kubeConfigDataField, namespace, pollOptions)
 	if err != nil {

--- a/pkg/v1/tkg/constants/cluster_internal.go
+++ b/pkg/v1/tkg/constants/cluster_internal.go
@@ -6,16 +6,18 @@ package constants
 
 // cluster related constants used internally
 const (
-	ClusterClassFeature       = "vmware-system-tkg-clusterclass"
-	TKCAPIFeature             = "vmware-system-tkg-tkc-api"
-	TKGSClusterClassNamespace = "vmware-system-tkg"
-	TKGSTKCAPINamespace       = "vmware-system-tkg"
-	TKGStkcapiNamespace       = "vmware-system-tkg"
+	ClusterClassFeature         = "vmware-system-tkg-clusterclass"
+	TKCAPIFeature               = "vmware-system-tkg-tkc-api"
+	TKGSClusterClassNamespace   = "vmware-system-tkg"
+	TKGSTKCAPINamespace         = "vmware-system-tkg"
+	CorePackagesNamespaceInTKGS = "vmware-system-tkg"
+	CorePackagesNamespaceInTKGM = "tkg-system"
 
 	ErrorMsgFeatureGateNotActivated = "vSphere with Tanzu environment detected, however, the feature '%v' is not activated in '%v' namespace"
 	ErrorMsgFeatureGateStatus       = "error while checking feature '%v' status in namespace '%v'"
 	ErrorMsgClusterExistsAlready    = "cluster with name %s already exists, please specify another name"
 	ErrorMsgClusterListError        = "unable to get list of workload clusters managed by current management cluster"
+	ErrorMsgIsTKGSCluster           = "unable to determine if management cluster is on vSphere with Tanzu"
 
 	ErrorMsgCClassInputFeatureFlagDisabled = "Input file is cluster class based but CLI feature flag '%v' is disabled, make sure its enabled to create cluster class based cluster"
 

--- a/pkg/v1/tkg/fakes/config/clusterbootstrap.yaml
+++ b/pkg/v1/tkg/fakes/config/clusterbootstrap.yaml
@@ -1,0 +1,91 @@
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: ClusterBootstrap
+metadata:
+  creationTimestamp: "2022-07-21T21:03:00Z"
+  finalizers:
+  - tkg.tanzu.vmware.com/addon
+  generation: 2
+  name: cc18
+  namespace: ns01
+  ownerReferences:
+  - apiVersion: cluster.x-k8s.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Cluster
+    name: cc18
+    uid: 0d3151d0-dbce-46f1-b580-5cd7a0b77488
+  resourceVersion: "4003994"
+  uid: be1e1877-9209-4202-8ab1-361eb67b9652
+spec:
+  additionalPackages:
+  - refName: guest-cluster-auth-service.tanzu.vmware.com.1.0.0+tkg.1-zshippable
+    valuesFrom:
+      secretRef: cc18-guest-cluster-auth-service-data-values
+  - refName: metrics-server.tanzu.vmware.com.0.6.1+vmware.1-tkg.1-zshippable
+  - refName: secretgen-controller.tanzu.vmware.com.0.9.1+vmware.1-tkg.1-zshippable
+  - refName: pinniped.tanzu.vmware.com.0.12.1+vmware.1-tkg.1-zshippable
+    valuesFrom:
+      secretRef: cc18-pinniped-package
+  - refName: capabilities.tanzu.vmware.com.0.25.0-dev-12-g9305a725+vmware.1
+  cni:
+    refName: antrea.tanzu.vmware.com.1.5.2+vmware.3-tkg.1-advanced-zshippable
+    valuesFrom:
+      providerRef:
+        apiGroup: cni.tanzu.vmware.com
+        kind: AntreaConfig
+        name: cc18-antrea-package
+  cpi:
+    refName: vsphere-cpi.tanzu.vmware.com.1.23.1+vmware.1-tkg.1-zshippable
+    valuesFrom:
+      providerRef:
+        apiGroup: cpi.tanzu.vmware.com
+        kind: VSphereCPIConfig
+        name: cc18-vsphere-cpi-package
+  csi:
+    refName: vsphere-pv-csi.tanzu.vmware.com.2.4.0+vmware.1-tkg.1-zshippable
+    valuesFrom:
+      providerRef:
+        apiGroup: csi.tanzu.vmware.com
+        kind: VSphereCSIConfig
+        name: cc18-vsphere-pv-csi-package
+  kapp:
+    refName: kapp-controller.tanzu.vmware.com.0.38.4+vmware.1-tkg.1-zshippable
+    valuesFrom:
+      providerRef:
+        apiGroup: run.tanzu.vmware.com
+        kind: KappControllerConfig
+        name: cc18-kapp-controller-package
+  paused: false
+status:
+  conditions:
+  - lastTransitionTime: "2022-07-21T21:09:57Z"
+    status: "True"
+    type: Antrea-ReconcileSucceeded
+  - lastTransitionTime: "2022-07-21T21:55:32Z"
+    message: |-
+      kapp: Error: waiting on reconcile deployment/tanzu-capabilities-controller-manager (apps/v1) namespace: tkg-system:
+        Finished unsuccessfully (Deployment is not progressing: ProgressDeadlineExceeded (message: ReplicaSet "tanzu-capabilities-controller-manager-67948789df" has timed out progressing.))
+    status: "True"
+    type: Capabilities-ReconcileFailed
+  - lastTransitionTime: "2022-07-21T21:07:11Z"
+    status: "True"
+    type: Guest-Cluster-Auth-Service-ReconcileSucceeded
+  - lastTransitionTime: "2022-07-21T21:08:43Z"
+    status: "True"
+    type: Kapp-Controller-ReconcileSucceeded
+  - lastTransitionTime: "2022-07-21T21:10:42Z"
+    status: "True"
+    type: Metrics-Server-ReconcileSucceeded
+  - lastTransitionTime: "2022-07-21T21:08:00Z"
+    status: "True"
+    type: Pinniped-ReconcileSucceeded
+  - lastTransitionTime: "2022-07-21T21:10:18Z"
+    status: "True"
+    type: Secretgen-Controller-ReconcileSucceeded
+  - lastTransitionTime: "2022-07-21T21:08:08Z"
+    status: "True"
+    type: Vsphere-Cpi-ReconcileSucceeded
+  - lastTransitionTime: "2022-07-21T21:09:11Z"
+    status: "True"
+    type: Vsphere-Pv-Csi-ReconcileSucceeded
+  resolvedTKR: v1.23.5---vmware.1-tkg.1-zshippable

--- a/pkg/v1/tkg/managementcomponents/management_component_install.go
+++ b/pkg/v1/tkg/managementcomponents/management_component_install.go
@@ -177,14 +177,14 @@ func WaitForManagementPackages(clusterClient clusterclient.Client, packageInstal
 
 	for _, packageName := range packageInstallNames {
 		pn := packageName
-		log.V(3).Warningf("Waiting for package: %s", pn)
+		log.V(3).Warningf("waiting for package: %s", pn)
 		group.Go(
 			func() error {
 				err := clusterClient.WaitForPackageInstall(pn, constants.TkgNamespace, packageInstallTimeout)
 				if err != nil {
-					log.V(3).Warningf("Error while waiting for package '%s'", pn)
+					log.V(3).Warningf("error while waiting for package '%s'", pn)
 				} else {
-					log.V(3).Infof("Successfully reconciled package: %s", pn)
+					log.V(3).Infof("successfully reconciled package: %s", pn)
 				}
 				return err
 			})

--- a/pkg/v1/tkg/tkgctl/create_cluster.go
+++ b/pkg/v1/tkg/tkgctl/create_cluster.go
@@ -57,7 +57,7 @@ type CreateClusterOptions struct {
 func (t *tkgctl) CreateCluster(cc CreateClusterOptions) error {
 	isTKGSCluster, err := t.tkgClient.IsPacificManagementCluster()
 	if err != nil {
-		return errors.Wrap(err, "unable to determine if management cluster is on vSphere with Tanzu")
+		return errors.Wrap(err, constants.ErrorMsgIsTKGSCluster)
 	}
 	isInputFileClusterClassBased, err := t.processWorkloadClusterInputFile(&cc, isTKGSCluster)
 	if err != nil {


### PR DESCRIPTION
### What this PR does / why we need it
This PR implements the monitoring logic for cluster class based workload cluster's addon's core packages installation, no changes have been done for the non-cluster class-based workload cluster monitoring logic. This applies to all infrastructure providers (tkgs, vsphere, aws, azure, docker).

The new monitoring logic for cluster class based workload cluster gets the workload cluster's boostrap object, then reads all core packages (kapp, cni, csi, cpi) details (package name and namespace) then first monitors the kapp-controller package installation in management/supervisor cluster, once kapp-controller package installed, then monitors the other addon's core packages (cni, csi, cpi) in workload cluster. If any package's not reconcile successfully then returns an error.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2780

### Describe testing done for PR
Unit test cases
TKGS Classy Workload cluster creation
AWS Classy Workload cluster creation
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
`tanzu cluster create classy-cluster.yaml` does monitors addons core packages (kapp, cni, csi, cpi) installation after cluster creation
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
