### PR TITLE
Enqueue AddonConfig if Cluster event happens

### DIFF
--- a/addons/controllers/antrea/antreaconfig_controller.go
+++ b/addons/controllers/antrea/antreaconfig_controller.go
@@ -21,6 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	addonconfig "github.com/vmware-tanzu/tanzu-framework/addons/pkg/config"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
@@ -100,6 +102,10 @@ func (r *AntreaConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&cniv1alpha1.AntreaConfig{}).
 		WithOptions(options).
+		Watches(
+			&source.Kind{Type: &clusterapiv1beta1.Cluster{}},
+			handler.EnqueueRequestsFromMapFunc(r.ClusterToAntreaConfig),
+		).
 		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.AntreaConfigKind, r.Config.SystemNamespace, r.Log)).
 		Complete(r)
 }

--- a/addons/controllers/antrea/antreaconfig_util.go
+++ b/addons/controllers/antrea/antreaconfig_util.go
@@ -4,9 +4,18 @@
 package controllers
 
 import (
-	"github.com/pkg/errors"
-	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"context"
+	"fmt"
 
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterapiutil "sigs.k8s.io/cluster-api/util"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
 	cniv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/addonconfigs/cni/v1alpha1"
 )
@@ -79,6 +88,56 @@ type antreaFeatureGates struct {
 	AntreaIPAM         bool `yaml:"AntreaIPAM"`
 	ServiceExternalIP  bool `yaml:"ServiceExternalIP"`
 	Multicast          bool `yaml:"Multicast"`
+}
+
+// ClusterToAntreaConfig returns a list of Requests with AntreaConfig ObjectKey
+func (r *AntreaConfigReconciler) ClusterToAntreaConfig(o client.Object) []ctrl.Request {
+	cluster, ok := o.(*clusterv1beta1.Cluster)
+	if !ok {
+		r.Log.Error(errors.New("invalid type"),
+			"Expected to receive Cluster resource",
+			"actualType", fmt.Sprintf("%T", o))
+		return nil
+	}
+
+	r.Log.V(4).Info("Mapping cluster to AntreaConfig")
+
+	configs := &cniv1alpha1.AntreaConfigList{}
+
+	if err := r.Client.List(context.Background(), configs); err != nil {
+		r.Log.Error(err, "Error listing AntreaConfig")
+		return nil
+	}
+
+	var requests []ctrl.Request
+	for i := range configs.Items {
+		config := &configs.Items[i]
+		if config.Namespace == cluster.Namespace {
+			// avoid enqueuing reconcile requests for template AntreaConfig CRs in event handler of Cluster CR
+			if _, ok := config.Annotations[constants.TKGAnnotationTemplateConfig]; ok && config.Namespace == r.Config.SystemNamespace {
+				continue
+			}
+
+			// corresponding AntreaConfig should have following ownerRef
+			ownerReference := metav1.OwnerReference{
+				APIVersion: clusterv1beta1.GroupVersion.String(),
+				Kind:       cluster.Kind,
+				Name:       cluster.Name,
+				UID:        cluster.UID,
+			}
+
+			if clusterapiutil.HasOwnerRef(config.OwnerReferences, ownerReference) || config.Name == fmt.Sprintf("%s-%s-package", cluster.Name, constants.AntreaAddonName) {
+				r.Log.V(4).Info("Adding AntreaConfig for reconciliation",
+					constants.NamespaceLogKey, config.Namespace, constants.NameLogKey, config.Name)
+
+				requests = append(requests, ctrl.Request{
+					NamespacedName: clusterapiutil.ObjectKey(config),
+				})
+			}
+		}
+	}
+
+	return requests
 }
 
 func mapAntreaConfigSpec(cluster *clusterapiv1beta1.Cluster, config *cniv1alpha1.AntreaConfig) (*antreaConfigSpec, error) {

--- a/addons/controllers/calico/calicoconfig_controller.go
+++ b/addons/controllers/calico/calicoconfig_controller.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	addonconfig "github.com/vmware-tanzu/tanzu-framework/addons/pkg/config"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
@@ -98,6 +100,10 @@ func (r *CalicoConfigReconciler) SetupWithManager(ctx context.Context, mgr ctrl.
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&cniv1alpha1.CalicoConfig{}).
 		WithOptions(options).
+		Watches(
+			&source.Kind{Type: &clusterapiv1beta1.Cluster{}},
+			handler.EnqueueRequestsFromMapFunc(r.ClusterToCalicoConfig),
+		).
 		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.CalicoConfigKind, r.Config.SystemNamespace, r.Log)).
 		Complete(r)
 }

