### PR TITLE
Add some clarity to the tanzu cluster describe return value

### DIFF
--- a/pkg/v1/cli/command/plugin/describe.go
+++ b/pkg/v1/cli/command/plugin/describe.go
@@ -15,7 +15,10 @@ func newDescribeCmd(description string) *cobra.Command {
 		Short:  "Describes the plugin",
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println(description)
+			if len(args) > 0 {
+				return fmt.Errorf("This command only describes a plugin's purpose... it doesn't accept any inputs.")
+			}
+			fmt.Println("Plugin description:", description)
 			return nil
 		},
 	}


### PR DESCRIPTION
Quick fix to make `tanzu cluster describe` output more self describing so it doesnt get confused w/ `kubectl describe ...` #3247 