### PR TITLE
Add e2e test to validate published TKRs are available on management c…

### DIFF
--- a/pkg/v1/tkg/test/framework/cluster_proxy.go
+++ b/pkg/v1/tkg/test/framework/cluster_proxy.go
@@ -18,6 +18,7 @@ import (
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kappcontrollerv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
 	runv1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
 )
 
@@ -118,6 +119,22 @@ func (p *ClusterProxy) GetProviderVersions(ctx context.Context) map[string]strin
 	return providersMap
 }
 
+// GetPackages gets the package objects in a namespace
+func (p *ClusterProxy) GetPackages(ctx context.Context, namespace string) []*kappcontrollerv1alpha1.Package {
+	c := p.GetClient()
+	packagesList := &kappcontrollerv1alpha1.PackageList{}
+	listOptions := &client.ListOptions{
+		Namespace: namespace,
+	}
+	err := c.List(ctx, packagesList, listOptions)
+	Expect(err).ToNot(HaveOccurred())
+	packages := make([]*kappcontrollerv1alpha1.Package, len(packagesList.Items))
+	for i := range packagesList.Items {
+		packages[i] = &packagesList.Items[i]
+	}
+	return packages
+}
+
 // GetTKRs gets the TKRs available in management cluster
 func (p *ClusterProxy) GetTKRs(ctx context.Context) []*runv1.TanzuKubernetesRelease {
 	c := p.GetClient()
@@ -129,7 +146,6 @@ func (p *ClusterProxy) GetTKRs(ctx context.Context) []*runv1.TanzuKubernetesRele
 	for i := range tkrList.Items {
 		tkrs = append(tkrs, &tkrList.Items[i])
 	}
-
 	return tkrs
 }
 
@@ -144,7 +160,6 @@ func (p *ClusterProxy) GetOSImages(ctx context.Context) []*runv1.OSImage {
 	for i := range osImageList.Items {
 		osImages[i] = &osImageList.Items[i]
 	}
-
 	return osImages
 }
 
@@ -158,7 +173,6 @@ func (p *ClusterProxy) GetCluster(ctx context.Context, clusterName, namespace st
 	}
 	err := c.Get(ctx, objKey, cluster)
 	Expect(err).ToNot(HaveOccurred())
-
 	return cluster
 }
 
@@ -172,7 +186,6 @@ func (p *ClusterProxy) GetClusterClass(ctx context.Context, clusterClassName, na
 	}
 	err := c.Get(ctx, objKey, cc)
 	Expect(err).ToNot(HaveOccurred())
