### PR TITLE
Setting IsOfficialBuild variable inside tkg module during build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ OCI_REGISTRY ?= projects.registry.vmware.com/tanzu_framework
 
 # TODO: Change package path to cli/runtime when this var is moved there.
 LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/pkg/v1/buildinfo.IsOfficialBuild=$(IS_OFFICIAL_BUILD)'
+LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/tkg/buildinfo.IsOfficialBuild=$(IS_OFFICIAL_BUILD)'
 
 ifneq ($(strip $(TANZU_CORE_BUCKET)),)
 LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/cli/core/pkg/config.CoreBucketName=$(TANZU_CORE_BUCKET)'

--- a/cli/core/Makefile
+++ b/cli/core/Makefile
@@ -73,6 +73,7 @@ endif
 
 
 LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/cli/core/pkg/buildinfo.IsOfficialBuild=$(IS_OFFICIAL_BUILD)'
+LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/tkg/buildinfo.IsOfficialBuild=$(IS_OFFICIAL_BUILD)'
 
 ifneq ($(strip $(TANZU_CORE_BUCKET)),)
 LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/cli/core/pkg/config.CoreBucketName=$(TANZU_CORE_BUCKET)'


### PR DESCRIPTION
Signed-off-by: Sathyanarayanan Saravanamuthu <sathyanarays@vmware.com>

### What this PR does / why we need it
Setting IsOfficialBuild variable inside `tkg` module during build time

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3427 
Related to PR  #3294

### Describe testing done for PR
 In Progress
<!-- Example: Created vSphere workload cluster to verify change. -->