--- a/addons/controllers/cpi/vspherecpiconfig_controller.go
+++ b/addons/controllers/cpi/vspherecpiconfig_controller.go
@@ -233,8 +233,8 @@ func (r *VSphereCPIConfigReconciler) SetupWithManager(_ context.Context, mgr ctr
 		WithOptions(options).
 		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.VSphereCPIConfigKind, r.Config.SystemNamespace, r.Log)).
 		Watches(
-			&source.Kind{Type: &capvvmwarev1beta1.VSphereCluster{}},
-			handler.EnqueueRequestsFromMapFunc(r.VSphereClusterToVSphereCPIConfig),
+			&source.Kind{Type: &clusterapiv1beta1.Cluster{}},
+			handler.EnqueueRequestsFromMapFunc(r.ClusterToVSphereCPIConfig),
 		).
 		Complete(r)
 }

--- a/addons/controllers/cpi/vspherecpiconfig_utils.go
+++ b/addons/controllers/cpi/vspherecpiconfig_utils.go
@@ -30,9 +30,9 @@ import (
 	cpiv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/addonconfigs/cpi/v1alpha1"
 )
 
-// VSphereClusterToVSphereCPIConfig returns a list of Requests with VSphereCPIConfig ObjectKey based on Cluster events
-func (r *VSphereCPIConfigReconciler) VSphereClusterToVSphereCPIConfig(o client.Object) []ctrl.Request {
-	cluster, ok := o.(*capvvmwarev1beta1.VSphereCluster)
+// ClusterToVSphereCPIConfig returns a list of Requests with VSphereCPIConfig ObjectKey based on Cluster events
+func (r *VSphereCPIConfigReconciler) ClusterToVSphereCPIConfig(o client.Object) []ctrl.Request {
+	cluster, ok := o.(*clusterapiv1beta1.Cluster)
 	if !ok {
 		r.Log.Error(errors.New("invalid type"),
 			"Expected to receive Cluster resource",
@@ -40,7 +40,7 @@ func (r *VSphereCPIConfigReconciler) VSphereClusterToVSphereCPIConfig(o client.O
 		return nil
 	}
 
-	r.Log.V(4).Info("Mapping VSphereCluster to VSphereCPIConfig")
+	r.Log.V(4).Info("Mapping Cluster to VSphereCPIConfig")
 
 	cs := &cpiv1alpha1.VSphereCPIConfigList{}
 	_ = r.List(context.Background(), cs)

--- a/addons/controllers/csi/vspherecsiconfig_controller.go
+++ b/addons/controllers/csi/vspherecsiconfig_controller.go
@@ -96,7 +96,7 @@ func (r *VSphereCSIConfigReconciler) SetupWithManager(_ context.Context, mgr ctr
 		WithOptions(options).
 		Watches(
 			&source.Kind{Type: &capvvmwarev1beta1.VSphereCluster{}},
-			handler.EnqueueRequestsFromMapFunc(r.ClusterToVSphereCSIConfig),
+			handler.EnqueueRequestsFromMapFunc(r.VSphereClusterToVSphereCSIConfig),
 		).
 		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.VSphereCSIConfigKind, r.Config.SystemNamespace, r.Log)).
 		Build(r)

--- a/addons/controllers/csi/vspherecsiconfig_controller.go
+++ b/addons/controllers/csi/vspherecsiconfig_controller.go
@@ -15,6 +15,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	capvvmwarev1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
 	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterapiutil "sigs.k8s.io/cluster-api/util"
 	clusterapipatchutil "sigs.k8s.io/cluster-api/util/patch"

--- a/addons/controllers/csi/vspherecsiconfig_controller.go
+++ b/addons/controllers/csi/vspherecsiconfig_controller.go
@@ -94,6 +94,10 @@ func (r *VSphereCSIConfigReconciler) SetupWithManager(_ context.Context, mgr ctr
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(&csiv1alpha1.VSphereCSIConfig{}).
 		WithOptions(options).
+		Watches(
+			&source.Kind{Type: &clusterapiv1beta1.Cluster{}},
+			handler.EnqueueRequestsFromMapFunc(r.ClusterToVSphereCSIConfig),
+		).
 		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.VSphereCSIConfigKind, r.Config.SystemNamespace, r.Log)).
 		Build(r)
 	if err != nil {
@@ -139,8 +143,8 @@ func (r *VSphereCSIConfigReconciler) SetupWithManager(_ context.Context, mgr ctr
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
 func (r *VSphereCSIConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	r.Log = r.Log.WithValues("VSphereCSIConfig", req.NamespacedName)
-	ctx = logr.NewContext(ctx, r.Log)
+	l := r.Log.WithValues("VSphereCSIConfig", req.NamespacedName)
+	ctx = logr.NewContext(ctx, l)
 	logger := log.FromContext(ctx)
 
 	vcsiConfig := &csiv1alpha1.VSphereCSIConfig{}

--- a/addons/controllers/csi/vspherecsiconfig_controller.go
+++ b/addons/controllers/csi/vspherecsiconfig_controller.go
@@ -15,7 +15,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	capvvmwarev1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/vmware/v1beta1"
 	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterapiutil "sigs.k8s.io/cluster-api/util"
 	clusterapipatchutil "sigs.k8s.io/cluster-api/util/patch"
@@ -96,8 +95,8 @@ func (r *VSphereCSIConfigReconciler) SetupWithManager(_ context.Context, mgr ctr
 		For(&csiv1alpha1.VSphereCSIConfig{}).
 		WithOptions(options).
 		Watches(
-			&source.Kind{Type: &capvvmwarev1beta1.VSphereCluster{}},
-			handler.EnqueueRequestsFromMapFunc(r.VSphereClusterToVSphereCSIConfig),
+			&source.Kind{Type: &clusterapiv1beta1.Cluster{}},
+			handler.EnqueueRequestsFromMapFunc(r.ClusterToVSphereCSIConfig),
 		).
 		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.VSphereCSIConfigKind, r.Config.SystemNamespace, r.Log)).
 		Build(r)

--- a/addons/controllers/csi/vspherecsiconfig_controller.go
+++ b/addons/controllers/csi/vspherecsiconfig_controller.go
@@ -95,7 +95,7 @@ func (r *VSphereCSIConfigReconciler) SetupWithManager(_ context.Context, mgr ctr
 		For(&csiv1alpha1.VSphereCSIConfig{}).
 		WithOptions(options).
 		Watches(
-			&source.Kind{Type: &clusterapiv1beta1.Cluster{}},
+			&source.Kind{Type: &capvvmwarev1beta1.VSphereCluster{}},
 			handler.EnqueueRequestsFromMapFunc(r.ClusterToVSphereCSIConfig),
 		).
 		WithEventFilter(predicates.ConfigOfKindWithoutAnnotation(constants.TKGAnnotationTemplateConfig, constants.VSphereCSIConfigKind, r.Config.SystemNamespace, r.Log)).

--- a/addons/controllers/csi/vspherecsiconfig_utils.go
+++ b/addons/controllers/csi/vspherecsiconfig_utils.go
@@ -29,8 +29,8 @@ import (
 	topologyv1alpha1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 )
 
-// ClusterToVSphereCSIConfig returns a list of Requests with VSphereCSIConfig ObjectKey
-func (r *VSphereCSIConfigReconciler) ClusterToVSphereCSIConfig(o client.Object) []ctrl.Request {
+// VSphereClusterToVSphereCSIConfig returns a list of Requests with VSphereCSIConfig ObjectKey
+func (r *VSphereCSIConfigReconciler) VSphereClusterToVSphereCSIConfig(o client.Object) []ctrl.Request {
 	cluster, ok := o.(*capvvmwarev1beta1.VSphereCluster)
 	if !ok {
 		r.Log.Error(errors.New("invalid type"),

--- a/addons/controllers/csi/vspherecsiconfig_utils.go
+++ b/addons/controllers/csi/vspherecsiconfig_utils.go
@@ -31,7 +31,7 @@ import (
 
 // ClusterToVSphereCSIConfig returns a list of Requests with VSphereCSIConfig ObjectKey
 func (r *VSphereCSIConfigReconciler) ClusterToVSphereCSIConfig(o client.Object) []ctrl.Request {
-	cluster, ok := o.(*clusterv1beta1.Cluster)
+	cluster, ok := o.(*capvvmwarev1beta1.VSphereCluster)
 	if !ok {
 		r.Log.Error(errors.New("invalid type"),
 			"Expected to receive Cluster resource",

--- a/addons/controllers/csi/vspherecsiconfig_utils.go
+++ b/addons/controllers/csi/vspherecsiconfig_utils.go
@@ -29,9 +29,9 @@ import (
 	topologyv1alpha1 "github.com/vmware-tanzu/vm-operator/external/tanzu-topology/api/v1alpha1"
 )
 
-// VSphereClusterToVSphereCSIConfig returns a list of Requests with VSphereCSIConfig ObjectKey
-func (r *VSphereCSIConfigReconciler) VSphereClusterToVSphereCSIConfig(o client.Object) []ctrl.Request {
-	cluster, ok := o.(*capvvmwarev1beta1.VSphereCluster)
+// ClusterToVSphereCSIConfig returns a list of Requests with VSphereCSIConfig ObjectKey
+func (r *VSphereCSIConfigReconciler) ClusterToVSphereCSIConfig(o client.Object) []ctrl.Request {
+	cluster, ok := o.(*clusterv1beta1.Cluster)
 	if !ok {
 		r.Log.Error(errors.New("invalid type"),
 			"Expected to receive Cluster resource",
@@ -39,7 +39,7 @@ func (r *VSphereCSIConfigReconciler) VSphereClusterToVSphereCSIConfig(o client.O
 		return nil
 	}
 
-	r.Log.V(4).Info("Mapping cluster to VSphereCSIConfig")
+	r.Log.V(4).Info("Mapping Cluster to VSphereCSIConfig")
 
 	configs := &csiv1alpha1.VSphereCSIConfigList{}
 

--- a/addons/controllers/kapp-controller/kappcontrollerconfig_handlers.go
+++ b/addons/controllers/kapp-controller/kappcontrollerconfig_handlers.go
@@ -43,7 +43,7 @@ func (r *KappControllerConfigReconciler) ClusterToKappControllerConfig(o client.
 	for i := range KappControllerConfigList.Items {
 		config := &KappControllerConfigList.Items[i]
 		if config.Namespace == cluster.Namespace {
-			// avoid enqueuing reconcile requests for template vSphereCSIConfig CRs in event handler of Cluster CR
+			// avoid enqueuing reconcile requests for template KappControllerConfig CRs in event handler of Cluster CR
 			if _, ok := config.Annotations[constants.TKGAnnotationTemplateConfig]; ok && config.Namespace == r.Config.SystemNamespace {
 				continue
 			}


### PR DESCRIPTION
### What this PR does / why we need it
Follow up of https://github.com/vmware-tanzu/tanzu-framework/pull/3318
For CNI, CSI, KAPP controller, enqueue relative config if cluster event happens.
Since the controller also depends on the Cluster object
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR


### Release note

```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