-
 	return cc
 }
 func initScheme() *runtime.Scheme {

--- a/pkg/v1/tkg/test/framework/schemes.go
+++ b/pkg/v1/tkg/test/framework/schemes.go
@@ -17,6 +17,7 @@ import (
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 	expv1 "sigs.k8s.io/cluster-api/exp/api/v1beta1"
 
+	kappcontrollerv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
 	runv1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
 )
 
@@ -55,4 +56,7 @@ func AddDefaultSchemes(scheme *runtime.Scheme) {
 
 	// Add the run v1alpha3 scheme
 	_ = runv1.AddToScheme(scheme)
+
+	// Add the kapp controller v1alpha1 scheme
+	_ = kappcontrollerv1alpha1.AddToScheme(scheme)
 }

--- a/pkg/v1/tkg/test/tkgctl/shared/tkr_cc_misc.go
+++ b/pkg/v1/tkg/test/tkgctl/shared/tkr_cc_misc.go
@@ -7,16 +7,27 @@ package shared
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
+	ctlimg "github.com/k14s/imgpkg/pkg/imgpkg/registry"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+	v1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kappcontrollerv1alpha1 "github.com/vmware-tanzu/carvel-kapp-controller/pkg/apiserver/apis/datapackaging/v1alpha1"
 	runv1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/test/framework"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/registry"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/controller/tkr-source/compatibility"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/util/sets"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v2/tkr/util/version"
 )
 
 type TKRCompatibilityValidationSpecInput struct {
@@ -24,19 +35,71 @@ type TKRCompatibilityValidationSpecInput struct {
 	OtherConfigs map[string]string
 }
 
+const (
+	tkrSourceControllerValuesSecretName      = "tkr-source-controller-values"
+	tkrSourceControllerValuesSecretNamespace = "tkg-system"
+)
+
 func TKRCompatibilityValidationSpec(ctx context.Context, inputGetter func() TKRCompatibilityValidationSpecInput) { //nolint:funlen
 	var (
+		err           error
 		input         TKRCompatibilityValidationSpecInput
 		mcProxy       *framework.ClusterProxy
 		mcContextName string
 		tkrs          []*runv1.TanzuKubernetesRelease
+		tkrRegistry   registry.Registry
 	)
-
+	const (
+		waitTimeout     = time.Minute * 15
+		pollingInterval = time.Second * 10
+	)
 	BeforeEach(func() { //nolint:dupl
 		input = inputGetter()
 		mcClusterName := input.E2EConfig.ManagementClusterName
 		mcContextName = mcClusterName + "-admin@" + mcClusterName
 		mcProxy = framework.NewClusterProxy(mcClusterName, "", mcContextName)
+		registryOps := &ctlimg.Opts{
+			Anon: true,
+		}
+		tkrRegistry, err = registry.New(registryOps)
+		Expect(err).To(BeNil(), "failed to initialize the TKR image registry")
+	})
+
+	It("Should validate the compatible TKRs and it's related resources(OSImages, ClusterBootStrapTemplate) are downloaded and available on management cluster  ", func() {
+		tkrCompatibility := &compatibility.Compatibility{
+			Client: mcProxy.GetClient(),
+			Config: compatibility.Config{
+				TKRNamespace: "tkg-system",
+			},
+			Log: logr.Discard(),
+		}
+
+		compatibleSet, err := tkrCompatibility.CompatibleVersions(context.Background())
+		fmt.Printf("CompatibleSet is :%+v \n", compatibleSet)
+		Expect(err).ToNot(HaveOccurred())
+		tkrRepoImagePath, resNamespace, err := GetTKRRepoImagePathAndNamespaceFromSecret(ctx, mcProxy.GetClient())
+		Expect(err).To(BeNil(), "failed to TKR repository Image path from secret")
+		Expect(tkrRepoImagePath).ToNot(BeEmpty(), "TKR repo Image path cannot be empty")
+		tkrImageTags, err := tkrRegistry.ListImageTags(tkrRepoImagePath)
+		Expect(err).To(BeNil(), fmt.Sprintf("failed to list TKR image tags for the repository url %s", tkrRepoImagePath))
+		tkrNames := TKRNamesFromTags(tkrImageTags)
+		expectedTKRs := filterTKRNames(tkrNames, func(tkr string) bool {
+			if compatibleSet.Has(version.FromLabel(tkr)) {
+				return true
+			}
+			return false
+		})
+
+		By("Validating the TKRs are available on management cluster")
+		Eventually(func() bool {
+			tkrs = mcProxy.GetTKRs(ctx)
+			err = VerifyTKRsAreAvailable(expectedTKRs, tkrs)
+			return err == nil
+		}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("TKRs availability validation failed: %v", err))
+
+		ValidateTKRsRelatedObjectsAvailability(ctx, mcProxy, expectedTKRs, resNamespace)
+
+		By("Test successful !")
 	})
 
 	It("Should validate the compatible status is correctly calculated for all TKRs", func() {
@@ -47,11 +110,20 @@ func TKRCompatibilityValidationSpec(ctx context.Context, inputGetter func() TKRC
 			},
 			Log: logr.Discard(),
 		}
-		By("Validating all TKRs compatibility status condition is updated correctly")
 		compatibleSet, err := tkrCompatibility.CompatibleVersions(context.Background())
 		fmt.Printf("CompatibleSet is :%+v \n", compatibleSet)
 		Expect(err).ToNot(HaveOccurred())
-		tkrs = mcProxy.GetTKRs(ctx)
+		By("Waiting for the compatible TKRs to be available on management cluster")
+		compatibleTKRNamesSet := compatibleSet.Map(func(s string) string {
+			return strings.ReplaceAll(s, "+", "---")
+		})
+		Eventually(func() bool {
+			tkrs = mcProxy.GetTKRs(ctx)
+			err = VerifyTKRsAreAvailable(compatibleTKRNamesSet.Slice(), tkrs)
+			return err == nil
+		}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("failed validating the Compatible TKRs availability on management cluster: %v", err))
+
+		By("Validating all TKRs compatibility status condition is updated correctly")
 		for i := range tkrs {
 			fmt.Printf("Validating the compatibility status condition for TKR '%s'\n", tkrs[i].Name)
 			if compatibleSet.Has(tkrs[i].Spec.Version) {
@@ -60,11 +132,146 @@ func TKRCompatibilityValidationSpec(ctx context.Context, inputGetter func() TKRC
 			} else {
 				Expect(conditions.IsFalse(tkrs[i], runv1.ConditionCompatible)).To(BeTrue(),
 					fmt.Sprintf("TKR '%s' is expected to have Compatible condition to be false", tkrs[i].Name))
-				Expect(*conditions.GetSeverity(tkrs[i], runv1.ConditionCompatible)).ToNot(Equal(clusterv1.ConditionSeverityWarning),
+				Expect(*conditions.GetSeverity(tkrs[i], runv1.ConditionCompatible)).To(Equal(clusterv1.ConditionSeverityWarning),
 					fmt.Sprintf("TKR '%s' Compatible condition's severity is expected to be 'Warning' if condition status is False", tkrs[i].Name))
 			}
 		}
 		By("Test successful !")
 	})
+}
+func ValidateTKRsRelatedObjectsAvailability(ctx context.Context, mcProxy *framework.ClusterProxy, expectedTKRs []string, resourceNS string) {
+	crClient := mcProxy.GetClient()
+	for i := range expectedTKRs {
+		fmt.Printf("Validating the availability of objectes related to TKR: %s \n", expectedTKRs[i])
+		tkr := &runv1.TanzuKubernetesRelease{}
+		err := crClient.Get(ctx, client.ObjectKey{Name: expectedTKRs[i]}, tkr)
+		Expect(err).To(BeNil(), fmt.Sprintf("failed to get TKR :%s", expectedTKRs[i]))
+		cbt := getClusterBootstrapTemplate(ctx, crClient, tkr.Name)
+		Expect(cbt).ToNot(BeNil(), fmt.Sprintf("failed to get CBT :%s", expectedTKRs[i]))
+		ValidateOSImagesOfTKR(ctx, mcProxy, tkr)
+		ValidatePackagesOfTKR(ctx, mcProxy, tkr, resourceNS)
+	}
+}
 
+func ValidatePackagesOfTKR(ctx context.Context, mcProxy *framework.ClusterProxy, tkr *runv1.TanzuKubernetesRelease, namespace string) {
+	var err error
+	expectedPackages := tkr.Spec.BootstrapPackages
+	Eventually(func() bool {
+		packages := mcProxy.GetPackages(ctx, namespace)
+		err = VerifyPackagesAreAvailable(expectedPackages, packages)
+		return err == nil
+	}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("OSImages availability validation failed: %v", err))
+}
+
+func ValidateOSImagesOfTKR(ctx context.Context, mcProxy *framework.ClusterProxy, tkr *runv1.TanzuKubernetesRelease) {
+	var err error
+	expectedOSImages := tkr.Spec.OSImages
+	Eventually(func() bool {
+		osImages := mcProxy.GetOSImages(ctx)
+		err = VerifyOSImagesAreAvailable(expectedOSImages, osImages)
+		return err == nil
+	}, waitTimeout, pollingInterval).Should(BeTrue(), fmt.Sprintf("OSImages availability validation failed: %v", err))
+}
+
+func GetTKRRepoImagePathAndNamespaceFromSecret(ctx context.Context, crClient client.Client) (string, string, error) {
+	s := &v1.Secret{}
+	if err := crClient.Get(ctx, client.ObjectKey{
+		Namespace: tkrSourceControllerValuesSecretNamespace,
+		Name:      tkrSourceControllerValuesSecretName,
+	}, s); err != nil {
+		return "", "", err
+	}
+
+	valuesMap := make(map[string]interface{})
+	if err := yaml.Unmarshal(s.Data["values.yaml"], valuesMap); err != nil {
+		return "", "", err
+	}
+
+	tkrRepoImagePath := valuesMap["tkrRepoImagePath"].(string)
+	resourcesNamespace := valuesMap["namespace"].(string)
+	return tkrRepoImagePath, resourcesNamespace, nil
+}
+
+func filterTKRNames(tkrNames []string, f func(string) bool) []string {
+	var res []string
+	for i := range tkrNames {
+		if f(tkrNames[i]) {
+			res = append(res, tkrNames[i])
+		}
+	}
+	return res
+}
+
+func VerifyTKRsAreAvailable(expectedTKRs []string, tkrs []*runv1.TanzuKubernetesRelease) error {
+	var missingTKRs []string
+	tkrNames := getTKRNames(tkrs)
+	for i := range expectedTKRs {
+		if !tkrNames.Has(expectedTKRs[i]) {
+			missingTKRs = append(missingTKRs, expectedTKRs[i])
+		}
+	}
+	if len(missingTKRs) != 0 {
+		return errors.Errorf("TKRs %v are not available on management cluster", missingTKRs)
+	}
+	return nil
+}
+
+func VerifyOSImagesAreAvailable(expectedOSImages []v1.LocalObjectReference, osImages []*runv1.OSImage) error {
+	var missingOSImages []string
+	osImageNames := getOSImagesNames(osImages)
+	for i := range expectedOSImages {
+		if !osImageNames.Has(expectedOSImages[i].Name) {
+			missingOSImages = append(missingOSImages, expectedOSImages[i].Name)
+		}
+	}
+	if len(missingOSImages) != 0 {
+		return errors.Errorf("OSImages %v are not available on management cluster", missingOSImages)
+	}
+	return nil
+}
+
+func VerifyPackagesAreAvailable(expectedPackages []v1.LocalObjectReference, packages []*kappcontrollerv1alpha1.Package) error {
+	var missingPackages []string
+	osImageNames := getPackagesNames(packages)
+	for i := range expectedPackages {
+		if !osImageNames.Has(expectedPackages[i].Name) {
+			missingPackages = append(missingPackages, expectedPackages[i].Name)
+		}
+	}
+	if len(missingPackages) != 0 {
+		return errors.Errorf("OSImages %v are not available on management cluster", missingPackages)
+	}
+	return nil
+}
+
+func TKRNamesFromTags(tkrImageTags []string) []string {
+	var res []string
+	for i := range tkrImageTags {
+		tkrName := strings.ReplaceAll(tkrImageTags[i], "_", "---")
+		res = append(res, tkrName)
+	}
+	return res
+}
+
+func getTKRNames(tkrs []*runv1.TanzuKubernetesRelease) sets.StringSet {
+	tkrNames := sets.StringSet{}
+	for i := range tkrs {
+		tkrNames.Add(tkrs[i].Name)
+	}
+	return tkrNames
+}
+
+func getOSImagesNames(osImages []*runv1.OSImage) sets.StringSet {
+	osImagesNames := sets.StringSet{}
+	for i := range osImages {
+		osImagesNames.Add(osImages[i].Name)
+	}
+	return osImagesNames
+}
+func getPackagesNames(packages []*kappcontrollerv1alpha1.Package) sets.StringSet {
+	packagesNames := sets.StringSet{}
+	for i := range packages {
+		packagesNames.Add(packages[i].Name)
+	}
+	return packagesNames
 }


### PR DESCRIPTION
…luster

Signed-off-by: Prem Kumar Kalle <pkalle@vmware.com>

### What this PR does / why we need it
This PR adds e2e tests to validate the published TKRs(and it's related objects) are downloaded from TKR image repository and available on the management cluster

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

Tested locally and it was successful.
```
❯ E2E_CONFIG=$PWD/pkg/v1/tkg/test/config/aws.yaml hack/tools/bin/ginkgo -nodes=3 -v -trace -tags embedproviders pkg/v1/tkg/test/tkgctl/aws_cc
Running Suite: tkgctl-aws-cc-e2e
================================
Random Seed: 1658960078
Will run 2 specs

Running in parallel across 3 nodes

STEP: Loading the e2e test configuration from "/Users/pkalle/projects/tanzu-framework/pkg/v1/tkg/test/config/aws.yaml"
.....
Functional tests for aws - TKR Compatibility tests 
  Should validate the compatible status is correctly calculated for all TKRs
  /Users/pkalle/projects/tanzu-framework/pkg/v1/tkg/test/tkgctl/shared/tkr_cc_misc.go:104

STEP: Validating all TKRs compatibility status condition is updated correctly
CompatibleSet is :map[v1.21.14+vmware.2-tkg.1-zshippable:{} v1.22.11+vmware.2-tkg.1-zshippable:{} v1.23.8+vmware.1-tkg.1-zshippable:{} v1.23.8+vmware.2-tkg.1-zshippable:{}] 
STEP: Waiting for the compatible TKRs to be available on management cluster
Validating the compatibility status condition for TKR 'v1.21.14---vmware.1-tkg.1-zshippable'
Validating the compatibility status condition for TKR 'v1.21.14---vmware.2-tkg.1-zshippable'
Validating the compatibility status condition for TKR 'v1.22.11---vmware.1-tkg.1-zshippable'
Validating the compatibility status condition for TKR 'v1.22.11---vmware.2-tkg.1-zshippable'
Validating the compatibility status condition for TKR 'v1.23.8---vmware.1-tkg.1-zshippable'
Validating the compatibility status condition for TKR 'v1.23.8---vmware.2-tkg.1-zshippable'
STEP: Test successful !

•
------------------------------
Functional tests for aws - TKR Compatibility tests 
  Should validate the compatible TKRs and it's related resources(OSImages, ClusterBootStrapTemplate) are downloaded and available on management cluster  
  /Users/pkalle/projects/tanzu-framework/pkg/v1/tkg/test/tkgctl/shared/tkr_cc_misc.go:67

CompatibleSet is :map[v1.21.14+vmware.2-tkg.1-zshippable:{} v1.22.11+vmware.2-tkg.1-zshippable:{} v1.23.8+vmware.1-tkg.1-zshippable:{} v1.23.8+vmware.2-tkg.1-zshippable:{}] 
STEP: Validating the TKRs are available on management cluster
Validating the availability of objectes related to TKR: v1.21.14---vmware.2-tkg.1-zshippable 
Validating the availability of objectes related to TKR: v1.22.11---vmware.2-tkg.1-zshippable 
Validating the availability of objectes related to TKR: v1.23.8---vmware.1-tkg.1-zshippable 
Validating the availability of objectes related to TKR: v1.23.8---vmware.2-tkg.1-zshippable 
STEP: Test successful !

•
------------------------------
compatibility file (/Users/pkalle/.config/tanzu/tkg/compatibility/tkg-compatibility.yaml) already exists, skipping download
BOM files inside /Users/pkalle/.config/tanzu/tkg/bom already exists, skipping download
writing checksum "07a010e6e0891e28462300a458daa4ce00c27dff08ce4d3f13bc37654ffea897" to file "/Users/pkalle/.config/tanzu/tkg/providers/providers.sha256sum"


Ran 2 of 2 Specs in 4.857 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped

```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
