### PR TITLE
explictly set the criSocket field in AWS and Azure to avoid race conditions

### DIFF
--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
@@ -1084,12 +1084,14 @@ spec:
               tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
         initConfiguration:
           nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
             name: '{{ ds.meta_data.local_hostname }}'
             kubeletExtraArgs:
               cloud-provider: aws
               tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
         joinConfiguration:
           nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
             name: '{{ ds.meta_data.local_hostname }}'
             kubeletExtraArgs:
               cloud-provider: aws
@@ -1138,6 +1140,7 @@ spec:
       useExperimentalRetryJoin: true
       joinConfiguration:
         nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
           name: '{{ ds.meta_data.local_hostname }}'
           kubeletExtraArgs:
             cloud-provider: aws

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -1335,6 +1335,7 @@ spec:
         files: []
         initConfiguration:
           nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
             kubeletExtraArgs:
               azure-container-registry-config: /etc/kubernetes/azure.json
               cloud-config: /etc/kubernetes/azure.json
@@ -1342,6 +1343,7 @@ spec:
             name: '{{ ds.meta_data["local_hostname"] }}'
         joinConfiguration:
           nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
             kubeletExtraArgs:
               azure-container-registry-config: /etc/kubernetes/azure.json
               cloud-config: /etc/kubernetes/azure.json
@@ -1416,6 +1418,7 @@ spec:
       files: []
       joinConfiguration:
         nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-config: /etc/kubernetes/azure.json

--- a/pkg/v1/providers/infrastructure-aws/v1.2.0/cconly/base.yaml
+++ b/pkg/v1/providers/infrastructure-aws/v1.2.0/cconly/base.yaml
@@ -1084,12 +1084,14 @@ spec:
               tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
         initConfiguration:
           nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
             name: '{{ ds.meta_data.local_hostname }}'
             kubeletExtraArgs:
               cloud-provider: aws
               tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
         joinConfiguration:
           nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
             name: '{{ ds.meta_data.local_hostname }}'
             kubeletExtraArgs:
               cloud-provider: aws
@@ -1138,6 +1140,7 @@ spec:
       useExperimentalRetryJoin: true
       joinConfiguration:
         nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
           name: '{{ ds.meta_data.local_hostname }}'
           kubeletExtraArgs:
             cloud-provider: aws

--- a/pkg/v1/providers/infrastructure-aws/v1.2.0/ytt/base-template.yaml
+++ b/pkg/v1/providers/infrastructure-aws/v1.2.0/ytt/base-template.yaml
@@ -53,6 +53,7 @@ spec:
     useExperimentalRetryJoin: true
     initConfiguration:
       nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
         name: '{{ ds.meta_data.local_hostname }}'
         kubeletExtraArgs:
           cloud-provider: aws
@@ -83,6 +84,7 @@ spec:
           tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
     joinConfiguration:
       nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
         name: '{{ ds.meta_data.local_hostname }}'
         kubeletExtraArgs:
           cloud-provider: aws
@@ -129,6 +131,7 @@ spec:
       useExperimentalRetryJoin: true
       joinConfiguration:
         nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
           name: '{{ ds.meta_data.local_hostname }}'
           kubeletExtraArgs:
             cloud-provider: aws

--- a/pkg/v1/providers/infrastructure-aws/v1.2.0/ytt/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-aws/v1.2.0/ytt/overlay.yaml
@@ -98,6 +98,7 @@ spec:
   kubeadmConfigSpec:
     initConfiguration:
       nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
         name: '{{ ds.meta_data.local_hostname }}'
         kubeletExtraArgs:
           cloud-provider: aws
@@ -127,6 +128,7 @@ spec:
         imageTag: #@ bomDataForK8sVersion.kubeadmConfigSpec.dns.imageTag
     joinConfiguration:
       nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
         name: '{{ ds.meta_data.local_hostname }}'
         kubeletExtraArgs:
           cloud-provider: aws
@@ -174,6 +176,7 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
           name: '{{ ds.meta_data.local_hostname }}'
           kubeletExtraArgs:
             cloud-provider: aws

--- a/pkg/v1/providers/infrastructure-aws/ytt/aws-overlay.yaml
+++ b/pkg/v1/providers/infrastructure-aws/ytt/aws-overlay.yaml
@@ -176,6 +176,7 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
           name: '{{ ds.meta_data.local_hostname }}'
           kubeletExtraArgs:
             cloud-provider: aws
