### PR TITLE
[release-0.25] Display correct error message when passing Cluster based resource without ClusterClass as part of cluster create

### DIFF
--- a/pkg/v1/tkg/constants/clusterclass_mapping.go
+++ b/pkg/v1/tkg/constants/clusterclass_mapping.go
@@ -279,7 +279,8 @@ const (
 
 	SPEC = "spec"
 
-	TopologyClassIncorrectValueErrMsg = "input cluster class file, attribute spec.topology.class has no value or incorrect value or not following correct naming convension"
+	TopologyClassIncorrectValueErrMsg            = "input cluster class file, attribute spec.topology.class has no value or incorrect value or not following correct naming convention"
+	ClusterResourceAsInputFileNotSupportedErrMsg = "input file with Cluster resource definition is not supported. Please provide cluster configuration"
 )
 
 // InfrastructureSpecificVariableMappingMap has, infra name to variable mapping map, which makes easy to get infra specific mapping map

--- a/pkg/v1/tkg/constants/clusterclass_mapping.go
+++ b/pkg/v1/tkg/constants/clusterclass_mapping.go
@@ -279,8 +279,8 @@ const (
 
 	SPEC = "spec"
 
-	TopologyClassIncorrectValueErrMsg            = "input cluster class file, attribute spec.topology.class has no value or incorrect value or not following correct naming convention"
-	ClusterResourceAsInputFileNotSupportedErrMsg = "input file with Cluster resource definition is not supported. Please provide cluster configuration"
+	TopologyClassIncorrectValueErrMsg            = "cluster class missing in configuration or not following naming convention"
+	ClusterResourceAsInputFileNotSupportedErrMsg = "input file with Cluster resource definition is not supported"
 )
 
 // InfrastructureSpecificVariableMappingMap has, infra name to variable mapping map, which makes easy to get infra specific mapping map

--- a/pkg/v1/tkg/tkgctl/create_cluster_test.go
+++ b/pkg/v1/tkg/tkgctl/create_cluster_test.go
@@ -327,6 +327,7 @@ var _ = Describe("Unit tests for (AWS)  cluster_aws.yaml as input file for 'tanz
 			mappedVal, _ = ctl.TKGConfigReaderWriter().Get(constants.ConfigVariableNodeMachineType2)
 			Expect("worker2").To(Equal(fmt.Sprintf("%v", mappedVal)))
 		})
+
 		It("When Input file is cluster type with multiple objects, Environment should be updated with legacy variables and CreateClusterOptions also updated with Cluster attribute values:", func() {
 
 			// Process input cluster yaml file, this should process input cluster yaml file
@@ -350,6 +351,18 @@ var _ = Describe("Unit tests for (AWS)  cluster_aws.yaml as input file for 'tanz
 			// checking manually for some variables mapping values
 			mappedVal, _ := ctl.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterName)
 			Expect("aws-workload-cluster1").To(Equal(fmt.Sprintf("%v", mappedVal)))
+		})
+
+		It("When Input file is cluster type with multiple objects but feature-flag (FeatureFlagPackageBasedLCM) is false, should return an error", func() {
+			tkgClient.IsFeatureActivatedReturns(false)
+			// Process input cluster yaml file, this should process input cluster yaml file
+			// and update the environment with legacy name and values
+			// most of cluster yaml attributes are mapped to legacy variable for more look this - constants.ClusterToLegacyVariablesMapAws
+			options.ClusterConfigFile = inputFileMultipleObjectsAws
+			IsInputFileClusterClassBased, err := ctl.processWorkloadClusterInputFile(&options, isTKGSCluster)
+			Expect(IsInputFileClusterClassBased).Should(BeTrue())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(constants.ClusterResourceAsInputFileNotSupportedErrMsg))
 		})
 
 		It("When Input file is cluster type does not have value for spec.topology.class, return an error", func() {

--- a/pkg/v1/tkg/tkgctl/helpers_test.go
+++ b/pkg/v1/tkg/tkgctl/helpers_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/utils"
 )
 
 var _ = Describe("Cluster Class - IP Family Validation related test cases: ", func() {
@@ -207,6 +208,60 @@ var _ = Describe("Cluster Class - IP Family Validation related test cases: ", fu
 				_, err := getProviderNameFromTopologyClassName(cidr)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(constants.TopologyClassIncorrectValueErrMsg))
+			})
+		})
+	})
+})
+
+var _ = Describe("Test cases for CheckIfInputFileIsClusterClassBased", func() {
+	Context("Test cases for CheckIfInputFileIsClusterClassBased", func() {
+		var (
+			configFile          string
+			configFileContent   string
+			isClusterClassBased bool
+			err                 error
+		)
+
+		JustBeforeEach(func() {
+			configFile, err = utils.CreateTempFile("", "")
+			Expect(err).To(BeNil())
+			err = utils.SaveFile(configFile, []byte(configFileContent))
+			Expect(err).To(BeNil())
+			isClusterClassBased, _, err = CheckIfInputFileIsClusterClassBased(configFile)
+		})
+		When("File contains cluster resource with clusterclass defined", func() {
+			BeforeEach(func() {
+				configFileContent = `apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: aws-workload-cluster1
+  namespace: default
+spec:
+  topology:
+    class: tkg-aws-default`
+			})
+			It("should return true and error should be nil", func() {
+				Expect(isClusterClassBased).To(BeTrue())
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		When("File doesn't contain cluster resource", func() {
+			BeforeEach(func() {
+				configFileContent = ``
+			})
+			It("should return false without error", func() {
+				Expect(isClusterClassBased).To(Equal(false))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+		When("File contain non-yaml string", func() {
+			BeforeEach(func() {
+				configFileContent = `incorrect yaml string`
+			})
+			It("should return false with error", func() {
+				Expect(isClusterClassBased).To(Equal(false))
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("Input file content is not yaml formatted"))
 			})
 		})
 	})


### PR DESCRIPTION
### What this PR does / why we need it
- Display correct error message when passing Cluster based resource without ClusterClass as part of cluster create

Currently, when user passes `Cluster` resource as part of `tanzu cluster create --file <input.yaml>` and the cluster resource doesn't include ClusterClass as part of `.spec.topology.cluster` thrown proper error message.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3054

### Describe testing done for PR
- Added unit tests
- Manually verified by passing `--dry-run` output to `tanzu cluster create --file <manifest.yaml>` and verified the error message
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Display correct error message when passing Cluster resource without ClusterClass as part of cluster create
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
