### PR TITLE
Fixing the ClusterClass CI

### DIFF
--- a/pkg/v1/providers/yttcb/clusterbootstrap.yaml
+++ b/pkg/v1/providers/yttcb/clusterbootstrap.yaml
@@ -181,22 +181,23 @@ metadata:
   annotations:
     tkg.tanzu.vmware.com/add-missing-fields-from-tkr: #@ data.values.KUBERNETES_RELEASE
 spec:
+  #@ if data.values.CNI == "antrea":
   cni:
-    #@ if data.values.CNI == "antrea":
     refName: antrea*
     valuesFrom:
       providerRef:
         apiGroup: cni.tanzu.vmware.com
         kind: AntreaConfig
         name: #@ data.values.CLUSTER_NAME
-    #@ elif data.values.CNI == "calico":
+  #@ elif data.values.CNI == "calico":
+  cni:
     refName: calico*
     valuesFrom:
       providerRef:
         apiGroup: cni.tanzu.vmware.com
         kind: CalicoConfig
         name: #@ data.values.CLUSTER_NAME
-    #@ end
+  #@ end
   #@ if vspherecpi_configs_exist() and not data.values.IS_WINDOWS_WORKLOAD_CLUSTER:
   cpi:
     refName: vsphere-cpi*


### PR DESCRIPTION
### What this PR does / why we need it
Fixing the ClusterClass CI.
* When there are cases that require customizing the ClusterBootstrap, but using the default cni, the CNI param is not defined. In this case the cni field in the ClusterBootstrap should not exist, instead of something like `cni:{}`
* Better catch the errors when there are bootstrap package providers who failed to generate the data values secret.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes: https://github.com/vmware-tanzu/tanzu-framework/issues/3130

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Passed the CAPA and CAPD ClusterClass integration tests in the pr CI

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
