### PR TITLE
Kickstart UI: Improve AWS AZ/VPC subnet tooltips and error messages

### DIFF
--- a/pkg/v1/tkg/web/src/app/views/landing/aws-wizard/node-setting-step/node-setting-step.component.html
+++ b/pkg/v1/tkg/web/src/app/views/landing/aws-wizard/node-setting-step/node-setting-step.component.html
@@ -257,7 +257,8 @@
                         <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                         <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
                             <span>
-                                Select an AWS availability zone.
+                                Choose an AWS availability zone (AWS subregion). If using an existing VPC, selecting an
+                                availability zone first is required for retrieving existing public and private subnets.
                             </span>
                         </clr-tooltip-content>
                     </clr-tooltip>
@@ -296,8 +297,9 @@
                             <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                             <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
                                 <span>
-                                    Choose a VPC public subnet associated with the selected AWS availability zone. If no
-                                    option is available, please add a public subnet to this availability zone.
+                                    {{
+                                        getVpcSubnetTooltip('public')
+                                    }}
                                 </span>
                             </clr-tooltip-content>
                         </clr-tooltip>
@@ -315,7 +317,11 @@
                     </select>
                     <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
                     <clr-control-helper></clr-control-helper>
-                    <clr-control-error>Selecting a VPC public subnet is required</clr-control-error>
+                    <clr-control-error>
+                        {{
+                            getVpcSubnetErrorMsg('public')
+                        }}
+                    </clr-control-error>
                 </clr-select-container>
             </div>
             <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
@@ -326,8 +332,9 @@
                             <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                             <clr-tooltip-content clrPosition="top-left" clrSize="lg" *clrIfOpen>
                                 <span>
-                                    Choose a VPC private subnet associated with the selected AWS availability zone. If no
-                                    option is available, please add a private subnet to this availability zone.
+                                    {{
+                                        getVpcSubnetTooltip('private')
+                                    }}
                                 </span>
                             </clr-tooltip-content>
                         </clr-tooltip>
@@ -345,7 +352,11 @@
                     </select>
                     <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
                     <clr-control-helper></clr-control-helper>
-                    <clr-control-error>Selecting a VPC private subnet is required</clr-control-error>
+                    <clr-control-error>
+                        {{
+                            getVpcSubnetErrorMsg('private')
+                        }}
+                    </clr-control-error>
                 </clr-select-container>
             </div>
             <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4"></div>
@@ -392,7 +403,8 @@
                         <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                         <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
                             <span>
-                                Select an AWS availability zone.
+                                Choose an AWS availability zone (AWS subregion). If using an existing VPC, selecting an
+                                availability zone first is required for retrieving existing public and private subnets.
                             </span>
                         </clr-tooltip-content>
                     </clr-tooltip>
@@ -431,8 +443,9 @@
                             <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                             <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
                                 <span>
-                                    Choose a VPC public subnet associated with the selected AWS availability zone. If no
-                                    option is available, please add a public subnet to this availability zone.
+                                    {{
+                                        getVpcSubnetTooltip('public')
+                                    }}
                                 </span>
                             </clr-tooltip-content>
                         </clr-tooltip>
@@ -450,7 +463,11 @@
                     </select>
                     <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
                     <clr-control-helper></clr-control-helper>
-                    <clr-control-error>Selecting a VPC public subnet is required</clr-control-error>
+                    <clr-control-error>
+                        {{
+                            getVpcSubnetErrorMsg('public')
+                        }}
+                    </clr-control-error>
                 </clr-select-container>
             </div>
             <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
@@ -461,8 +478,9 @@
                             <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                             <clr-tooltip-content clrPosition="top-left" clrSize="lg" *clrIfOpen>
                                 <span>
-                                    Choose a VPC private subnet associated with the selected AWS availability zone. If no
-                                    option is available, please add a private subnet to this availability zone.
+                                    {{
+                                        getVpcSubnetTooltip('private')
+                                    }}
                                 </span>
                             </clr-tooltip-content>
                         </clr-tooltip>
