### PR TITLE
Fix linter issues

### DIFF
--- a/cmd/cli/plugin-admin/test/test/main.go
+++ b/cmd/cli/plugin-admin/test/test/main.go
@@ -19,7 +19,7 @@ func main() {
 	defer Cleanup()
 	p, err := plugin.NewPlugin(descriptor)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal(err) //nolint:gocritic
 	}
 	p.Cmd.RunE = test
 	if err := p.Execute(); err != nil {

--- a/cmd/cli/plugin/login/main.go
+++ b/cmd/cli/plugin/login/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/cli/runtime/plugin"
 )
 
+//nolint: gocritic
 // Note: Shall be deprecated in a future version. Superseded by 'tanzu context' command.
 var descriptor = cliapi.PluginDescriptor{
 	Name:        "login",

--- a/tkg/azure/client.go
+++ b/tkg/azure/client.go
@@ -3,6 +3,7 @@
 
 package azure
 
+//nolint:staticcheck
 import (
 	"context"
 	"strings"

--- a/tkg/azure/client_test.go
+++ b/tkg/azure/client_test.go
@@ -3,6 +3,7 @@
 
 package azure
 
+//nolint:staticcheck
 import (
 	"context"
 	"errors"

--- a/tkg/client/delete_region.go
+++ b/tkg/client/delete_region.go
@@ -467,7 +467,7 @@ func (c *TkgClient) cleanUpAVIResourcesInManagementCluster(regionalClusterClient
 	if !ok {
 		return errors.Errorf("management cluster %s ako add-on secret yaml data parse error", clusterName)
 	}
-	akoSetting["delete_config"] = "true"
+	akoSetting["delete_config"] = trueStr
 	akoAddonSecretData, err = yaml.Marshal(&values)
 	if err != nil {
 		return err

--- a/tkg/client/get_cluster_pinniped_info.go
+++ b/tkg/client/get_cluster_pinniped_info.go
@@ -76,7 +76,7 @@ func (c *TkgClient) GetWCClusterPinnipedInfo(regionalClusterClient clusterclient
 		return nil, errors.Wrap(err, "failed to get workload cluster information")
 	}
 
-	// The existing PinnipedInfoConfigMap struct is a marshalled form of a
+	// The existing PinnipedInfoConfigMap struct is a marshaled form of a
 	// ConfigMap. Marshal and unmarshal the raw CM into that struct so we can
 	// use it.
 	// TODO(mayankbh) This is a shorter term approach. The _right_ thing might
@@ -98,7 +98,7 @@ func (c *TkgClient) GetWCClusterPinnipedInfo(regionalClusterClient clusterclient
 	managementClusterPinnipedInfo := &utils.PinnipedConfigMapInfo{}
 
 	// Really, this should never fail unless we're doing something silly like
-	// marshalling a channel/function. Which we aren't.
+	// marshaling a channel/function. Which we aren't.
 	if err := json.Unmarshal(marshalledCM, managementClusterPinnipedInfo); err != nil {
 		return nil, errors.New("failed to unmarshal pinniped-info from management cluster")
 	}

--- a/tkg/client/init.go
+++ b/tkg/client/init.go
@@ -430,7 +430,6 @@ func (c *TkgClient) PatchClusterInitOperations(regionalClusterClient clusterclie
 			return errors.Wrap(err, "unable to remove kapp-controller labels from the clusterclass resources")
 		}
 	}
-
 	return err
 }
 
@@ -445,7 +444,6 @@ func (c *TkgClient) MoveObjects(fromKubeconfigPath, toKubeconfigPath, namespace 
 }
 
 func (c *TkgClient) ensureKindCluster(kubeconfig string, useExistingCluster bool, backupPath string) (string, error) {
-
 	// skip if using existing cluster
 	if useExistingCluster {
 		if kubeconfig == "" {

--- a/tkg/client/machine_deployment_cc.go
+++ b/tkg/client/machine_deployment_cc.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/tkg/clusterclient"
 )
 
+//nolint:funlen,gocyclo
 func DoSetMachineDeploymentCC(clusterClient clusterclient.Client, cluster *capi.Cluster, options *SetMachineDeploymentOptions) error {
 	var update *capi.MachineDeploymentTopology
 	var base *capi.MachineDeploymentTopology
@@ -127,6 +128,7 @@ func DoSetMachineDeploymentCC(clusterClient clusterclient.Client, cluster *capi.
 	return createNewMachineDeployment(clusterClient, cluster, options, base)
 }
 
+//nolint:gocyclo
 func createNewMachineDeployment(clusterClient clusterclient.Client, cluster *capi.Cluster, options *SetMachineDeploymentOptions, base *capi.MachineDeploymentTopology) error {
 	if options.NodeMachineType != "" {
 		var workerVariable = getClusterVariableByName("worker", base.Variables.Overrides)
@@ -214,6 +216,7 @@ func createNewMachineDeployment(clusterClient clusterclient.Client, cluster *cap
 	return clusterClient.UpdateResource(cluster, options.ClusterName, options.Namespace)
 }
 
+//nolint:gocyclo
 func setVSphereVCenterOptions(options *SetMachineDeploymentOptions, base *capi.MachineDeploymentTopology, cluster *capi.Cluster) error {
 	if options.VSphere.CloneMode != "" || options.VSphere.Datacenter != "" || options.VSphere.Datastore != "" ||
 		options.VSphere.Folder != "" || options.VSphere.Network != "" || options.VSphere.ResourcePool != "" ||

--- a/tkg/client/machine_deployment_cc_test.go
+++ b/tkg/client/machine_deployment_cc_test.go
@@ -16,10 +16,13 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/tkg/fakes"
 )
 
+//nolint:goimports
 const (
-	md0Name     = "md-0"
-	md1Name     = "md-1"
-	unknownName = "unknown"
+	md0Name      = "md-0"
+	md1Name      = "md-1"
+	unknownName  = "unknown"
+	osNameUbuntu = "os-name=ubuntu"
+	tkgWorker    = "tkg-worker"
 )
 
 var _ = Describe("GetMachineDeploymentCC", func() {
@@ -441,7 +444,7 @@ var _ = Describe("SetMachineDeploymentCC", func() {
 								{
 									Name:     md0Name,
 									Replicas: func(i int32) *int32 { return &i }(1),
-									Class:    "tkg-worker",
+									Class:    tkgWorker,
 									Variables: &capi.MachineDeploymentVariables{
 										Overrides: []capi.ClusterVariable{
 											{
@@ -456,7 +459,7 @@ var _ = Describe("SetMachineDeploymentCC", func() {
 								{
 									Name:     md1Name,
 									Replicas: func(i int32) *int32 { return &i }(2),
-									Class:    "tkg-worker",
+									Class:    tkgWorker,
 									Variables: &capi.MachineDeploymentVariables{
 										Overrides: []capi.ClusterVariable{
 											{
@@ -507,8 +510,8 @@ var _ = Describe("SetMachineDeploymentCC", func() {
 		Context("without a base machine deployment", func() {
 			BeforeEach(func() {
 				options.NodeMachineType = "t3.large"
-				options.WorkerClass = "tkg-worker"
-				options.TKRResolver = "os-name=ubuntu"
+				options.WorkerClass = tkgWorker
+				options.TKRResolver = osNameUbuntu
 			})
 
 			It("should populate the machine deployment", func() {
@@ -565,8 +568,8 @@ var _ = Describe("SetMachineDeploymentCC", func() {
 				options.VSphere.StoragePolicyName = "policy"
 				options.VSphere.VCIP = "1.1.1.1"
 
-				options.WorkerClass = "tkg-worker"
-				options.TKRResolver = "os-name=ubuntu"
+				options.WorkerClass = tkgWorker
+				options.TKRResolver = osNameUbuntu
 			})
 
 			It("should populate the vsphere machine", func() {
@@ -621,12 +624,12 @@ var _ = Describe("SetMachineDeploymentCC", func() {
 								{
 									Name:     md0Name,
 									Replicas: func(i int32) *int32 { return &i }(1),
-									Class:    "tkg-worker",
+									Class:    tkgWorker,
 								},
 								{
 									Name:     md1Name,
 									Replicas: func(i int32) *int32 { return &i }(2),
-									Class:    "tkg-worker",
+									Class:    tkgWorker,
 								},
 							},
 						},

--- a/tkg/client/package_helper.go
+++ b/tkg/client/package_helper.go
@@ -28,7 +28,7 @@ func GetClusterBootstrap(managementClusterClient clusterclient.Client, clusterNa
 }
 
 // GetCorePackagesFromClusterBootstrap returns addon's core packages details from the given ClusterBootstrap object
-func GetCorePackagesFromClusterBootstrap(regionalClusterClient clusterclient.Client, workloadClusterClient clusterclient.Client, clusterBootstrap *runtanzuv1alpha3.ClusterBootstrap, corePackagesNamespace, clusterName string) ([]kapppkgv1alpha1.Package, error) {
+func GetCorePackagesFromClusterBootstrap(regionalClusterClient clusterclient.Client, workloadClusterClient clusterclient.Client, clusterBootstrap *runtanzuv1alpha3.ClusterBootstrap, corePackagesNamespace, clusterName string) ([]kapppkgv1alpha1.Package, error) { //nolint:gocritic
 	var packages []kapppkgv1alpha1.Package
 	// kapp package is installed in management cluster, in namespace in which workload cluster created
 	if isPackageExists(clusterBootstrap.Spec.Kapp) {
@@ -92,12 +92,12 @@ func GeneratePackageInstallName(clusterName, addonName string) string {
 }
 
 // MonitorAddonsCorePackageInstallation monitors addon's core packages (kapp, cni, csi and cpi) and returns error if any while monitoring packages or any packages are not installed successfully. First it monitors kapp package in management cluster then it monitors other core packages in workload cluster.
-func MonitorAddonsCorePackageInstallation(regionalClusterClient clusterclient.Client, workloadClusterClient clusterclient.Client, packages []kapppkgv1alpha1.Package, packageInstallTimeout time.Duration) error {
+func MonitorAddonsCorePackageInstallation(regionalClusterClient clusterclient.Client, workloadClusterClient clusterclient.Client, packages []kapppkgv1alpha1.Package, packageInstallTimeout time.Duration) error { //nolint:gocritic
 	if len(packages) == 0 {
 		return nil
 	}
 	var corePackagesOnWorkloadCluster, corePackagesOnManagementCluster []kapppkgv1alpha1.Package
-	for _, currentPackage := range packages {
+	for _, currentPackage := range packages { //nolint:gocritic
 		if strings.Contains(currentPackage.ObjectMeta.Name, "kapp-controller") {
 			corePackagesOnManagementCluster = append(corePackagesOnManagementCluster, currentPackage)
 		} else {
@@ -117,7 +117,7 @@ func WaitForPackagesInstallation(clusterClient clusterclient.Client, packages []
 	// we are using currentClusterClient which will point to correct cluster
 	group, _ := errgroup.WithContext(context.Background())
 
-	for _, currentPackage := range packages {
+	for _, currentPackage := range packages { //nolint:gocritic
 		pn := currentPackage.ObjectMeta.Name
 		ns := currentPackage.ObjectMeta.Namespace
 		log.V(3).Warningf("waiting for package: '%s'", pn)

--- a/tkg/client/upgrade_cluster.go
+++ b/tkg/client/upgrade_cluster.go
@@ -763,7 +763,7 @@ func isNewAzureTemplateRequired(machineTemplate *capzv1beta1.AzureMachineTemplat
 		return true
 	}
 
-	if isSharedGalleryImage(&clusterUpgradeConfig.UpgradeComponentInfo.AzureImage) && // nolint:dupl
+	if isSharedGalleryImage(&clusterUpgradeConfig.UpgradeComponentInfo.AzureImage) && //nolint:dupl
 		(machineTemplate.Spec.Template.Spec.Image.SharedGallery == nil ||
 			machineTemplate.Spec.Template.Spec.Image.SharedGallery.ResourceGroup != clusterUpgradeConfig.UpgradeComponentInfo.AzureImage.ResourceGroup ||
 			machineTemplate.Spec.Template.Spec.Image.SharedGallery.Name != clusterUpgradeConfig.UpgradeComponentInfo.AzureImage.Name ||

--- a/tkg/client/upgrade_cluster_test.go
+++ b/tkg/client/upgrade_cluster_test.go
@@ -206,8 +206,8 @@ var _ = Describe("Unit tests for upgrading legacy cluster", func() {
 
 	Describe("When upgrading cluster", func() {
 		BeforeEach(func() {
-			newK8sVersion = "v1.18.0+vmware.1"     // nolint:goconst
-			currentK8sVersion = "v1.17.3+vmware.2" // nolint:goconst
+			newK8sVersion = "v1.18.0+vmware.1"
+			currentK8sVersion = "v1.17.3+vmware.2"
 			setupBomFile("../fakes/config/bom/tkg-bom-v1.3.1.yaml", testingDir)
 			setupBomFile("../fakes/config/bom/tkr-bom-v1.18.0+vmware.1-tkg.2.yaml", testingDir)
 			regionalClusterClient.GetKCPObjectForClusterReturns(getDummyKCP(constants.KindVSphereMachineTemplate), nil)
@@ -567,7 +567,7 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 		return nil
 	}
 
-	getVCClientAndDataCenter = func(clusterName, clusterNamespace, vsphereMachineTemplateObjectName string) (vc.Client, string, error) { // nolint:unparam
+	getVCClientAndDataCenter = func(clusterName, clusterNamespace, vsphereMachineTemplateObjectName string) (vc.Client, string, error) { //nolint:unparam
 		return vcClient, "dc0", nil
 	}
 

--- a/tkg/client/upgrade_region.go
+++ b/tkg/client/upgrade_region.go
@@ -85,6 +85,7 @@ type providersUpgradeInfo struct {
 // 	d) Call the clusterctl ApplyUpgrade() to upgrade providers
 //  e) Wait for providers to be up and running
 // 2. call the UpgradeCluster() for upgrading the k8s version of the Management cluster
+//nolint:gocyclo
 func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) error {
 	contexts, err := c.GetRegionContexts(options.ClusterName)
 	if err != nil || len(contexts) == 0 {

--- a/tkg/client/utils_test.go
+++ b/tkg/client/utils_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Utils", func() {
 
 			Context("when CLUSTER_TOPOLOGY is explicitly overridden", func() {
 				It("The retains the value", func() {
-					var value string
+					var value string //nolint:govet
 					tkgClient.TKGConfigReaderWriter().Set(constants.ConfigVariableClusterTopology, "false")
 					tkgClient.ensureClusterTopologyConfiguration()
 					value, err = tkgClient.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterTopology)

--- a/tkg/client/validate.go
+++ b/tkg/client/validate.go
@@ -1852,7 +1852,7 @@ func getDockerBridgeNetworkCidr() (string, error) {
 	return networkCidr, nil
 }
 
-// ConfigureAndValidateAVIConfiguration validates the configuration inputs of Avi aka. NSX Advanced Load Balancer
+// ConfigureAndValidateAviConfiguration validates the configuration inputs of Avi aka. NSX Advanced Load Balancer
 func (c *TkgClient) ConfigureAndValidateAviConfiguration() error {
 	aviEnable, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviEnable)
 	// ignoring error because AVI_ENABLE is an optional configuration
@@ -1935,7 +1935,7 @@ func (c *TkgClient) ValidateAviControllerAccount(aviClient avi.Client) error {
 	return nil
 }
 
-// ValidateAVIControllerVersion validates AVI controller version format, it shoulde be something like 20.1.7
+// ValidateAviControllerVersion validates AVI controller version format, it shoulde be something like 20.1.7
 func (c *TkgClient) ValidateAviControllerVersion() error {
 	aviVersion, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviControllerVersion)
 	if aviVersion == "" {
@@ -1948,7 +1948,7 @@ func (c *TkgClient) ValidateAviControllerVersion() error {
 	return nil
 }
 
-// ValidateAVICloud validates if configured cloud exists or not
+// ValidateAviCloud validates if configured cloud exists or not
 func (c *TkgClient) ValidateAviCloud(aviClient avi.Client) error {
 	aviCloud, err := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviCloudName)
 	if err != nil {
@@ -1960,7 +1960,7 @@ func (c *TkgClient) ValidateAviCloud(aviClient avi.Client) error {
 	return nil
 }
 
-// ValidateAVIManagementClusterServiceEngineGroup validates if configured service engine group exists or not
+// ValidateAviServiceEngineGroup validates if configured service engine group exists or not
 func (c *TkgClient) ValidateAviServiceEngineGroup(aviClient avi.Client) error {
 	aviServiceEngineGroup, err := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviServiceEngineGroup)
 	if err != nil {
@@ -1972,7 +1972,7 @@ func (c *TkgClient) ValidateAviServiceEngineGroup(aviClient avi.Client) error {
 	return nil
 }
 
-// ValidateAVIManagementClusterServiceEngineGroup validates if configured management cluster service engine group exists or not
+// ValidateAviManagementClusterServiceEngineGroup validates if configured management cluster service engine group exists or not
 func (c *TkgClient) ValidateAviManagementClusterServiceEngineGroup(aviClient avi.Client) error {
 	aviManagementClusterSEG, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviManagementClusterServiceEngineGroup)
 	// this field is optional, only validates if it has value
@@ -1984,7 +1984,7 @@ func (c *TkgClient) ValidateAviManagementClusterServiceEngineGroup(aviClient avi
 	return nil
 }
 
-// ValidateAVIControlPlaneNetwork validates if workload clusters' data plane vip network is valid or not
+// ValidateAviDataPlaneNetwork validates if workload clusters' data plane vip network is valid or not
 func (c *TkgClient) ValidateAviDataPlaneNetwork(aviClient avi.Client) error {
 	aviDataNetworkName, err := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviDataPlaneNetworkName)
 	if err != nil {
@@ -1994,13 +1994,13 @@ func (c *TkgClient) ValidateAviDataPlaneNetwork(aviClient avi.Client) error {
 	if err != nil {
 		return err
 	}
-	if err = c.ValidateAviNetwork(aviDataNetworkName, aviDataNetworkCIDR, aviClient); err != nil {
+	if err := c.ValidateAviNetwork(aviDataNetworkName, aviDataNetworkCIDR, aviClient); err != nil {
 		return err
 	}
 	return nil
 }
 
-// ValidateAVIControlPlaneNetwork validates if workload clusters' control plane vip network is valid or not
+// ValidateAviControlPlaneNetwork validates if workload clusters' control plane vip network is valid or not
 func (c *TkgClient) ValidateAviControlPlaneNetwork(aviClient avi.Client) error {
 	aviControlPlaneNetworkName, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviControlPlaneNetworkName)
 	aviControlPlaneNetworkCIDR, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviControlPlaneNetworkCIDR)
@@ -2013,7 +2013,7 @@ func (c *TkgClient) ValidateAviControlPlaneNetwork(aviClient avi.Client) error {
 	return nil
 }
 
-// ValidateAVIManagementClusterDataPlaneNetwork checks if configured management cluster data plane vip network is valid or not
+// ValidateAviManagementClusterDataPlaneNetwork checks if configured management cluster data plane vip network is valid or not
 func (c *TkgClient) ValidateAviManagementClusterDataPlaneNetwork(aviClient avi.Client) error {
 	aviManagementClusterDataPlaneNetworkName, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviManagementClusterDataPlaneNetworkName)
 	aviManagementClusterDataPlaneNetworkCIDR, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviManagementClusterDataPlaneNetworkCIDR)
@@ -2026,7 +2026,7 @@ func (c *TkgClient) ValidateAviManagementClusterDataPlaneNetwork(aviClient avi.C
 	return nil
 }
 
-// ValidateAVIManagementClusterControlPlaneNetwork checks if configured management cluster control plane vip network is valid or not
+// ValidateAviManagementClusterControlPlaneNetwork checks if configured management cluster control plane vip network is valid or not
 func (c *TkgClient) ValidateAviManagementClusterControlPlaneNetwork(aviClient avi.Client) error {
 	aviManagementClusterControlPlaneNetworkName, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviManagementClusterControlPlaneVipNetworkName)
 	aviManagementClusterControlPlaneNetworkCIDR, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviManagementClusterControlPlaneVipNetworkCIDR)
@@ -2039,7 +2039,7 @@ func (c *TkgClient) ValidateAviManagementClusterControlPlaneNetwork(aviClient av
 	return nil
 }
 
-// ValidateAVINetwork validates if the network can be found in AVI controller or not and the subnet CIDR format is correct or not
+// ValidateAviNetwork validates if the network can be found in AVI controller or not and the subnet CIDR format is correct or not
 func (c *TkgClient) ValidateAviNetwork(networkName, networkCIDR string, aviClient avi.Client) error {
 	_, err := aviClient.GetVipNetworkByName(networkName)
 	if err != nil {

--- a/tkg/constants/cluster_internal.go
+++ b/tkg/constants/cluster_internal.go
@@ -18,7 +18,7 @@ const (
 	ErrorMsgClusterExistsAlready    = "cluster with name %s already exists, please specify another name"
 	ErrorMsgClusterListError        = "unable to get list of workload clusters managed by current management cluster"
 
-	ErrorMsgCClassInputFeatureFlagDisabled = "Input file is cluster class based but CLI feature flag '%v' is disabled, make sure its enabled to create cluster class based cluster"
+	ErrorMsgCClassInputFeatureFlagDisabled = "input file is cluster class based but CLI feature flag '%v' is disabled, make sure its enabled to create cluster class based cluster"
 
 	PacificGCMControllerDeployment = "vmware-system-tkg-controller-manager"
 	PacificGCMControllerNamespace  = "vmware-system-tkg"
@@ -141,7 +141,7 @@ const (
 	PackageTypeLabel = "tkg.tanzu.vmware.com/package-type"
 	// CLIPluginImageRepositoryOverrideLabel is the label on the configmap which specifies CLIPlugin image repository override
 	CLIPluginImageRepositoryOverrideLabel = "cli.tanzu.vmware.com/cliplugin-image-repository-override"
-	//KappController labels
+	// KappController labels
 	KappControllerAppLabel         = "kapp.k14s.io/app"
 	KappControllerAssociationLabel = "kapp.k14s.io/association"
 )
@@ -154,7 +154,7 @@ const (
 	PackageTypeManagement              = "management"
 )
 
-// Avi aka. NSX Advanced LoadBalancer version regex expression
+// AviControllerVersionRegex Avi aka. NSX Advanced LoadBalancer version regex expression
 const AviControllerVersionRegex = `^\d+(\.\d+)*$`
 
 const (

--- a/tkg/managementcomponents/helper_test.go
+++ b/tkg/managementcomponents/helper_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/tkg/tkgconfigbom"
 )
 
+const (
+	verStr = "v0.21.0"
+)
+
 var _ = Describe("Test GetTKGPackageConfigValuesFileFromUserConfig", func() {
 	var (
 		managementPackageVersion string
@@ -64,7 +68,7 @@ tkr-package:
 
 	Context("When provider type is AWS", func() {
 		BeforeEach(func() {
-			managementPackageVersion = "v0.21.0"
+			managementPackageVersion = verStr
 			providerType = "aws"
 			outputFile = "test/output_aws.yaml"
 		})
@@ -80,7 +84,7 @@ tkr-package:
 
 	Context("When provider type is vSphere", func() {
 		BeforeEach(func() {
-			managementPackageVersion = "v0.21.0"
+			managementPackageVersion = verStr
 			providerType = "vsphere"
 			outputFile = "test/output_vsphere.yaml"
 		})
@@ -96,7 +100,7 @@ tkr-package:
 
 	Context("When provider type is Azure", func() {
 		BeforeEach(func() {
-			managementPackageVersion = "v0.21.0"
+			managementPackageVersion = verStr
 			providerType = "azure"
 			outputFile = "test/output_azure.yaml"
 		})
@@ -112,7 +116,7 @@ tkr-package:
 
 	Context("When provider type is Docker", func() {
 		BeforeEach(func() {
-			managementPackageVersion = "v0.21.0"
+			managementPackageVersion = verStr
 			providerType = "docker"
 			outputFile = "test/output_docker.yaml"
 		})
@@ -128,7 +132,7 @@ tkr-package:
 
 	Context("When provider type is not provided", func() {
 		BeforeEach(func() {
-			managementPackageVersion = "v0.21.0"
+			managementPackageVersion = verStr
 			providerType = ""
 		})
 		It("should not return error", func() {

--- a/tkg/managementcomponents/management_component_install.go
+++ b/tkg/managementcomponents/management_component_install.go
@@ -70,7 +70,7 @@ func pauseAddonSecretReconciliation(clusterClient clusterclient.Client, addonSec
 	jsonPatch := []map[string]interface{}{
 		{
 			"op":    "add",
-			"path":  fmt.Sprintf("/metadata/annotations/tkg.tanzu.vmware.com~1addon-paused"),
+			"path":  "/metadata/annotations/tkg.tanzu.vmware.com~1addon-paused",
 			"value": "",
 		},
 	}
@@ -113,7 +113,7 @@ func pausePackageInstallReconciliation(clusterClient clusterclient.Client, pkgiN
 	return nil
 }
 
-// PausedAddonLifecycleManagement pauses/unpauses the lifecycle management of addon package with given name and namespace
+// PauseAddonLifecycleManagement pauses/unpauses the lifecycle management of addon package with given name and namespace
 func PauseAddonLifecycleManagement(clusterClient clusterclient.Client, clusterName, addonName, namespace string) error {
 	log.Infof("Pausing lifecycle management for %s", addonName)
 	pkgiName := fmt.Sprintf("tanzu-%s", addonsManagerName)

--- a/tkg/managementcomponents/management_component_install_test.go
+++ b/tkg/managementcomponents/management_component_install_test.go
@@ -20,6 +20,10 @@ import (
 	. "github.com/vmware-tanzu/tanzu-framework/tkg/managementcomponents"
 )
 
+const (
+	addonsManager = "addons-manager"
+)
+
 func Test(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "ManagementComponent Suite")
@@ -176,12 +180,6 @@ var _ = Describe("Test WaitForManagementPackages", func() {
 })
 
 var _ = Describe("Test PauseAddonLifecycleManagement", func() {
-
-	type fakeGroupResource struct {
-		Group    string
-		Resource string
-	}
-
 	var (
 		clusterClient *fakes.ClusterClient
 		err           error
@@ -196,7 +194,7 @@ var _ = Describe("Test PauseAddonLifecycleManagement", func() {
 	BeforeEach(func() {
 		clusterClient = &fakes.ClusterClient{}
 		clusterName = "mgmtCluster"
-		addonName = "addons-manager"
+		addonName = addonsManager
 	})
 
 	JustBeforeEach(func() {
@@ -228,11 +226,6 @@ var _ = Describe("Test PauseAddonLifecycleManagement", func() {
 })
 
 var _ = Describe("Test NoopDeletePackageInstall", func() {
-	type fakeGroupResource struct {
-		Group    string
-		Resource string
-	}
-
 	var (
 		clusterClient *fakes.ClusterClient
 		err           error
@@ -245,7 +238,7 @@ var _ = Describe("Test NoopDeletePackageInstall", func() {
 
 	BeforeEach(func() {
 		clusterClient = &fakes.ClusterClient{}
-		addonName = "addons-manager"
+		addonName = addonsManager
 		clusterClient.PatchResourceReturns(nil)
 		clusterClient.DeleteResourceReturns(nil)
 	})
@@ -295,12 +288,6 @@ var _ = Describe("Test NoopDeletePackageInstall", func() {
 })
 
 var _ = Describe("Test DeleteAddonSecret", func() {
-
-	type fakeGroupResource struct {
-		Group    string
-		Resource string
-	}
-
 	var (
 		clusterClient *fakes.ClusterClient
 		err           error
@@ -313,7 +300,7 @@ var _ = Describe("Test DeleteAddonSecret", func() {
 
 	BeforeEach(func() {
 		clusterClient = &fakes.ClusterClient{}
-		addonName = "addons-manager"
+		addonName = addonsManager
 		clusterClient.GetResourceReturns(nil)
 		clusterClient.UpdateResourceReturns(nil)
 		clusterClient.PatchResourceReturns(nil)
@@ -382,11 +369,6 @@ var _ = Describe("Test DeleteAddonSecret", func() {
 
 var _ = Describe("Test AddonSecretExists", func() {
 
-	type fakeGroupResource struct {
-		Group    string
-		Resource string
-	}
-
 	var (
 		clusterClient               *fakes.ClusterClient
 		err                         error
@@ -399,7 +381,7 @@ var _ = Describe("Test AddonSecretExists", func() {
 
 	BeforeEach(func() {
 		clusterClient = &fakes.ClusterClient{}
-		addonName = "addons-manager"
+		addonName = addonsManager
 		clusterClient.GetResourceReturns(nil)
 		clusterClient.UpdateResourceReturns(nil)
 		clusterClient.PatchResourceReturns(nil)

--- a/tkg/tkgctl/compatibility.go
+++ b/tkg/tkgctl/compatibility.go
@@ -17,6 +17,7 @@ const (
 )
 
 // SetCompatibilityFileBasedOnEdition changes the compatibility file for the edition.
+//nolint:staticcheck
 func SetCompatibilityFileBasedOnEdition() error {
 	// Acquire tanzu config lock
 	config.AcquireTanzuConfigLock()

--- a/tkg/tkgctl/compatibility_test.go
+++ b/tkg/tkgctl/compatibility_test.go
@@ -1,6 +1,7 @@
 // Copyright 2022 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//nolint:staticcheck
 package tkgctl
 
 import (

--- a/tkg/tkgctl/create_cluster.go
+++ b/tkg/tkgctl/create_cluster.go
@@ -52,8 +52,8 @@ type CreateClusterOptions struct {
 	Edition string
 }
 
-//nolint:gocritic
 // CreateCluster create tkg cluster
+//nolint:gocritic,gocyclo,revive
 func (t *tkgctl) CreateCluster(cc CreateClusterOptions) error {
 	isTKGSCluster, err := t.tkgClient.IsPacificManagementCluster()
 	if err != nil {
@@ -65,8 +65,8 @@ func (t *tkgctl) CreateCluster(cc CreateClusterOptions) error {
 	}
 	if cc.GenerateOnly && isInputFileClusterClassBased {
 		if config, err := os.ReadFile(cc.ClusterConfigFile); err == nil {
-			_, err = os.Stdout.Write(config)
-			return err
+			_, err1 := os.Stdout.Write(config)
+			return err1
 		} else {
 			return err
 		}
@@ -211,7 +211,7 @@ func (t *tkgctl) validateTKGSFeatureGateStatus(isInputFileClusterClassBased bool
 	} else {
 		isTKCFeatureActivated, err := t.featureGateHelper.FeatureActivatedInNamespace(context.Background(), constants.TKCAPIFeature, constants.TKGSTKCAPINamespace)
 		if err != nil {
-			//ignore the error, because the supervisor could be vSphere7 based (which does not support tkc-api featuregate)
+			// ignore the error, because the supervisor could be vSphere7 based (which does not support tkc-api featuregate)
 			return nil
 		}
 		if !isTKCFeatureActivated {

--- a/tkg/tkgctl/create_cluster_test.go
+++ b/tkg/tkgctl/create_cluster_test.go
@@ -29,9 +29,10 @@ const inputFileAwsEmptyClass = "../fakes/config/cluster_aws_emptyClass.yaml"
 const inputFileMultipleObjectsAws = "../fakes/config/cluster_aws_multipleObjects.yaml"
 const inputFileAzure = "../fakes/config/cluster_azure.yaml"
 const inputFileVsphere = "../fakes/config/cluster_vsphere.yaml"
-const inputFileTKGS_ClusterClass = "../fakes/config/cluster_tkgs.yaml"
-const inputFileTKGS_TKC = "../fakes/config/cluster_tkgs_tkc.yaml"
+const inputFileTKGSClusterClass = "../fakes/config/cluster_tkgs.yaml"
+const inputFileTKGSTKC = "../fakes/config/cluster_tkgs_tkc.yaml"
 const inputFileLegacy = "../fakes/config/cluster1_config.yaml"
+const errFeatureStatus = "error while checking feature status in featuregate" //nolint:goimports
 
 var testingDir string
 
@@ -598,7 +599,7 @@ var _ = Describe("TKGS Cluster - cluster_tkgs.yaml as input file for 'tanzu clus
 				TkrVersion:             fakeTKRVersion,
 				SkipPrompt:             true,
 				Edition:                "tkg",
-				ClusterConfigFile:      inputFileTKGS_ClusterClass,
+				ClusterConfigFile:      inputFileTKGSClusterClass,
 			}
 		})
 		It("Environment should be updated with legacy variables with input cluster attribute values:", func() {
@@ -642,13 +643,13 @@ var _ = Describe("Clusterclass FeatureGate specific use cases", func() {
 				TkrVersion:             fakeTKRVersion,
 				SkipPrompt:             true,
 				Edition:                "tkg",
-				ClusterConfigFile:      inputFileTKGS_ClusterClass,
+				ClusterConfigFile:      inputFileTKGSClusterClass,
 			}
 			fg = &fakes.FakeFeatureGateHelper{}
-			kubeConfigPath := inputFileTKGS_ClusterClass
+			kubeConfigPath := inputFileTKGSClusterClass
 			regionContext = region.RegionContext{
 				ContextName:    "queen-anne-context",
-				SourceFilePath: inputFileTKGS_ClusterClass,
+				SourceFilePath: inputFileTKGSClusterClass,
 			}
 			tkgConfigReaderWriter, _ := tkgconfigreaderwriter.NewReaderWriterFromConfigFile(configFilePath, configFilePath)
 			tkgConfigReaderWriter.Set(constants.ConfigVariableClusterPlan, "dev")
@@ -722,7 +723,7 @@ var _ = Describe("Clusterclass FeatureGate specific use cases", func() {
 		})
 
 		It("Return error when featuregate api throws error", func() {
-			errorMsg := "error while checking feature status in featuregate"
+			errorMsg := errFeatureStatus
 			fg.FeatureActivatedInNamespaceReturns(true, fmt.Errorf(errorMsg))
 			tkgClient.IsPacificManagementClusterReturnsOnCall(0, true, nil)
 			tkgClient.GetCurrentRegionContextReturns(regionContext, nil)
@@ -751,13 +752,13 @@ var _ = Describe("Clusterclass FeatureGate specific use cases", func() {
 				TkrVersion:             fakeTKRVersion,
 				SkipPrompt:             true,
 				Edition:                "tkg",
-				ClusterConfigFile:      inputFileTKGS_TKC,
+				ClusterConfigFile:      inputFileTKGSTKC,
 			}
 			fg = &fakes.FakeFeatureGateHelper{}
-			kubeConfigPath := inputFileTKGS_TKC
+			kubeConfigPath := inputFileTKGSTKC
 			regionContext = region.RegionContext{
 				ContextName:    "queen-anne-context",
-				SourceFilePath: inputFileTKGS_TKC,
+				SourceFilePath: inputFileTKGSTKC,
 			}
 			tkgConfigReaderWriter, _ := tkgconfigreaderwriter.NewReaderWriterFromConfigFile(configFilePath, configFilePath)
 			tkgConfigReaderWriter.Set(constants.ConfigVariableClusterPlan, "dev")
@@ -826,7 +827,7 @@ var _ = Describe("Clusterclass FeatureGate specific use cases", func() {
 		})
 
 		It("create cluster even when tkc-api featuregate api throws error", func() {
-			errorMsg := "error while checking feature status in featuregate"
+			errorMsg := errFeatureStatus
 			fg.FeatureActivatedInNamespaceReturns(true, fmt.Errorf(errorMsg))
 			tkgClient.IsPacificManagementClusterReturnsOnCall(0, true, nil)
 			tkgClient.GetCurrentRegionContextReturns(regionContext, nil)

--- a/tkg/tkgctl/featuregate_helper.go
+++ b/tkg/tkgctl/featuregate_helper.go
@@ -13,8 +13,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
 	configv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/config/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/tkg/api/tmc/v1alpha1"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/clusterclient"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/constants"
 )
@@ -145,7 +145,7 @@ func namespacesMatchingSelector(ctx context.Context, c client.Client, selector *
 // API to decide ClusterClass feature is supported or not.
 // Assumption is only vSphere8 based TKGS clusters will have this featuregate API as well as support for
 // ClusterClass feature
-func (fg *featureGateHelper) isClusterClassFeatureActivated(clusterClient clusterclient.Client, feature, namespace string) (bool, error) {
+func (fg *featureGateHelper) isClusterClassFeatureActivated(clusterClient clusterclient.Client, feature, namespace string) (bool, error) { //nolint:unparam
 	isFeaturegateCRDExists, err := clusterClient.VerifyExistenceOfCRD("featuregates", configv1alpha1.GroupVersion.Group)
 	if err != nil {
 		return false, err

--- a/tkg/tkgctl/get_cluster.go
+++ b/tkg/tkgctl/get_cluster.go
@@ -66,8 +66,8 @@ func (t *tkgctl) IsClusterExists(clustername, namespace string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	for _, cluster := range clusters {
-		if cluster.Name == clustername && cluster.Namespace == namespace {
+	for index := range clusters {
+		if clusters[index].Name == clustername && clusters[index].Namespace == namespace {
 			return true, nil
 		}
 	}

--- a/tkg/tkr/pkg/constants/constants.go
+++ b/tkg/tkr/pkg/constants/constants.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// This file is copied over from github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr/pkg/constants
+// Package constants provides constant variables
 package constants
 
 const (


### PR DESCRIPTION
### What this PR does / why we need it
This PR is to fix or skip linter issues for follow directories:
https://github.com/vmware-tanzu/tanzu-framework/tree/main/tkg
https://github.com/vmware-tanzu/tanzu-framework/tree/main/cmd/cli/plugin/login
https://github.com/vmware-tanzu/tanzu-framework/tree/main/cmd/cli/plugin-admin/test

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3437

### Describe testing done for PR

1. Ran the `golangci-lint` binary locally for [/main/tkg](https://github.com/vmware-tanzu/tanzu-framework/tree/main/tkg) directory

Here is the `golangci-lint` output for [/main/tkg](https://github.com/vmware-tanzu/tanzu-framework/tree/main/tkg) directory:
```
❯ ../hack/tools/bin/golangci-lint run -v --timeout=10m
INFO [config_reader] Config search paths: [./ /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework/tkg /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework /Users/cpamuluri/tkg/tasks/plugin899/latest2 /Users/cpamuluri/tkg/tasks/plugin899 /Users/cpamuluri/tkg/tasks /Users/cpamuluri/tkg /Users/cpamuluri /Users /] 
INFO [config_reader] Used config file ../.golangci.yaml 
INFO [lintersdb] Active 32 linters: [bodyclose deadcode depguard dogsled dupl errcheck funlen goconst gocritic gocyclo goheader goimports goprintffuncname gosec gosimple govet ineffassign misspell nakedret noctx nolintlint revive rowserrcheck staticcheck structcheck stylecheck typecheck unconvert unparam unused varcheck whitespace] 
INFO [loader] Go packages loading at mode 575 (compiled_files|name|types_sizes|deps|exports_file|files|imports) took 6.92946184s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 172.992358ms 
INFO [linters context/goanalysis] analyzers took 37m18.49989688s with top 10 stages: gocritic: 11m2.285754295s, goimports: 5m12.370998612s, buildir: 3m27.822376545s, buildssa: 2m47.777188185s, goheader: 2m11.777559965s, the_only_name: 2m7.551483332s, dupl: 1m30.878916017s, gosec: 59.41655014s, misspell: 41.199387586s, S1038: 40.863702065s 
INFO [runner/skip dirs] Skipped 28 issues from dir test/framework by pattern test/ 
INFO [runner/skip dirs] Skipped 2 issues from dir fakes/providers by pattern fakes/ 
INFO [runner/skip dirs] Skipped 29 issues from dir test/tkgctl/tkgs by pattern test/ 
INFO [runner/skip dirs] Skipped 50 issues from dir test/tkgctl/aws_cc by pattern test/ 
INFO [runner/skip dirs] Skipped 20 issues from dir test/tkgctl/vsphere67 by pattern test/ 
INFO [runner/skip dirs] Skipped 20 issues from dir test/tkgctl/aws by pattern test/ 
INFO [runner/skip dirs] Skipped 22 issues from dir test/tkgctl/azure by pattern test/ 
INFO [runner/skip dirs] Skipped 2 issues from dir test/cmp/strings by pattern test/ 
INFO [runner/skip dirs] Skipped 9 issues from dir test/tkgctl/docker_cc by pattern test/ 
INFO [runner/skip dirs] Skipped 382 issues from dir test/tkgctl/shared by pattern test/ 
INFO [runner/skip dirs] Skipped 30 issues from dir fakes/helper by pattern fakes/ 
INFO [runner/skip dirs] Skipped 52 issues from dir test/tkgctl/tkgs_cc by pattern test/ 
INFO [runner/skip dirs] Skipped 9 issues from dir test/framework/exec by pattern test/ 
INFO [runner/skip dirs] Skipped 22 issues from dir test/tkgctl/docker by pattern test/ 
INFO [runner] Issues before processing: 4720, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_files: 4720/4720, exclude-rules: 317/911, cgo: 4720/4720, filename_unadjuster: 4720/4720, path_prettifier: 4720/4720, exclude: 911/1170, skip_dirs: 4043/4720, autogenerated_exclude: 1170/4043, nolint: 0/317, identifier_marker: 1170/1170 
INFO [runner] processing took 502.390842ms with stages: autogenerated_exclude: 236.362159ms, nolint: 152.23899ms, path_prettifier: 40.226779ms, exclude-rules: 31.129274ms, identifier_marker: 29.887926ms, exclude: 7.646704ms, skip_dirs: 2.783195ms, filename_unadjuster: 1.161862ms, cgo: 948.302µs, max_same_issues: 1.367µs, uniq_by_line: 761ns, source_code: 515ns, severity-rules: 471ns, skip_files: 469ns, max_from_linter: 433ns, diff: 392ns, path_shortener: 359ns, max_per_file_from_linter: 346ns, sort_results: 336ns, path_prefixer: 202ns 
INFO [runner] linters took 3m36.773891973s with stages: goanalysis_metalinter: 3m36.271207377s 
INFO File cache stats: 309 entries of total size 2.8MiB 
INFO Memory: 2213 samples, avg is 1624.0MB, max is 2018.4MB 
INFO Execution took 3m43.901736574s    
```

2. Ran the `golangci-lint` binary locally for [/main/cmd/cli/plugin/login](https://github.com/vmware-tanzu/tanzu-framework/tree/main/cmd/cli/plugin/login) directory
Here is the `golangci-lint` output for [/main/cmd/cli/plugin/login](https://github.com/vmware-tanzu/tanzu-framework/tree/main/cmd/cli/plugin/login) directory:
```
❯ /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework/hack/tools/bin/golangci-lint run -v --timeout=10m
INFO [config_reader] Config search paths: [./ /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework/cmd/cli/plugin/login /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework/cmd/cli/plugin /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework/cmd/cli /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework/cmd /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework /Users/cpamuluri/tkg/tasks/plugin899/latest2 /Users/cpamuluri/tkg/tasks/plugin899 /Users/cpamuluri/tkg/tasks /Users/cpamuluri/tkg /Users/cpamuluri /Users /] 
INFO [config_reader] Used config file ../../../../.golangci.yaml 
INFO [lintersdb] Active 32 linters: [bodyclose deadcode depguard dogsled dupl errcheck funlen goconst gocritic gocyclo goheader goimports goprintffuncname gosec gosimple govet ineffassign misspell nakedret noctx nolintlint revive rowserrcheck staticcheck structcheck stylecheck typecheck unconvert unparam unused varcheck whitespace] 
INFO [loader] Go packages loading at mode 575 (deps|imports|types_sizes|compiled_files|exports_file|files|name) took 1.176931265s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 1.319415ms 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 12, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_files: 12/12, identifier_marker: 12/12, exclude: 11/12, nolint: 0/8, cgo: 12/12, exclude-rules: 8/11, autogenerated_exclude: 12/12, skip_dirs: 12/12, filename_unadjuster: 12/12, path_prettifier: 12/12 
INFO [runner] processing took 2.787082ms with stages: nolint: 1.780051ms, exclude-rules: 317.221µs, autogenerated_exclude: 281.343µs, identifier_marker: 234.862µs, path_prettifier: 108.049µs, exclude: 40.36µs, skip_dirs: 15.246µs, filename_unadjuster: 3.073µs, cgo: 1.788µs, max_same_issues: 1.106µs, uniq_by_line: 845ns, max_from_linter: 591ns, max_per_file_from_linter: 569ns, source_code: 380ns, skip_files: 327ns, severity-rules: 294ns, diff: 294ns, path_shortener: 280ns, sort_results: 256ns, path_prefixer: 147ns 
INFO [runner] linters took 673.268071ms with stages: goanalysis_metalinter: 670.364874ms 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 20 samples, avg is 58.3MB, max is 71.3MB 
INFO Execution took 1.868710187s 
```

3. Ran the `golangci-lint` binary locally for [/main/cmd/cli/plugin-admin/test](https://github.com/vmware-tanzu/tanzu-framework/tree/main/cmd/cli/plugin-admin/test) directory
Here is the `golangci-lint` output for [/main/cmd/cli/plugin-admin/test](https://github.com/vmware-tanzu/tanzu-framework/tree/main/cmd/cli/plugin-admin/test) directory:
```
❯ /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework/hack/tools/bin/golangci-lint run -v --timeout=10m
INFO [config_reader] Config search paths: [./ /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework/cmd/cli/plugin-admin/test /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework/cmd/cli/plugin-admin /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework/cmd/cli /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework/cmd /Users/cpamuluri/tkg/tasks/plugin899/latest2/tanzu-framework /Users/cpamuluri/tkg/tasks/plugin899/latest2 /Users/cpamuluri/tkg/tasks/plugin899 /Users/cpamuluri/tkg/tasks /Users/cpamuluri/tkg /Users/cpamuluri /Users /] 
INFO [config_reader] Used config file ../../../../.golangci.yaml 
INFO [lintersdb] Active 32 linters: [bodyclose deadcode depguard dogsled dupl errcheck funlen goconst gocritic gocyclo goheader goimports goprintffuncname gosec gosimple govet ineffassign misspell nakedret noctx nolintlint revive rowserrcheck staticcheck structcheck stylecheck typecheck unconvert unparam unused varcheck whitespace] 
INFO [loader] Go packages loading at mode 575 (imports|compiled_files|exports_file|files|types_sizes|deps|name) took 1.245215018s 
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 624.669µs 
INFO [linters context/goanalysis] analyzers took 0s with no stages 
INFO [runner] Issues before processing: 4, after processing: 0 
INFO [runner] Processors filtering stat (out/in): skip_files: 4/4, autogenerated_exclude: 4/4, exclude: 4/4, skip_dirs: 4/4, cgo: 4/4, filename_unadjuster: 4/4, path_prettifier: 4/4, identifier_marker: 4/4, nolint: 0/4, exclude-rules: 4/4 
INFO [runner] processing took 1.88986ms with stages: nolint: 798.198µs, autogenerated_exclude: 363.032µs, exclude-rules: 316.92µs, path_prettifier: 197.482µs, identifier_marker: 147.027µs, exclude: 38.64µs, skip_dirs: 21.393µs, cgo: 1.886µs, max_same_issues: 949ns, filename_unadjuster: 877ns, skip_files: 542ns, uniq_by_line: 473ns, source_code: 433ns, max_from_linter: 419ns, severity-rules: 321ns, max_per_file_from_linter: 293ns, diff: 284ns, sort_results: 264ns, path_shortener: 242ns, path_prefixer: 185ns 
INFO [runner] linters took 570.316073ms with stages: goanalysis_metalinter: 568.297184ms 
INFO File cache stats: 0 entries of total size 0B 
INFO Memory: 20 samples, avg is 60.0MB, max is 70.6MB 
INFO Execution took 1.835894484s     
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fixed or skipped linter issues
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer
Below two GitHub issues created to fix these linter issues permanently 
https://github.com/vmware-tanzu/tanzu-framework/issues/3478 
https://github.com/vmware-tanzu/tanzu-framework/issues/3479
<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
