### PR TITLE
[release-0.25] Fixed "tanzu cluster get" command to return Classy cluster details on TKGS

### DIFF
--- a/cmd/cli/plugin/cluster/get.go
+++ b/cmd/cli/plugin/cluster/get.go
@@ -25,7 +25,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
-
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgctl"
 )
 
@@ -139,7 +138,9 @@ func getCluster(server *v1alpha1.Server, clusterName string) error {
 	if len(cl.Roles) != 0 {
 		clusterRoles = strings.Join(cl.Roles, ",")
 	}
-	t.AddRow(cl.Name, cl.Namespace, cl.Status, cl.ControlPlaneCount, cl.WorkerCount, cl.K8sVersion, clusterRoles, cl.TKR)
+	if cl.Name != "" {
+		t.AddRow(cl.Name, cl.Namespace, cl.Status, cl.ControlPlaneCount, cl.WorkerCount, cl.K8sVersion, clusterRoles, cl.TKR)
+	}
 
 	t.Render()
 


### PR DESCRIPTION
… TKGS

- This is achieved by fixing the "DescribeCluster" API to detect the Classy clusters
  in TKGS and return the overall details of the cluster( same as for TKC cluster).However
  It doesn't show the tree view of the various cluster related resources(same as current behaviour for TKC)

Signed-off-by: Prem Kumar Kalle <pkalle@vmware.com>

### What this PR does / why we need it
This PR fixes the DescribeCluster API to support the Classy clusters in TKGS and return the cluster details. However it doesn't return the cluster related objects that were used to show the tree view in "tanzu cluster get" command.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3032 

### Describe testing done for PR

Unit tested and tested locally on TKGS testbed and it was successful.
```
❯ tanzu cluster get prem-cc01 -n ns01
  NAME       NAMESPACE  STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES   TKR
  prem-cc01  ns01       running  1/1           1/1      v1.23.8+vmware.2  <none>  v1.23.8---vmware.2-tkg.1-zshippable
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
 Fixed "tanzu cluster get" command to return Classy cluster details on TKGS
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
