### PR TITLE
identify if valid info is present in cmd out

### DIFF
--- a/cmd/cli/plugin-admin/builder/command/cli_compile.go
+++ b/cmd/cli/plugin-admin/builder/command/cli_compile.go
@@ -13,7 +13,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync"
 	"time"
 
@@ -267,18 +266,8 @@ func buildPlugin(path string, arch cli.Arch, id string) (plugin, error) {
 	var desc cliv1alpha1.PluginDescriptor
 	err = json.Unmarshal(b, &desc)
 	if err != nil {
-		// try to identify if a json info is present in the command output
-		i := strings.Index(string(b), "{")
-		if i < 0 {
-			log.Errorf("%s - error unmarshalling plugin descriptor: %v", id, err)
-			return plugin{}, err
-		}
-		newB := string(b)[i:]
-		if berr := json.Unmarshal([]byte(newB), &desc); berr != nil {
-			// initial error is return due to backup flow fail as well
-			log.Errorf("%s - error unmarshalling plugin descriptor: %v", id, err)
-			return plugin{}, err
-		}
+		log.Errorf("%s - error unmarshalling plugin descriptor: %v", id, err)
+		return plugin{}, err
 	}
 
 	testPath := filepath.Join(path, "test")

--- a/cmd/cli/plugin-admin/builder/command/cli_compile.go
+++ b/cmd/cli/plugin-admin/builder/command/cli_compile.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -266,8 +267,18 @@ func buildPlugin(path string, arch cli.Arch, id string) (plugin, error) {
 	var desc cliv1alpha1.PluginDescriptor
 	err = json.Unmarshal(b, &desc)
 	if err != nil {
-		log.Errorf("%s - error unmarshalling plugin descriptor: %v", id, err)
-		return plugin{}, err
+		// try to identify if a json info is present in the command output
+		i := strings.Index(string(b), "{")
+		if i < 0 {
+			log.Errorf("%s - error unmarshalling plugin descriptor: %v", id, err)
+			return plugin{}, err
+		}
+		newB := string(b)[i:]
+		if berr := json.Unmarshal([]byte(newB), &desc); berr != nil {
+			// initial error is return due to backup flow fail as well
+			log.Errorf("%s - error unmarshalling plugin descriptor: %v", id, err)
+			return plugin{}, err
+		}
 	}
 
 	testPath := filepath.Join(path, "test")


### PR DESCRIPTION
### What this PR does / why we need it

Adds an extra validation in the builder to try to identify if a valid info is produced by a plugin

### Which issue(s) this PR fixes

Fixes #3393

### Describe testing done for PR

Compile [apps cli plugin](https://github.com/vmware-tanzu/apps-cli-plugin/tree/v0.9.0) with environment variable `export CGO_ENABLED=1` and latest [Xcode 14](https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes) command line tools

![image](https://user-images.githubusercontent.com/2386675/190831484-7e651492-d7de-4169-834f-b9b48c2eb464.png)


![image](https://user-images.githubusercontent.com/2386675/190831469-25fbce3c-d3ba-4880-86dd-039428f80e16.png)


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
