### PR TITLE
Add node-role.kubernetes.io/control-plane toleration for featuregates-manager

### DIFF
--- a/packages/featuregates/bundle/config/upstream/tanzu-featuregates-manager.yaml
+++ b/packages/featuregates/bundle/config/upstream/tanzu-featuregates-manager.yaml
@@ -61,6 +61,8 @@ spec:
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
       #@ end
       #@ if hasattr(data.values, 'deployment') and hasattr(data.values.deployment, 'nodeSelector') and data.values.deployment.nodeSelector:
       #@overlay/match missing_ok=True


### PR DESCRIPTION
Add `node-role.kubernetes.io/control-plane` toleration to featuregates-manager Deployment template in preparation for the phase-out of `node-role.kubernetes.io/master` toleration in Kubernetes 1.24.

Signed-off-by: F. Gold <fgold@vmware.com>

### What this PR does / why we need it

Kubernetes 1.24 will no longer recognize the `node-role.kubernetes.io/master` taint. We need to add its replacement, `node-role.kubernetes.io/control-plane` in order for featuregates-manager to not break in this next version.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

**Test procedure summary**
1. Ensure backward compatibility by testing on k8s v1.23. Create Kind cluster with Kubernetes v1.23, both the new and old tolerations. I expect featuregates to come up without error.
2. Ensure forward compatibility, part 1: fail case. Delete k8s v.1.23 Kind cluster. Create Kind cluster with Kubernetes v1.24 with only the old toleration (before this PR). I expect error pod cannot be scheduled on control-plane (master) node. Delete featuregates controller manager.
3. Ensure forward compatibility, part 2: success case. Deploy featuregates controller manager having both new and old tolerations (this PR). Expect featuregates is scheduled and runs without error.

**Test procedure in detail:**

1. Expect no error while featuregates has both old and new tolerations (this PR) on a Kind cluster running Kubernetes server version 1.23.12.

Create a Kind cluster using k8s v1.23.12.

```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.3", GitCommit:"816c97ab8cff8a1c72eccca1026f7820e93e0d25", GitTreeState:"clean", BuildDate:"2022-01-25T21:17:57Z", GoVersion:"go1.17.6", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.12", GitCommit:"c6939792865ef0f70f92006081690d77411c8ed5", GitTreeState:"clean", BuildDate:"2022-09-22T06:04:07Z", GoVersion:"go1.17.13", Compiler:"gc", Platform:"linux/amd64"}
```

Add a taint to the control-plane node.
```
$ kubectl taint nodes featuregates-k8s-1.23-control-plane node-role.kubernetes.io/control-plane:NoSchedule
node/featuregates-k8s-1.23-control-plane tainted
$ kubectl describe node featuregates-k8s-1.23-control-plane | grep Taint
Taints: node-role.kubernetes.io/control-plane:NoSchedule
```

Deploy featuregates controller manager. Verify the featuregates pod has both old and new tolerations (this PR):

```
$ kubectl describe pod/tanzu-featuregates-controller-manager-ddd54c88c-v7qdn -n tkg-system | grep -A1 Tolerations
Tolerations: node-role.kubernetes.io/control-plane:NoSchedule
                    node-role.kubernetes.io/master:NoSchedule
```

The pod is having no problems, being ready, with running status and no restarts for at least 10 minutes:
```
$ kubectl get pod -n tkg-system
NAME   READY   STATUS    RESTARTS   AGE
pod/tanzu-featuregates-controller-manager-ddd54c88c-v7qdn    1/1    Running    0    10m
```

2. Expect error while featuregates has only the old toleration (before this PR's changes) on a Kind cluster running Kubernetes server version 1.24.0.

Delete k8s v1.23.12 cluster and create a v1.24.0 cluster.

```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"23", GitVersion:"v1.23.3", GitCommit:"816c97ab8cff8a1c72eccca1026f7820e93e0d25", GitTreeState:"clean", BuildDate:"2022-01-25T21:17:57Z", GoVersion:"go1.17.6", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.0", GitCommit:"4ce5a8954017644c5420bae81d72b09b735c21f0", GitTreeState:"clean", BuildDate:"2022-05-19T15:39:43Z", GoVersion:"go1.18.1", Compiler:"gc", Platform:"linux/amd64"}
```

Add a taint to the control-plane node.
```
$ kubectl taint nodes featuregates-k8s-1.24-control-plane node-role.kubernetes.io/control-plane:NoSchedule
node/featuregates-k8s-1.24-control-plane tainted
$ kubectl describe node featuregates-k8s-1.24-control-plane | grep Taint
Taints:             node-role.kubernetes.io/control-plane:NoSchedule
```

Deploy featuregates controller manager. Verify the featuregates pod has only the old toleration (before this PR's changes):

```
$ kubectl describe pod/tanzu-featuregates-controller-manager-76f54f7d4c-zjv5n -n tkg-system | grep -A1 Tolerations
Tolerations:  node-role.kubernetes.io/master:NoSchedule
                     node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
```

The pod is unable to run, staying in pending status for more than 3 minutes.
```
$ kubectl get pod -n tkg-system
NAME   READY   STATUS    RESTARTS   AGE
pod/tanzu-featuregates-controller-manager-76f54f7d4c-zjv5n   0/1    Pending     0   3m22s
```

The reason is due to FailedScheduling and an untolerated taint, seen in the pod's Events.

```
$ kubectl describe pod/tanzu-featuregates-controller-manager-76f54f7d4c-zjv5n -n tkg-system | grep -A5 Events
Events:
  Type     Reason            Age    From               Message
  ----     ------            ----   ----               -------
  Warning  FailedScheduling  25s (x2 over 5m47s)  default-scheduler  0/1 nodes are available: 1 node(s) had untolerated taint {node-role.kubernetes.io/control-plane: }. preemption: 0/1 nodes are available: 1 Preemption is not helpful for scheduling.
```

3. Expect no error while featuregates has both the old and new tolerations (this PR) on a Kind cluster running Kubernetes server version 1.24.0.

Delete featuregates controller manager and deploy new featuregates controller manager that has both the old and new tolerations (this PR).

```
$ kubectl describe pod/tanzu-featuregates-controller-manager-5c864697f7-k4j29 -n tkg-system | grep -A1 Tolerations
Tolerations: node-role.kubernetes.io/control-plane:NoSchedule
                    node-role.kubernetes.io/master:NoSchedule
```

The pod is now able to be scheduled and run.
```
$ kubectl get pod -n tkg-system
NAME    READY   STATUS    RESTARTS   AGE
pod/tanzu-featuregates-controller-manager-5c864697f7-k4j29   1/1   Running   0   7m27s
```

All expectations are met and tests pass. ✅

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add new `node-role.kubernetes.io/control-plane` toleration for featuregates-manager.
``` 

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
