### PR TITLE
Support test plugins with `context-aware-cli-for-plugins` feature-flag enabled

### DIFF
--- a/.github/workflows/plugin_tests.yaml
+++ b/.github/workflows/plugin_tests.yaml
@@ -82,11 +82,6 @@ jobs:
           echo "##[set-output name=bompath;]$(echo "$BOMCOMMENT" | awk -F : '{print $2}')"
         id: extract_bom
 
-      # Using `ENABLE_CONTEXT_AWARE_PLUGIN_DISCOVERY=false` to build and install cli and plugins because
-      # currently, context-aware-plugin-discovery does not support test plugins
-      # Issue: https://github.com/vmware-tanzu/tanzu-framework/issues/1164
-      # above issue need to be addressed and as part of the change we can use context-aware way of plugin
-      # tests as part of this test workflow.
       - name: Build
         run: |
           if [[ ! -z "${{ steps.extract_bom.outputs.bompath }}" ]]; then
@@ -94,17 +89,20 @@ jobs:
           fi
           env | sort
           make configure-bom
-          make build-cli-local ENABLE_CONTEXT_AWARE_PLUGIN_DISCOVERY=false
-
-      - name: Install Tanzu CLI
-        run: |
-          make install-cli ENABLE_CONTEXT_AWARE_PLUGIN_DISCOVERY=false
-
-      - name: Install CLI plugins
-        run: make install-cli-plugins ENABLE_CONTEXT_AWARE_PLUGIN_DISCOVERY=false
+          make build-cli-local
 
       - name: Cleanup
         run: rm -rf ~/.tanzu ~/.tkg ~/.config ~/.cache/tanzu; docker kill $(docker ps -q) | true; docker system prune -a --volumes -f
+
+      - name: Install Tanzu CLI
+        run: |
+          make install-cli
+          tanzu config set features.global.context-aware-cli-for-plugins true
+
+      - name: Install CLI plugins
+        run: |
+          tanzu plugin install all --local artifacts/linux/amd64/cli/
+          tanzu plugin install all --local artifacts-admin/linux/amd64/cli/
 
       - name: Run cluster test plugin
         run: tanzu test plugin cluster

--- a/cli/core/pkg/artifact/http.go
+++ b/cli/core/pkg/artifact/http.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 const (
@@ -71,4 +73,9 @@ func (g *HTTPArtifact) Fetch() ([]byte, error) {
 	}
 
 	return out, nil
+}
+
+// FetchTest returns test artifact
+func (g *HTTPArtifact) FetchTest() ([]byte, error) {
+	return nil, errors.New("fetching test plugin from HTTP source is not yet supported")
 }

--- a/cli/core/pkg/artifact/interface.go
+++ b/cli/core/pkg/artifact/interface.go
@@ -14,6 +14,8 @@ import (
 type Artifact interface {
 	// Fetch the binary for a plugin version.
 	Fetch() ([]byte, error)
+	// FetchTest the test binary for a plugin version.
+	FetchTest() ([]byte, error)
 }
 
 // NewURIArtifact creates new artifacts based on the URI

--- a/cli/core/pkg/artifact/local.go
+++ b/cli/core/pkg/artifact/local.go
@@ -58,13 +58,13 @@ func (l *LocalArtifact) FetchTest() ([]byte, error) {
 		return nil, errors.Wrap(err, "unable to read test plugin directory")
 	}
 	if len(dirEntries) != 1 {
-		return nil, errors.Errorf("Expected only 1 file under the '%v' directory, but found %v files", testPluginDir, len(dirEntries))
+		return nil, errors.Errorf("expected only 1 file under the '%v' directory, but found %v files", testPluginDir, len(dirEntries))
 	}
 
 	// Assuming the file under the test directory is the test plugin binary
 	testPluginFile := dirEntries[0]
 	if testPluginFile.IsDir() {
-		return nil, errors.Errorf("Expected to find test plugin binary but found directory '%v'", testPluginFile)
+		return nil, errors.Errorf("expected to find test plugin binary but found directory %q", testPluginFile.Name())
 	}
 
 	testPluginPath := filepath.Join(testPluginDir, testPluginFile.Name())

--- a/cli/core/pkg/artifact/local.go
+++ b/cli/core/pkg/artifact/local.go
@@ -45,3 +45,32 @@ func (l *LocalArtifact) Fetch() ([]byte, error) {
 	}
 	return b, nil
 }
