### PR TITLE
Added feedback messages for successful execution of commands

### DIFF
--- a/cli/core/pkg/command/discovery_source.go
+++ b/cli/core/pkg/command/discovery_source.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/aunum/log"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -129,6 +131,7 @@ var addDiscoverySourceCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		log.Successf("successfully added discovery source %s", discoverySourceName)
 		return nil
 	},
 }
@@ -175,6 +178,7 @@ var updateDiscoverySourceCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		log.Successf("updated discovery source %s", discoveryName)
 		return nil
 	},
 }
@@ -211,6 +215,7 @@ var deleteDiscoverySourceCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		log.Successf("deleted discovery source %s", discoveryName)
 		return nil
 	},
 }

--- a/cli/core/pkg/command/plugin_manager.go
+++ b/cli/core/pkg/command/plugin_manager.go
@@ -366,7 +366,11 @@ var upgradePluginCmd = &cobra.Command{
 
 		versionSelector := repo.VersionSelector()
 		err = cli.UpgradePlugin(pluginName, plugin.FindVersion(versionSelector), repo)
-		return
+		if err != nil {
+			return err
+		}
+		log.Successf("successfully upgraded plugin %s", pluginName)
+		return nil
 	},
 }
 
@@ -402,8 +406,11 @@ var deletePluginCmd = &cobra.Command{
 		}
 
 		err = cli.DeletePlugin(pluginName)
-
-		return
+		if err != nil {
+			return err
+		}
+		log.Successf("successfully deleted plugin %s", pluginName)
+		return nil
 	},
 }
 
@@ -412,9 +419,20 @@ var cleanPluginCmd = &cobra.Command{
 	Short: "Clean the plugins",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		if config.IsFeatureActivated(config.FeatureContextAwareCLIForPlugins) {
-			return pluginmanager.Clean()
+			err = pluginmanager.Clean()
+			if err != nil {
+				return err
+			}
+			log.Success("successfully cleaned up all plugins")
+			return nil
 		}
-		return cli.Clean()
+
+		err = cli.Clean()
+		if err != nil {
+			return err
+		}
+		log.Success("successfully cleaned up all plugins")
+		return nil
 	},
 }
 

--- a/cli/core/pkg/command/repo.go
+++ b/cli/core/pkg/command/repo.go
@@ -6,6 +6,8 @@ package command
 import (
 	"fmt"
 
+	"github.com/aunum/log"
+
 	"github.com/spf13/cobra"
 
 	configv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
@@ -104,6 +106,7 @@ var addRepoCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		log.Successf("successfully added repository %s", pluginRepo.GCPPluginRepository.Name)
 		return nil
 	},
 }
@@ -152,6 +155,7 @@ var updateRepoCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		log.Successf("successfully updated repository configuration for %s", repoName)
 		return nil
 	},
 }
@@ -191,6 +195,7 @@ var deleteRepoCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		log.Successf("successfully deleted repository %s", repoName)
 		return nil
 	},
 }


### PR DESCRIPTION
Added feedback messages for successful execution of plugin clean and plugin repo commands

### What this PR does / why we need it
This PR enhances the UX of the Tanzu CLI

### Which issue(s) this PR fixes
Fixes #744

### Describe testing done for PR
1. Built the code with the changes
2. Ran the following commands
```
tanzu plugin repo add -n core -b tanzu-cli-framework -p gcr.io
✔  successfully added repository core

tanzu plugin repo update -b tanzu-cli-framework core
✔  Successfully updated repository configuration for core

tanzu plugin repo delete core
✔  Successfully deleted repository core

tanzu plugin clean
✔  Successfully cleaned up all plugins
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Improved UX of the Tanzu CLI by adding success manages if commands complete successfully
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
