### PR TITLE
Add --all-namespaces to tanzu cluster list command

### DIFF
--- a/cmd/cli/plugin/cluster/list.go
+++ b/cmd/cli/plugin/cluster/list.go
@@ -17,9 +17,10 @@ import (
 )
 
 type listClusterOptions struct {
-	namespace    string
-	includeMC    bool
-	outputFormat string
+	namespace     string
+	includeMC     bool
+	outputFormat  string
+	allNamespaces bool
 }
 
 var lc = &listClusterOptions{}
@@ -32,7 +33,8 @@ var listClustersCmd = &cobra.Command{
 }
 
 func init() {
-	listClustersCmd.Flags().StringVarP(&lc.namespace, "namespace", "n", "", "The namespace from which to list workload clusters. If not provided clusters from all namespaces will be returned")
+	listClustersCmd.Flags().StringVarP(&lc.namespace, "namespace", "n", "default", "The namespace from which to list workload clusters. If not provided clusters from default namespace will be returned")
+	listClustersCmd.Flags().BoolVarP(&lc.allNamespaces, "all-namespaces", "A", false, "If present, list the cluster(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	listClustersCmd.Flags().BoolVarP(&lc.includeMC, "include-management-cluster", "", false, "Show active management cluster information as well")
 	listClustersCmd.Flags().StringVarP(&lc.outputFormat, "output", "o", "", "Output format (yaml|json|table)")
 }
@@ -57,9 +59,10 @@ func listClusters(cmd *cobra.Command, server *configapi.Server) error {
 	}
 
 	ccOptions := tkgctl.ListTKGClustersOptions{
-		ClusterName: "",
-		Namespace:   lc.namespace,
-		IncludeMC:   lc.includeMC,
+		ClusterName:   "",
+		Namespace:     lc.namespace,
+		IncludeMC:     lc.includeMC,
+		AllNamespaces: lc.allNamespaces,
 	}
 
 	clusters, err := tkgctlClient.GetClusters(ccOptions)

--- a/tkg/tkgctl/get_cluster.go
+++ b/tkg/tkgctl/get_cluster.go
@@ -16,9 +16,10 @@ import (
 
 // ListTKGClustersOptions ptions passed while getting a list of TKG Clusters
 type ListTKGClustersOptions struct {
-	ClusterName string
-	Namespace   string
-	IncludeMC   bool
+	ClusterName   string
+	Namespace     string
+	IncludeMC     bool
+	AllNamespaces bool
 }
 
 // GetClusters returns list of cluster
@@ -34,12 +35,17 @@ func (t *tkgctl) GetClusters(options ListTKGClustersOptions) ([]client.ClusterIn
 			return nil, errors.Wrap(err, fmt.Sprintf(constants.ErrorMsgFeatureGateStatus, constants.ClusterClassFeature, constants.TKGSClusterClassNamespace))
 		}
 	}
+	namespace := options.Namespace
+	allNamespaces := options.AllNamespaces
+	// if allNamespaces is present, namespace in current context is ignored even if specified with --namespace.
+	if allNamespaces {
+		namespace = ""
+	}
 	listTKGClustersOptions := client.ListTKGClustersOptions{
-		Namespace:                          options.Namespace,
+		Namespace:                          namespace,
 		IncludeMC:                          options.IncludeMC,
 		IsTKGSClusterClassFeatureActivated: isTKGSClusterClassFeatureActivated,
 	}
-
 	clusters, err := t.tkgClient.ListTKGClusters(listTKGClustersOptions)
 	if err != nil {
 		return nil, err

--- a/tkg/tkgctl/get_cluster_test.go
+++ b/tkg/tkgctl/get_cluster_test.go
@@ -42,10 +42,12 @@ var _ = Describe("Unit test for get clusters", func() {
 			Expect(err.Error()).To(ContainSubstring("fake-error"))
 		})
 	})
-	Context("when the management cluster is not Pacific(TKGS) supervisor cluster and is able to list clusters", func() {
+	Context("when the management cluster is not Pacific(TKGS) supervisor cluster and is able to list clusters with option --AllNamespace false", func() {
 		BeforeEach(func() {
+			ops.AllNamespaces = false
+			ops.Namespace = "default"
 			tkgClient.IsPacificManagementClusterReturns(false, nil)
-			tkgClient.ListTKGClustersReturns([]client.ClusterInfo{{Name: "my-cluster", Namespace: "default"}, {Name: "my-cluster-2", Namespace: "my-system"}}, nil)
+			tkgClient.ListTKGClustersReturns([]client.ClusterInfo{{Name: "my-cluster", Namespace: "default"}}, nil)
 		})
 		It("should not return an error", func() {
 			Expect(err).ToNot(HaveOccurred())
@@ -98,6 +100,18 @@ var _ = Describe("Unit test for get clusters", func() {
 			Expect(err).ToNot(HaveOccurred())
 			options := tkgClient.ListTKGClustersArgsForCall(3)
 			Expect(options.IsTKGSClusterClassFeatureActivated).To(BeTrue())
+		})
+	})
+	Context("when the management cluster is not Pacific(TKGS) supervisor cluster and the listCluster with --AllNamespace", func() {
+		BeforeEach(func() {
+			ops.AllNamespaces = true
+			tkgClient.IsPacificManagementClusterReturns(false, nil)
+			tkgClient.ListTKGClustersReturns([]client.ClusterInfo{{Name: "my-cluster", Namespace: "default"}, {Name: "my-cluster-2", Namespace: "my-system"}}, nil)
+		})
+		It("should not return an error", func() {
+			Expect(err).ToNot(HaveOccurred())
+			options := tkgClient.ListTKGClustersArgsForCall(0)
+			Expect(options.IsTKGSClusterClassFeatureActivated).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
### What this PR does / why we need it

### Which issue(s) this PR fixes

The namespace from which to list workload clusters. If not provided clusters from the default namespace will be returned.
if allNamespaces parameter is present, the namespace in the current context is ignored even if specified with --namespace