+
+// FetchTest reads test plugin artifact based on the local plugin artifact path
+// To fetch the test binary from the plugin we are using plugin binary path and creating test plugin path from it
+// If the plugin binary path is `artifacts/darwin/amd64/cli/cluster/v0.27.0-dev/tanzu-cluster-darwin_amd64`
+// then test plugin binary will be under `artifacts/darwin/amd64/cli/cluster/v0.27.0-dev/test/` directory
+func (l *LocalArtifact) FetchTest() ([]byte, error) {
+	// test plugin directory based on the plugin binary location
+	testPluginDir := filepath.Join(filepath.Dir(l.Path), "test")
+	dirEntries, err := os.ReadDir(testPluginDir)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to read test plugin directory")
+	}
+	if len(dirEntries) != 1 {
+		return nil, errors.Errorf("Expected only 1 file under the '%v' directory, but found %v files", testPluginDir, len(dirEntries))
+	}
+
+	// Assuming the file under the test directory is the test plugin binary
+	testPluginFile := dirEntries[0]
+	if testPluginFile.IsDir() {
+		return nil, errors.Errorf("Expected to find test plugin binary but found directory '%v'", testPluginFile)
+	}
+
+	testPluginPath := filepath.Join(testPluginDir, testPluginFile.Name())
+	b, err := os.ReadFile(testPluginPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error while reading test artifact")
+	}
+	return b, nil
+}

--- a/cli/core/pkg/artifact/local_test.go
+++ b/cli/core/pkg/artifact/local_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package artifact
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// When local artifact directory exists and test directory exists
+func TestLocalArtifactWhenArtifactAndTestDirExists(t *testing.T) {
+	assert := assert.New(t)
+
+	testPluginPath, err := filepath.Abs(filepath.Join("test", "local", "v0.0.1", "tanzu-plugin-darwin_amd64"))
+	assert.NoError(err)
+	artifact := NewLocalArtifact(testPluginPath)
+
+	b, err := artifact.Fetch()
+	assert.NoError(err)
+	assert.Contains(string(b), "plugin binary")
+
+	b, err = artifact.FetchTest()
+	assert.NoError(err)
+	assert.Contains(string(b), "test plugin binary")
+}
+
+// When local artifact doesn't exists and multiple files exists within test directory
+func TestLocalArtifactWhenArtifactDoesntExistsAndMultipleFilesUnderTest(t *testing.T) {
+	assert := assert.New(t)
+
+	testPluginPath, err := filepath.Abs(filepath.Join("test", "local", "v0.0.2", "plugin_binary_does_not_exists"))
+	assert.NoError(err)
+
+	artifact := NewLocalArtifact(testPluginPath)
+
+	// When local artifact doesn't exists
+	_, err = artifact.Fetch()
+	assert.Error(err)
+	assert.ErrorContains(err, "error while reading artifact")
+
+	// When multiple files exists under test directory
+	_, err = artifact.FetchTest()
+	assert.Error(err)
+	assert.ErrorContains(err, "Expected only 1 file under the")
+}

--- a/cli/core/pkg/artifact/local_test.go
+++ b/cli/core/pkg/artifact/local_test.go
@@ -44,5 +44,5 @@ func TestLocalArtifactWhenArtifactDoesntExistsAndMultipleFilesUnderTest(t *testi
 	// When multiple files exists under test directory
 	_, err = artifact.FetchTest()
 	assert.Error(err)
-	assert.ErrorContains(err, "Expected only 1 file under the")
+	assert.ErrorContains(err, "expected only 1 file under the")
 }

--- a/cli/core/pkg/artifact/oci.go
+++ b/cli/core/pkg/artifact/oci.go
@@ -57,3 +57,8 @@ func (g *OCIArtifact) Fetch() ([]byte, error) {
 
 	return bytesData, nil
 }
