### PR TITLE
VSphereCPIConfig derives the insecure flags from the TLS thumbprint in cluster variable.

### DIFF
--- a/addons/controllers/cpi/vspherecpiconfig_utils.go
+++ b/addons/controllers/cpi/vspherecpiconfig_utils.go
@@ -120,8 +120,16 @@ func (r *VSphereCPIConfigReconciler) mapCPIConfigToDataValuesNonParavirtual( // 
 
 	d.Region = tryParseString(d.Region, c.Region)
 	d.Zone = tryParseString(d.Zone, c.Zone)
+
+	d.InsecureFlag = d.TLSThumbprint == ""
 	if c.Insecure != nil {
 		d.InsecureFlag = *c.Insecure
+	}
+	if !d.InsecureFlag && d.TLSThumbprint == "" {
+		return nil, errors.New("empty thumbprint is provided while TLS peer verification is enabled")
+	}
+	if d.InsecureFlag && d.TLSThumbprint != "" {
+		r.Log.Info("ignore provided thumbprint because TLS peer verification is disabled", "thumbprint", d.TLSThumbprint)
 	}
 
 	if c.VMNetwork != nil {

--- a/apis/addonconfigs/config/crd/bases/cpi.tanzu.vmware.com_vspherecpiconfigs.yaml
+++ b/apis/addonconfigs/config/crd/bases/cpi.tanzu.vmware.com_vspherecpiconfigs.yaml
@@ -57,7 +57,6 @@ spec:
                     description: The datacenter in which VMs are created/located
                     type: string
                   insecure:
-                    default: false
                     description: The flag that disables TLS peer verification
                     type: boolean
                   ipFamily:

--- a/apis/addonconfigs/cpi/v1alpha1/vspherecpiconfig_types.go
+++ b/apis/addonconfigs/cpi/v1alpha1/vspherecpiconfig_types.go
@@ -128,7 +128,6 @@ type NonParavirtualConfig struct {
 
 	// The flag that disables TLS peer verification
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:=false
 	Insecure *bool `json:"insecure,omitempty"`
 
 	// The IP family configuration

--- a/packages/addons-manager/bundle/config/upstream/addonconfigscrds/cpi.tanzu.vmware.com_vspherecpiconfigs.yaml
+++ b/packages/addons-manager/bundle/config/upstream/addonconfigscrds/cpi.tanzu.vmware.com_vspherecpiconfigs.yaml
@@ -57,7 +57,6 @@ spec:
                     description: The datacenter in which VMs are created/located
                     type: string
                   insecure:
-                    default: false
                     description: The flag that disables TLS peer verification
                     type: boolean
                   ipFamily:


### PR DESCRIPTION
### What this PR does / why we need it

This PR changes  the data values reconcile logics in the VSphereCPIConfig controller. 

First, in the reconcile loop, the `tlsthumbprint` will be resolved in the following priority

* `spec.vsphereCPI.thumbprint` in the VSphereCPIConfig CR that user specified
* `thumbprint` derived from the cluster variables

Second, the controller then determine the value of `insecureFlag`, and make it possible to be overriden if user specifies in `spec.vsphereCPI.insecure`.



### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

https://github.com/vmware-tanzu/tanzu-framework/issues/3381

This PR aims to fix cpi package reconcilation error `vsphereCPI tlsThumbprint should be provided when insecureFlag is False`

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
package-based-lcm: VSphereCPIConfig derives the insecure flags from the TLS thumbprint in cluster variable.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
