### PR TITLE
Read config variable from mgmt cluster into cleanup cluster when deleting mgmt cluster

### DIFF
--- a/tkg/client/delete_region.go
+++ b/tkg/client/delete_region.go
@@ -152,6 +152,15 @@ func (c *TkgClient) DeleteRegion(options DeleteRegionOptions) error { //nolint:f
 
 		// If clusterclass feature flag is enabled then deploy management components
 		if config.IsFeatureActivated(config.FeatureFlagPackageBasedLCM) {
+			// Read config variable from management cluster and set it into cleanup cluster
+			configValues, err := c.getUserConfigVariableValueMapFromSecret(regionContext.SourceFilePath, regionContext.ContextName)
+			if err != nil {
+				return errors.Wrap(err, "unable to get config variables from management cluster")
+			}
+			for k, v := range configValues {
+				// Handle bool, int and string
+				c.TKGConfigReaderWriter().Set(k, fmt.Sprint(v))
+			}
 			if err = c.InstallOrUpgradeManagementComponents(cleanupClusterKubeconfigPath, "", false); err != nil {
 				return errors.Wrap(err, "unable to install management components to bootstrap cluster")
 			}

--- a/tkg/client/management_components.go
+++ b/tkg/client/management_components.go
@@ -106,7 +106,7 @@ func (c *TkgClient) getTKGPackageConfigValuesFile(managementPackageVersion, kube
 	var err error
 
 	if upgrade {
-		userProviderConfigValues, err = c.getUserConfigVariableValueMapForUpgrade(kubeconfig, kubecontext)
+		userProviderConfigValues, err = c.getUserConfigVariableValueMapFromSecret(kubeconfig, kubecontext)
 	} else {
 		userProviderConfigValues, err = c.getUserConfigVariableValueMap()
 	}
@@ -137,7 +137,7 @@ func (c *TkgClient) getUserConfigVariableValueMap() (map[string]interface{}, err
 	return c.GetUserConfigVariableValueMap(path, c.TKGConfigReaderWriter())
 }
 
-func (c *TkgClient) getUserConfigVariableValueMapForUpgrade(kubeconfig, kubecontext string) (map[string]interface{}, error) {
+func (c *TkgClient) getUserConfigVariableValueMapFromSecret(kubeconfig, kubecontext string) (map[string]interface{}, error) {
 	clusterClient, err := clusterclient.NewClient(kubeconfig, kubecontext, clusterclient.Options{})
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get cluster client")


### PR DESCRIPTION
### What this PR does / why we need it

When deleting management cluster, fetch tkg-tkp-tkg-system-values from mgmt cluster and configure it onto the cleanup cluster before install management packages.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3420 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