+
+// FetchTest returns test artifact
+func (g *OCIArtifact) FetchTest() ([]byte, error) {
+	return nil, errors.New("fetching test plugin from OCI source is not yet supported")
+}

--- a/cli/core/pkg/artifact/test/local/v0.0.1/tanzu-plugin-darwin_amd64
+++ b/cli/core/pkg/artifact/test/local/v0.0.1/tanzu-plugin-darwin_amd64
@@ -1,0 +1,1 @@
+plugin binary

--- a/cli/core/pkg/artifact/test/local/v0.0.1/test/tanzu-test-plugin-darwin_amd64
+++ b/cli/core/pkg/artifact/test/local/v0.0.1/test/tanzu-test-plugin-darwin_amd64
@@ -1,0 +1,1 @@
+test plugin binary

--- a/cli/core/pkg/artifact/test/local/v0.0.2/tanzu-plugin-darwin_amd64
+++ b/cli/core/pkg/artifact/test/local/v0.0.2/tanzu-plugin-darwin_amd64
@@ -1,0 +1,1 @@
+plugin binary

--- a/cli/core/pkg/artifact/test/local/v0.0.2/test/tanzu-test-plugin-darwin_amd64
+++ b/cli/core/pkg/artifact/test/local/v0.0.2/test/tanzu-test-plugin-darwin_amd64
@@ -1,0 +1,1 @@
+test plugin binary

--- a/cli/core/pkg/cli/cmd.go
+++ b/cli/core/pkg/cli/cmd.go
@@ -140,9 +140,9 @@ func TestCmd(p *cliapi.PluginDescriptor) *cobra.Command {
 		Use:   p.Name,
 		Short: p.Description,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := NewRunner(p.Name, p.TestPluginInstallationPath, args)
+			runner := NewRunner(p.Name, p.InstallationPath, args)
 			ctx := context.Background()
-			return runner.Run(ctx)
+			return runner.RunTest(ctx)
 		},
 		DisableFlagParsing: true,
 	}

--- a/cli/core/pkg/cli/cmd.go
+++ b/cli/core/pkg/cli/cmd.go
@@ -140,9 +140,9 @@ func TestCmd(p *cliapi.PluginDescriptor) *cobra.Command {
 		Use:   p.Name,
 		Short: p.Description,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			runner := NewRunner(p.Name, p.InstallationPath, args)
+			runner := NewRunner(p.Name, p.TestPluginInstallationPath, args)
 			ctx := context.Background()
-			return runner.RunTest(ctx)
+			return runner.Run(ctx)
 		},
 		DisableFlagParsing: true,
 	}

--- a/cli/core/pkg/cli/runner.go
+++ b/cli/core/pkg/cli/runner.go
@@ -140,5 +140,10 @@ func (r *Runner) pluginPath() string {
 }
 
 func (r *Runner) testPluginPath() string {
-	return filepath.Join(r.pluginRoot, "test", BinTestFromPluginName(r.name))
+	return TestPluginPathFromPluginPath(r.pluginAbsPath)
+}
+
+func TestPluginPathFromPluginPath(pluginPath string) string {
+	testPluginFilename := "test-" + filepath.Base(pluginPath)
+	return filepath.Join(filepath.Dir(pluginPath), testPluginFilename)
 }

--- a/cli/core/pkg/command/plugin_manager.go
+++ b/cli/core/pkg/command/plugin_manager.go
@@ -254,7 +254,7 @@ var installPluginCmd = &cobra.Command{
 				if err != nil {
 					return err
 				}
-				err = pluginmanager.InstallPluginsFromLocalSource(pluginName, version, local)
+				err = pluginmanager.InstallPluginsFromLocalSource(pluginName, version, local, false)
 				if err != nil {
 					return err
 				}

--- a/cli/core/pkg/distribution/artifact.go
+++ b/cli/core/pkg/distribution/artifact.go
@@ -80,6 +80,27 @@ func (aMap Artifacts) Fetch(version, os, arch string) ([]byte, error) {
 		"arch:%s", version, os, arch)
 }
 
