### PR TITLE
Fix the issue of tkg-clusterclass packageinstall reconcile failed after 15 minutes of management-cluster creation

### DIFF
--- a/pkg/v1/tkg/client/init.go
+++ b/pkg/v1/tkg/client/init.go
@@ -14,8 +14,16 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/juju/fslock"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	capav1beta1 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta1"
+	capzv1beta1 "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	capvv1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	clusterctl "sigs.k8s.io/cluster-api/cmd/clusterctl/client"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	crtclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
@@ -415,6 +423,14 @@ func (c *TkgClient) PatchClusterInitOperations(regionalClusterClient clusterclie
 		return errors.Wrap(err, "unable to patch optional metadata under labels")
 	}
 
+	if config.IsFeatureActivated(config.FeatureFlagPackageBasedLCM) {
+		// Patch and remove kapp-controller labels from clusterclass resources
+		err = c.removeKappControllerLabelsFromClusterClassResources(regionalClusterClient)
+		if err != nil {
+			return errors.Wrap(err, "unable to remove kapp-controller labels from the clusterclass resources")
+		}
+	}
+
 	return err
 }
 
@@ -767,4 +783,30 @@ func (c *TkgClient) safelyAddFeatureFlag(featureFlags map[string]string, feature
 		featureFlags = map[string]string{feature: value}
 	}
 	return featureFlags
+}
+
+// removeKappControllerLabelsFromClusterClassResources removes kapp-controller labels from clusterclass resources
+func (c *TkgClient) removeKappControllerLabelsFromClusterClassResources(regionalClusterClient clusterclient.Client) error {
+	errList := []error{}
+	labelsToBeDeleted := []string{constants.KappControllerAppLabel, constants.KappControllerAssociationLabel}
+	gvkToResourcesMap := map[schema.GroupVersionKind]string{
+		capi.GroupVersion.WithKind(constants.KindClusterClass):                          constants.ResourceClusterClass,
+		controlplanev1.GroupVersion.WithKind(constants.KindKubeadmControlPlaneTemplate): constants.ResourceKubeadmControlPlaneTemplate,
+		bootstrapv1.GroupVersion.WithKind(constants.KindKubeadmConfigTemplate):          constants.ResourceKubeadmConfigTemplate,
+		capav1beta1.GroupVersion.WithKind(constants.KindAWSClusterTemplate):             constants.ResourceAWSClusterTemplate,
+		capav1beta1.GroupVersion.WithKind(constants.KindAWSMachineTemplate):             constants.ResourceAWSMachineTemplate,
+		capzv1beta1.GroupVersion.WithKind(constants.KindAzureClusterTemplate):           constants.ResourceAzureClusterTemplate,
+		capzv1beta1.GroupVersion.WithKind(constants.KindAzureMachineTemplate):           constants.ResourceAzureMachineTemplate,
+		capvv1beta1.GroupVersion.WithKind(constants.KindVSphereClusterTemplate):         constants.ResourceVSphereClusterTemplate,
+		capvv1beta1.GroupVersion.WithKind(constants.KindVSphereMachineTemplate):         constants.ResourceVSphereMachineTemplate,
+	}
+
+	for gvk, resourceName := range gvkToResourcesMap {
+		if exists, err := regionalClusterClient.VerifyExistenceOfCRD(resourceName, gvk.Group); err != nil || !exists {
+			continue
+		}
+		errList = append(errList, regionalClusterClient.RemoveMatchingLabelsFromResources(gvk, constants.TkgNamespace, labelsToBeDeleted))
+	}
+
+	return kerrors.NewAggregate(errList)
 }

