### PR TITLE
Use TKR API commands based on feature-gate on the supervisor-cluster

### DIFF
--- a/pkg/v1/tkg/tkgctl/client.go
+++ b/pkg/v1/tkg/tkgctl/client.go
@@ -176,7 +176,7 @@ func New(options Options) (TKGClient, error) { //nolint:gocritic
 		tkgClient:                tkgClient,
 		providerGetter:           options.ProviderGetter,
 		tkgConfigReaderWriter:    allClients.ConfigClient.TKGConfigReaderWriter(),
-		featureGateHelper:        newFeatureGateHelper(&clusterClientOptions, options.KubeContext, options.KubeConfig),
+		featureGateHelper:        NewFeatureGateHelper(&clusterClientOptions, options.KubeContext, options.KubeConfig),
 	}, nil
 }
 


### PR DESCRIPTION
### What this PR does / why we need it
- Use TKR v1alpha3 API commands based on feature-gate on the supervisor-cluster
Signed-off-by: Anuj Chaudhari <anujc@vmware.com>

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3040

### Describe testing done for PR
1. `tanzu login` to vSphere8 based supervisor cluster which has TKR v1alpha3 API
2. Disable the feature-flag `tanzu config set features.global.tkr-version-v1alpha3-beta false`
3. Get the TKRs
```
~ $ tanzu kr get
  NAME                                 VERSION                            COMPATIBLE  ACTIVE
  v1.22.8---vmware.1-tkg.2-zshippable  v1.22.8+vmware.1-tkg.2-zshippable  True        True
  v1.23.5---vmware.1-tkg.1-zshippable  v1.23.5+vmware.1-tkg.1-zshippable  True        True
```
4. Deactivate and activate TKRs to verify it is taking effect
```
~ $ tanzu kr deactivate v1.22.8---vmware.1-tkg.2-zshippable
Applying patch to resource v1.22.8---vmware.1-tkg.2-zshippable of type *v1alpha3.TanzuKubernetesRelease ...
```
```
~ $ tanzu kr get
  NAME                                 VERSION                            COMPATIBLE  ACTIVE
  v1.23.5---vmware.1-tkg.1-zshippable  v1.23.5+vmware.1-tkg.1-zshippable  True        True
```
```
~ $ tanzu kr activate v1.22.8---vmware.1-tkg.2-zshippable
Applying patch to resource v1.22.8---vmware.1-tkg.2-zshippable of type *v1alpha3.TanzuKubernetesRelease ...
```
```
~ $ tanzu kr get
  NAME                                 VERSION                            COMPATIBLE  ACTIVE
  v1.22.8---vmware.1-tkg.2-zshippable  v1.22.8+vmware.1-tkg.2-zshippable  True        True
  v1.23.5---vmware.1-tkg.1-zshippable  v1.23.5+vmware.1-tkg.1-zshippable  True        True
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Use TKR v1alpha3 API commands based on feature-gate on the supervisor-cluster
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
