### PR TITLE
Fix data race in cluster pause webhook

### DIFF
--- a/addons/Makefile
+++ b/addons/Makefile
@@ -42,7 +42,7 @@ all: test manager ## Tests and builds the binaries
 .PHONY: test
 test: fmt vet template-tests ## Run Tests
 	$(MAKE) kubebuilder -C $(TOOLS_DIR)
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_BIN_DIR) go test ./... -timeout 60m -coverprofile coverage.txt -v 2
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_BIN_DIR) go test ./... -timeout 60m -race -coverprofile coverage.txt -v 2
 
 .PHONY: test-verbose
 test-verbose: ## Verbose tests with streaming output for debugging

--- a/addons/pkg/crdwait/crd_wait_test.go
+++ b/addons/pkg/crdwait/crd_wait_test.go
@@ -1,5 +1,6 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+//go:build !race
 
 package crdwait
 

--- a/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
+++ b/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
@@ -359,8 +359,8 @@ spec:
         name: tanzu-addons-controller
         resources:
           limits:
-            cpu: 100m
-            memory: 500Mi
+            cpu: 500m
+            memory: 1200Mi
           requests:
             cpu: 100m
             memory: 40Mi


### PR DESCRIPTION
### What this PR does / why we need it
* Fix data race in cluster pause webhook
* Refactor tests in cluster pause webhook to not rely on global vars
* Ignore data race in crd_wait_test.go caused by write of context object
* Add `-race` to addons tests to catch issues in CI
* Update memory for addons-manager to match cluster-api. This also addresses memory
 usage for 190 clusters in wcp system test env. Bump cpu limit

Signed-off-by: Vijay Katam <vkatam@vmware.com>

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3046 

### Describe testing done for PR

* Tested in system test environment.
* Unit tests.
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: Fix data race in cluster pause webhook
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->


