### PR TITLE
Adds upgrade integration test for custom CB clusters

### DIFF
--- a/pkg/v1/tkg/test/tkgctl/tkgs_cc/tkgs_cc_workload_cluster_test.go
+++ b/pkg/v1/tkg/test/tkgctl/tkgs_cc/tkgs_cc_workload_cluster_test.go
@@ -67,13 +67,14 @@ var _ = Describe("TKGS ClusterClass based workload cluster tests", func() {
 		})
 
 		It("should successfully create a cluster and verify successful addons reconciliation", func() {
-			shared.CheckTKGSAddons(ctx, tkgctlClient, svClusterName, clusterName, namespace, e2eConfig.TKGSKubeconfigPath, constants.InfrastructureProviderTkgs, false)
 			Expect(err).ToNot(HaveOccurred())
+			shared.CheckTKGSAddons(ctx, tkgctlClient, svClusterName, clusterName, namespace, e2eConfig.TKGSKubeconfigPath, constants.InfrastructureProviderTkgs, false)
 		})
 
 		It("should successfully upgrade a cluster", func() {
 			Expect(err).ToNot(HaveOccurred())
 			shared.TestClusterUpgrade(tkgctlClient, clusterName, namespace)
+			shared.CheckTKGSAddons(ctx, tkgctlClient, svClusterName, clusterName, namespace, e2eConfig.TKGSKubeconfigPath, constants.InfrastructureProviderTkgs, false)
 		})
 	})
 
@@ -100,12 +101,13 @@ var _ = Describe("TKGS ClusterClass based workload cluster tests", func() {
 		})
 
 		It("should successfully create a cluster and verify successful addons reconciliation", func() {
-			shared.CheckTKGSAddons(ctx, tkgctlClient, svClusterName, clusterName, namespace, e2eConfig.TKGSKubeconfigPath, constants.InfrastructureProviderTkgs, false)
 			Expect(err).ToNot(HaveOccurred())
+			shared.CheckTKGSAddons(ctx, tkgctlClient, svClusterName, clusterName, namespace, e2eConfig.TKGSKubeconfigPath, constants.InfrastructureProviderTkgs, false)
 		})
 		It("should successfully upgrade a cluster", func() {
 			Expect(err).ToNot(HaveOccurred())
 			shared.TestClusterUpgrade(tkgctlClient, clusterName, namespace)
+			shared.CheckTKGSAddons(ctx, tkgctlClient, svClusterName, clusterName, namespace, e2eConfig.TKGSKubeconfigPath, constants.InfrastructureProviderTkgs, false)
 		})
 	})
 
@@ -160,6 +162,13 @@ var _ = Describe("TKGS ClusterClass based workload cluster tests", func() {
 			By(fmt.Sprintf("Verify addon packages on workload cluster %q matches clusterBootstrap info on management cluster %q", e2eConfig.WorkloadClusterOptions.ClusterName, clusterName))
 			err = shared.CheckClusterCB(context.Background(), mngClient, wlcClient, clusterName, namespace, clusterName, namespace, e2eConfig.InfrastructureName, false, true)
 			Expect(err).To(BeNil())
+		})
+
+		It("should successfully upgrade a cluster with custom CB and verify addons", func() {
+			Expect(err).ToNot(HaveOccurred())
+			shared.CheckTKGSAddons(context.TODO(), tkgctlClient, svClusterName, clusterName, namespace, e2eConfig.TKGSKubeconfigPath, e2eConfig.InfrastructureName, true)
+			shared.TestClusterUpgrade(tkgctlClient, clusterName, namespace)
+			shared.CheckTKGSAddons(context.TODO(), tkgctlClient, svClusterName, clusterName, namespace, e2eConfig.TKGSKubeconfigPath, e2eConfig.InfrastructureName, true)
 		})
 	})
 


### PR DESCRIPTION
### What this PR does / why we need it
 Adds upgrade integration test for custom CB clusters
- deploys cluster with custom cluster bootstrap
- checks addons installations
- upgrades cluster to next available tkr
- checks addons installations


This pr also adds checks for addons installation to  classy cluster upgrade test. 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2452

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Adds upgrade integration test for custom CB clusters

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
Testing done: 
ran following command locally:
```
E2E_CONFIG=/Users/aduarte/testing/tanzu-framework/trash/customcbtesting/tkgs.yaml hack/tools/bin/ginkgo -v -trace --focus="should successfully upgrade a cluster with custom CB and verify addons" pkg/v1/tkg/test/tkgctl/tkgs_cc
```
result

```
TKGS ClusterClass based workload cluster tests
/Users/aduarte/testing/tanzu-framework/pkg/v1/tkg/test/tkgctl/tkgs_cc/tkgs_cc_workload_cluster_test.go:32
  when input file is cluster class based with custom Cluster Bootstrap
  /Users/aduarte/testing/tanzu-framework/pkg/v1/tkg/test/tkgctl/tkgs_cc/tkgs_cc_workload_cluster_test.go:114
    should successfully upgrade a cluster with custom CB and verify addons
    /Users/aduarte/testing/tanzu-framework/pkg/v1/tkg/test/tkgctl/tkgs_cc/tkgs_cc_workload_cluster_test.go:167
------------------------------
SSS
JUnit report was created: /var/folders/3y/xfxl51_563q457kydkzw10yc0000gq/T/artifacts/junit/junit.e2e_suite.1.xml

Ran 1 of 9 Specs in 1542.476 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 8 Skipped
PASS

```
