### PR TITLE
Kickstart UI: Fixes issue with blank AVI/Cluster labels in payload

### DIFF
--- a/pkg/v1/tkg/web/src/app/views/landing/wizard/shared/wizard-base/wizard-base.ts
+++ b/pkg/v1/tkg/web/src/app/views/landing/wizard/shared/wizard-base/wizard-base.ts
@@ -349,7 +349,7 @@ export abstract class WizardBaseDirective extends BasicSubscriber implements Wiz
      * @param arrObj of type [ {key: 'a', value: '1}, {key : 'b, value:'2}]
      * @param params.key<Function> To Identify the ObjectKey
      * @param params.value<Function> To Identify the ObjectValue
-     * @return Object {'a': 1 , 'b': '1'}
+     * @return Object {'a': 1 , 'b': '1'} and drops values with empty string on key
      */
     arrayOfObjectsToObject<T>(arrObj: T[], params: Params<T>): KeyValueObject {
         if (!arrObj || !(arrObj instanceof Array)) {

--- a/pkg/v1/tkg/web/src/app/views/landing/wizard/shared/wizard-base/wizard-base.ts
+++ b/pkg/v1/tkg/web/src/app/views/landing/wizard/shared/wizard-base/wizard-base.ts
@@ -1,43 +1,43 @@
 // Angular imports
-import { Directive, ElementRef, OnInit, Type, ViewChild } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
-import { Router } from '@angular/router';
-import { Title } from '@angular/platform-browser';
+import {Directive, ElementRef, OnInit, Type, ViewChild} from '@angular/core';
+import {FormBuilder, FormGroup} from '@angular/forms';
+import {Router} from '@angular/router';
+import {Title} from '@angular/platform-browser';
 // Third party imports
-import { takeUntil } from 'rxjs/operators';
-import { Observable } from 'rxjs';
+import {takeUntil} from 'rxjs/operators';
+import {Observable} from 'rxjs';
 // App imports
-import { APP_ROUTES, Routes } from 'src/app/shared/constants/routes.constants';
+import {APP_ROUTES, Routes} from 'src/app/shared/constants/routes.constants';
 import AppServices from '../../../../../shared/service/appServices';
-import { BasicSubscriber } from 'src/app/shared/abstracts/basic-subscriber';
-import { CeipField } from '../components/steps/ceip-step/ceip-step.fieldmapping';
-import { ClusterType, IdentityManagementType, WizardForm } from "../constants/wizard.constants";
-import { ConfigFileInfo } from '../../../../../swagger/models/config-file-info.model';
-import { EditionData } from '../../../../../shared/service/branding.service';
-import { FieldMapping } from '../field-mapping/FieldMapping';
-import { FormDataForHTML, FormUtility } from '../components/steps/form-utility';
-import { IdentityField } from '../components/steps/identity-step/identity-step.fieldmapping';
+import {BasicSubscriber} from 'src/app/shared/abstracts/basic-subscriber';
+import {CeipField} from '../components/steps/ceip-step/ceip-step.fieldmapping';
+import {ClusterType, IdentityManagementType, WizardForm} from "../constants/wizard.constants";
+import {ConfigFileInfo} from '../../../../../swagger/models/config-file-info.model';
+import {EditionData} from '../../../../../shared/service/branding.service';
+import {FieldMapping} from '../field-mapping/FieldMapping';
+import {FormDataForHTML, FormUtility} from '../components/steps/form-utility';
+import {IdentityField} from '../components/steps/identity-step/identity-step.fieldmapping';
 import {
     LoadBalancerField,
     LoadBalancerStepMapping
 } from '../components/steps/load-balancer/load-balancer-step.fieldmapping';
-import { MetadataField, MetadataStepMapping } from '../components/steps/metadata-step/metadata-step.fieldmapping';
-import { MetadataStepComponent } from '../components/steps/metadata-step/metadata-step.component';
-import { NetworkField } from '../components/steps/network-step/network-step.fieldmapping';
-import { OsImageField } from '../components/steps/os-image-step/os-image-step.fieldmapping';
-import { Providers, PROVIDERS } from 'src/app/shared/constants/app.constants';
-import { SharedCeipStepComponent } from '../components/steps/ceip-step/ceip-step.component';
-import { SharedIdentityStepComponent } from '../components/steps/identity-step/identity-step.component';
-import { SharedNetworkStepComponent } from '../components/steps/network-step/network-step.component';
-import { StepFormDirective } from '../step-form/step-form';
+import {MetadataField, MetadataStepMapping} from '../components/steps/metadata-step/metadata-step.fieldmapping';
+import {MetadataStepComponent} from '../components/steps/metadata-step/metadata-step.component';
+import {NetworkField} from '../components/steps/network-step/network-step.fieldmapping';
+import {OsImageField} from '../components/steps/os-image-step/os-image-step.fieldmapping';
+import {Providers, PROVIDERS} from 'src/app/shared/constants/app.constants';
+import {SharedCeipStepComponent} from '../components/steps/ceip-step/ceip-step.component';
+import {SharedIdentityStepComponent} from '../components/steps/identity-step/identity-step.component';
+import {SharedNetworkStepComponent} from '../components/steps/network-step/network-step.component';
+import {StepFormDirective} from '../step-form/step-form';
 import {
     StepCompletedPayload,
     StepDescriptionChangePayload,
     StepStartedPayload,
     TanzuEventType
 } from './../../../../../shared/service/Messenger';
-import { StepWrapperSetComponent } from '../step-wrapper/step-wrapper-set.component';
-import { NodeSettingField } from '../components/steps/node-setting-step/node-setting-step.fieldmapping';
+import {StepWrapperSetComponent} from '../step-wrapper/step-wrapper-set.component';
+import {NodeSettingField} from '../components/steps/node-setting-step/node-setting-step.fieldmapping';
 
 // This interface describes a wizard that can register a step component
 export interface WizardStepRegistrar {
@@ -62,6 +62,10 @@ export interface Params<T> {
 export interface Label {
     key: string,
     value: string
+}
+
+export interface KeyValueObject {
+    [key: string]: string
 }
 
 @Directive()
@@ -343,14 +347,23 @@ export abstract class WizardBaseDirective extends BasicSubscriber implements Wiz
 
     /**
      * @param arrObj of type [ {key: 'a', value: '1}, {key : 'b, value:'2}]
-     * @param key To Identify the ObjectKey
-     * @param value To Identify the ObjectValue
+     * @param params.key<Function> To Identify the ObjectKey
+     * @param params.value<Function> To Identify the ObjectValue
      * @return Object {'a': 1 , 'b': '1'}
      */
-    arrayOfObjectsToObject<T>(arrObj: T[], params: Params<T>): { [key: string]: string; } {
-        return arrObj && arrObj instanceof Array
-            ? arrObj.reduce((obj, item) => ((obj[params.key(item)] = params.value(item)), obj), {})
-            : {};
+    arrayOfObjectsToObject<T>(arrObj: T[], params: Params<T>): KeyValueObject {
+        if (!arrObj || !(arrObj instanceof Array)) {
+            return {};
+        }
+
+        return arrObj.reduce<KeyValueObject>(
+            (accum, item) => {
+                const itemKey = params.key(item);
+                if (itemKey) {
+                    accum[itemKey] = params.value(item);
+                }
+                return accum;
+            }, {});
     }
 
     /**
@@ -537,6 +550,7 @@ export abstract class WizardBaseDirective extends BasicSubscriber implements Wiz
                 'name': this.getFieldValue(WizardForm.LOADBALANCER, LoadBalancerField.WORKLOAD_CLUSTER_CONTROL_PLANE_VIP_NETWORK_NAME),
                 'cidr': this.getFieldValue(WizardForm.LOADBALANCER, LoadBalancerField.WORKLOAD_CLUSTER_CONTROL_PLANE_VIP_NETWORK_CIDR)
             },
+            // thinking should cleanse formarray data in payload here, maybe an additional utility or add to arrayOfObjectsToObject
             'labels': this.arrayOfObjectsToObject<{ key: string, value: string }>(
                 loadBalancerLabels,
                 {


### PR DESCRIPTION
### What this PR does / why we need it
Fixes issue where Cluster and AVI key/value pair labels are including a pair of blank strings. This resulted in a failure when setting up AVI LB.

The fix now sets the value of labels to an empty object, ommitting any blank string key/value pairs.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Issue was raised in Slack

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Have confirmed that UI payload during cluster creation includes an empty object for Cluster and Avi labels when user has not specify labels. Have also verified that key/value pair of empty strings is no longer included when user does provide labels.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
none
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
