### PR TITLE
Display correct error message when passing Cluster based resource without ClusterClass as part of cluster create

### DIFF
--- a/pkg/v1/tkg/constants/clusterclass_mapping.go
+++ b/pkg/v1/tkg/constants/clusterclass_mapping.go
@@ -279,7 +279,8 @@ const (
 
 	SPEC = "spec"
 
-	TopologyClassIncorrectValueErrMsg = "input cluster class file, attribute spec.topology.class has no value or incorrect value or not following correct naming convension"
+	TopologyClassIncorrectValueErrMsg                = "input cluster class file, attribute spec.topology.class has no value or incorrect value or not following correct naming convention"
+	ClusterResourceWithoutTopologyNotSupportedErrMsg = "input file contains Cluster resource which doesn't have ClusterClass specified. Passing Cluster resource without ClusterClass specification is not supported"
 )
 
 // InfrastructureSpecificVariableMappingMap has, infra name to variable mapping map, which makes easy to get infra specific mapping map

--- a/pkg/v1/tkg/tkgctl/create_cluster_test.go
+++ b/pkg/v1/tkg/tkgctl/create_cluster_test.go
@@ -359,7 +359,7 @@ var _ = Describe("Unit tests for (AWS)  cluster_aws.yaml as input file for 'tanz
 			// most of cluster.yaml attributes are mapped to legacy variable for more look this - constants.clusterToLegacyVariablesMapAws
 			options.ClusterConfigFile = inputFileAwsEmptyClass
 			_, err := ctl.processWorkloadClusterInputFile(&options, isTKGSCluster)
-			Expect(fmt.Sprint(err)).To(Equal(constants.TopologyClassIncorrectValueErrMsg))
+			Expect(fmt.Sprint(err)).To(Equal(constants.ClusterResourceWithoutTopologyNotSupportedErrMsg))
 		})
 
 		It("When Input file is aws clusterclass.yaml file, but in-correct spec.topology.class name:", func() {


### PR DESCRIPTION
### What this PR does / why we need it
- Display correct error message when passing Cluster based resource without ClusterClass as part of cluster create

Currently, when user passes `Cluster` resource as part of `tanzu cluster create --file <input.yaml>` and the cluster resource doesn't include ClusterClass as part of `.spec.topology.cluster` thrown proper error message.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3054

### Describe testing done for PR
- Added unit tests
- Manually verified by passing `--dru-run` output to `tanzu cluster create --file <manifest.yaml>` and verified the error message
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Display correct error message when passing Cluster resource without ClusterClass as part of cluster create
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
