### PR TITLE
Handle plugin errors properly

### DIFF
--- a/cmd/cli/tanzu/main.go
+++ b/cmd/cli/tanzu/main.go
@@ -4,7 +4,8 @@
 package main
 
 import (
-	"fmt"
+	"os"
+	"os/exec"
 
 	"github.com/aunum/log"
 
@@ -13,7 +14,14 @@ import (
 
 func main() {
 	if err := core.Execute(); err != nil {
-		fmt.Println("")
-		log.Fatal(err)
+		if errStr, ok := err.(*exec.ExitError); ok {
+			// If a plugin exited with an error, we don't want to print its
+			// exit status as a string, but want to use it as our own exit code.
+			os.Exit(errStr.ExitCode())
+		} else {
+			// We got an error other than a plugin exiting with an error, let's
+			// print the error message.
+			log.Fatal(err)
+		}
 	}
 }

--- a/pkg/v1/cli/command/core/root.go
+++ b/pkg/v1/cli/command/core/root.go
@@ -23,6 +23,9 @@ import (
 // RootCmd is the core root Tanzu command
 var RootCmd = &cobra.Command{
 	Use: "tanzu",
+	// Don't have Cobra print the error message, the CLI will
+	// print it itself in a nicer format.
+	SilenceErrors: true,
 }
 
 var (


### PR DESCRIPTION
### What this PR does / why we need it

Currently, when a plugin exists with an error the CLI will print `✖  exit status 1`.
However, in such a case, we shouldn't print the plugin exit code as a string but instead should use it as our own exit code.

This commit catches the fact that the error is due to a plugin exiting with error and behaves accordingly.

Furthermore, to avoid duplicating error message, this commit tells Cobra not to print final error messages since the CLI prints them itself.

### Which issue(s) this PR fixes

Fixes #44 

### Describe testing done for PR

I first recompile the `cluster` plugin to return an exit code of 2 just for testing.
Then I ran the following before applying the PR.  The first command uses the `cluster` plugin while the second command uses a native CLI command, so we can compare.
We can see:
1. for a plugin the `exit status 2` string is printed (twice)
2. the exit code of a plugin is not used as the CLI exit code (see the `===== errcode 1` which should be a value of 2)
3. for a native command, the error is printed twice

```
$ tz cluster kubeconfig get; echo "===== errcode $?"
Error: accepts 1 arg(s), received 0
Error: exit status 2

✖  exit status 2
===== errcode 1
$ tz plugin delete
Error: must provide plugin name as positional argument

✖  must provide plugin name as positional argument
```

Then I ran the same tests with the PR applied.  We can see that:
1. the CLI no longer prints the `exit status 1` string
2. upon error, the exit code of the plugin is also the exit code of the CLI
3. error strings are only printed once 
```
$ tz cluster kubeconfig get; echo "===== errcode $?"
Error: accepts 1 arg(s), received 0
===== errcode 2
$ tz plugin delete
✖  must provide plugin name as positional argument
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
A plugin error code is propagated to the core CLI.
When a command fails the error messages are no longer duplicated.
```

### Additional information

#### Special notes for your reviewer

When dealing with native commands, it is the CLI that prints the error using "github.com/aunum/log".  The format is nicer as it uses colors and icons.  However it prints the error to `stdout` and there does not seem to be a way to print it to `stderr`.  I believe such errors should go to stderr.  I will open a separate issue to track this.
