### PR TITLE
Update codepwners of /cmd/cli/plugin/package/kctrl

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 /addons/pinniped @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-iam-owners
 /cmd/cli @vmware-tanzu/tanzu-framework-reviewers
 /cmd/cli/plugin/package @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-addons-owners
-/cmd/cli/plugin/package/kctrl @vmware-tanzu/carvel-writers
+/cmd/cli/plugin/package/kctrl @vmware-tanzu/carvel-kctrl
 /cmd/cli/plugin/pinniped-auth @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-iam-owners
 /cmd/cli/plugin/secret @vmware-tanzu/tanzu-framework-reviewers @vmware-tanzu/tkg-addons-owners
 /cmd/cli/plugin/tkr @vmware-tanzu/tanzu-framework-reviewers @prkalle


### PR DESCRIPTION
### What this PR does / why we need it
Update codeowners of `/cmd/cli/plugin/package/kctrl`.
Use a smaller group to avoid review notifications being sent to a larger group of people.