### PR TITLE
Acquire lock before reading tanzu config file to avoid possible misconfigured file reads

### DIFF
--- a/pkg/v1/cli/command/core/config.go
+++ b/pkg/v1/cli/command/core/config.go
@@ -88,7 +88,7 @@ var setConfigCmd = &cobra.Command{
 		config.AcquireTanzuConfigLock()
 		defer config.ReleaseTanzuConfigLock()
 
-		cfg, err := config.GetClientConfig()
+		cfg, err := config.GetClientConfigNoLock()
 		if err != nil {
 			return err
 		}
@@ -204,7 +204,7 @@ var initConfigCmd = &cobra.Command{
 		config.AcquireTanzuConfigLock()
 		defer config.ReleaseTanzuConfigLock()
 
-		cfg, err := config.GetClientConfig()
+		cfg, err := config.GetClientConfigNoLock()
 		if err != nil {
 			return err
 		}
@@ -336,7 +336,7 @@ var unsetConfigCmd = &cobra.Command{
 		config.AcquireTanzuConfigLock()
 		defer config.ReleaseTanzuConfigLock()
 
-		cfg, err := config.GetClientConfig()
+		cfg, err := config.GetClientConfigNoLock()
 		if err != nil {
 			return err
 		}

--- a/pkg/v1/cli/command/core/discovery_source.go
+++ b/pkg/v1/cli/command/core/discovery_source.go
@@ -108,7 +108,7 @@ var addDiscoverySourceCmd = &cobra.Command{
 		config.AcquireTanzuConfigLock()
 		defer config.ReleaseTanzuConfigLock()
 
-		cfg, err := config.GetClientConfig()
+		cfg, err := config.GetClientConfigNoLock()
 		if err != nil {
 			return err
 		}
@@ -152,7 +152,7 @@ var updateDiscoverySourceCmd = &cobra.Command{
 		config.AcquireTanzuConfigLock()
 		defer config.ReleaseTanzuConfigLock()
 
-		cfg, err := config.GetClientConfig()
+		cfg, err := config.GetClientConfigNoLock()
 		if err != nil {
 			return err
 		}
@@ -193,7 +193,7 @@ var deleteDiscoverySourceCmd = &cobra.Command{
 		config.AcquireTanzuConfigLock()
 		defer config.ReleaseTanzuConfigLock()
 
-		cfg, err := config.GetClientConfig()
+		cfg, err := config.GetClientConfigNoLock()
 		if err != nil {
 			return err
 		}

--- a/pkg/v1/cli/command/core/repo.go
+++ b/pkg/v1/cli/command/core/repo.go
@@ -72,7 +72,7 @@ var addRepoCmd = &cobra.Command{
 		config.AcquireTanzuConfigLock()
 		defer config.ReleaseTanzuConfigLock()
 
-		cfg, err := config.GetClientConfig()
+		cfg, err := config.GetClientConfigNoLock()
 		if err != nil {
 			return err
 		}
@@ -119,7 +119,7 @@ var updateRepoCmd = &cobra.Command{
 		config.AcquireTanzuConfigLock()
 		defer config.ReleaseTanzuConfigLock()
 
-		cfg, err := config.GetClientConfig()
+		cfg, err := config.GetClientConfigNoLock()
 		if err != nil {
 			return err
 		}
@@ -167,7 +167,7 @@ var deleteRepoCmd = &cobra.Command{
 		config.AcquireTanzuConfigLock()
 		defer config.ReleaseTanzuConfigLock()
 
-		cfg, err := config.GetClientConfig()
+		cfg, err := config.GetClientConfigNoLock()
 		if err != nil {
 			return err
 		}

--- a/pkg/v1/config/clientconfig.go
+++ b/pkg/v1/config/clientconfig.go
@@ -27,7 +27,7 @@ func init() {
 	AcquireTanzuConfigLock()
 	defer ReleaseTanzuConfigLock()
 
-	c, err := GetClientConfig()
+	c, err := GetClientConfigNoLock()
 	if err != nil {
 		log.Warningf("unable to get client config: %v", err)
 	}
@@ -306,8 +306,16 @@ func CopyLegacyConfigDir() error {
 	return nil
 }
 
-// GetClientConfig retrieves the config from the local directory.
+// GetClientConfig retrieves the config from the local directory with file lock
 func GetClientConfig() (cfg *configv1alpha1.ClientConfig, err error) {
+	// Acquire tanzu config lock
+	AcquireTanzuConfigLock()
+	defer ReleaseTanzuConfigLock()
+	return GetClientConfigNoLock()
+}
+
+// GetClientConfigNoLock retrieves the config from the local directory without acquiring the lock
+func GetClientConfigNoLock() (cfg *configv1alpha1.ClientConfig, err error) {
 	cfgPath, err := ClientConfigPath()
 	if err != nil {
 		return nil, err
@@ -519,7 +527,7 @@ func AddServer(s *configv1alpha1.Server, setCurrent bool) error {
 	AcquireTanzuConfigLock()
 	defer ReleaseTanzuConfigLock()
 
-	cfg, err := GetClientConfig()
+	cfg, err := GetClientConfigNoLock()
 	if err != nil {
 		return err
 	}
@@ -550,7 +558,7 @@ func PutServer(s *configv1alpha1.Server, setCurrent bool) error {
 	AcquireTanzuConfigLock()
 	defer ReleaseTanzuConfigLock()
 
-	cfg, err := GetClientConfig()
+	cfg, err := GetClientConfigNoLock()
 	if err != nil {
 		return err
 	}
@@ -590,7 +598,7 @@ func RemoveServer(name string) error {
 	AcquireTanzuConfigLock()
 	defer ReleaseTanzuConfigLock()
 
-	cfg, err := GetClientConfig()
+	cfg, err := GetClientConfigNoLock()
 	if err != nil {
 		return err
 	}
@@ -635,7 +643,7 @@ func SetCurrentServer(name string) error {
 	AcquireTanzuConfigLock()
 	defer ReleaseTanzuConfigLock()
 
-	cfg, err := GetClientConfig()
+	cfg, err := GetClientConfigNoLock()
 	if err != nil {
 		return err
 	}

--- a/pkg/v1/config/context.go
+++ b/pkg/v1/config/context.go
@@ -35,7 +35,7 @@ func AddContext(c *configv1alpha1.Context, setCurrent bool) error {
 	AcquireTanzuConfigLock()
 	defer ReleaseTanzuConfigLock()
 
-	cfg, err := GetClientConfig()
+	cfg, err := GetClientConfigNoLock()
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func RemoveContext(name string) error {
 	AcquireTanzuConfigLock()
 	defer ReleaseTanzuConfigLock()
 
-	cfg, err := GetClientConfig()
+	cfg, err := GetClientConfigNoLock()
 	if err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func SetCurrentContext(name string) error {
 	AcquireTanzuConfigLock()
 	defer ReleaseTanzuConfigLock()
 
-	cfg, err := GetClientConfig()
+	cfg, err := GetClientConfigNoLock()
 	if err != nil {
 		return err
 	}

--- a/pkg/v1/tkg/test/framework/utils.go
+++ b/pkg/v1/tkg/test/framework/utils.go
@@ -185,7 +185,7 @@ func SetCliConfigFlag(flagName string, value string) error {
 	config.AcquireTanzuConfigLock()
 	defer config.ReleaseTanzuConfigLock()
 
-	cfg, err := config.GetClientConfig()
+	cfg, err := config.GetClientConfigNoLock()
 	if err != nil {
 		return err
 	}

--- a/pkg/v1/tkg/tkgctl/compatibility.go
+++ b/pkg/v1/tkg/tkgctl/compatibility.go
@@ -22,7 +22,7 @@ func SetCompatibilityFileBasedOnEdition() error {
 	config.AcquireTanzuConfigLock()
 	defer config.ReleaseTanzuConfigLock()
 
-	clientConfig, err := config.GetClientConfig()
+	clientConfig, err := config.GetClientConfigNoLock()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What this PR does / why we need it
- Fix unit test failures when reading config in parallel make sure to acquire lock for reading the client config

- After doing more investigation, it was found that in the parallel execution tests, the failures are happening when reading configuration when another thread is writing to the file and file write operation is not completed yet. Resulting in the corrupt file read.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3175

### Describe testing done for PR
- Unit tests should be successful
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Acquire lock before reading tanzu config file to avoid races with config writes
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
