### PR TITLE
Fill plugin buildinfo variables

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -50,6 +50,11 @@ LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.Date=$(
 LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.SHA=$(BUILD_SHA)'
 LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.Version=$(BUILD_VERSION)'
 
+# Set buildinfo for plugins
+LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/cli/runtime/buildinfo.Date=$(BUILD_DATE)'
+LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/cli/runtime/buildinfo.SHA=$(BUILD_SHA)'
+LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/cli/runtime/buildinfo.Version=$(BUILD_VERSION)'
+
 # Add supported OS-ARCHITECTURE combinations here
 ENVS ?= linux-amd64 windows-amd64 darwin-amd64
 STANDALONE_PLUGINS ?= login management-cluster package pinniped-auth secret telemetry


### PR DESCRIPTION
### What this PR does / why we need it

#3261 added `buildinfo` variable to the new `cli/runtime` library that is meant to be used by plugins.
Since Framework's plugins are all built through the `Makefile`, those new `buildinfo` variables should be set by the `Makefile` so plugins can start using them transparently.

This PR sets those variables.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3344

### Describe testing done for PR

Before the PR:
1. Update the `test` plugin to use the new `github.com/vmware-tanzu/tanzu-framework/cli/runtime/buildinfo` (see #3328)
1. Build using `make build-plugin-admin-with-local-discovery` => this will fail with `output: ✖  plugin "test" version cannot be empty; version "test" "" is not a valid semantic version`
1. Apply this PR
2. `make build-plugin-admin-with-local-discovery` => this will now pass

### Additional information

As discussed directly with @yharish991, this change is pulled out of #3284 as it is needed by all plugins.

