### PR TITLE
[backport release-0.25 branch]Add support for "tanzu cluster get" to show tree view of cluster for …

### DIFF
--- a/cmd/cli/plugin/cluster/get.go
+++ b/cmd/cli/plugin/cluster/get.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aunum/log"
 	"github.com/fatih/color"
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
@@ -25,6 +24,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/cli/component"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/config"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/tkgctl"
 )
 
@@ -144,19 +144,13 @@ func getCluster(server *v1alpha1.Server, clusterName string) error {
 
 	t.Render()
 
-	isPacific, err := tkgctlClient.IsPacificRegionalCluster()
-	if err != nil {
-		return errors.New("error determining 'Tanzu Kubernetes Cluster service for vSphere' management cluster")
+	if results.Objs != nil && results.Cluster != nil {
+		log.Infof("\n\nDetails:\n\n")
+		treeView(results.Objs, results.Cluster)
+	} else {
+		// printing the below at log level 1, so that if users want to know why the tree view is not available(for TKGS) it could provide insights
+		log.V(1).Infof("\n\n  Warning! Unable to get cluster ObjectTree/cluster objects, so detailed(tree) view of cluster resources is not available!!\n\n")
 	}
-
-	if isPacific {
-		return nil
-	}
-
-	// TODO: Can be removed when TKGS and TKGm converge to the same CAPI version.
-	// https://github.com/vmware-tanzu/tanzu-framework/issues/1063
-	log.Infof("\n\nDetails:\n\n")
-	treeView(results.Objs, results.Cluster)
 
 	// If it is a Management Cluster, output the providers
 	if results.InstalledProviders != nil {

--- a/pkg/v1/tkg/tkgctl/describe_cluster.go
+++ b/pkg/v1/tkg/tkgctl/describe_cluster.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/constants"
+	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/log"
 )
 
 // DescribeTKGClustersOptions options that can be passed while requesting to describe a cluster
@@ -103,14 +104,14 @@ func (t *tkgctl) DescribeCluster(options DescribeTKGClustersOptions) (DescribeCl
 		}
 	}
 
-	// TODO: Can be removed when TKGS and TKGm converge to the same CAPI version.
-	// https://github.com/vmware-tanzu/tanzu-framework/issues/1063
-	if isPacific {
-		return results, nil
-	}
-
 	objs, cluster, installedProviders, err := t.tkgClient.DescribeCluster(DescribeTKGClustersOptions)
 	if err != nil {
+		// If it is pacific(TKGS), it would be the best effort to return the objectTree and cluster, so if there is an error
+		// fetching these objects, return empty objects without error.
+		if isPacific {
+			log.V(5).Infof("Failed to get cluster ObjectTree/cluster objects(so detailed(tree) view of cluster resources may be affected), reason: %v", err)
+			return results, nil
+		}
 		return results, err
 	}
 	results.Objs = objs


### PR DESCRIPTION
…TKGS

- It would be best effort to show the treeview of the cluster object for TKGS provider
 because the older TKGS versions supports different CAPI version causing the clusterctl
 describe library unable to query/list the clsuter objects. So if clusterctl library
 successfully query the objects the treeview would be shown.
Signed-off-by: Prem Kumar Kalle <pkalle@vmware.com>

Signed-off-by: Prem Kumar Kalle <pkalle@vmware.com>

### What this PR does / why we need it

This PR adds support for "tanzu cluster get" command to show details (tree view) for TKGS

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1063 

### Describe testing done for PR

Tested with version of TKGS that has CAPI version `v1alpha3` , it didn't show the cluster resources details(tree view). If user wants to know why it is not being shown, using log verbose level 1 or higher would show the warning message

```
❯ tanzu cluster get guestcluster1 -n gctest
  NAME           NAMESPACE  STATUS   CONTROLPLANE  WORKERS  KUBERNETES                       ROLES   TKR
  guestcluster1  gctest     running  1/1           2/2      v1.20.12+vmware.1-tkg.1.10b2767  <none>  v1.20.12---vmware.1-tkg.1.10b2767
❯ tanzu cluster get guestcluster1 -n gctest -v 1
  NAME           NAMESPACE  STATUS   CONTROLPLANE  WORKERS  KUBERNETES                       ROLES   TKR
  guestcluster1  gctest     running  1/1           2/2      v1.20.12+vmware.1-tkg.1.10b2767  <none>  v1.20.12---vmware.1-tkg.1.10b2767


  Warning! Unable to get cluster ObjectTree/cluster objects, so detailed(tree) view of cluster resources is not available!!
```

Tested with with version of TKGS that has CAPI version `v1beta1` and it successfully shown the cluster resources details(tree view)
```
❯ tanzu cluster list
  NAME          NAMESPACE  STATUS    CONTROLPLANE  WORKERS  KUBERNETES        ROLES   PLAN  TKR
  test01        ns01       deleting  1/1                    v1.23.8+vmware.2  <none>        v1.23.8---vmware.2-tkg.1-zshippable
  test02        ns01       running   1/1           1/1      v1.23.8+vmware.2  <none>        v1.23.8---vmware.2-tkg.2-zshippable
  tkc-e2e-2wj4  ns01       running   1/1           1/1      v1.23.8+vmware.2  <none>        v1.23.8---vmware.2-tkg.2-zshippable
  tkc-e2e-keaf  ns01       running   1/1           1/1      v1.23.8+vmware.2  <none>        v1.23.8---vmware.2-tkg.1-zshippable
❯ tanzu cluster get test02 -n ns01
  NAME    NAMESPACE  STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES   TKR
  test02  ns01       running  1/1           1/1      v1.23.8+vmware.2  <none>  v1.23.8---vmware.2-tkg.2-zshippable


Details:

NAME                                                    READY  SEVERITY  REASON  SINCE  MESSAGE
/test02                                                 True                     4h42m
├─ClusterInfrastructure - VSphereCluster/test02-xvgl8   True                     4h45m
├─ControlPlane - KubeadmControlPlane/test02-dn8n2       True                     4h42m
│ └─Machine/test02-dn8n2-xvnck                          True                     4h42m
└─Workers
  └─MachineDeployment/test02-node-pool-1-2xmrf          True                     4h39m
    └─Machine/test02-node-pool-1-2xmrf-5bfc945cb-rrkqr  True                     4h40m
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Adds support for "tanzu cluster get" command to show details (tree view) for TKGS
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->

