### PR TITLE
Provide automatic buildinfo for plugins

### DIFF
--- a/cli/runtime/buildinfo/buildinfo.go
+++ b/cli/runtime/buildinfo/buildinfo.go
@@ -1,0 +1,22 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package buildinfo holds global variables set at build time to provide information about the plugin build.
+package buildinfo
+
+var (
+	// Date is the date the plugin binary was built.
+	// It should be set using:
+	//  go build --ldflags "-X 'github.com/vmware-tanzu/tanzu-framework/cli/runtime/buildinfo.Date=...'"
+	Date string
+
+	// SHA is the git commit SHA the plugin binary was built with.
+	// Is should be set using:
+	//  go build --ldflags "-X 'github.com/vmware-tanzu/tanzu-framework/cli/runtime/buildinfo.SHA=...'"
+	SHA string
+
+	// Version is the version of the plugin built.
+	// It should be set using:
+	//  go build --ldflags "-X 'github.com/vmware-tanzu/tanzu-framework/cli/runtime/buildinfo.Version=...'"
+	Version string
+)

--- a/pkg/v1/builder/template/plugintemplates/Makefile.tmpl
+++ b/pkg/v1/builder/template/plugintemplates/Makefile.tmpl
@@ -11,6 +11,10 @@ GOARCH ?= $(shell go env GOARCH)
 GOHOSTOS ?= $(shell go env GOHOSTOS)
 GOHOSTARCH ?= $(shell go env GOHOSTARCH)
 
+LD_FLAGS = -X 'github.com/vmware-tanzu/tanzu-framework/cli/runtime/buildinfo.Date=$(BUILD_DATE)'
+LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/cli/runtime/buildinfo.SHA=$(BUILD_SHA)'
+LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/cli/runtime/buildinfo.Version=$(BUILD_VERSION)'
+
 TOOLS_DIR := tools
 TOOLS_BIN_DIR := $(TOOLS_DIR)/bin
 GOLANGCI_LINT := $(TOOLS_BIN_DIR)/golangci-lint

--- a/pkg/v1/builder/template/plugintemplates/main.go.tmpl
+++ b/pkg/v1/builder/template/plugintemplates/main.go.tmpl
@@ -6,14 +6,15 @@ import (
 	"github.com/aunum/log"
 
 	cliv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/cli/runtime/buildinfo"
 	"github.com/vmware-tanzu/tanzu-framework/cli/runtime/plugin"
 )
 
 var descriptor = cliv1alpha1.PluginDescriptor{
 	Name:        "{{ .PluginName | ToLower }}",
 	Description: "{{ .Description | ToLower }}",
-	Version:     "v0.0.1",
-	BuildSHA:    "",
+	Version:     buildinfo.Version,
+	BuildSHA:    buildinfo.SHA,
 	Group:       cliv1alpha1.ManageCmdGroup, // set group
 }
 


### PR DESCRIPTION
### What this PR does / why we need it

This is kind of a follow-up of the refactoring of #3201.
The PR simply copies `pkg/v1/buildinfo/buildvar.go` to a new `cli/runtime/buildinfo` package.
This will allow plugins to get access to `buildinfo.Version`, `buildinfo.SHA` and `buildinfo.Date` without having to import Framework.

The PR also updates the `Makefile.tmpl` template to inject those values and the `main.go.tmpl` to use this mechanism for new plugins.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3230

### Describe testing done for PR

Created a new plugin and built it and verified that Version and SHA were injected automatically:
```
tanzu builder init myplugin --repo-type github
cd myplugin
tanzu builder cli add-plugin myplugin --description myplugin
git add .
git commit -m start
make init || true

# point the go.mod to my local Framework repo
echo "replace github.com/vmware-tanzu/tanzu-framework/cli/runtime => /Users/$USER/git/tanzu-framework/cli/runtime" >> go.mod
go mod tidy -compat=1.17
make build-local

# Call the built binary which depends on your machine arch and os
artifacts/darwin/arm64/cli/myplugin/v0.0.1/tanzu-myplugin-darwin_arm64 info

# Check that the Version and SHA are set properly
```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->

### Additional information

We would need some doc to teach this to plugin developers.  I can add it once #3259 is merged.