@@ -189,6 +190,7 @@ spec:
     spec:
       joinConfiguration:
         nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
           name: '{{ ds.meta_data.local_hostname }}'
           kubeletExtraArgs:
             cloud-provider: aws

--- a/pkg/v1/providers/infrastructure-azure/v1.4.0/cconly/base.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.4.0/cconly/base.yaml
@@ -1335,6 +1335,7 @@ spec:
         files: []
         initConfiguration:
           nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
             kubeletExtraArgs:
               azure-container-registry-config: /etc/kubernetes/azure.json
               cloud-config: /etc/kubernetes/azure.json
@@ -1342,6 +1343,7 @@ spec:
             name: '{{ ds.meta_data["local_hostname"] }}'
         joinConfiguration:
           nodeRegistration:
+            criSocket: /var/run/containerd/containerd.sock
             kubeletExtraArgs:
               azure-container-registry-config: /etc/kubernetes/azure.json
               cloud-config: /etc/kubernetes/azure.json
@@ -1416,6 +1418,7 @@ spec:
       files: []
       joinConfiguration:
         nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-config: /etc/kubernetes/azure.json

--- a/pkg/v1/providers/infrastructure-azure/v1.4.0/ytt/base-template.yaml
+++ b/pkg/v1/providers/infrastructure-azure/v1.4.0/ytt/base-template.yaml
@@ -108,6 +108,7 @@ spec:
         permissions: "0644"
     initConfiguration:
       nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-config: /etc/kubernetes/azure.json
@@ -115,6 +116,7 @@ spec:
         name: '{{ ds.meta_data["local_hostname"] }}'
     joinConfiguration:
       nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
         kubeletExtraArgs:
           azure-container-registry-config: /etc/kubernetes/azure.json
           cloud-config: /etc/kubernetes/azure.json
@@ -214,6 +216,7 @@ spec:
           permissions: "0644"
       joinConfiguration:
         nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             azure-container-registry-config: /etc/kubernetes/azure.json
             cloud-config: /etc/kubernetes/azure.json

--- a/pkg/v1/providers/infrastructure-azure/ytt/azure-overlay.yaml
+++ b/pkg/v1/providers/infrastructure-azure/ytt/azure-overlay.yaml
@@ -153,6 +153,7 @@ spec:
         permissions: "0644"
       joinConfiguration:
         nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure
@@ -198,6 +199,7 @@ spec:
         permissions: "0644"
       joinConfiguration:
         nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-config: /etc/kubernetes/azure.json
             cloud-provider: azure

--- a/pkg/v1/providers/infrastructure-azure/yttcc/azure-overlay.yaml
+++ b/pkg/v1/providers/infrastructure-azure/yttcc/azure-overlay.yaml
@@ -153,6 +153,7 @@
 #!        permissions: "0644"
 #!      joinConfiguration:
 #!        nodeRegistration:
+#!          criSocket: /var/run/containerd/containerd.sock
 #!          kubeletExtraArgs:
 #!            cloud-config: /etc/kubernetes/azure.json
 #!            cloud-provider: azure
@@ -198,6 +199,7 @@
 #!        permissions: "0644"
 #!      joinConfiguration:
 #!        nodeRegistration:
+#!          criSocket: /var/run/containerd/containerd.sock
 #!          kubeletExtraArgs:
 #!            cloud-config: /etc/kubernetes/azure.json
 #!            cloud-provider: azure


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

### What this PR does / why we need it
This PR fixes an issue where we weren't setting the `criSocket` explicitly for Azure and AWS. What happens:

- containerd startup is slow, the containerd sock is not yet there
- kubeadm init sees that in our config in Azure and AWS we’re not specifying the CRISocketPath and tries to default that dynamically in-memory https://github.com/kubernetes/kubernetes/blob/b1aa1bd3088fad184cbb4fe36bd156dde7605ee4/cmd/kubeadm/app/util/config/initconfiguration.go#L111
- no socket is in there because containerd slowness, kubeadm defaults to the docker socket for backward compatibility
- kubeadm assumes docker for preflight checks, but fails since the binary isn’t installed

### Describe testing done for PR

- tested that specifying the socket fixes this
- generated the ytt output for the management cluster, it shows that `kubeadmControlPlane` and `KubeadmConfigTemplate` had the field in the right place

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
explicitly set criSocket for KubeadmControlPlane and KubeadmConfigTemplate in AWS and Azure to avoid race conditions at the node level
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

cc @randomvariable 
<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
