### PR TITLE
Update osInfo annotation on Cluster resource during cluster upgrade

### DIFF
--- a/pkg/v1/tkg/clusterclient/clusterclient.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient.go
@@ -242,6 +242,8 @@ type Client interface {
 	PatchClusterWithOperationStartedStatus(clusterName, namespace, operationType string, timeout time.Duration) error
 	// PatchClusterObjectWithTKGVersion applies patch to cluster objects based on given tkgVersion string
 	PatchClusterObjectWithTKGVersion(clusterName, clusterNamespace, tkgVersion string) error
+	// PatchClusterObjectAnnotations applies patch to cluster objects to update annotation with specified key:value
+	PatchClusterObjectAnnotations(clusterName, namespace, key, value string) error
 	// GetManagementClusterTKGVersion returns the TKG version of a management cluster based on the
 	// annotation value present in cluster object
 	GetManagementClusterTKGVersion(mgmtClusterName, clusterNamespace string) (string, error)
@@ -1049,6 +1051,15 @@ func (c *client) PatchClusterObjectWithTKGVersion(clusterName, namespace, tkgVer
 	err := c.PatchClusterObject(clusterName, namespace, patchAnnotations)
 	if err != nil {
 		return errors.Wrap(err, "unable to patch the management cluster object with TKG version")
+	}
+	return nil
+}
+
+func (c *client) PatchClusterObjectAnnotations(clusterName, namespace, key, value string) error {
+	patchAnnotations := fmt.Sprintf(annotationPatchFormat, key, value)
+	err := c.PatchClusterObject(clusterName, namespace, patchAnnotations)
+	if err != nil {
+		return errors.Wrapf(err, "unable to patch the cluster object with %v", patchAnnotations)
 	}
 	return nil
 }

--- a/pkg/v1/tkg/clusterclient/clusterclient_test.go
+++ b/pkg/v1/tkg/clusterclient/clusterclient_test.go
@@ -2993,6 +2993,92 @@ prod.repo.com: prod.custom.repo.com`
 		})
 	})
 
+	Describe("Unit tests for PatchClusterObjectAnnotations", func() {
+		var (
+			fakeClientSet crtclient.Client
+			resources     []runtime.Object
+			key, value    string
+		)
+		fakecluster1 := &capi.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fake-cluster-1",
+				Namespace: "fake-namespace",
+				Annotations: map[string]string{
+					"key-foo": "value-foo",
+					"key-bar": "value-bar",
+				},
+			},
+		}
+
+		JustBeforeEach(func() {
+			reInitialize()
+
+			fakeClientSet = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(resources...).Build()
+			crtClientFactory.NewClientReturns(fakeClientSet, nil)
+
+			clusterClientOptions = NewOptions(poller, crtClientFactory, discoveryClientFactory, nil)
+			kubeConfigPath := getConfigFilePath("config1.yaml")
+			clstClient, err = NewClient(kubeConfigPath, "", clusterClientOptions)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = clstClient.PatchClusterObjectAnnotations("fake-cluster-1", "fake-namespace", key, value)
+		})
+
+		Context("When matching cluster not found", func() {
+			BeforeEach(func() {
+				resources = []runtime.Object{}
+			})
+			It("should return error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unable to patch the cluster object with"))
+			})
+		})
+
+		Context("When cluster object is found and matching annotation doesn't exists", func() {
+			BeforeEach(func() {
+				resources = []runtime.Object{fakecluster1}
+				key = "key-fake"
+				value = "value-fake"
+			})
+			It("should not return error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("should add new annotation", func() {
+				cluster := &capi.Cluster{}
+				err = clstClient.GetResource(cluster, "fake-cluster-1", "fake-namespace", nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				annotations := cluster.GetAnnotations()
+				Expect(annotations).To(HaveKey("key-bar"))
+				Expect(annotations).To(HaveKey("key-foo"))
+				Expect(annotations).To(HaveKey("key-fake"))
+				Expect(annotations["key-bar"]).To(Equal("value-bar"))
+				Expect(annotations["key-foo"]).To(Equal("value-foo"))
+				Expect(annotations["key-fake"]).To(Equal("value-fake"))
+			})
+		})
+
+		Context("When cluster object is found and matching annotation exists", func() {
+			BeforeEach(func() {
+				resources = []runtime.Object{fakecluster1}
+				key = "key-bar"
+				value = "value-bar-updated"
+			})
+			It("should not return error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("should update existing annotation", func() {
+				cluster := &capi.Cluster{}
+				err = clstClient.GetResource(cluster, "fake-cluster-1", "fake-namespace", nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				annotations := cluster.GetAnnotations()
+				Expect(annotations).To(HaveKey("key-bar"))
+				Expect(annotations).To(HaveKey("key-foo"))
+				Expect(annotations["key-bar"]).To(Equal("value-bar-updated"))
+				Expect(annotations["key-foo"]).To(Equal("value-foo"))
+			})
+		})
+	})
+
 })
 
 func createTempDirectory() {

--- a/pkg/v1/tkg/fakes/clusterclient.go
+++ b/pkg/v1/tkg/fakes/clusterclient.go
@@ -765,6 +765,20 @@ type ClusterClient struct {
 	patchClusterObjectReturnsOnCall map[int]struct {
 		result1 error
 	}
+	PatchClusterObjectAnnotationsStub        func(string, string, string, string) error
+	patchClusterObjectAnnotationsMutex       sync.RWMutex
+	patchClusterObjectAnnotationsArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+	}
+	patchClusterObjectAnnotationsReturns struct {
+		result1 error
+	}
+	patchClusterObjectAnnotationsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	PatchClusterObjectWithOptionalMetadataStub        func(string, string, string, map[string]string) (string, error)
 	patchClusterObjectWithOptionalMetadataMutex       sync.RWMutex
 	patchClusterObjectWithOptionalMetadataArgsForCall []struct {
@@ -4758,6 +4772,70 @@ func (fake *ClusterClient) PatchClusterObjectReturnsOnCall(i int, result1 error)
 	}{result1}
 }
 
+func (fake *ClusterClient) PatchClusterObjectAnnotations(arg1 string, arg2 string, arg3 string, arg4 string) error {
+	fake.patchClusterObjectAnnotationsMutex.Lock()
+	ret, specificReturn := fake.patchClusterObjectAnnotationsReturnsOnCall[len(fake.patchClusterObjectAnnotationsArgsForCall)]
+	fake.patchClusterObjectAnnotationsArgsForCall = append(fake.patchClusterObjectAnnotationsArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.PatchClusterObjectAnnotationsStub
+	fakeReturns := fake.patchClusterObjectAnnotationsReturns
+	fake.recordInvocation("PatchClusterObjectAnnotations", []interface{}{arg1, arg2, arg3, arg4})
+	fake.patchClusterObjectAnnotationsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *ClusterClient) PatchClusterObjectAnnotationsCallCount() int {
+	fake.patchClusterObjectAnnotationsMutex.RLock()
+	defer fake.patchClusterObjectAnnotationsMutex.RUnlock()
+	return len(fake.patchClusterObjectAnnotationsArgsForCall)
+}
+
+func (fake *ClusterClient) PatchClusterObjectAnnotationsCalls(stub func(string, string, string, string) error) {
+	fake.patchClusterObjectAnnotationsMutex.Lock()
+	defer fake.patchClusterObjectAnnotationsMutex.Unlock()
+	fake.PatchClusterObjectAnnotationsStub = stub
+}
+
+func (fake *ClusterClient) PatchClusterObjectAnnotationsArgsForCall(i int) (string, string, string, string) {
+	fake.patchClusterObjectAnnotationsMutex.RLock()
+	defer fake.patchClusterObjectAnnotationsMutex.RUnlock()
+	argsForCall := fake.patchClusterObjectAnnotationsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *ClusterClient) PatchClusterObjectAnnotationsReturns(result1 error) {
+	fake.patchClusterObjectAnnotationsMutex.Lock()
+	defer fake.patchClusterObjectAnnotationsMutex.Unlock()
+	fake.PatchClusterObjectAnnotationsStub = nil
+	fake.patchClusterObjectAnnotationsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ClusterClient) PatchClusterObjectAnnotationsReturnsOnCall(i int, result1 error) {
+	fake.patchClusterObjectAnnotationsMutex.Lock()
+	defer fake.patchClusterObjectAnnotationsMutex.Unlock()
+	fake.PatchClusterObjectAnnotationsStub = nil
+	if fake.patchClusterObjectAnnotationsReturnsOnCall == nil {
+		fake.patchClusterObjectAnnotationsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.patchClusterObjectAnnotationsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *ClusterClient) PatchClusterObjectWithOptionalMetadata(arg1 string, arg2 string, arg3 string, arg4 map[string]string) (string, error) {
 	fake.patchClusterObjectWithOptionalMetadataMutex.Lock()
 	ret, specificReturn := fake.patchClusterObjectWithOptionalMetadataReturnsOnCall[len(fake.patchClusterObjectWithOptionalMetadataArgsForCall)]
@@ -7021,6 +7099,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.patchClusterAPIAWSControllersToUseEC2CredentialsMutex.RUnlock()
 	fake.patchClusterObjectMutex.RLock()
 	defer fake.patchClusterObjectMutex.RUnlock()
+	fake.patchClusterObjectAnnotationsMutex.RLock()
+	defer fake.patchClusterObjectAnnotationsMutex.RUnlock()
 	fake.patchClusterObjectWithOptionalMetadataMutex.RLock()
 	defer fake.patchClusterObjectWithOptionalMetadataMutex.RUnlock()
 	fake.patchClusterObjectWithPollOptionsMutex.RLock()


### PR DESCRIPTION
### What this PR does / why we need it
- This changes updates osInfo annotation on the cluster resource during
  cluster upgrade

Signed-off-by: Anuj Chaudhari <anujc@vmware.com>

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3090

### Describe testing done for PR
- Added unit tests for patch operations

Manual testing:
- Create workload cluster with `OS_NAME: amazon` variable
- Verified the `osInfo` annotation on the cluster resource has `amazon,2,amd64`
- Upgrade the workload cluster with `--os-name ubuntu` option
- Cluster was upgraded successfully
- Verified the annotation on the cluster resource and it was updated to specify `ubuntu,20.04,amd64`

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixed `osInfo` annotation in Cluster CR is not correct after upgrade workload cluster with another os
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
