### PR TITLE
Revert "Dev experience fixes for package-tools"

### DIFF
--- a/hack/packages/package-tools/cmd/package-bundle-generate.go
+++ b/hack/packages/package-tools/cmd/package-bundle-generate.go
@@ -31,7 +31,7 @@ var packageBundleGenerateCmd = &cobra.Command{
 func init() {
 	packageBundleCmd.AddCommand(packageBundleGenerateCmd)
 	packageBundleGenerateCmd.Flags().StringVar(&packageRepository, "repository", "", "Package repository of the package bundle being created")
-	packageBundleGenerateCmd.Flags().StringVar(&registry, "registry", constants.LocalRegistryURL, "OCI registry where the package bundle image needs to be stored")
+	packageBundleGenerateCmd.Flags().StringVar(&registry, "registry", "", "OCI registry where the package bundle image needs to be stored")
 	packageBundleGenerateCmd.Flags().StringVar(&version, "version", "", "Package bundle version")
 	packageBundleGenerateCmd.Flags().StringVar(&subVersion, "sub-version", "", "Package bundle subversion")
 	packageBundleGenerateCmd.Flags().BoolVar(&all, "all", false, "Generate all package bundles in a repository")
@@ -167,7 +167,6 @@ func generatePackageBundle(pkg *Package, projectRootDir, toolsBinDir, packageNam
 		fmt.Println("Including thick tarball...")
 		var cmdErr bytes.Buffer
 
-		packageURL := fmt.Sprintf("%s/%s:%s", registry, packageName, imagePackageVersion)
 		packageURL := fmt.Sprintf("%s/%s:%s", constants.LocalRegistryURL, packageName, imagePackageVersion)
 		imgpkgPushCmd := exec.Command(
 			filepath.Join(toolsBinDir, "imgpkg"),
@@ -230,7 +229,6 @@ func generatePackageBundles(projectRootDir, toolsBinDir string) error {
 			lockOutputFile := pkgVals.Repositories[repo].Packages[i].Name + "-" + imagePackageVersion + "-lock-output.yaml"
 			imgpkgCmd := exec.Command(
 				filepath.Join(toolsBinDir, "imgpkg"),
-				"push", "-b", registry+"/"+pkgVals.Repositories[repo].Packages[i].Name+":"+imagePackageVersion,
 				"push", "-b", constants.LocalRegistryURL+"/"+pkgVals.Repositories[repo].Packages[i].Name+":"+imagePackageVersion,
 				"--file", filepath.Join(packagePath, "bundle"),
 				"--lock-output", lockOutputFile,
@@ -256,7 +254,6 @@ func generatePackageBundles(projectRootDir, toolsBinDir string) error {
 			pkgVals.Repositories[repo].Packages[i].Version = formatVersion(&pkgVals.Repositories[repo].Packages[i], "_").version
 			pkgVals.Repositories[repo].Packages[i].Sha256 = utils.AfterString(
 				bundleLock.Bundle.Image,
-				registry+"/"+pkgVals.Repositories[repo].Packages[i].Name+"@sha256:",
 				constants.LocalRegistryURL+"/"+pkgVals.Repositories[repo].Packages[i].Name+"@sha256:",
 			)
 			yamlData, err := yaml.Marshal(&pkgVals)

--- a/hack/packages/package-tools/cmd/package-bundle-generate.go
+++ b/hack/packages/package-tools/cmd/package-bundle-generate.go
@@ -128,12 +128,10 @@ func generateSingleImgpkgLockOutput(toolsBinDir, packagePath string, envArray ..
 	kbldCmd.Stderr = &kbldCmdErrBytes
 	yttCmd.Stderr = &yttCmdErrBytes
 
-	fmt.Println("Running command: ", yttCmd.String())
 	if err := yttCmd.Start(); err != nil {
 		return fmt.Errorf("couldn't run ytt command: %w", err)
 	}
 
-	fmt.Println("Running command: ", kbldCmd.String())
 	if err := kbldCmd.Run(); err != nil {
 		return fmt.Errorf("couldn't run kbld command to generate imgpkg lock output file: %s", kbldCmdErrBytes.String())
 	}
@@ -170,6 +168,7 @@ func generatePackageBundle(pkg *Package, projectRootDir, toolsBinDir, packageNam
 		var cmdErr bytes.Buffer
 
 		packageURL := fmt.Sprintf("%s/%s:%s", registry, packageName, imagePackageVersion)
+		packageURL := fmt.Sprintf("%s/%s:%s", constants.LocalRegistryURL, packageName, imagePackageVersion)
 		imgpkgPushCmd := exec.Command(
 			filepath.Join(toolsBinDir, "imgpkg"),
 			"push",
@@ -177,7 +176,6 @@ func generatePackageBundle(pkg *Package, projectRootDir, toolsBinDir, packageNam
 			"--file", filepath.Join(packagePath, "bundle"),
 		) // #nosec G204
 		imgpkgPushCmd.Stderr = &cmdErr
-		fmt.Println("Running command: ", imgpkgPushCmd.String())
 		if err := imgpkgPushCmd.Run(); err != nil {
 			fmt.Println("cmd:", imgpkgPushCmd.String())
 			fmt.Println("err:", err)
@@ -192,7 +190,6 @@ func generatePackageBundle(pkg *Package, projectRootDir, toolsBinDir, packageNam
 			"--to-tar", filepath.Join(tarBallPath, tarBallFileName),
 		) // #nosec G204
 		imgpkgCopyCmd.Stderr = &cmdErr
-		fmt.Println("Running command: ", imgpkgCopyCmd.String())
 		if err := imgpkgCopyCmd.Run(); err != nil {
 			return fmt.Errorf("generating thick tarball: %s", cmdErr.String())
 		}
@@ -234,13 +231,13 @@ func generatePackageBundles(projectRootDir, toolsBinDir string) error {
 			imgpkgCmd := exec.Command(
 				filepath.Join(toolsBinDir, "imgpkg"),
 				"push", "-b", registry+"/"+pkgVals.Repositories[repo].Packages[i].Name+":"+imagePackageVersion,
+				"push", "-b", constants.LocalRegistryURL+"/"+pkgVals.Repositories[repo].Packages[i].Name+":"+imagePackageVersion,
 				"--file", filepath.Join(packagePath, "bundle"),
 				"--lock-output", lockOutputFile,
 			) // #nosec G204
 
 			var imgpkgCmdErrBytes bytes.Buffer
 			imgpkgCmd.Stderr = &imgpkgCmdErrBytes
-			fmt.Println("Running command: ", imgpkgCmd.String())
 			if err := imgpkgCmd.Run(); err != nil {
 				return fmt.Errorf("couldn't push the imgpkg bundle: %s", imgpkgCmdErrBytes.String())
 			}
@@ -260,6 +257,7 @@ func generatePackageBundles(projectRootDir, toolsBinDir string) error {
 			pkgVals.Repositories[repo].Packages[i].Sha256 = utils.AfterString(
 				bundleLock.Bundle.Image,
 				registry+"/"+pkgVals.Repositories[repo].Packages[i].Name+"@sha256:",
+				constants.LocalRegistryURL+"/"+pkgVals.Repositories[repo].Packages[i].Name+"@sha256:",
 			)
 			yamlData, err := yaml.Marshal(&pkgVals)
 			if err != nil {

--- a/hack/packages/package-tools/cmd/repo-bundle-generate.go
+++ b/hack/packages/package-tools/cmd/repo-bundle-generate.go
@@ -66,6 +66,7 @@ func runRepoBundleGenerate(cmd *cobra.Command, args []string) error {
 
 	if packageValuesFile == "" {
 		if err := generatePackageBundlesSha256(projectRootDir, registry); err != nil {
+		if err := generatePackageBundlesSha256(projectRootDir, constants.LocalRegistryURL); err != nil {
 			return fmt.Errorf("couldn't generate package-values-sha256.yaml: %w", err)
 		}
 		packageValuesFile = filepath.Join(projectRootDir, constants.PackageValuesSha256FilePath)

--- a/hack/packages/package-tools/cmd/repo-bundle-generate.go
+++ b/hack/packages/package-tools/cmd/repo-bundle-generate.go
@@ -65,7 +65,6 @@ func runRepoBundleGenerate(cmd *cobra.Command, args []string) error {
 	}
 
 	if packageValuesFile == "" {
-		if err := generatePackageBundlesSha256(projectRootDir, registry); err != nil {
 		if err := generatePackageBundlesSha256(projectRootDir, constants.LocalRegistryURL); err != nil {
 			return fmt.Errorf("couldn't generate package-values-sha256.yaml: %w", err)
 		}

--- a/hack/packages/package-tools/constants/constants.go
+++ b/hack/packages/package-tools/constants/constants.go
@@ -4,7 +4,7 @@
 package constants
 
 const (
-	// LocalRegistryURL is the url of the default local docker registry
+	// LocalRegistryURL is the url of the local docker registry
 	LocalRegistryURL = "localhost:5001"
 
 	// ToolsBinDirPath is the tools bin directory path

--- a/hack/packages/package-tools/utils/utils.go
+++ b/hack/packages/package-tools/utils/utils.go
@@ -40,7 +40,6 @@ func RunMakeTarget(path, target string, envArray ...string) error {
 	cmd.Stderr = &errBytes
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, envArray...)
-	fmt.Println("Running make target: ", cmd.String())
 	err := cmd.Run()
 	if err != nil {
 		return fmt.Errorf("couldn't run the make target %s: %s", target, errBytes.String())


### PR DESCRIPTION
This pr reverts vmware-tanzu/tanzu-framework#3132 as the changes in #3132 are breaking the downstream builds