### PR TITLE
[Backport]: Fix data race in cluster pause webhook (#3055)

### DIFF
--- a/addons/Makefile
+++ b/addons/Makefile
@@ -42,7 +42,7 @@ all: test manager ## Tests and builds the binaries
 .PHONY: test
 test: fmt vet template-tests ## Run Tests
 	$(MAKE) kubebuilder -C $(TOOLS_DIR)
-	KUBEBUILDER_ASSETS=$(KUBEBUILDER_BIN_DIR) go test ./... -timeout 60m -coverprofile coverage.txt -v 2
+	KUBEBUILDER_ASSETS=$(KUBEBUILDER_BIN_DIR) go test ./... -timeout 60m -race -coverprofile coverage.txt -v 2
 
 .PHONY: test-verbose
 test-verbose: ## Verbose tests with streaming output for debugging

--- a/addons/pkg/crdwait/crd_wait_test.go
+++ b/addons/pkg/crdwait/crd_wait_test.go
@@ -1,5 +1,6 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+//go:build !race
 
 package crdwait
 

--- a/addons/webhooks/clusterbootstrap_webhook.go
+++ b/addons/webhooks/clusterbootstrap_webhook.go
@@ -48,7 +48,7 @@ type ClusterBootstrap struct {
 	aggregatedAPIResourcesClient client.Client
 	// cache for resolved api-resources so that look up is fast (cleared periodically)
 	providerGVR map[schema.GroupKind]*schema.GroupVersionResource
-    // mutex for GVR lookup and clearing
+	// mutex for GVR lookup and clearing
 	lock sync.Mutex
 }
 

--- a/addons/webhooks/clusterbootstrap_webhook.go
+++ b/addons/webhooks/clusterbootstrap_webhook.go
@@ -6,6 +6,7 @@ package webhooks
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -47,6 +48,8 @@ type ClusterBootstrap struct {
 	aggregatedAPIResourcesClient client.Client
 	// cache for resolved api-resources so that look up is fast (cleared periodically)
 	providerGVR map[schema.GroupKind]*schema.GroupVersionResource
+    // mutex for GVR lookup and clearing
+	lock sync.Mutex
 }
 
 // SetupWebhookWithManager performs the setup actions for an ClusterBootstrap webhook, using the passed in mgr.
@@ -267,6 +270,8 @@ func (wh *ClusterBootstrap) validateValuesFrom(ctx context.Context, valuesFrom *
 // TODO: Consider to use provider_util.go#GetGVRForGroupKind()
 // getGVR returns a GroupVersionResource for a GroupKind
 func (wh *ClusterBootstrap) getGVR(gk schema.GroupKind) (*schema.GroupVersionResource, error) {
+	wh.lock.Lock()
+	defer wh.lock.Unlock()
 	if gvr, ok := wh.providerGVR[gk]; ok {
 		return gvr, nil
 	}
@@ -300,8 +305,10 @@ func (wh *ClusterBootstrap) periodicGVRCachesClean(ctx context.Context) {
 			ticker.Stop()
 			return
 		case <-ticker.C:
+			wh.lock.Lock()
 			wh.cachedDiscoveryClient.Invalidate()
 			wh.providerGVR = make(map[schema.GroupKind]*schema.GroupVersionResource)
+			wh.lock.Unlock()
 		}
 	}
 }

--- a/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
+++ b/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
@@ -359,8 +359,8 @@ spec:
         name: tanzu-addons-controller
         resources:
           limits:
-            cpu: 100m
-            memory: 500Mi
+            cpu: 500m
+            memory: 1200Mi
           requests:
             cpu: 100m
             memory: 40Mi


### PR DESCRIPTION
What this PR does / why we need it

* Fix data race in cluster pause webhook
* Refactor tests in cluster pause webhook to not rely on global vars
* Ignore data race in crd_wait_test.go caused by write of context object
* Add -race to addons tests to catch issues in CI
* Update memory for addons-manager to match cluster-api. This also addresses memory
* usage for 190 clusters in wcp system test env. Bump cpu limit

Signed-off-by: Vijay Katam [vkatam@vmware.com](mailto:vkatam@vmware.com)
Which issue(s) this PR fixes

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/3046

Describe testing done for PR

* Tested in system test environment.
*  Unit tests.

Release note
```
package-based-lcm: Fix data race in cluster pause webhook
```