+// FetchTest the test binary for a plugin version.
+func (aMap Artifacts) FetchTest(version, os, arch string) ([]byte, error) {
+	a, err := aMap.GetArtifact(version, os, arch)
+	if err != nil {
+		return nil, err
+	}
+
+	if a.Image != "" {
+		return artifact.NewOCIArtifact(a.Image).FetchTest()
+	}
+	if a.URI != "" {
+		u, err := artifact.NewURIArtifact(a.URI)
+		if err != nil {
+			return nil, err
+		}
+		return u.FetchTest()
+	}
+
+	return nil, errors.Errorf("invalid artifact for version:%s, os:%s, arch:%s", version, os, arch)
+}
+
 // GetDigest returns the SHA256 hash of the binary for a plugin version.
 func (aMap Artifacts) GetDigest(version, os, arch string) (string, error) {
 	a, err := aMap.GetArtifact(version, os, arch)

--- a/cli/core/pkg/distribution/interface.go
+++ b/cli/core/pkg/distribution/interface.go
@@ -12,6 +12,9 @@ type Distribution interface {
 	// Fetch the binary for a plugin version.
 	Fetch(version, os, arch string) ([]byte, error)
 
+	// FetchTest the test binary for a plugin version.
+	FetchTest(version, os, arch string) ([]byte, error)
+
 	// GetDigest returns the SHA256 hash of the binary for a plugin version.
 	GetDigest(version, os, arch string) (string, error)
 

--- a/cli/core/pkg/pluginmanager/manager.go
+++ b/cli/core/pkg/pluginmanager/manager.go
@@ -488,6 +488,16 @@ func installOrUpgradePlugin(serverName string, p *plugin.Discovered, version str
 	descriptor.Discovery = p.Source
 	descriptor.DiscoveredRecommendedVersion = p.RecommendedVersion
 
+	b, err = p.Distribution.FetchTest(version, runtime.GOOS, runtime.GOARCH)
+	if err == nil {
+		testpluginPath := filepath.Join(common.DefaultPluginRoot, pluginName, fmt.Sprintf("test-%s", version))
+		err = os.WriteFile(testpluginPath, b, 0755)
+		if err != nil {
+			return errors.Wrap(err, "error while saving test plugin binary")
+		}
+		descriptor.TestPluginInstallationPath = testpluginPath
+	}
+
 	c, err := catalog.NewContextCatalog(serverName)
 	if err != nil {
 		return err

--- a/cli/core/pkg/pluginmanager/manager.go
+++ b/cli/core/pkg/pluginmanager/manager.go
@@ -495,7 +495,6 @@ func installOrUpgradePlugin(serverName string, p *plugin.Discovered, version str
 		if err != nil {
 			return errors.Wrap(err, "error while saving test plugin binary")
 		}
-		descriptor.TestPluginInstallationPath = testpluginPath
 	}
 
 	c, err := catalog.NewContextCatalog(serverName)

--- a/cli/core/pkg/pluginmanager/manager.go
+++ b/cli/core/pkg/pluginmanager/manager.go
@@ -393,7 +393,7 @@ func InstallPlugin(serverName, pluginName, version string) error {
 			if availablePlugins[i].Scope == common.PluginScopeStandalone {
 				serverName = ""
 			}
-			return installOrUpgradePlugin(serverName, &availablePlugins[i], version)
+			return installOrUpgradePlugin(serverName, &availablePlugins[i], version, false)
 		}
 	}
 
@@ -412,7 +412,7 @@ func UpgradePlugin(serverName, pluginName, version string) error {
 			if availablePlugins[i].Scope == common.PluginScopeStandalone {
 				serverName = ""
 			}
-			return installOrUpgradePlugin(serverName, &availablePlugins[i], version)
+			return installOrUpgradePlugin(serverName, &availablePlugins[i], version, false)
 		}
 	}
 
@@ -434,7 +434,7 @@ func GetRecommendedVersionOfPlugin(serverName, pluginName string) (string, error
 	return "", errors.Errorf("unable to find plugin '%v'", pluginName)
 }
 
-func installOrUpgradePlugin(serverName string, p *plugin.Discovered, version string) error {
+func installOrUpgradePlugin(serverName string, p *plugin.Discovered, version string, installTestPlugin bool) error {
 	log.Infof("Installing plugin '%v:%v'", p.Name, version)
 
 	// verify plugin before download
@@ -488,8 +488,12 @@ func installOrUpgradePlugin(serverName string, p *plugin.Discovered, version str
 	descriptor.Discovery = p.Source
 	descriptor.DiscoveredRecommendedVersion = p.RecommendedVersion
 
-	b, err = p.Distribution.FetchTest(version, runtime.GOOS, runtime.GOARCH)
-	if err == nil {
+	if installTestPlugin {
+		log.Infof("Installing test plugin for '%v:%v'", p.Name, version)
+		b, err = p.Distribution.FetchTest(version, runtime.GOOS, runtime.GOARCH)
+		if err != nil {
+			return errors.Wrapf(err, "unable to install test plugin for '%v:%v'", p.Name, version)
+		}
 		testpluginPath := filepath.Join(common.DefaultPluginRoot, pluginName, fmt.Sprintf("test-%s", version))
 		err = os.WriteFile(testpluginPath, b, 0755)
 		if err != nil {
@@ -574,7 +578,7 @@ func SyncPlugins(serverName string) error {
 }
 
 // InstallPluginsFromLocalSource installs plugin from local source directory
-func InstallPluginsFromLocalSource(pluginName, version, localPath string) error {
+func InstallPluginsFromLocalSource(pluginName, version, localPath string, installTestPlugin bool) error {
 	// Set default local plugin distro to localpath as while installing the plugin
 	// from local source we should take t
 	common.DefaultLocalPluginDistroDir = localPath
@@ -590,7 +594,7 @@ func InstallPluginsFromLocalSource(pluginName, version, localPath string) error 
 	for idx := range plugins {
 		if pluginName == cli.AllPlugins || pluginName == plugins[idx].Name {
 			found = true
-			err := installOrUpgradePlugin("", &plugins[idx], plugins[idx].RecommendedVersion)
+			err := installOrUpgradePlugin("", &plugins[idx], plugins[idx].RecommendedVersion, installTestPlugin)
 			if err != nil {
 				errList = append(errList, err)
 			}

--- a/cli/core/pkg/pluginmanager/manager_test.go
+++ b/cli/core/pkg/pluginmanager/manager_test.go
@@ -196,12 +196,12 @@ func Test_InstallPlugin_InstalledPlugins_From_LocalSource(t *testing.T) {
 	localPluginSourceDir := filepath.Join(currentDirAbsPath, "test", "local")
 
 	// Try installing nonexistent plugin
-	err := InstallPluginsFromLocalSource("notexists", "v0.2.0", localPluginSourceDir)
+	err := InstallPluginsFromLocalSource("notexists", "v0.2.0", localPluginSourceDir, false)
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "unable to find plugin 'notexists'")
 
 	// Install login from local source directory
-	err = InstallPluginsFromLocalSource("login", "v0.2.0", localPluginSourceDir)
+	err = InstallPluginsFromLocalSource("login", "v0.2.0", localPluginSourceDir, false)
 	assert.Nil(err)
 	// Verify installed plugin
 	installedServerPlugins, installedStandalonePlugins, err := InstalledPlugins("")
@@ -211,7 +211,7 @@ func Test_InstallPlugin_InstalledPlugins_From_LocalSource(t *testing.T) {
 	assert.Equal("login", installedStandalonePlugins[0].Name)
 
 	// Try installing cluster plugin from local source directory
-	err = InstallPluginsFromLocalSource("cluster", "v0.2.0", localPluginSourceDir)
+	err = InstallPluginsFromLocalSource("cluster", "v0.2.0", localPluginSourceDir, false)
 	assert.Nil(err)
 	installedServerPlugins, installedStandalonePlugins, err = InstalledPlugins("")
 	assert.Nil(err)
@@ -219,7 +219,7 @@ func Test_InstallPlugin_InstalledPlugins_From_LocalSource(t *testing.T) {
 	assert.Equal(2, len(installedStandalonePlugins))
 
 	// Try installing a plugin from incorrect local path
-	err = InstallPluginsFromLocalSource("cluster", "v0.2.0", "fakepath")
+	err = InstallPluginsFromLocalSource("cluster", "v0.2.0", "fakepath", false)
 	assert.NotNil(err)
 	assert.Contains(err.Error(), "no such file or directory")
 }
@@ -615,7 +615,7 @@ func Test_InstallPluginsFromLocalSourceWithLegacyDirectoryStructure(t *testing.T
 
 	// Using generic InstallPluginsFromLocalSource to test the legacy directory install
 	// When passing legacy directory structure which contains manifest.yaml file
-	err := InstallPluginsFromLocalSource("all", "", filepath.Join("test", "legacy"))
+	err := InstallPluginsFromLocalSource("all", "", filepath.Join("test", "legacy"), false)
 	assert.Nil(err)
 
 	// Verify installed plugin

--- a/cli/runtime/apis/cli/v1alpha1/catalog_types.go
+++ b/cli/runtime/apis/cli/v1alpha1/catalog_types.go
@@ -141,10 +141,6 @@ type PluginDescriptor struct {
 	// E.g., cluster/v0.3.2@sha256:...
 	InstallationPath string `json:"installationPath"`
 
-	// TestPluginInstallationPath is a installation path for a test plugin binary.
-	// E.g., cluster/test-v0.3.2
-	TestPluginInstallationPath string `json:"testPluginInstallationPath"`
-
 	// Discovery is the name of the discovery from where
 	// this plugin is discovered.
 	Discovery string `json:"discovery"`

--- a/cli/runtime/apis/cli/v1alpha1/catalog_types.go
+++ b/cli/runtime/apis/cli/v1alpha1/catalog_types.go
@@ -141,6 +141,10 @@ type PluginDescriptor struct {
 	// E.g., cluster/v0.3.2@sha256:...
 	InstallationPath string `json:"installationPath"`
 
+	// TestPluginInstallationPath is a installation path for a test plugin binary.
+	// E.g., cluster/test-v0.3.2
+	TestPluginInstallationPath string `json:"testPluginInstallationPath"`
+
 	// Discovery is the name of the discovery from where
 	// this plugin is discovered.
 	Discovery string `json:"discovery"`

--- a/cmd/cli/plugin-admin/test/go.sum
+++ b/cmd/cli/plugin-admin/test/go.sum
@@ -736,6 +736,7 @@ github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mo
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
+github.com/otiai10/copy v1.4.2 h1:RTiz2sol3eoXPLF4o+YWqEybwfUa/Q2Nkc4ZIUs3fwI=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=

--- a/cmd/cli/plugin-admin/test/main.go
+++ b/cmd/cli/plugin-admin/test/main.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/aunum/log"
 	"github.com/spf13/cobra"
 
@@ -25,7 +27,7 @@ var descriptor = cliapi.PluginDescriptor{
 var local string
 
 func init() {
-	fetchCmd.PersistentFlags().StringVarP(&local, "local", "l", "", "path to local repository")
+	fetchCmd.Flags().StringVarP(&local, "local", "l", "", "path to local repository")
 	_ = fetchCmd.MarkFlagRequired("local")
 }
 
@@ -46,7 +48,9 @@ func main() {
 	}
 
 	for _, d := range standalonePlugins {
-		if d.TestPluginInstallationPath == "" {
+		// Check if test plugin binary installed. If available add a plugin command
+		_, err := os.Stat(cli.TestPluginPathFromPluginPath(d.InstallationPath))
+		if err != nil {
 			continue
 		}
 		pluginsCmd.AddCommand(cli.TestCmd(d.DeepCopy()))

--- a/cmd/cli/plugin-admin/test/main.go
+++ b/cmd/cli/plugin-admin/test/main.go
@@ -70,6 +70,6 @@ var fetchCmd = &cobra.Command{
 	Use:   "fetch",
 	Short: "Fetch the plugin tests",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return pluginmanager.InstallPluginsFromLocalSource("all", "", local)
+		return pluginmanager.InstallPluginsFromLocalSource("all", "", local, true)
 	},
 }

--- a/cmd/cli/plugin-admin/test/main.go
+++ b/cmd/cli/plugin-admin/test/main.go
@@ -4,15 +4,13 @@
 package main
 
 import (
-	"path/filepath"
-
 	"github.com/aunum/log"
 	"github.com/spf13/cobra"
 
 	"github.com/vmware-tanzu/tanzu-framework/cli/core/pkg/cli"
+	"github.com/vmware-tanzu/tanzu-framework/cli/core/pkg/pluginmanager"
 	cliapi "github.com/vmware-tanzu/tanzu-framework/cli/runtime/apis/cli/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/cli/runtime/buildinfo"
-	"github.com/vmware-tanzu/tanzu-framework/cli/runtime/config"
 	"github.com/vmware-tanzu/tanzu-framework/cli/runtime/plugin"
 )
 
@@ -24,10 +22,11 @@ var descriptor = cliapi.PluginDescriptor{
 	BuildSHA:    buildinfo.SHA,
 }
 
-var local []string
+var local string
 
 func init() {
-	fetchCmd.PersistentFlags().StringSliceVarP(&local, "local", "l", []string{}, "paths to local repository")
+	fetchCmd.PersistentFlags().StringVarP(&local, "local", "l", "", "path to local repository")
+	_ = fetchCmd.MarkFlagRequired("local")
 }
 
 func main() {
@@ -35,17 +34,22 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
 	p.AddCommands(
 		fetchCmd,
 		pluginsCmd,
 	)
-	descs, err := cli.ListPlugins("test")
+
+	_, standalonePlugins, err := pluginmanager.InstalledPlugins("")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	for _, d := range descs {
-		pluginsCmd.AddCommand(cli.TestCmd(d))
+	for _, d := range standalonePlugins {
+		if d.TestPluginInstallationPath == "" {
+			continue
+		}
+		pluginsCmd.AddCommand(cli.TestCmd(d.DeepCopy()))
 	}
 
 	if err := p.Execute(); err != nil {
@@ -53,37 +57,15 @@ func main() {
 	}
 }
 
-var fetchCmd = &cobra.Command{
-	Use:   "fetch",
-	Short: "Fetch the plugin tests",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		repos := getRepositories()
-		err := cli.EnsureTests(repos, "test")
-		if err != nil {
-			log.Fatal(err)
-		}
-		return nil
-	},
-}
-
 var pluginsCmd = &cobra.Command{
 	Use:   "plugin",
 	Short: "Plugin tests",
 }
 
-func getRepositories() *cli.MultiRepo {
-	if len(local) != 0 {
-		m := cli.NewMultiRepo()
-		for _, l := range local {
-			n := filepath.Base(l)
-			r := cli.NewLocalRepository(n, l)
-			m.AddRepository(r)
-		}
-		return m
-	}
-	cfg, err := config.GetClientConfig()
-	if err != nil {
-		log.Fatal(err)
-	}
-	return cli.NewMultiRepo(cli.LoadRepositories(cfg)...)
+var fetchCmd = &cobra.Command{
+	Use:   "fetch",
+	Short: "Fetch the plugin tests",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return pluginmanager.InstallPluginsFromLocalSource("all", "", local)
+	},
 }


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds support for installing test plugin along with plugin installation in local mode with `tanzu test fetch --local` command.

- The change also implements `FetchTest` interface for `local` artifacts and throws error when using the same with `oci` and `http` artifacts.

- This change also updates `Plugin Test` pipeline to not rely on old implementation and uses new `context-aware-cli-for-plugins: true` to deploy and run test plugins.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #1164

### Describe testing done for PR
- Build the cli and plugins locally. Generates artifacts under `artifacts/darwin/amd64/cli/` directory
- Use `tanzu plugin install all --local artifacts/darwin/amd64/cli/` to install plugins along with test plugins
- Run `tanzu test plugin --help` to verify all plugins are available under the command to run tests
- Run `tanzu test plugin <plugin-name>` to run the plugin tests

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support test plugins with `context-aware-cli-for-plugins` feature-flag enabled
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information


#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
