### PR TITLE
Add a flag for tanzu management cluster to init bootstrap cluster only.

### DIFF
--- a/cmd/cli/plugin/managementcluster/create.go
+++ b/cmd/cli/plugin/managementcluster/create.go
@@ -20,6 +20,7 @@ import (
 type initRegionOptions struct {
 	ui                          bool
 	useExistingCluster          bool
+	bootstrapClusterOnly        bool
 	enableTKGSOnVsphere7        bool
 	deployTKGonVsphere7         bool
 	unattended                  bool
@@ -84,6 +85,9 @@ func init() {
 	createCmd.Flags().BoolVarP(&iro.unattended, "yes", "y", false, "Create management cluster without asking for confirmation")
 
 	createCmd.Flags().BoolVarP(&iro.useExistingCluster, "use-existing-bootstrap-cluster", "e", false, "Use an existing bootstrap cluster to deploy the management cluster")
+
+	createCmd.Flags().BoolVarP(&iro.bootstrapClusterOnly, "bootstrap-cluster-only", "", false, "Only create the bootstrap cluster and pause before creating the management cluster")
+
 	createCmd.Flags().DurationVarP(&iro.timeout, "timeout", "t", constants.DefaultLongRunningOperationTimeout, "Time duration to wait for an operation before timeout. Timeout duration in hours(h)/minutes(m)/seconds(s) units or as some combination of them (e.g. 2h, 30m, 2h30m10s)")
 
 	createCmd.Flags().StringVarP(&iro.infrastructureProvider, "infrastructure", "i", "", "Infrastructure to deploy the management cluster on ['aws', 'vsphere', 'azure']")
@@ -162,6 +166,7 @@ func runInit() error {
 		UI:                          iro.ui,
 		ClusterName:                 iro.clusterName,
 		UseExistingCluster:          iro.useExistingCluster,
+		BootstrapClusterOnly:        iro.bootstrapClusterOnly,
 		CoreProvider:                iro.coreProvider,
 		BootstrapProvider:           iro.bootstrapProvider,
 		InfrastructureProvider:      iro.infrastructureProvider,

--- a/pkg/v1/tkg/client/client.go
+++ b/pkg/v1/tkg/client/client.go
@@ -80,6 +80,7 @@ type InitRegionOptions struct {
 	LaunchUI                     bool
 	CeipOptIn                    bool
 	UseExistingCluster           bool
+	BootstrapClusterOnly         bool
 	IsInputFileClusterClassBased bool
 }
 

--- a/pkg/v1/tkg/client/init.go
+++ b/pkg/v1/tkg/client/init.go
@@ -233,6 +233,11 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 
 	isStartedRegionalClusterCreation = true
 
+	if options.BootstrapClusterOnly {
+		log.Infof("\nPause before setting up management cluster, since --boostrap-cluster-only is specified...\n")
+		return nil
+	}
+
 	targetClusterNamespace := defaultTkgNamespace
 	if options.Namespace != "" {
 		targetClusterNamespace = options.Namespace

--- a/pkg/v1/tkg/tkgctl/init.go
+++ b/pkg/v1/tkg/tkgctl/init.go
@@ -42,6 +42,7 @@ type InitRegionOptions struct {
 	Timeout                     time.Duration
 	UI                          bool
 	UseExistingCluster          bool
+	BootstrapClusterOnly        bool
 	EnableTKGSOnVsphere7        bool
 	DeployTKGonVsphere7         bool
 	SkipPrompt                  bool
@@ -344,6 +345,7 @@ func (t *tkgctl) populateClientInitRegionOptions(options *InitRegionOptions, nod
 		LaunchUI:                    options.UI,
 		ClusterName:                 options.ClusterName,
 		UseExistingCluster:          options.UseExistingCluster,
+		BootstrapClusterOnly:        options.BootstrapClusterOnly,
 		InfrastructureProvider:      options.InfrastructureProvider,
 		ControlPlaneProvider:        options.ControlPlaneProvider,
 		BootstrapProvider:           options.BootstrapProvider,


### PR DESCRIPTION
### What this PR does / why we need it

Let's add a new flag `--bootstrap-cluster-only` to the `management-cluster create` command. This is useful for developer to take a pause after the init bootstrap cluster is provisioned and inspect the provider installation status.

We are asking specifically for the Oracle integration use case where some hacks of the OSImage CR should be performed right before creating the management cluster.

cc @randomvariable 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add a flag for tanzu management cluster to init bootstrap cluster only.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
