### PR TITLE
Remove installation of kubeval

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -82,12 +82,11 @@ KBLD               := $(TOOLS_BIN_DIR)/kbld
 VENDIR             := $(TOOLS_BIN_DIR)/vendir
 IMGPKG             := $(TOOLS_BIN_DIR)/imgpkg
 KAPP               := $(TOOLS_BIN_DIR)/kapp
-KUBEVAL            := $(TOOLS_BIN_DIR)/kubeval
 GINKGO             := $(TOOLS_BIN_DIR)/ginkgo
 VALE               := $(TOOLS_BIN_DIR)/vale
 YQ                 := $(TOOLS_BIN_DIR)/yq
 CONVERSION_GEN     := $(TOOLS_BIN_DIR)/conversion-gen
-TOOLING_BINARIES   := $(CONTROLLER_GEN) $(GOLANGCI_LINT) $(YTT) $(KBLD) $(VENDIR) $(IMGPKG) $(KAPP) $(KUBEVAL) $(KUSTOMIZE) $(GOIMPORTS) $(GOBINDATA) $(GINKGO) $(VALE) $(YQ) $(CONVERSION_GEN)
+TOOLING_BINARIES   := $(CONTROLLER_GEN) $(GOLANGCI_LINT) $(YTT) $(KBLD) $(VENDIR) $(IMGPKG) $(KAPP) $(KUSTOMIZE) $(GOIMPORTS) $(GOBINDATA) $(GINKGO) $(VALE) $(YQ) $(CONVERSION_GEN)
 
 ## --------------------------------------
 ##@ API/controller building and generation

--- a/hack/tools/Makefile
+++ b/hack/tools/Makefile
@@ -29,7 +29,6 @@ YTT_VERSION=v0.40.0
 KBLD_VERSION=v0.31.0
 KAPP_VERSION=v0.42.0
 VENDIR_VERSION=v0.23.0
-KUBEVAL_VERSION=0.15.0
 VALE_VERSION=2.17.0
 K8S_VERSION=1.23.5
 
@@ -43,7 +42,6 @@ GINKGO             := $(BIN_DIR)/ginkgo
 GOLANGCI_LINT      := $(BIN_DIR)/golangci-lint
 GOIMPORTS          := $(BIN_DIR)/goimports
 KUBEBUILDER        := $(BIN_DIR)/kubebuilder
-KUBEVAL            := $(BIN_DIR)/kubeval
 KUSTOMIZE := $(BIN_DIR)/kustomize
 GOBINDATA          := $(BIN_DIR)/gobindata
 VALE               := $(BIN_DIR)/vale
@@ -97,13 +95,6 @@ $(KUBEBUILDER):
 kustomize: $(KUSTOMIZE)
 $(KUSTOMIZE): $(BIN_DIR) go.mod go.sum # Build kustomize from tools folder.
 	CGO_ENABLED=0 go build -tags=tools -o $@ sigs.k8s.io/kustomize/kustomize/v4
-
-kubeval: $(KUBEVAL) ## Install kubeval
-$(KUBEVAL):
-	mkdir -p $(BIN_DIR)
-	curl -sL https://github.com/instrumenta/kubeval/releases/download/$(KUBEVAL_VERSION)/kubeval-$(HOST_OS)-$(HOST_ARCH).tar.gz | tar -xz -C /tmp/
-	mv /tmp/kubeval $(@)
-	chmod a+x $(@)
 
 gobindata: $(GOBINDATA)
 $(GOBINDATA): go.mod go.sum # Build go-bindata


### PR DESCRIPTION

### What this PR does / why we need it

This PR removes the installation of `kubeval` which is not used anymore.
Trying to install it breaks the `make lint` target on `arm64` since there is no `kubeval` release for that architecture.

Note that the use of `kubeval` was removed in #204.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3075 

### Describe testing done for PR

On a Mac ARM machine, ran `make tools` to see that the installation of `kubeval` failed before the PR and passes after applying the PR.

Also ran `make lint` to see that it no longer failed when trying to intall `kubeval`.  Note that this requires some tweaking for `vale` and `misspell` which also fail on ARM (there is a PR for vale already #3071).

/cc @vuil 
