### PR TITLE
[release-0.25] Implement logr wrapper as part of existing logger and use with clusterctl

### DIFF
--- a/pkg/v1/tkg/log/interface.go
+++ b/pkg/v1/tkg/log/interface.go
@@ -66,8 +66,12 @@ type LoggerImpl interface {
 	// SetThreshold implements a New Option that allows to set the threshold level for a logger.
 	// The logger will write only log messages with a level/V(x) equal or higher to the threshold.
 	SetThreshold(threshold *int32)
-
+	// Clone creates cloned copy of the logger
+	Clone() LoggerImpl
+	// CloneWithLevel creates cloned copy of the logger with updated log level
 	CloneWithLevel(level int) LoggerImpl
+	// WithCallDepth implements a New Option that allows to set the callDepth level for a logger.
+	WithCallDepth(callDepth int) LoggerImpl
 }
 
 var l = NewLogger()
@@ -124,11 +128,6 @@ func WithName(name string) LoggerImpl {
 // WithValues adds some key-value pairs of context to a logger.
 func WithValues(kvList ...interface{}) LoggerImpl {
 	return l.WithValues(kvList...)
-}
-
-// GetLogr logs a warning messages with the given message format with format specifier and arguments.
-func GetLogr() LoggerImpl {
-	return l
 }
 
 var logWriter = NewWriter()

--- a/pkg/v1/tkg/log/interface.go
+++ b/pkg/v1/tkg/log/interface.go
@@ -122,12 +122,12 @@ func V(level int) LoggerImpl {
 
 // WithName adds a new element to the logger's name.
 func WithName(name string) LoggerImpl {
-	return l.WithName(name)
+	return l.Clone().WithName(name)
 }
 
 // WithValues adds some key-value pairs of context to a logger.
 func WithValues(kvList ...interface{}) LoggerImpl {
-	return l.WithValues(kvList...)
+	return l.Clone().WithValues(kvList...)
 }
 
 var logWriter = NewWriter()

--- a/pkg/v1/tkg/log/logr.go
+++ b/pkg/v1/tkg/log/logr.go
@@ -1,0 +1,68 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package log
+
+import "github.com/go-logr/logr"
+
+// GetLogr returns logr logger object that can be used to attach to some external logr logger
+func GetLogr() logr.Logger {
+	lr := logr.Logger{}.WithSink(&logrWrapper{logger: l.WithCallDepth(2)})
+	return lr
+}
+
+// logrWrapper is a logr.LogSink implementation wrapper using LoggerImpl interface
+type logrWrapper struct {
+	logger LoggerImpl
+}
+
+var _ logr.LogSink = &logrWrapper{}
+
+// Init receives optional information about the logr library for LogSink
+// implementations that need it.
+func (lr *logrWrapper) Init(info logr.RuntimeInfo) {
+	lr.logger = lr.logger.WithCallDepth(info.CallDepth)
+}
+
+// Enabled tests whether this LogSink is enabled at the specified V-level.
+// For example, commandline flags might be used to set the logging
+// verbosity and disable some info logs.
+func (lr *logrWrapper) Enabled(level int) bool {
+	return lr.logger.V(level).Enabled()
+}
+
+// Info logs a non-error message with the given key/value pairs as context.
+// The level argument is provided for optional logging.  This method will
+// only be called when Enabled(level) is true. See Logger.Info for more
+// details.
+func (lr *logrWrapper) Info(level int, msg string, keysAndValues ...interface{}) {
+	lr.logger.V(level).Info(msg, keysAndValues...)
+}
+
+// Error logs an error, with the given message and key/value pairs as
+// context.  See Logger.Error for more details.
+func (lr *logrWrapper) Error(err error, msg string, keysAndValues ...interface{}) {
+	lr.logger.Error(err, msg, keysAndValues...)
+}
+
+// WithValues returns a new LogSink with additional key/value pairs.  See
+// Logger.WithValues for more details.
+func (lr *logrWrapper) WithValues(keysAndValues ...interface{}) logr.LogSink {
+	nlr := lr.clone()
+	nlr.logger.WithValues(keysAndValues...)
+	return nlr
+}
+
+// WithName returns a new LogSink with the specified name appended.  See
+// Logger.WithName for more details.
+func (lr *logrWrapper) WithName(name string) logr.LogSink {
+	nlr := lr.clone()
+	nlr.logger.WithName(name)
+	return nlr
+}
+
+func (lr *logrWrapper) clone() *logrWrapper {
+	return &logrWrapper{
+		logger: lr.logger.Clone(),
+	}
+}

--- a/pkg/v1/tkg/tkgctl/client.go
+++ b/pkg/v1/tkg/tkgctl/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	clusterctllogger "sigs.k8s.io/cluster-api/cmd/clusterctl/log"
 
 	providergetterclient "github.com/vmware-tanzu/tanzu-framework/pkg/v1/providers/client"
 	"github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkg/client"
@@ -241,6 +242,8 @@ func configureLogging(logOptions LoggingOptions) {
 	}
 	log.QuietMode(logOptions.Quietly)
 	log.SetVerbosity(logOptions.Verbosity)
+
+	clusterctllogger.SetLogger(log.GetLogr())
 }
 
 func getDefaultProviderGetter() providerinterface.ProviderInterface {


### PR DESCRIPTION
### What this PR does / why we need it
- Implement logr wrapper as part of existing logger and use with clusterctl
This change will allow `cluster` and `management-cluster` plugin to fetch logs from `clusterctl` library so that those logs can be printed to log file as well as kickstart UI.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3105

### Describe testing done for PR
- Verified the log-file output with `tanzu mc create --file <> -v 3 --log-file <log-file-path>` command and `clusterctl` logs are getting printed correctly.
- Sample output:
```
I0808 23:39:56.791181 init.go:115] Validating configuration...
I0808 23:39:56.791776 init.go:181] Using infrastructure provider aws:v1.2.0
I0808 23:39:56.792087 init.go:183] Generating cluster configuration...
I0808 23:39:56.792477 init.go:186] Setting up bootstrapper...
I0808 23:39:56.793513 init.go:196] Bootstrapper created. Kubeconfig: /Users/anujc/.kube-tkg/tmp/config_6Zlsh8Cy
I0808 23:39:56.816175 init.go:215] Installing providers on bootstrapper...
I0808 23:39:56.863403 inventory.go:175] Installing the clusterctl inventory CRD
I0808 23:39:56.954875 init.go:97] Fetching providers
I0808 23:39:57.990234 cert_manager.go:174] Installing cert-manager Version="v1.7.2"
I0808 23:39:59.827764 cert_manager.go:536] Waiting for cert-manager to be available...
^[[1;2C^[[1;2CI0808 23:40:35.242658 installer.go:104] Installing Provider="cluster-api" Version="v1.1.5" TargetNamespace="capi-system"
I0808 23:40:35.243905 installer.go:108] Creating objects Provider="cluster-api" Version="v1.1.5" TargetNamespace="capi-system"
I0808 23:40:36.834581 installer.go:113] Creating inventory entry Provider="cluster-api" Version="v1.1.5" TargetNamespace="capi-system"
I0808 23:40:36.936235 installer.go:104] Installing Provider="bootstrap-kubeadm" Version="v1.1.5" TargetNamespace="capi-kubeadm-bootstrap-system"
I0808 23:40:36.938359 installer.go:108] Creating objects Provider="bootstrap-kubeadm" Version="v1.1.5" TargetNamespace="capi-kubeadm-bootstrap-system"
I0808 23:40:38.251125 installer.go:113] Creating inventory entry Provider="bootstrap-kubeadm" Version="v1.1.5" TargetNamespace="capi-kubeadm-bootstrap-system"
I0808 23:40:38.301780 installer.go:104] Installing Provider="control-plane-kubeadm" Version="v1.1.5" TargetNamespace="capi-kubeadm-control-plane-system"
I0808 23:40:38.303577 installer.go:108] Creating objects Provider="control-plane-kubeadm" Version="v1.1.5" TargetNamespace="capi-kubeadm-control-plane-system"
I0808 23:40:40.627647 installer.go:113] Creating inventory entry Provider="control-plane-kubeadm" Version="v1.1.5" TargetNamespace="capi-kubeadm-control-plane-system"
I0808 23:40:40.856080 installer.go:104] Installing Provider="infrastructure-aws" Version="v1.2.0" TargetNamespace="capa-system"
I0808 23:40:40.857033 installer.go:108] Creating objects Provider="infrastructure-aws" Version="v1.2.0" TargetNamespace="capa-system"
I0808 23:40:47.056148 installer.go:113] Creating inventory entry Provider="infrastructure-aws" Version="v1.2.0" TargetNamespace="capa-system"
I0808 23:40:47.114856 init.go:541] installed  Component=="cluster-api"  Type=="CoreProvider"  Version=="v1.1.5"
I0808 23:40:47.116720 init.go:541] installed  Component=="kubeadm"  Type=="BootstrapProvider"  Version=="v1.1.5"
I0808 23:40:47.118223 init.go:541] installed  Component=="kubeadm"  Type=="ControlPlaneProvider"  Version=="v1.1.5"
I0808 23:40:47.119803 init.go:541] installed  Component=="aws"  Type=="InfrastructureProvider"  Version=="v1.2.0"
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Implement logr wrapper as part of existing logger and use with clusterctl
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