@@ -480,7 +498,11 @@
                     </select>
                     <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
                     <clr-control-helper></clr-control-helper>
-                    <clr-control-error>Selecting a VPC private subnet is required</clr-control-error>
+                    <clr-control-error>
+                        {{
+                            getVpcSubnetErrorMsg('private')
+                        }}
+                    </clr-control-error>
                 </clr-select-container>
             </div>
             <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4"></div>
@@ -527,7 +549,8 @@
                         <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                         <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
                             <span>
-                                Select an AWS availability zone.
+                                Choose an AWS availability zone (AWS subregion). If using an existing VPC, selecting an
+                                availability zone first is required for retrieving existing public and private subnets.
                             </span>
                         </clr-tooltip-content>
                     </clr-tooltip>
@@ -566,8 +589,9 @@
                             <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                             <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
                                 <span>
-                                    Choose a VPC public subnet associated with the selected AWS availability zone. If no
-                                    option is available, please add a public subnet to this availability zone.
+                                    {{
+                                        getVpcSubnetTooltip('public')
+                                    }}
                                 </span>
                             </clr-tooltip-content>
                         </clr-tooltip>
@@ -585,7 +609,11 @@
                     </select>
                     <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
                     <clr-control-helper></clr-control-helper>
-                    <clr-control-error>Selecting a VPC public subnet is required</clr-control-error>
+                    <clr-control-error>
+                        {{
+                            getVpcSubnetErrorMsg('public')
+                        }}
+                    </clr-control-error>
                 </clr-select-container>
             </div>
             <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
@@ -596,8 +624,9 @@
                             <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                             <clr-tooltip-content clrPosition="top-left" clrSize="lg" *clrIfOpen>
                                 <span>
-                                    Choose a VPC private subnet associated with the selected AWS availability zone. If no
-                                    option is available, please add a private subnet to this availability zone.
+                                    {{
+                                        getVpcSubnetTooltip('private')
+                                    }}
                                 </span>
                             </clr-tooltip-content>
                         </clr-tooltip>
@@ -615,7 +644,11 @@
                     </select>
                     <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
                     <clr-control-helper></clr-control-helper>
-                    <clr-control-error>Selecting a VPC private subnet is required</clr-control-error>
+                    <clr-control-error>
+                        {{
+                            getVpcSubnetErrorMsg('private')
+                        }}
+                    </clr-control-error>
                 </clr-select-container>
             </div>
             <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4"></div>

--- a/pkg/v1/tkg/web/src/app/views/landing/aws-wizard/node-setting-step/node-setting-step.component.ts
+++ b/pkg/v1/tkg/web/src/app/views/landing/aws-wizard/node-setting-step/node-setting-step.component.ts
@@ -468,6 +468,17 @@ export class NodeSettingStepComponent extends NodeSettingStepDirective<string> i
         }
     }
 
+    getVpcSubnetTooltip(access: string): string {
+        return `Choose a VPC ${access} subnet associated with the selected AWS availability zone. If no
+            option is available, please add a ${access} subnet to this availability zone or create a new VPC in the
+            previous step.`;
+    }
+
+    getVpcSubnetErrorMsg(access: string): string {
+        return `Selecting a VPC ${access} subnet is required. If no subnets are available, please add a ${access} subnet to this
+            subregion or create a new VPC in the previous step.`;
+    }
+
     get isVpcTypeExisting(): boolean {
         return this.vpcType === VpcType.EXISTING;
     }


### PR DESCRIPTION
### What this PR does / why we need it
Improves tooltips and error messages shown when user:
 - Selects an existing VPC
 - Has to select 1-3 availability zones
 - Has to select VPC public and private subnets
 
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

Built and ran management cluster plugin to verify UI changes are present

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
none
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
