### PR TITLE
update error message as generic to the infrastructure provider (#3094)

### DIFF
--- a/pkg/v1/tkg/client/cluster.go
+++ b/pkg/v1/tkg/client/cluster.go
@@ -248,7 +248,7 @@ func (c *TkgClient) waitForClusterCreation(regionalClusterClient clusterclient.C
 	}
 	isTKGSCluster, err := regionalClusterClient.IsPacificRegionalCluster()
 	if err != nil {
-		return errors.Wrap(err, constants.ErrorMsgIsTKGSCluster)
+		return err
 	}
 	if isClusterClassBased {
 		log.Info("waiting for addons core packages installation...")
@@ -763,12 +763,12 @@ func (c *TkgClient) IsPacificManagementCluster() (bool, error) {
 
 	regionalClusterClient, err := clusterclient.NewClient(currentRegion.SourceFilePath, currentRegion.ContextName, clusterclientOptions)
 	if err != nil {
-		return false, errors.Wrap(err, "unable to get cluster client")
+		return false, errors.Wrap(err, "unable to get management cluster client")
 	}
 
 	isPacific, err := regionalClusterClient.IsPacificRegionalCluster()
 	if err != nil {
-		return false, errors.Wrap(err, "error determining Tanzu Kubernetes Cluster service for vSphere management cluster ")
+		return false, errors.Wrap(err, "error while determining infrastructure provider type")
 	}
 	return isPacific, nil
 }

--- a/pkg/v1/tkg/constants/cluster_internal.go
+++ b/pkg/v1/tkg/constants/cluster_internal.go
@@ -21,7 +21,6 @@ const (
 	ErrorMsgFeatureGateStatus       = "error while checking feature '%v' status in namespace '%v'"
 	ErrorMsgClusterExistsAlready    = "cluster with name %s already exists, please specify another name"
 	ErrorMsgClusterListError        = "unable to get list of workload clusters managed by current management cluster"
-	ErrorMsgIsTKGSCluster           = "unable to determine if management cluster is on vSphere with Tanzu"
 
 	ErrorMsgCClassInputFeatureFlagDisabled = "Input file is cluster class based but CLI feature flag '%v' is disabled, make sure its enabled to create cluster class based cluster"
 

--- a/pkg/v1/tkg/tkgctl/create_cluster.go
+++ b/pkg/v1/tkg/tkgctl/create_cluster.go
@@ -57,7 +57,7 @@ type CreateClusterOptions struct {
 func (t *tkgctl) CreateCluster(cc CreateClusterOptions) error {
 	isTKGSCluster, err := t.tkgClient.IsPacificManagementCluster()
 	if err != nil {
-		return errors.Wrap(err, constants.ErrorMsgIsTKGSCluster)
+		return err
 	}
 	isInputFileClusterClassBased, err := t.processWorkloadClusterInputFile(&cc, isTKGSCluster)
 	if err != nil {

--- a/pkg/v1/tkg/tkgctl/describe_cluster.go
+++ b/pkg/v1/tkg/tkgctl/describe_cluster.go
@@ -55,7 +55,7 @@ func (t *tkgctl) DescribeCluster(options DescribeTKGClustersOptions) (DescribeCl
 
 	isPacific, err := t.tkgClient.IsPacificManagementCluster()
 	if err != nil {
-		return results, errors.Wrap(err, "unable to determine if management cluster is on vSphere with Tanzu")
+		return results, err
 	}
 
 	var isTKGSClusterClassFeatureActivated bool

--- a/pkg/v1/tkg/tkgctl/describe_cluster_test.go
+++ b/pkg/v1/tkg/tkgctl/describe_cluster_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Unit test for describe cluster", func() {
 		})
 		It("should return an error", func() {
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("unable to determine if management cluster is on vSphere with Tanzu"))
+			Expect(err.Error()).To(ContainSubstring("fake-error"))
 		})
 	})
 	Context("when the management cluster is not Pacific(TKGS) supervisor cluster and failed to list tkg clusters", func() {

--- a/pkg/v1/tkg/tkgctl/get_cluster.go
+++ b/pkg/v1/tkg/tkgctl/get_cluster.go
@@ -25,7 +25,7 @@ type ListTKGClustersOptions struct {
 func (t *tkgctl) GetClusters(options ListTKGClustersOptions) ([]client.ClusterInfo, error) {
 	isPacific, err := t.tkgClient.IsPacificManagementCluster()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to determine if management cluster is on vSphere with Tanzu")
+		return nil, err
 	}
 	var isTKGSClusterClassFeatureActivated bool
 	if isPacific {

--- a/pkg/v1/tkg/tkgctl/get_cluster_test.go
+++ b/pkg/v1/tkg/tkgctl/get_cluster_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Unit test for get clusters", func() {
 		})
 		It("should return an error", func() {
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("unable to determine if management cluster is on vSphere with Tanzu"))
+			Expect(err.Error()).To(ContainSubstring("fake-error"))
 		})
 	})
 	Context("when the management cluster is not Pacific(TKGS) supervisor cluster and is able to list clusters", func() {

--- a/pkg/v1/tkg/tkgctl/upgrade_cluster.go
+++ b/pkg/v1/tkg/tkgctl/upgrade_cluster.go
@@ -53,7 +53,7 @@ func (t *tkgctl) UpgradeCluster(options UpgradeClusterOptions) error {
 
 	isPacific, err := t.tkgClient.IsPacificManagementCluster()
 	if err != nil {
-		return errors.Wrap(err, "unable to determine if management cluster is on vSphere with Tanzu")
+		return err
 	}
 
 	if isPacific {


### PR DESCRIPTION
### What this PR does / why we need it
Updates the error message as a generic error message while checking the infrastructure provider

Current error message specific to tkgs (vSphere with Tanzu) even though the user might not be on tkgs cluster which misleads the end user.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3095 
### Describe testing done for PR
Unite test cases are updated
Tested for TKGS cluster creation
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
