### PR TITLE
Fix template issues in vsphere clusterclass implementation

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -75,11 +75,6 @@ metadata:
 spec:
   template:
     spec:
-      machineTemplate:
-        infrastructureRef:
-          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-          kind: VSphereMachineTemplate
-          name: 'tkg-vsphere-control-plane'
       kubeadmConfigSpec:
         useExperimentalRetryJoin: true
         clusterConfiguration:
@@ -161,7 +156,8 @@ spec:
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
       - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
-      postKubeadmCommands: []
+      postKubeadmCommands:
+      - echo "running postKubeadmCommands…"
       files:
       - path: /tmp/empty.txt
         owner: "root:root"
@@ -202,7 +198,6 @@ spec:
         kind: VSphereMachineTemplate
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         name: 'tkg-vsphere-control-plane'
-    machineHealthCheck:
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -212,7 +207,6 @@ spec:
   workers:
     machineDeployments:
     - class: tkg-worker
-      machineHealthCheck:
       template:
         bootstrap:
           ref:
@@ -227,7 +221,6 @@ spec:
             name: 'tkg-vsphere-worker'
             namespace: #@ data.values.NAMESPACE
     - class: tkg-worker-windows
-      machineHealthCheck:
       template:
         bootstrap:
           ref:
@@ -712,7 +705,7 @@ spec:
                     value: "20"
                   - name: vip_retryperiod
                     value: "4"
