### PR TITLE
Clarify error when discovery source is invalid

### DIFF
--- a/pkg/v1/cli/command/core/discovery_source.go
+++ b/pkg/v1/cli/command/core/discovery_source.go
@@ -229,8 +229,10 @@ func createDiscoverySource(dsType, dsName, uri string) (configv1alpha1.PluginDis
 		pluginDiscoverySource.Local = createLocalDiscoverySource(dsName, uri)
 	case common.DiscoveryTypeOCI:
 		pluginDiscoverySource.OCI = createOCIDiscoverySource(dsName, uri)
-	default:
+	case common.DiscoveryTypeGCP, common.DiscoveryTypeKubernetes, common.DiscoveryTypeREST:
 		return pluginDiscoverySource, errors.Errorf("discovery source type '%s' is not yet supported", dsType)
+	default:
+		return pluginDiscoverySource, errors.Errorf("unknown discovery source type '%s'", dsType)
 	}
 	return pluginDiscoverySource, nil
 }

--- a/pkg/v1/cli/command/core/discovery_source_test.go
+++ b/pkg/v1/cli/command/core/discovery_source_test.go
@@ -44,6 +44,26 @@ func Test_createDiscoverySource(t *testing.T) {
 	assert.NotNil(pd.OCI)
 	assert.Equal(pd.OCI.Name, "fake-oci-discovery-name")
 	assert.Equal(pd.OCI.Image, "test.registry.com/test-image:v1.0.0")
+
+	// When discovery source is gcp
+	_, err = createDiscoverySource("gcp", "fake-discovery-name", "fake/path")
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "not yet supported")
+
+	// When discovery source is kubernetes
+	_, err = createDiscoverySource("kubernetes", "fake-discovery-name", "fake/path")
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "not yet supported")
+
+	// When discovery source is rest
+	_, err = createDiscoverySource("rest", "fake-discovery-name", "fake/path")
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "not yet supported")
+
+	// When discovery source is an unknown value
+	_, err = createDiscoverySource("unexpectedValue", "fake-discovery-name", "fake/path")
+	assert.NotNil(err)
+	assert.Contains(err.Error(), "unknown discovery source type 'unexpectedValue'")
 }
 
 func Test_addDiscoverySource(t *testing.T) {


### PR DESCRIPTION
### What this PR does / why we need it

Clarify error when a plugin discovery source is invalid versus when it is not yet supported.

### Which issue(s) this PR fixes

Fixes #3078

### Describe testing done for PR

Before the PR we can see that an invalid discovery source of type `fish` gives the same error as an valid but unsupported discovery source type of `GCP`:
```
$ tanzu plugin source add -n test -u example.com/test --type fish
✖  discovery source type 'fish' is not yet supported
$ tanzu plugin source add -n test -u example.com/test --type GCP
✖  discovery source type 'GCP' is not yet supported
```
With the PR applied, only valid discovery source types give the `unsupported` error, while others give an `invalid` error:
```
$ tz plugin source add -n test -u example.com/test --type fish
✖  unknown discovery source type 'fish'
$ tz plugin source add -n test -u example.com/test --type GCP
✖  discovery source type 'GCP' is not yet supported
$ tz plugin source add -n test -u example.com/test --type kubernetes
✖  discovery source type 'kubernetes' is not yet supported
$ tz plugin source add -n test -u example.com/test --type rest
✖  discovery source type 'rest' is not yet supported
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Improved error messages when the user attempts to add a discovery source of an invalid type.
```