--- a/pkg/v1/tkg/client/machine_deployment.go
+++ b/pkg/v1/tkg/client/machine_deployment.go
@@ -205,13 +205,13 @@ func DoSetMachineDeployment(clusterClient clusterclient.Client, options *SetMach
 		}
 
 		switch iaasType := baseMD.Spec.Template.Spec.InfrastructureRef.Kind; iaasType {
-		case constants.VSphereMachineTemplate:
+		case constants.KindVSphereMachineTemplate:
 			err = createVSphereMachineTemplate(clusterClient, &baseMD.Spec.Template.Spec.InfrastructureRef, machineTemplateName, options)
-		case constants.AWSMachineTemplate:
+		case constants.KindAWSMachineTemplate:
 			err = createAWSMachineTemplate(clusterClient, &baseMD.Spec.Template.Spec.InfrastructureRef, machineTemplateName, options)
-		case constants.AzureMachineTemplate:
+		case constants.KindAzureMachineTemplate:
 			err = createAzureMachineTemplate(clusterClient, &baseMD.Spec.Template.Spec.InfrastructureRef, machineTemplateName, options)
-		case constants.DockerMachineTemplate:
+		case constants.KindDockerMachineTemplate:
 			err = createDockerMachineTemplate(clusterClient, &baseMD.Spec.Template.Spec.InfrastructureRef, machineTemplateName, options)
 		default:
 			return errors.Errorf("unable to match MachineTemplate type: %s", iaasType)
@@ -378,7 +378,7 @@ func DoDeleteMachineDeployment(clusterClient clusterclient.Client, options *Dele
 	var deleteCmd func() error
 	var infraTemplateName string
 	switch machineKind := toDelete.Spec.Template.Spec.InfrastructureRef.Kind; machineKind {
-	case constants.VSphereMachineTemplate:
+	case constants.KindVSphereMachineTemplate:
 		var machineTemplate vsphere.VSphereMachineTemplate
 		infraTemplateName = toDelete.Spec.Template.Spec.InfrastructureRef.Name
 		err = retrieveMachineTemplate(clusterClient, infraTemplateName, options.Namespace, &machineTemplate)
@@ -388,7 +388,7 @@ func DoDeleteMachineDeployment(clusterClient clusterclient.Client, options *Dele
 		deleteCmd = func() error {
 			return clusterClient.DeleteResource(&machineTemplate)
 		}
-	case constants.AWSMachineTemplate:
+	case constants.KindAWSMachineTemplate:
 		var machineTemplate aws.AWSMachineTemplate
 		infraTemplateName = toDelete.Spec.Template.Spec.InfrastructureRef.Name
 		err = retrieveMachineTemplate(clusterClient, infraTemplateName, options.Namespace, &machineTemplate)
@@ -398,7 +398,7 @@ func DoDeleteMachineDeployment(clusterClient clusterclient.Client, options *Dele
 		deleteCmd = func() error {
 			return clusterClient.DeleteResource(&machineTemplate)
 		}
-	case constants.AzureMachineTemplate:
+	case constants.KindAzureMachineTemplate:
 		var machineTemplate azure.AzureMachineTemplate
 		infraTemplateName = toDelete.Spec.Template.Spec.InfrastructureRef.Name
 		err = retrieveMachineTemplate(clusterClient, infraTemplateName, options.Namespace, &machineTemplate)
@@ -408,7 +408,7 @@ func DoDeleteMachineDeployment(clusterClient clusterclient.Client, options *Dele
 		deleteCmd = func() error {
 			return clusterClient.DeleteResource(&machineTemplate)
 		}
-	case constants.DockerMachineTemplate:
+	case constants.KindDockerMachineTemplate:
 		var machineTemplate docker.DockerMachineTemplate
 		infraTemplateName = toDelete.Spec.Template.Spec.InfrastructureRef.Name
 		err = retrieveMachineTemplate(clusterClient, infraTemplateName, options.Namespace, &machineTemplate)

--- a/pkg/v1/tkg/client/machine_deployment_test.go
+++ b/pkg/v1/tkg/client/machine_deployment_test.go
@@ -436,7 +436,7 @@ var _ = Describe("Machine Deployment", func() {
 									},
 								},
 								InfrastructureRef: corev1.ObjectReference{
-									Kind: constants.VSphereMachineTemplate,
+									Kind: constants.KindVSphereMachineTemplate,
 									Name: "test-cluster-np-1-mt",
 								},
 							},
@@ -456,7 +456,7 @@ var _ = Describe("Machine Deployment", func() {
 									},
 								},
 								InfrastructureRef: corev1.ObjectReference{
-									Kind: constants.VSphereMachineTemplate,
+									Kind: constants.KindVSphereMachineTemplate,
 									Name: "test-cluster-np-2-mt",
 								},
 							},
@@ -476,7 +476,7 @@ var _ = Describe("Machine Deployment", func() {
 									},
 								},
 								InfrastructureRef: corev1.ObjectReference{
-									Kind: constants.VSphereMachineTemplate,
+									Kind: constants.KindVSphereMachineTemplate,
 									Name: "test-cluster-np-3-mt",
 								},
 							},
@@ -690,7 +690,7 @@ var _ = Describe("Machine Deployment", func() {
 				})
 				When("there is an error deleting the machine deployment", func() {
 					BeforeEach(func() {
-						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AWSMachineTemplate
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.KindAWSMachineTemplate
 						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
 						callIndex := 0
 						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
@@ -717,7 +717,7 @@ var _ = Describe("Machine Deployment", func() {
 				})
 				When("there is an error deleting the machine template", func() {
 					BeforeEach(func() {
-						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AWSMachineTemplate
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.KindAWSMachineTemplate
 						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
 						callIndex := 0
 						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
@@ -745,7 +745,7 @@ var _ = Describe("Machine Deployment", func() {
 				})
 				When("there is an error deleting the kubeadmconfig template", func() {
 					BeforeEach(func() {
-						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AWSMachineTemplate
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.KindAWSMachineTemplate
 						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
 						callIndex := 0
 						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
@@ -774,7 +774,7 @@ var _ = Describe("Machine Deployment", func() {
 				})
 				When("the node pool is deleted successfully", func() {
 					BeforeEach(func() {
-						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AWSMachineTemplate
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.KindAWSMachineTemplate
 						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
 						callIndex := 0
 						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
@@ -827,7 +827,7 @@ var _ = Describe("Machine Deployment", func() {
 				})
 				When("there is an error deleting the machine deployment", func() {
 					BeforeEach(func() {
-						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AzureMachineTemplate
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.KindAzureMachineTemplate
 						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
 						callIndex := 0
 						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
@@ -854,7 +854,7 @@ var _ = Describe("Machine Deployment", func() {
 				})
 				When("there is an error deleting the machine template", func() {
 					BeforeEach(func() {
-						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AzureMachineTemplate
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.KindAzureMachineTemplate
 						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
 						callIndex := 0
 						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
@@ -882,7 +882,7 @@ var _ = Describe("Machine Deployment", func() {
 				})
 				When("there is an error deleting the kubeadmconfig template", func() {
 					BeforeEach(func() {
-						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AzureMachineTemplate
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.KindAzureMachineTemplate
 						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
 						callIndex := 0
 						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
@@ -911,7 +911,7 @@ var _ = Describe("Machine Deployment", func() {
 				})
 				When("the node pool is deleted successfully", func() {
 					BeforeEach(func() {
-						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.AzureMachineTemplate
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.KindAzureMachineTemplate
 						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
 						callIndex := 0
 						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
@@ -964,7 +964,7 @@ var _ = Describe("Machine Deployment", func() {
 				})
 				When("there is an error deleting the machine deployment", func() {
 					BeforeEach(func() {
-						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.DockerMachineTemplate
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.KindDockerMachineTemplate
 						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
 						callIndex := 0
 						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
@@ -991,7 +991,7 @@ var _ = Describe("Machine Deployment", func() {
 				})
 				When("there is an error deleting the machine template", func() {
 					BeforeEach(func() {
-						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.DockerMachineTemplate
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.KindDockerMachineTemplate
 						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
 						callIndex := 0
 						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
@@ -1019,7 +1019,7 @@ var _ = Describe("Machine Deployment", func() {
 				})
 				When("there is an error deleting the kubeadmconfig template", func() {
 					BeforeEach(func() {
-						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.DockerMachineTemplate
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.KindDockerMachineTemplate
 						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
 						callIndex := 0
 						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
@@ -1048,7 +1048,7 @@ var _ = Describe("Machine Deployment", func() {
 				})
 				When("the node pool is deleted successfully", func() {
 					BeforeEach(func() {
-						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.DockerMachineTemplate
+						md1.Spec.Template.Spec.InfrastructureRef.Kind = constants.KindDockerMachineTemplate
 						clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md2, md3}, nil)
 						callIndex := 0
 						clusterClient.GetResourceStub = func(obj interface{}, name, namespace string, postVerifyFn clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
@@ -1319,7 +1319,7 @@ var _ = Describe("Machine Deployment", func() {
 									},
 									InfrastructureRef: corev1.ObjectReference{
 										Name: "test-cluster-np-1-mt",
-										Kind: constants.VSphereMachineTemplate,
+										Kind: constants.KindVSphereMachineTemplate,
 									},
 								},
 							},
@@ -1462,7 +1462,7 @@ var _ = Describe("Machine Deployment", func() {
 									},
 									InfrastructureRef: corev1.ObjectReference{
 										Name: "test-cluster-np-1-mt",
-										Kind: constants.AWSMachineTemplate,
+										Kind: constants.KindAWSMachineTemplate,
 									},
 									FailureDomain: &az,
 								},
@@ -1475,7 +1475,7 @@ var _ = Describe("Machine Deployment", func() {
 					md3.Spec.Template.Labels = map[string]string{
 						"existing": "md3",
 					}
-					md3.Spec.Template.Spec.InfrastructureRef.Kind = constants.AWSMachineTemplate
+					md3.Spec.Template.Spec.InfrastructureRef.Kind = constants.KindAWSMachineTemplate
 					md3.Spec.Selector.MatchLabels = map[string]string{}
 					clusterClient.GetMDObjectForClusterReturns([]capi.MachineDeployment{md1, md3}, nil)
 					awsMachineTemplate = aws.AWSMachineTemplate{
@@ -1603,7 +1603,7 @@ var _ = Describe("Machine Deployment", func() {
 									},
 									InfrastructureRef: corev1.ObjectReference{
 										Name: "test-cluster-np-1-mt",
-										Kind: constants.AzureMachineTemplate,
+										Kind: constants.KindAzureMachineTemplate,
 									},
 									FailureDomain: &az,
 								},

--- a/pkg/v1/tkg/client/upgrade_addon.go
+++ b/pkg/v1/tkg/client/upgrade_addon.go
@@ -132,7 +132,7 @@ func (c *TkgClient) DoUpgradeAddon(regionalClusterClient clusterclient.Client, /
 	if err != nil {
 		return errors.Wrapf(err, "unable to find control plane node object for cluster %s", options.ClusterName)
 	}
-	if kcp.Spec.MachineTemplate.InfrastructureRef.Kind == constants.VSphereMachineTemplate {
+	if kcp.Spec.MachineTemplate.InfrastructureRef.Kind == constants.KindVSphereMachineTemplate {
 		// As vSphereControlPlaneEndpointIP is required for vSphere cluster for --dry-run
 		// while creating workload cluster template, setting this to dummy value currently
 		// Note: This value will not be used for addons upgrade

--- a/pkg/v1/tkg/client/upgrade_addon_test.go
+++ b/pkg/v1/tkg/client/upgrade_addon_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Unit tests for addons upgrade", func() {
 			setupBomFile("../fakes/config/bom/tkr-bom-v1.18.0+vmware.1-tkg.2.yaml", testingDir)
 			setupBomFile("../fakes/config/bom/tkg-bom-v1.3.1.yaml", testingDir)
 			regionalClusterClient.PatchResourceReturns(nil)
-			regionalClusterClient.GetKCPObjectForClusterReturns(getDummyKCP(constants.DockerMachineTemplate), nil)
+			regionalClusterClient.GetKCPObjectForClusterReturns(getDummyKCP(constants.KindDockerMachineTemplate), nil)
 			currentClusterClient.GetKubernetesVersionReturns(currentK8sVersion, nil)
 			regionalClusterClient.ListResourcesCalls(func(clusterList interface{}, options ...client.ListOption) error {
 				if clusterList, ok := clusterList.(*capiv1alpha3.ClusterList); ok {

--- a/pkg/v1/tkg/client/upgrade_cluster.go
+++ b/pkg/v1/tkg/client/upgrade_cluster.go
@@ -593,13 +593,13 @@ func (c *TkgClient) createInfrastructureTemplateForUpgrade(regionalClusterClient
 	}
 
 	switch kcp.Spec.MachineTemplate.InfrastructureRef.Kind {
-	case constants.VSphereMachineTemplate:
+	case constants.KindVSphereMachineTemplate:
 		return c.createVsphereInfrastructureTemplateForUpgrade(regionalClusterClient, kcp, clusterUpgradeConfig)
-	case constants.AWSMachineTemplate:
+	case constants.KindAWSMachineTemplate:
 		return c.createAWSInfrastructureTemplateForUpgrade(regionalClusterClient, kcp, clusterUpgradeConfig)
-	case constants.AzureMachineTemplate:
+	case constants.KindAzureMachineTemplate:
 		return c.createAzureInfrastructureTemplateForUpgrade(regionalClusterClient, kcp, clusterUpgradeConfig)
-	case constants.DockerMachineTemplate:
+	case constants.KindDockerMachineTemplate:
 		return c.createCAPDInfrastructureTemplateForUpgrade(regionalClusterClient, kcp, clusterUpgradeConfig)
 	default:
 		return errors.New("infrastructure template associated with KubeadmControlPlane object is invalid")
@@ -1095,7 +1095,7 @@ func (c *TkgClient) PatchKubernetesVersionToKubeadmControlPlane(regionalClusterC
 
 	var newKCP *capikubeadmv1beta1.KubeadmControlPlane
 	// If iaas == vsphere, attempt increasing kube-vip parameters
-	if currentKCP.Spec.MachineTemplate.InfrastructureRef.Kind == constants.VSphereMachineTemplate {
+	if currentKCP.Spec.MachineTemplate.InfrastructureRef.Kind == constants.KindVSphereMachineTemplate {
 		log.V(6).Infof("Kind %s", currentKCP.Spec.MachineTemplate.InfrastructureRef.Kind)
 		newKCP, _ = c.UpdateKCPObjectWithIncreasedKubeVip(currentKCP)
 		if newKCP != nil {
@@ -1382,13 +1382,13 @@ func (c *TkgClient) configureOSOptionsForUpgrade(regionalClusterClient clustercl
 
 			provider := ""
 			switch kcp.Spec.MachineTemplate.InfrastructureRef.Name {
-			case constants.VSphereMachineTemplate:
+			case constants.KindVSphereMachineTemplate:
 				provider = constants.InfrastructureProviderVSphere
-			case constants.AWSMachineTemplate:
+			case constants.KindAWSMachineTemplate:
 				provider = constants.InfrastructureProviderAWS
-			case constants.AzureMachineTemplate:
+			case constants.KindAzureMachineTemplate:
 				provider = constants.InfrastructureProviderAzure
-			case constants.DockerMachineTemplate:
+			case constants.KindDockerMachineTemplate:
 			}
 
 			osInfo := tkgconfighelper.GetDefaultOsOptionsForTKG12(provider)

--- a/pkg/v1/tkg/client/upgrade_cluster_test.go
+++ b/pkg/v1/tkg/client/upgrade_cluster_test.go
@@ -210,7 +210,7 @@ var _ = Describe("Unit tests for upgrading legacy cluster", func() {
 			currentK8sVersion = "v1.17.3+vmware.2" // nolint:goconst
 			setupBomFile("../fakes/config/bom/tkg-bom-v1.3.1.yaml", testingDir)
 			setupBomFile("../fakes/config/bom/tkr-bom-v1.18.0+vmware.1-tkg.2.yaml", testingDir)
-			regionalClusterClient.GetKCPObjectForClusterReturns(getDummyKCP(constants.VSphereMachineTemplate), nil)
+			regionalClusterClient.GetKCPObjectForClusterReturns(getDummyKCP(constants.KindVSphereMachineTemplate), nil)
 			regionalClusterClient.GetResourceReturns(nil)
 			regionalClusterClient.PatchResourceReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForWorkerNodesReturns(nil)
@@ -233,7 +233,7 @@ var _ = Describe("Unit tests for upgrading legacy cluster", func() {
 
 		Context("When environment is Vsphere", func() {
 			BeforeEach(func() {
-				regionalClusterClient.GetKCPObjectForClusterReturns(getDummyKCP(constants.VSphereMachineTemplate), nil)
+				regionalClusterClient.GetKCPObjectForClusterReturns(getDummyKCP(constants.KindVSphereMachineTemplate), nil)
 			})
 
 			Context("When get/verification of vsphere template fails", func() {
@@ -275,7 +275,7 @@ var _ = Describe("Unit tests for upgrading legacy cluster", func() {
 			})
 			Context("template upgrade is not required", func() {
 				BeforeEach(func() {
-					dummyKcp := getDummyKCP(constants.VSphereMachineTemplate)
+					dummyKcp := getDummyKCP(constants.KindVSphereMachineTemplate)
 					dummyKcp.Spec.Version = newK8sVersion
 					regionalClusterClient.GetKCPObjectForClusterReturns(dummyKcp, nil)
 					dummyMd := getDummyMD()
@@ -310,7 +310,7 @@ var _ = Describe("Unit tests for upgrading legacy cluster", func() {
 
 		Context("When environment is AWS", func() {
 			BeforeEach(func() {
-				regionalClusterClient.GetKCPObjectForClusterReturns(getDummyKCP(constants.AWSMachineTemplate), nil)
+				regionalClusterClient.GetKCPObjectForClusterReturns(getDummyKCP(constants.KindAWSMachineTemplate), nil)
 				regionalClusterClient.GetResourceCalls(func(resourceReference interface{}, resourceName, namespace string, postVerify clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
 					clusterObj, ok := resourceReference.(*capav1beta1.AWSCluster)
 					if !ok {
@@ -417,7 +417,7 @@ var _ = Describe("Unit tests for upgrading legacy cluster", func() {
 
 		Context("When environment is Azure", func() {
 			BeforeEach(func() {
-				regionalClusterClient.GetKCPObjectForClusterReturns(getDummyKCP(constants.AzureMachineTemplate), nil)
+				regionalClusterClient.GetKCPObjectForClusterReturns(getDummyKCP(constants.KindAzureMachineTemplate), nil)
 				regionalClusterClient.GetResourceCalls(func(resourceReference interface{}, resourceName, namespace string, postVerify clusterclient.PostVerifyrFunc, pollOptions *clusterclient.PollOptions) error {
 					return nil
 				})
@@ -641,7 +641,7 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 					Replicas:        3,
 					K8sVersion:      "v1.18.2+vmware.1",
 					InfrastructureTemplate: fakehelper.TestObject{
-						Kind:      constants.VSphereMachineTemplate,
+						Kind:      constants.KindVSphereMachineTemplate,
 						Name:      "cluster-1-control-plane",
 						Namespace: constants.DefaultNamespace,
 					},
@@ -652,7 +652,7 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 					UpdatedReplicas: 3,
 					Replicas:        3,
 					InfrastructureTemplate: fakehelper.TestObject{
-						Kind:      constants.VSphereMachineTemplate,
+						Kind:      constants.KindVSphereMachineTemplate,
 						Name:      "cluster-1-md-0",
 						Namespace: constants.DefaultNamespace,
 					},
@@ -771,7 +771,7 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 			})
 			Context("Testing the KCP modifier helper function", func() {
 				It("Updates the KCP object with increased timeouts", func() {
-					currentKCP := getDummyKCP(constants.VSphereMachineTemplate)
+					currentKCP := getDummyKCP(constants.KindVSphereMachineTemplate)
 					newKCP, err := tkgClient.UpdateKCPObjectWithIncreasedKubeVip(currentKCP)
 
 					Expect(err).To(BeNil())
@@ -815,7 +815,7 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 					Replicas:        3,
 					K8sVersion:      "v1.18.2+vmware.1",
 					InfrastructureTemplate: fakehelper.TestObject{
-						Kind:      constants.VSphereMachineTemplate,
+						Kind:      constants.KindVSphereMachineTemplate,
 						Name:      "cluster-1-control-plane",
 						Namespace: constants.DefaultNamespace,
 					},
@@ -826,7 +826,7 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 					UpdatedReplicas: 3,
 					Replicas:        3,
 					InfrastructureTemplate: fakehelper.TestObject{
-						Kind:      constants.VSphereMachineTemplate,
+						Kind:      constants.KindVSphereMachineTemplate,
 						Name:      "cluster-1-md-0",
 						Namespace: constants.DefaultNamespace,
 					},

--- a/pkg/v1/tkg/constants/cluster_internal.go
+++ b/pkg/v1/tkg/constants/cluster_internal.go
@@ -6,14 +6,11 @@ package constants
 
 // cluster related constants used internally
 const (
-	KindCluster                = "Cluster"
-	KindTanzuKubernetesCluster = "TanzuKubernetesCluster"
-	KindClusterClass           = "ClusterClass"
-	ClusterClassFeature        = "vmware-system-tkg-clusterclass"
-	TKCAPIFeature              = "vmware-system-tkg-tkc-api"
-	TKGSClusterClassNamespace  = "vmware-system-tkg"
-	TKGSTKCAPINamespace        = "vmware-system-tkg"
-	TKGStkcapiNamespace        = "vmware-system-tkg"
+	ClusterClassFeature       = "vmware-system-tkg-clusterclass"
+	TKCAPIFeature             = "vmware-system-tkg-tkc-api"
+	TKGSClusterClassNamespace = "vmware-system-tkg"
+	TKGSTKCAPINamespace       = "vmware-system-tkg"
+	TKGStkcapiNamespace       = "vmware-system-tkg"
 
 	ErrorMsgFeatureGateNotActivated = "vSphere with Tanzu environment detected, however, the feature '%v' is not activated in '%v' namespace"
 	ErrorMsgFeatureGateStatus       = "error while checking feature '%v' status in namespace '%v'"
@@ -103,14 +100,6 @@ var InfrastructureProviders = map[string]bool{
 	InfrastructureProviderDocker:  true,
 }
 
-// machine template name constants
-const (
-	VSphereMachineTemplate = "VSphereMachineTemplate"
-	AWSMachineTemplate     = "AWSMachineTemplate"
-	AzureMachineTemplate   = "AzureMachineTemplate"
-	DockerMachineTemplate  = "DockerMachineTemplate"
-)
-
 const (
 	// InfrastructureRefVSphere is the vSphere infrastructure
 	InfrastructureRefVSphere = "VSphereCluster"
@@ -151,6 +140,9 @@ const (
 	PackageTypeLabel = "tkg.tanzu.vmware.com/package-type"
 	// CLIPluginImageRepositoryOverrideLabel is the label on the configmap which specifies CLIPlugin image repository override
 	CLIPluginImageRepositoryOverrideLabel = "cli.tanzu.vmware.com/cliplugin-image-repository-override"
+	//KappController labels
+	KappControllerAppLabel         = "kapp.k14s.io/app"
+	KappControllerAssociationLabel = "kapp.k14s.io/association"
 )
 
 // TKG management package related constants
@@ -166,4 +158,33 @@ const AviControllerVersionRegex = `^\d+(\.\d+)*$`
 
 const (
 	TanzuCLISystemNamespace = "tanzu-cli-system"
+)
+
+// Kind constants
+const (
+	KindCluster                     = "Cluster"
+	KindTanzuKubernetesCluster      = "TanzuKubernetesCluster"
+	KindClusterClass                = "ClusterClass"
+	KindKubeadmControlPlaneTemplate = "KubeadmControlPlaneTemplate"
+	KindKubeadmConfigTemplate       = "KubeadmConfigTemplate"
+	KindAWSClusterTemplate          = "AWSClusterTemplate"
+	KindAWSMachineTemplate          = "AWSMachineTemplate"
+	KindAzureClusterTemplate        = "AzureClusterTemplate"
+	KindAzureMachineTemplate        = "AzureMachineTemplate"
+	KindVSphereClusterTemplate      = "VSphereClusterTemplate"
+	KindVSphereMachineTemplate      = "VSphereMachineTemplate"
+	KindDockerMachineTemplate       = "DockerMachineTemplate"
+)
+
+// Resources constants
+const (
+	ResourceClusterClass                = "clusterclasses"
+	ResourceKubeadmControlPlaneTemplate = "kubeadmcontrolplanetemplates"
+	ResourceKubeadmConfigTemplate       = "kubeadmconfigtemplates"
+	ResourceAWSClusterTemplate          = "awsclustertemplates"
+	ResourceAWSMachineTemplate          = "awsmachinetemplates"
+	ResourceAzureClusterTemplate        = "azureclustertemplates"
+	ResourceAzureMachineTemplate        = "azuremachinetemplates"
+	ResourceVSphereClusterTemplate      = "vsphereclustertemplates"
+	ResourceVSphereMachineTemplate      = "vspheremachinetemplates"
 )

--- a/pkg/v1/tkg/fakes/clusterclient.go
+++ b/pkg/v1/tkg/fakes/clusterclient.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	v1beta1a "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
@@ -881,6 +882,19 @@ type ClusterClient struct {
 		result1 error
 	}
 	removeCEIPTelemetryJobReturnsOnCall map[int]struct {
+		result1 error
+	}
+	RemoveMatchingLabelsFromResourcesStub        func(schema.GroupVersionKind, string, []string) error
+	removeMatchingLabelsFromResourcesMutex       sync.RWMutex
+	removeMatchingLabelsFromResourcesArgsForCall []struct {
+		arg1 schema.GroupVersionKind
+		arg2 string
+		arg3 []string
+	}
+	removeMatchingLabelsFromResourcesReturns struct {
+		result1 error
+	}
+	removeMatchingLabelsFromResourcesReturnsOnCall map[int]struct {
 		result1 error
 	}
 	ScalePacificClusterControlPlaneStub        func(string, string, int32) error
@@ -5314,6 +5328,74 @@ func (fake *ClusterClient) RemoveCEIPTelemetryJobReturnsOnCall(i int, result1 er
 	}{result1}
 }
 
+func (fake *ClusterClient) RemoveMatchingLabelsFromResources(arg1 schema.GroupVersionKind, arg2 string, arg3 []string) error {
+	var arg3Copy []string
+	if arg3 != nil {
+		arg3Copy = make([]string, len(arg3))
+		copy(arg3Copy, arg3)
+	}
+	fake.removeMatchingLabelsFromResourcesMutex.Lock()
+	ret, specificReturn := fake.removeMatchingLabelsFromResourcesReturnsOnCall[len(fake.removeMatchingLabelsFromResourcesArgsForCall)]
+	fake.removeMatchingLabelsFromResourcesArgsForCall = append(fake.removeMatchingLabelsFromResourcesArgsForCall, struct {
+		arg1 schema.GroupVersionKind
+		arg2 string
+		arg3 []string
+	}{arg1, arg2, arg3Copy})
+	stub := fake.RemoveMatchingLabelsFromResourcesStub
+	fakeReturns := fake.removeMatchingLabelsFromResourcesReturns
+	fake.recordInvocation("RemoveMatchingLabelsFromResources", []interface{}{arg1, arg2, arg3Copy})
+	fake.removeMatchingLabelsFromResourcesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *ClusterClient) RemoveMatchingLabelsFromResourcesCallCount() int {
+	fake.removeMatchingLabelsFromResourcesMutex.RLock()
+	defer fake.removeMatchingLabelsFromResourcesMutex.RUnlock()
+	return len(fake.removeMatchingLabelsFromResourcesArgsForCall)
+}
+
+func (fake *ClusterClient) RemoveMatchingLabelsFromResourcesCalls(stub func(schema.GroupVersionKind, string, []string) error) {
+	fake.removeMatchingLabelsFromResourcesMutex.Lock()
+	defer fake.removeMatchingLabelsFromResourcesMutex.Unlock()
+	fake.RemoveMatchingLabelsFromResourcesStub = stub
+}
+
+func (fake *ClusterClient) RemoveMatchingLabelsFromResourcesArgsForCall(i int) (schema.GroupVersionKind, string, []string) {
+	fake.removeMatchingLabelsFromResourcesMutex.RLock()
+	defer fake.removeMatchingLabelsFromResourcesMutex.RUnlock()
+	argsForCall := fake.removeMatchingLabelsFromResourcesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *ClusterClient) RemoveMatchingLabelsFromResourcesReturns(result1 error) {
+	fake.removeMatchingLabelsFromResourcesMutex.Lock()
+	defer fake.removeMatchingLabelsFromResourcesMutex.Unlock()
+	fake.RemoveMatchingLabelsFromResourcesStub = nil
+	fake.removeMatchingLabelsFromResourcesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ClusterClient) RemoveMatchingLabelsFromResourcesReturnsOnCall(i int, result1 error) {
+	fake.removeMatchingLabelsFromResourcesMutex.Lock()
+	defer fake.removeMatchingLabelsFromResourcesMutex.Unlock()
+	fake.RemoveMatchingLabelsFromResourcesStub = nil
+	if fake.removeMatchingLabelsFromResourcesReturnsOnCall == nil {
+		fake.removeMatchingLabelsFromResourcesReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.removeMatchingLabelsFromResourcesReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *ClusterClient) ScalePacificClusterControlPlane(arg1 string, arg2 string, arg3 int32) error {
 	fake.scalePacificClusterControlPlaneMutex.Lock()
 	ret, specificReturn := fake.scalePacificClusterControlPlaneReturnsOnCall[len(fake.scalePacificClusterControlPlaneArgsForCall)]
@@ -6957,6 +7039,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.patchResourceMutex.RUnlock()
 	fake.removeCEIPTelemetryJobMutex.RLock()
 	defer fake.removeCEIPTelemetryJobMutex.RUnlock()
+	fake.removeMatchingLabelsFromResourcesMutex.RLock()
+	defer fake.removeMatchingLabelsFromResourcesMutex.RUnlock()
 	fake.scalePacificClusterControlPlaneMutex.RLock()
 	defer fake.scalePacificClusterControlPlaneMutex.RUnlock()
 	fake.scalePacificClusterWorkerNodesMutex.RLock()

--- a/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
+++ b/pkg/v1/tkg/fakes/helper/fakeobjectcreater.go
@@ -264,11 +264,11 @@ func NewInfrastructureTemplates(options TestAllClusterComponentOptions) []runtim
 // NewInfrastructureMachineTemplate returns new Machine template based on infa
 func NewInfrastructureMachineTemplate(templateOptions TestObject) runtime.Object {
 	switch templateOptions.Kind {
-	case constants.VSphereMachineTemplate:
+	case constants.KindVSphereMachineTemplate:
 		return NewVSphereMachineTemplate(templateOptions)
-	case constants.AWSMachineTemplate:
+	case constants.KindAWSMachineTemplate:
 		return NewAWSMachineTemplate(templateOptions)
-	case constants.AzureMachineTemplate:
+	case constants.KindAzureMachineTemplate:
 		return NewAzureMachineTemplate(templateOptions)
 	default:
 		return nil


### PR DESCRIPTION
### What this PR does / why we need it
Remove kapp labels from clusterclass resources after move during management-cluster creation

- Solves the issue of clusterclass packageinstall reconciliation failures after 15 minutes of move because of the invalid kapp-controller labels that got updated during move.
- This change try to solve this PR by removing kapp-controller labels from clusterclass resources so that clusterclass package can override the resources and manages the resources through packageinstalls

Signed-off-by: Anuj Chaudhari <anujc@vmware.com>

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3027

### Describe testing done for PR

- Added unit tests for the core function of updating labels
- Create AWS management-cluster using `package-based-lcm-beta` feature-flag enabled
- Once the management-cluster creation is successful waited for 30 minutes and verified the packageinstall statuses.
- All management-packages were in `Reconcile Succeeded` status and clusterclass resources had correct labels.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Fix the issue of tkg-clusterclass packageinstall reconcile failed after 15 minutes of management-cluster creation
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
