### PR TITLE
Update generate-all-docs command logic to fetch installed plugins

### DIFF
--- a/cli/runtime/plugin/doc.go
+++ b/cli/runtime/plugin/doc.go
@@ -6,21 +6,24 @@ package plugin
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
+
+// DefaultDocsDir is the base docs directory
+const DefaultDocsDir = "docs/cli/commands"
+const ErrorDocsOutputFolderNotExists = "error reading docs output directory '%v', make sure directory exists or provide docs output directory as input value to '--docs-dir' flag"
 
 var (
 	docsDir string
 )
 
-// DefaultDocsDir is the base docs directory
-const DefaultDocsDir = "docs/cli/commands"
-
 func init() {
-	genDocsCmd.Flags().StringVarP(&docsDir, "docs-dir", "d", DefaultDocsDir, "destination for docss output")
+	genDocsCmd.Flags().StringVarP(&docsDir, "docs-dir", "d", DefaultDocsDir, "destination for docs output")
 }
 
 var genDocsCmd = &cobra.Command{
@@ -28,6 +31,12 @@ var genDocsCmd = &cobra.Command{
 	Short:  "Generate Cobra CLI docs for all subcommands",
 	Hidden: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if docsDir == "" {
+			docsDir = DefaultDocsDir
+		}
+		if dir, err := os.Stat(docsDir); err != nil || !dir.IsDir() {
+			return errors.Wrap(err, fmt.Sprintf(ErrorDocsOutputFolderNotExists, docsDir))
+		}
 		identity := func(s string) string {
 			if !strings.HasPrefix(s, "tanzu") {
 				return fmt.Sprintf("tanzu_%s", s)

--- a/pkg/v1/cli/catalog.go
+++ b/pkg/v1/cli/catalog.go
@@ -186,6 +186,8 @@ func saveCatalogCache(catalog *cliv1alpha1.Catalog) error {
 }
 
 // ListPlugins returns the available plugins.
+//
+// Deprecated: Use pluginmanager.AvailablePluginsFromLocalSource or pluginmanager.AvailablePlugins instead
 func ListPlugins(exclude ...string) (list []*cliv1alpha1.PluginDescriptor, err error) {
 	pluginDescriptors, err := getPluginsFromCatalogCache()
 	if err != nil {


### PR DESCRIPTION
### What this PR does / why we need it
The `tanzu generate-all-docs` command is broken because it's using the legacy API to fetch installed plugins and does not consider user input value for the output directory; this PR fixes below:
1. `tanzu generate-all-docs` command logic updated to use context-aware plugin list API, and deprecate the legacy API
2. `tanzu generate-all-docs --docs-dir` command logic updated to consider the user input value for the input flag '--docs-dir' docs output directory and generate docs to the given output directory
3. update the error message if there is any error while reading the output directory

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1765

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

- Manual testing is done for `tanzu generate-all-docs` to test docs for all installed plugins
- Manual testing is done for `tanzu generate-all-docs --docs-dir` to test docs to be generated on the given output directory
- Unit test cases are updated

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
`tanzu generate-all-docs` command implementation has been updated to use context-aware plugin list API and generate docs to given output folder
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