-                  image: {{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}/kube-vip:{{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageTag}}
+                  image: {{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageRepository}}/kube-vip:{{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageTag}}
                   imagePullPolicy: IfNotPresent
                   name: kube-vip
                   resources: {}
@@ -749,14 +742,14 @@ spec:
           template: |
             devices:
             - networkName: {{ .vcenter.network }}
-            {{ if .controlPlane.network.nameservers -}}
-              nameservers:
-              {{- range .controlPlane.network.nameservers }}
-            - {{ . }}
+              {{ if .controlPlane.network.nameservers -}}
+                nameservers:
+                {{- range .controlPlane.network.nameservers }}
+              - {{ . }}
+                {{- end }}
               {{- end }}
-            {{- end }}
-            {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
-            {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
+              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
+              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
     - selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: VSphereMachineTemplate
@@ -772,14 +765,14 @@ spec:
           template: |
             devices:
             - networkName: {{ .vcenter.network }}
-            {{ if .worker.network.nameservers -}}
-              nameservers:
-              {{- range .worker.network.nameservers }}
-            - {{ . }}
+              {{ if .worker.network.nameservers -}}
+                nameservers:
+                {{- range .worker.network.nameservers }}
+              - {{ . }}
+                {{- end }}
               {{- end }}
-            {{- end }}
-            {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
-            {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
+              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
+              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
   - name: clusterApiServerPort
     enabledIf: '{{ not (empty .apiServerPort) }}'
     definitions:
@@ -892,13 +885,15 @@ spec:
           template: |
             {{ $first := true }}
             {{- range $key, $val := (index .TKR_DATA .builtin.controlPlane.version).labels }}
+            {{- if regexMatch "^(?:[a-zA-z])(?:[-\\w\\.]*[a-zA-z])$" $val }}
             {{- if $first }}
               {{- $first = false }}
             {{- else -}}
               ,
             {{- end }}
             {{- $key -}} = {{- $val }}
-            {{- end}}
+            {{- end }}
+            {{- end }}
     - selector:
         apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
         kind: KubeadmConfigTemplate
@@ -914,13 +909,15 @@ spec:
           template: |
             {{ $first := true }}
             {{- range $key, $val := (index .TKR_DATA .builtin.machineDeployment.version).labels }}
+            {{- if regexMatch "^(?:[a-zA-z])(?:[-\\w\\.]*[a-zA-z])$" $val }}
             {{- if $first }}
               {{- $first = false }}
             {{- else -}}
               ,
             {{- end }}
             {{- $key -}} = {{- $val }}
-            {{- end}}
+            {{- end }}
+            {{- end }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/overlay.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/overlay.yaml
@@ -14,8 +14,9 @@ spec:
     machineInfrastructure:
       ref:
         name: tkg-vsphere-control-plane
+    #@ if data.values.ENABLE_MHC or data.values.ENABLE_MHC_CONTROL_PLANE:
+    #@overlay/match missing_ok=True
     machineHealthCheck:
-      #@ if data.values.ENABLE_MHC or data.values.ENABLE_MHC_CONTROL_PLANE:
       nodeStartupTimeout: #@ data.values.NODE_STARTUP_TIMEOUT
       unhealthyConditions:
       - type: Ready
@@ -24,7 +25,7 @@ spec:
       - type: Ready
         status: "False"
         timeout: #@ data.values.MHC_FALSE_STATUS_TIMEOUT
-      #@ end
+    #@ end
   infrastructure:
     ref:
       name: tkg-vsphere-infrastructure
@@ -33,8 +34,9 @@ spec:
     machineDeployments:
     #@overlay/match by="class"
     - class: tkg-worker
+      #@ if data.values.ENABLE_MHC or data.values.ENABLE_MHC_WORKER_NODE:
+      #@overlay/match missing_ok=True
       machineHealthCheck:
-        #@ if data.values.ENABLE_MHC or data.values.ENABLE_MHC_WORKER_NODE:
         nodeStartupTimeout: #@ data.values.NODE_STARTUP_TIMEOUT
         unhealthyConditions:
         - type: Ready
@@ -43,7 +45,7 @@ spec:
         - type: Ready
           status: "False"
           timeout: #@ data.values.MHC_FALSE_STATUS_TIMEOUT
-        #@ end
+      #@ end
       template:
         bootstrap:
           ref:
@@ -56,8 +58,9 @@ spec:
 
     #@overlay/match by="class", missing_ok=True
     - class: tkg-worker-windows
+      #@ if data.values.ENABLE_MHC or data.values.ENABLE_MHC_WORKER_NODE:
+      #@overlay/match missing_ok=True
       machineHealthCheck:
-        #@ if data.values.ENABLE_MHC or data.values.ENABLE_MHC_WORKER_NODE:
         nodeStartupTimeout: #@ data.values.NODE_STARTUP_TIMEOUT
         unhealthyConditions:
         - type: Ready
@@ -66,7 +69,7 @@ spec:
         - type: Ready
           status: "False"
           timeout: #@ data.values.MHC_FALSE_STATUS_TIMEOUT
-        #@ end
+      #@ end
       template:
         bootstrap:
           ref:

--- a/pkg/v1/providers/config_default.yaml
+++ b/pkg/v1/providers/config_default.yaml
@@ -485,6 +485,8 @@ OS_NAME: ""
 OS_VERSION: ""
 OS_ARCH: ""
 
+USE_TOPOLOGY_CATEGORIES: false
+
 
 
 #! ---------------------------------------------------------------------

--- a/pkg/v1/providers/infrastructure-vsphere/v1.3.1/cconly/base.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.3.1/cconly/base.yaml
@@ -75,11 +75,6 @@ metadata:
 spec:
   template:
     spec:
-      machineTemplate:
-        infrastructureRef:
-          apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-          kind: VSphereMachineTemplate
-          name: 'tkg-vsphere-control-plane'
       kubeadmConfigSpec:
         useExperimentalRetryJoin: true
         clusterConfiguration:
@@ -161,7 +156,8 @@ spec:
       - echo "127.0.0.1   localhost" >>/etc/hosts
       - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
       - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
-      postKubeadmCommands: []
+      postKubeadmCommands:
+      - echo "running postKubeadmCommands…"
       files:
       - path: /tmp/empty.txt
         owner: "root:root"
@@ -202,7 +198,6 @@ spec:
         kind: VSphereMachineTemplate
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         name: 'tkg-vsphere-control-plane'
-    machineHealthCheck:
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -212,7 +207,6 @@ spec:
   workers:
     machineDeployments:
     - class: tkg-worker
-      machineHealthCheck:
       template:
         bootstrap:
           ref:
@@ -227,7 +221,6 @@ spec:
             name: 'tkg-vsphere-worker'
             namespace: #@ data.values.NAMESPACE
     - class: tkg-worker-windows
-      machineHealthCheck:
       template:
         bootstrap:
           ref:
@@ -712,7 +705,7 @@ spec:
                     value: "20"
                   - name: vip_retryperiod
                     value: "4"
-                  image: {{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}/kube-vip:{{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageTag}}
+                  image: {{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageRepository}}/kube-vip:{{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageTag}}
                   imagePullPolicy: IfNotPresent
                   name: kube-vip
                   resources: {}
@@ -749,14 +742,14 @@ spec:
           template: |
             devices:
             - networkName: {{ .vcenter.network }}
-            {{ if .controlPlane.network.nameservers -}}
-              nameservers:
-              {{- range .controlPlane.network.nameservers }}
-            - {{ . }}
+              {{ if .controlPlane.network.nameservers -}}
+                nameservers:
+                {{- range .controlPlane.network.nameservers }}
+              - {{ . }}
+                {{- end }}
               {{- end }}
-            {{- end }}
-            {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
-            {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
+              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
+              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
     - selector:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: VSphereMachineTemplate
@@ -772,14 +765,14 @@ spec:
           template: |
             devices:
             - networkName: {{ .vcenter.network }}
-            {{ if .worker.network.nameservers -}}
-              nameservers:
-              {{- range .worker.network.nameservers }}
-            - {{ . }}
+              {{ if .worker.network.nameservers -}}
+                nameservers:
+                {{- range .worker.network.nameservers }}
+              - {{ . }}
+                {{- end }}
               {{- end }}
-            {{- end }}
-            {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
-            {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
+              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp4: true {{- end }}
+              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily -}} dhcp6: true {{- end }}
   - name: clusterApiServerPort
     enabledIf: '{{ not (empty .apiServerPort) }}'
     definitions:
@@ -892,13 +885,15 @@ spec:
           template: |
             {{ $first := true }}
             {{- range $key, $val := (index .TKR_DATA .builtin.controlPlane.version).labels }}
+            {{- if regexMatch "^(?:[a-zA-z])(?:[-\\w\\.]*[a-zA-z])$" $val }}
             {{- if $first }}
               {{- $first = false }}
             {{- else -}}
               ,
             {{- end }}
             {{- $key -}} = {{- $val }}
-            {{- end}}
+            {{- end }}
+            {{- end }}
     - selector:
         apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
         kind: KubeadmConfigTemplate
@@ -914,13 +909,15 @@ spec:
           template: |
             {{ $first := true }}
             {{- range $key, $val := (index .TKR_DATA .builtin.machineDeployment.version).labels }}
+            {{- if regexMatch "^(?:[a-zA-z])(?:[-\\w\\.]*[a-zA-z])$" $val }}
             {{- if $first }}
               {{- $first = false }}
             {{- else -}}
               ,
             {{- end }}
             {{- $key -}} = {{- $val }}
-            {{- end}}
+            {{- end }}
+            {{- end }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}

--- a/pkg/v1/providers/infrastructure-vsphere/v1.3.1/cconly/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.3.1/cconly/overlay.yaml
@@ -14,8 +14,9 @@ spec:
     machineInfrastructure:
       ref:
         name: tkg-vsphere-control-plane
+    #@ if data.values.ENABLE_MHC or data.values.ENABLE_MHC_CONTROL_PLANE:
+    #@overlay/match missing_ok=True
     machineHealthCheck:
-      #@ if data.values.ENABLE_MHC or data.values.ENABLE_MHC_CONTROL_PLANE:
       nodeStartupTimeout: #@ data.values.NODE_STARTUP_TIMEOUT
       unhealthyConditions:
       - type: Ready
@@ -24,7 +25,7 @@ spec:
       - type: Ready
         status: "False"
         timeout: #@ data.values.MHC_FALSE_STATUS_TIMEOUT
-      #@ end
+    #@ end
   infrastructure:
     ref:
       name: tkg-vsphere-infrastructure
@@ -33,8 +34,9 @@ spec:
     machineDeployments:
     #@overlay/match by="class"
     - class: tkg-worker
+      #@ if data.values.ENABLE_MHC or data.values.ENABLE_MHC_WORKER_NODE:
+      #@overlay/match missing_ok=True
       machineHealthCheck:
-        #@ if data.values.ENABLE_MHC or data.values.ENABLE_MHC_WORKER_NODE:
         nodeStartupTimeout: #@ data.values.NODE_STARTUP_TIMEOUT
         unhealthyConditions:
         - type: Ready
@@ -43,7 +45,7 @@ spec:
         - type: Ready
           status: "False"
           timeout: #@ data.values.MHC_FALSE_STATUS_TIMEOUT
-        #@ end
+      #@ end
       template:
         bootstrap:
           ref:
@@ -56,8 +58,9 @@ spec:
 
     #@overlay/match by="class", missing_ok=True
     - class: tkg-worker-windows
+      #@ if data.values.ENABLE_MHC or data.values.ENABLE_MHC_WORKER_NODE:
+      #@overlay/match missing_ok=True
       machineHealthCheck:
-        #@ if data.values.ENABLE_MHC or data.values.ENABLE_MHC_WORKER_NODE:
         nodeStartupTimeout: #@ data.values.NODE_STARTUP_TIMEOUT
         unhealthyConditions:
         - type: Ready
@@ -66,7 +69,7 @@ spec:
         - type: Ready
           status: "False"
           timeout: #@ data.values.MHC_FALSE_STATUS_TIMEOUT
-        #@ end
+      #@ end
       template:
         bootstrap:
           ref:

--- a/pkg/v1/providers/infrastructure-vsphere/v1.3.1/yttcc/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.3.1/yttcc/overlay.yaml
@@ -1,7 +1,6 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
 
-
 #@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "get_default_tkg_bom_data", "kubeadm_image_repo", "get_image_repo_for_component", "get_vsphere_thumbprint")
 
 #@ load("lib/validate.star", "validate_configuration")
@@ -30,8 +29,6 @@ metadata:
     cluster-role.tkg.tanzu.vmware.com/(@= data.values.TKG_CLUSTER_ROLE @): ""
     #@ end
     tkg.tanzu.vmware.com/cluster-name: #@ data.values.CLUSTER_NAME
-    #@overlay/match missing_ok=True
-    tanzuKubernetesRelease: #@ data.values.KUBERNETES_RELEASE
 spec:
   clusterNetwork:
     pods:
@@ -43,9 +40,15 @@ spec:
   topology:
     class: #@ data.values.CLUSTER_CLASS
     #! VVV TODO(vui) compute
-    version: #@ data.values.KUBERNETES_VERSION
+    #! version: #@ data.values.KUBERNETES_VERSION
+    #! hack to match up tkr
+    version: #@ "{}-tkg.1-zshippable".format(data.values.KUBERNETES_VERSION)
     controlPlane:
       replicas: #@ data.values.CONTROL_PLANE_MACHINE_COUNT
+      #@overlay/match missing_ok=True
+      metadata:
+        annotations:
+          run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=photon
     workers:
       machineDeployments:
       #@ if not data.values.IS_WINDOWS_WORKLOAD_CLUSTER:
@@ -54,6 +57,10 @@ spec:
         name: md-0
         #@overlay/match missing_ok=True
         replicas: #@ data.values.WORKER_MACHINE_COUNT
+        #@overlay/match missing_ok=True
+        metadata:
+          annotations:
+            run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=photon
         #@ if data.values.VSPHERE_AZ_0:
         #@overlay/match missing_ok=True
         failureDomain: #@ data.values.VSPHERE_AZ_0
@@ -63,6 +70,10 @@ spec:
       - class: tkg-worker
         name: md-1
         replicas: #@ data.values.WORKER_MACHINE_COUNT_1
+        #@overlay/match missing_ok=True
+        metadata:
+          annotations:
+            run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=photon
         #@ if data.values.VSPHERE_AZ_1:
         failureDomain: #@ data.values.VSPHERE_AZ_1
         #@ end
@@ -70,6 +81,10 @@ spec:
       - class: tkg-worker
         name: md-2
         replicas: #@ data.values.WORKER_MACHINE_COUNT_2
+        #@overlay/match missing_ok=True
+        metadata:
+          annotations:
+            run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=photon
         #@ if data.values.VSPHERE_AZ_2:
         failureDomain: #@ data.values.VSPHERE_AZ_2
         #@ end
@@ -80,6 +95,11 @@ spec:
       - class: tkg-worker-windows
         name: md-0
         replicas: #@ data.values.WORKER_MACHINE_COUNT
+        #@overlay/match missing_ok=True
+        metadata:
+          annotations:
+            #! VVV TODO(tenczar) os-name handling
+            run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=windows
       #@ if data.values.CLUSTER_PLAN == "prodcc":
       #@overlay/append
       - class: tkg-worker-windows
@@ -88,6 +108,11 @@ spec:
         #@ if data.values.VSPHERE_AZ_1:
         failureDomain: #@ data.values.VSPHERE_AZ_1
         #@ end
+        #@overlay/match missing_ok=True
+        metadata:
+          annotations:
+            #! VVV TODO(tenczar) os-name handling
+            run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=windows
       #@overlay/append
       - class: tkg-worker-windows
         name: md-2
@@ -95,6 +120,10 @@ spec:
         #@ if data.values.VSPHERE_AZ_2:
         failureDomain: #@ data.values.VSPHERE_AZ_2
         #@ end
+        metadata:
+          annotations:
+            #! VVV TODO(tenczar) os-name handling
+            run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=windows
       #@ end
       #@ end
     #@overlay/match missing_ok=True

--- a/pkg/v1/providers/yttcb/clusterbootstrap.yaml
+++ b/pkg/v1/providers/yttcb/clusterbootstrap.yaml
@@ -95,18 +95,18 @@ kind: Secret
 metadata:
   name: #@ data.values.CLUSTER_NAME + "-vsphere-credential"
   namespace: #@ data.values.NAMESPACE
-data:
-  password: #@ data.values.VSPHERE_USERNAME
-  username: #@ data.values.VSPHERE_PASSWORD
+stringData:
+  username: #@ data.values.VSPHERE_USERNAME
+  password: #@ data.values.VSPHERE_PASSWORD
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: #@ data.values.CLUSTER_NAME + "-nsxt-credential"
   namespace: #@ data.values.NAMESPACE
-data:
-  password: #@ data.values.NSXT_USERNAME
-  username: #@ data.values.NSXT_PASSWORD
+stringData:
+  username: #@ data.values.NSXT_USERNAME
+  password: #@ data.values.NSXT_PASSWORD
 ---
 apiVersion: cpi.tanzu.vmware.com/v1alpha1
 kind: VSphereCPIConfig
@@ -138,8 +138,8 @@ spec:
         kind: Secret
         name: #@ data.values.CLUSTER_NAME + "-nsxt-credential"
       apiHost: #@ data.values.NSXT_MANAGER_HOST
-      insecure: #@ data.values.NSXT_ALLOW_UNVERIFIED_SSL
-      remoteAuth: #@ data.values.NSXT_REMOTE_AUTH
+      insecure: #@ bool(data.values.NSXT_ALLOW_UNVERIFIED_SSL)
+      remoteAuth: #@ bool(data.values.NSXT_REMOTE_AUTH)
       vmcAccessToken: #@ data.values.NSXT_VMC_ACCESS_TOKEN
       vmcAuthHost: #@ data.values.NSXT_VMC_AUTH_HOST
       clientCertKeyData: #@ data.values.NSXT_CLIENT_CERT_KEY_DATA


### PR DESCRIPTION
### What this PR does / why we need it
This PR updates ytt and go text templates for vsphere clusterclass that prevented successful deployment of clusterclass based capv clusters. Changes include:
- Fix indentation issue in VsphereMachineTemplate when updating network settings
- Fix the kube-vip image and tag declaration to properly access resources from TKR_DATA
- Adds a regex matcher for applying node labels. This prevents values from the TKR_DATA being used as node-labels if those values are not valid node-label values
- Fix machineHealthCheck definition to only add this block if a cluster definition specifies mhcs.
- Fixes credential values
- Fixes an issue with incorrectly typed config values being passed to the clusterbootstrap
- 
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3439 

### Describe testing done for PR

Manually deployed a clusterclass based management cluster using Antrea and validated that the cluster is created successfully.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixes vsphere clusterclass definition to successfully deploy clusterclass capv clusters.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
