### PR TITLE
Update the builder plugin to make version flag optional and add new 'build-plugin-local' make target 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ endif
 # Package tooling related variables
 PACKAGE_VERSION ?= ${BUILD_VERSION}
 REPO_BUNDLE_VERSION ?= ${BUILD_VERSION}
+PLUGIN_PATH ?= ./cmd/cli/plugin
 
 DOCKER_DIR := /app
 SWAGGER=docker run --rm -v ${PWD}:${DOCKER_DIR}:$(DOCKER_VOL_OPTS) quay.io/goswagger/swagger:v0.21.0
@@ -239,6 +240,20 @@ build-plugin-admin-with-oci-discovery: ${CLI_ADMIN_JOBS_OCI_DISCOVERY} publish-a
 
 .PHONY: build-plugin-admin-with-local-discovery
 build-plugin-admin-with-local-discovery: ${CLI_ADMIN_JOBS_LOCAL_DISCOVERY} publish-admin-plugins-all-local ## Build Tanzu CLI admin plugins with Local standalone discovery
+
+.PHONY: build-plugin-local
+build-plugin-local: prepare-builder ## Build given CLI Plugin locally, needs PLUGIN_NAME
+	@if [ "${PLUGIN_NAME}" = "" ] || [ ! -d ${PLUGIN_PATH}/${PLUGIN_NAME} ]; then \
+		echo "The PLUGIN_NAME: '${PLUGIN_NAME}' is not valid or not exists or empty, please provide valid PLUGIN_NAME." ; \
+	else \
+		$(BUILDER) cli compile --match "$(PLUGIN_NAME)" --version $(BUILD_VERSION) --ldflags "$(LD_FLAGS)" --path $(PLUGIN_PATH) --target local --artifacts artifacts/${GOHOSTOS}/${GOHOSTARCH}/cli ; \
+	fi
+
+.PHONY: install-plugin-local
+install-plugin-local: build-plugin-local ## Build and Install given CLI Plugin locally, needs PLUGIN_NAME
+	@if [ "${PLUGIN_NAME}" != "" ] && [ -d ${PLUGIN_PATH}/${PLUGIN_NAME} ]; then \
+		tanzu plugin install ${PLUGIN_NAME} --local $(ARTIFACTS_DIR)/$(GOHOSTOS)/$(GOHOSTARCH)/cli ; \
+	fi
 
 .PHONY: build-plugin-admin-%
 build-plugin-admin-%: prepare-builder

--- a/cmd/cli/plugin-admin/builder/cli.go
+++ b/cmd/cli/plugin-admin/builder/cli.go
@@ -45,7 +45,7 @@ func newCompileCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&compileArgs.Version, "version", "", "Version of the root cli (required)")
+	cmd.Flags().StringVar(&compileArgs.Version, "version", "", "Version of the core tanzu cli")
 	cmd.Flags().StringVar(&compileArgs.LDFlags, "ldflags", "", "ldflags to set on build")
 	cmd.Flags().StringVar(&compileArgs.Tags, "tags", "", "Tags to set on build")
 	cmd.Flags().StringVar(&compileArgs.Match, "match", compileArgs.Match, "Match a plugin name to build, supports globbing")
@@ -54,8 +54,6 @@ func newCompileCmd() *cobra.Command {
 	cmd.Flags().StringVar(&compileArgs.ArtifactsDir, "artifacts", compileArgs.ArtifactsDir, "Path to output artifacts")
 	cmd.Flags().StringVar(&compileArgs.CorePath, "corepath", "", "Path for core binary")
 	cmd.Flags().StringVar(&compileArgs.GoPrivate, "goprivate", "", "Comma-separated list of glob patterns of module path prefixes to set as GOPRIVATE on build")
-
-	_ = cmd.MarkFlagRequired("version")
 
 	return cmd
 }

--- a/cmd/cli/plugin-admin/builder/command/cli_compile.go
+++ b/cmd/cli/plugin-admin/builder/command/cli_compile.go
@@ -131,10 +131,6 @@ type errInfo struct {
 // setGlobals initializes a set of global variables used throughout the compile
 // process, based on the arguments passed in.
 func setGlobals(compileArgs *PluginCompileArgs) {
-	if compileArgs.Version == "" {
-		log.Fatal("version value must be set")
-	}
-
 	version = compileArgs.Version
 	artifactsDir = compileArgs.ArtifactsDir
 	ldflags = compileArgs.LDFlags


### PR DESCRIPTION
### What this PR does / why we need it

1. Updates the command `tanzu builder cli compile --match <package_name> --version` logic to make the flag "--version" as optional and the help text of the flag.
2. New make targets `build-plugin-local` and `install-plugin-local` has added to give flexibility to users to build and install the given plugin locally.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #https://github.com/vmware-tanzu/tanzu-framework/issues/899

### Describe testing done for PR

1. The command ` tanzu builder cli compile --match package --version $(make version) --ldflags "-X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.Version=v0.27.0-dev'"` tested with --ldflags having Version info, works fine.
2. The command ` tanzu builder cli compile --match package ---ldflags "-X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.Version=v0.27.0-dev'"` tested without --version flag, works fine.
3. The new make target `build-plugin-local` tested: With valid plugin name `make build-plugin-local PLUGIN_NAME=package` works fine, builds the given plugin. Also tested with empty and in-valid PLUGIN_NAME, it does throw an error saying: `The PLUGIN_NAME: '' is not valid or not exists or empty, please provide valid PLUGIN_NAME.`
4. The new make target `install-plugin-local` tested: With valid plugin name `make install-plugin-local PLUGIN_NAME=login` works fine, build and install the given plugin. Also tested with empty and in-valid PLUGIN_NAME, it does throw an error saying: `The PLUGIN_NAME: '' is not valid or not exists or empty, please provide valid PLUGIN_NAME.`

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The command `tanzu builder cli compile` has been updated to make the flag `--version` as optional
New make target  `build-plugin-local` has been added to build the given plugin locally
New make target `install-plugin-local` has been added to build and install the given plugin locally
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
