### PR TITLE
Add actionlint GitHub workflow #1320

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of string
+  labels:
+    - tkg

--- a/.github/workflows/check-actionlint.yaml
+++ b/.github/workflows/check-actionlint.yaml
@@ -1,0 +1,29 @@
+name: Check - actionlint
+
+on:
+  pull_request:
+    types:
+      - assigned
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - ".github/workflows/**"
+
+jobs:
+  checkactionlint:
+    name: Check actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: "1.17"
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Run actionlint
+        run: |
+          make actionlint

--- a/.github/workflows/security_codeql.yaml
+++ b/.github/workflows/security_codeql.yaml
@@ -2,7 +2,7 @@ name: 'Security - CodeQL scan (periodic)'
 
 on:
   schedule:
-    - cron: '* 1 * * *'
+    - cron: '0 1 * * *'
 
 jobs:
   analyze:

--- a/Makefile
+++ b/Makefile
@@ -482,6 +482,10 @@ lint: tools go-lint doc-lint misspell yamllint ## Run linting and misspell check
 misspell:
 	hack/check/misspell.sh
 
+actionlint:
+	go install github.com/rhysd/actionlint/cmd/actionlint@latest
+	actionlint -shellcheck= -ignore 'property "clustergen" is not defined'
+
 yamllint:
 	hack/check/check-yaml.sh
 


### PR DESCRIPTION
### What this PR does / why we need it

Adds the actionlint GitHub workflow, just like as implemented in the TCE repository.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1320

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

The linter is reporting an error in the `Post Cluster Generation Results As Comment` workflow as defined in the `.github/workflows/recv_providers.yaml` file. The `clustergen` step is actually defined in the `Provider Template Tests` workflow, which is the prerequisite workflow. The action seems to run fine however, as comments are appearing in issues. 

I've added a `--ignore` in the Makefile task to ignore this error and provide a discussion point.

```shell
.github/workflows/recv_providers.yaml:53:17: property "clustergen" is not defined in object type {read_artifact: {outcome: string; outputs: {string => string}; conclusion: string}; time: {conclusion: string; outcome: string; outputs: {string => string}}} [expression]
   |
53 |         if: ${{ steps.clustergen.outputs.diffstatus == 0 }}
   |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```