### PR TITLE
Golang 1.18

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.18'
       id: go
 
     - name: Use Node 16.x
@@ -116,7 +116,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: 1.18
       id: go
 
     - name: go cache

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: 1.18
       id: go
 
     - name: Use Node 16.x

--- a/.github/workflows/package_integration_test.yaml
+++ b/.github/workflows/package_integration_test.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: 1.18
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/package_integration_test.yaml
+++ b/.github/workflows/package_integration_test.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: '1.17'
+          go-version: '1.18'
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/plugin_tests.yaml
+++ b/.github/workflows/plugin_tests.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: "1.17"
+          go-version: 1.18
         id: go
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/providers.yaml
+++ b/.github/workflows/providers.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: 1.18
       id: go
 
     - name: go cache

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: 1.18
       id: go
 
     - name: Use Node 16.x

--- a/.github/workflows/release_staging.yaml
+++ b/.github/workflows/release_staging.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: 1.18
       id: go
 
     - name: Use Node 16.x

--- a/.github/workflows/security_codeql.yaml
+++ b/.github/workflows/security_codeql.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: 1.18
       id: go
 
     - name: Use Node 16.x

--- a/.github/workflows/tkg_integration_tests.yaml
+++ b/.github/workflows/tkg_integration_tests.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: 1.18
       id: go
 
     - name: Check out code into the Go module directory
@@ -114,7 +114,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: 1.18
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/tkg_integration_tests_clusterclass.yaml
+++ b/.github/workflows/tkg_integration_tests_clusterclass.yaml
@@ -122,7 +122,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: '1.17'
+        go-version: 1.18
       id: go
 
     - name: Check out code into the Go module directory
@@ -209,7 +209,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v3
         with:
-          go-version: '1.17'
+          go-version: 1.18
         id: go
 
       - name: Check out code into the Go module directory
@@ -285,7 +285,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17'
+          go-version: 1.18
         id: go
 
       - name: Check out code into the Go module directory

--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build from publicly reachable source by default, but allow people to re-build images on
 # top of their own trusted images.
-ARG BUILDER_BASE_IMAGE=golang:1.17
+ARG BUILDER_BASE_IMAGE=golang:1.18
 
 # Build the manager binary
 FROM $BUILDER_BASE_IMAGE as builder

--- a/addons/go.mod
+++ b/addons/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/addons
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/addonconfigs => ./../apis/addonconfigs

--- a/addons/hack/tools/go.mod
+++ b/addons/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/addons/hack/tools
 
-go 1.17
+go 1.18
 
 require github.com/maxbrunsfeld/counterfeiter/v6 v6.5.0
 

--- a/apis/addonconfigs/go.mod
+++ b/apis/addonconfigs/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/apis/addonconfigs
 
-go 1.17
+go 1.18
 
 require (
 	k8s.io/api v0.23.5

--- a/apis/cli/go.mod
+++ b/apis/cli/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/apis/cli
 
-go 1.17
+go 1.18
 
 replace github.com/vmware-tanzu/tanzu-framework/apis/config => ../../apis/config
 

--- a/apis/config/go.mod
+++ b/apis/config/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/apis/config
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.8

--- a/apis/core/go.mod
+++ b/apis/core/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/apis/core
 
-go 1.17
+go 1.18
 
 require (
 	k8s.io/api v0.23.5

--- a/apis/run/go.mod
+++ b/apis/run/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/apis/run
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.6

--- a/capabilities/Makefile
+++ b/capabilities/Makefile
@@ -20,7 +20,7 @@ CRD_OPTIONS ?= "crd"
 all: manager
 
 # Run tests
-test: fmt vet manifests
+test: fmt vet
 	cd client && go test ./... -coverprofile cover.out
 	cd controller && go test ./... -coverprofile cover.out
 

--- a/capabilities/client/go.mod
+++ b/capabilities/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/capabilities/client
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/run => ../../apis/run

--- a/capabilities/controller/Dockerfile
+++ b/capabilities/controller/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build from publicly reachable source by default, but allow people to re-build images on
 # top of their own trusted images.
-ARG BUILDER_BASE_IMAGE=golang:1.17
+ARG BUILDER_BASE_IMAGE=golang:1.18
 
 # Build the manager binary
 FROM $BUILDER_BASE_IMAGE as builder

--- a/capabilities/controller/go.mod
+++ b/capabilities/controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/capabilities/controller
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/core => ../../apis/core

--- a/cli/core/go.mod
+++ b/cli/core/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/cli/core
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli => ./../../apis/cli

--- a/cli/core/hack/tools/go.mod
+++ b/cli/core/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/cli/core/hack/tools
 
-go 1.17
+go 1.18
 
 require golang.org/x/tools v0.1.12
 

--- a/cli/runtime/go.mod
+++ b/cli/runtime/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/cli/runtime
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli => ../../apis/cli

--- a/cli/runtime/hack/tools/go.mod
+++ b/cli/runtime/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/cli/runtime/hack/tools
 
-go 1.17
+go 1.18
 
 require (
 	golang.org/x/tools v0.1.12

--- a/cmd/cli/plugin-admin/builder/go.mod
+++ b/cmd/cli/plugin-admin/builder/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/plugin/builder
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli => ../../../../apis/cli

--- a/cmd/cli/plugin-admin/builder/template/plugintemplates/github_workflow_release.yaml.tmpl
+++ b/cmd/cli/plugin-admin/builder/template/plugintemplates/github_workflow_release.yaml.tmpl
@@ -16,7 +16,7 @@ jobs:
   - name: Set up Go 1.x
     uses: actions/setup-go@v2
     with:
-      go-version: ^1.17
+      go-version: ^1.18
       id: go
 
   - name: Check out code into the Go module directory

--- a/cmd/cli/plugin-admin/builder/template/plugintemplates/gitlab-ci.yaml.tmpl
+++ b/cmd/cli/plugin-admin/builder/template/plugintemplates/gitlab-ci.yaml.tmpl
@@ -2,7 +2,7 @@ buildpush:
   only:
     - master
 stage: deploy
-image: golang:1.17.6
+image: golang:1.18
 script:
   # Note: this is all one step because the artifacts were too large to copy over.
   - make

--- a/cmd/cli/plugin-admin/builder/template/plugintemplates/gomod.tmpl
+++ b/cmd/cli/plugin-admin/builder/template/plugintemplates/gomod.tmpl
@@ -1,6 +1,6 @@
 module {{ .RepositoryName }}
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aunum/log v0.0.0-20200821225356-38d2e2c8b489

--- a/cmd/cli/plugin-admin/codegen/go.mod
+++ b/cmd/cli/plugin-admin/codegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/codegen/plugin
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli => ../../../../apis/cli

--- a/cmd/cli/plugin-admin/test/go.mod
+++ b/cmd/cli/plugin-admin/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/plugin/test
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli => ../../../../apis/cli

--- a/cmd/cli/plugin/feature/go.mod
+++ b/cmd/cli/plugin/feature/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/featuregate/plugin
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli => ./../../../../apis/cli

--- a/cmd/cli/plugin/login/go.mod
+++ b/cmd/cli/plugin/login/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/plugin/login
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli => ../../../../apis/cli

--- a/cmd/cli/plugin/package/go.mod
+++ b/cmd/cli/plugin/package/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/cmd/cli/plugin/package
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli => ../../../../apis/cli

--- a/cmd/cli/plugin/pinniped-auth/go.mod
+++ b/cmd/cli/plugin/pinniped-auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/plugin/pinniped-auth
 
-go 1.17
+go 1.18
 
 replace github.com/vmware-tanzu/tanzu-framework/cli/runtime => ../../../../cli/runtime
 

--- a/cmd/cli/plugin/secret/go.mod
+++ b/cmd/cli/plugin/secret/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/cmd/cli/plugin/secret
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli => ../../../../apis/cli

--- a/common.mk
+++ b/common.mk
@@ -5,7 +5,7 @@ GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 GOHOSTOS ?= $(shell go env GOHOSTOS)
 GOHOSTARCH ?= $(shell go env GOHOSTARCH)
-GOVERSION ?= 1.17
+GOVERSION ?= 1.18
 
 ROOT_DIR := $(shell git rev-parse --show-toplevel)
 RELATIVE_ROOT ?= .

--- a/featuregates/client/go.mod
+++ b/featuregates/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/featuregates/client
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework => ../../

--- a/featuregates/controller/Dockerfile
+++ b/featuregates/controller/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build from publicly reachable source by default, but allow people to re-build images on
 # top of their own trusted images.
-ARG BUILDER_BASE_IMAGE=golang:1.17
+ARG BUILDER_BASE_IMAGE=golang:1.18
 
 # Build the manager binary
 FROM $BUILDER_BASE_IMAGE as builder

--- a/featuregates/controller/go.mod
+++ b/featuregates/controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/featuregates/controller
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli => ../../apis/cli

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli => ./apis/cli

--- a/hack/packages/kbld-image-replace/go.mod
+++ b/hack/packages/kbld-image-replace/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/hack/packages
 
-go 1.17
+go 1.18
 
 require (
 	github.com/k14s/kbld v0.32.0

--- a/hack/packages/package-tools/go.mod
+++ b/hack/packages/package-tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/hack/packages/package-tools
 
-go 1.17
+go 1.18
 
 require (
 	github.com/spf13/cobra v1.3.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/hack/tools
 
-go 1.17
+go 1.18
 
 require (
 	github.com/golangci/golangci-lint v1.43.0

--- a/packageclients/go.mod
+++ b/packageclients/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/packageclients
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aunum/log v0.0.0-20200821225356-38d2e2c8b489

--- a/packages/cluster-api-bootstrap-kubeadm/test/go.mod
+++ b/packages/cluster-api-bootstrap-kubeadm/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/packages/cluster-api-bootstrap-kubeadm/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/packages/cluster-api-provider-aws/test/go.mod
+++ b/packages/cluster-api-provider-aws/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/packages/cluster-api-provider-aws/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/packages/cluster-api-provider-azure/test/go.mod
+++ b/packages/cluster-api-provider-azure/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/packages/cluster-api-provider-azure/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/packages/cluster-api-provider-docker/test/go.mod
+++ b/packages/cluster-api-provider-docker/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/packages/cluster-api-provider-docker/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/packages/cluster-api-provider-vsphere/test/go.mod
+++ b/packages/cluster-api-provider-vsphere/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/packages/cluster-api-provider-vsphere/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/packages/cluster-api/test/go.mod
+++ b/packages/cluster-api/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/packages/cluster-api/test
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/pinniped-components/hack/tools/go.mod
+++ b/pinniped-components/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/hack/tools
 
-go 1.17
+go 1.18
 
 require (
 	github.com/golangci/golangci-lint v1.43.0

--- a/pinniped-components/post-deploy/Dockerfile
+++ b/pinniped-components/post-deploy/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build from publicly reachable source by default, but allow people to re-build images on
 # top of their own trusted images.
-ARG BUILDER_BASE_IMAGE=golang:1.17
+ARG BUILDER_BASE_IMAGE=golang:1.18
 
 # Build the post-deploy binary
 FROM $BUILDER_BASE_IMAGE as builder

--- a/pinniped-components/post-deploy/go.mod
+++ b/pinniped-components/post-deploy/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/pinniped-components/post-deploy
 
-go 1.17
+go 1.18
 
 // Right now, we depend on Kube 1.23, but Pinniped 1.20.
 //

--- a/pinniped-components/tanzu-auth-controller-manager/Dockerfile
+++ b/pinniped-components/tanzu-auth-controller-manager/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build from publicly reachable source by default, but allow people to re-build images on
 # top of their own trusted images.
-ARG BUILDER_BASE_IMAGE=golang:1.17
+ARG BUILDER_BASE_IMAGE=golang:1.18
 
 # Build the tanzu-auth-controller-manager binary
 FROM $BUILDER_BASE_IMAGE as builder

--- a/pinniped-components/tanzu-auth-controller-manager/go.mod
+++ b/pinniped-components/tanzu-auth-controller-manager/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/pinniped-components/tanzu-auth-controller-manager
 
-go 1.17
+go 1.18
 
 // TODO: are these the right dependencies?
 replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.1.5

--- a/pkg/v1/providers/tests/go.mod
+++ b/pkg/v1/providers/tests/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/pkg/v1/providers/tests
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/pkg/v1/tkr/Dockerfile
+++ b/pkg/v1/tkr/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build from publicly reachable source by default, but allow people to re-build images on
 # top of their own trusted images.
-ARG BUILDER_BASE_IMAGE=golang:1.17
+ARG BUILDER_BASE_IMAGE=golang:1.18
 
 # Build the manager binary
 FROM $BUILDER_BASE_IMAGE as builder

--- a/pkg/v2/object-propagation/Dockerfile
+++ b/pkg/v2/object-propagation/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build from publicly reachable source by default, but allow people to re-build images on
 # top of their own trusted images.
-ARG BUILDER_BASE_IMAGE=golang:1.17
+ARG BUILDER_BASE_IMAGE=golang:1.18
 
 # Build the manager binary
 FROM $BUILDER_BASE_IMAGE as builder

--- a/pkg/v2/tkr/controller/tkr-source/Dockerfile
+++ b/pkg/v2/tkr/controller/tkr-source/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build from publicly reachable source by default, but allow people to re-build images on
 # top of their own trusted images.
-ARG BUILDER_BASE_IMAGE=golang:1.17
+ARG BUILDER_BASE_IMAGE=golang:1.18
 
 # Build the manager binary
 FROM $BUILDER_BASE_IMAGE as builder

--- a/pkg/v2/tkr/controller/tkr-status/Dockerfile
+++ b/pkg/v2/tkr/controller/tkr-status/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build from publicly reachable source by default, but allow people to re-build images on
 # top of their own trusted images.
-ARG BUILDER_BASE_IMAGE=golang:1.17
+ARG BUILDER_BASE_IMAGE=golang:1.18
 
 # Build the manager binary
 FROM $BUILDER_BASE_IMAGE as builder

--- a/pkg/v2/tkr/webhook/cluster/tkr-resolver/Dockerfile
+++ b/pkg/v2/tkr/webhook/cluster/tkr-resolver/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build from publicly reachable source by default, but allow people to re-build images on
 # top of their own trusted images.
-ARG BUILDER_BASE_IMAGE=golang:1.17
+ARG BUILDER_BASE_IMAGE=golang:1.18
 
 # Build the manager binary
 FROM $BUILDER_BASE_IMAGE as builder

--- a/pkg/v2/tkr/webhook/cluster/vsphere-template-resolver/Dockerfile
+++ b/pkg/v2/tkr/webhook/cluster/vsphere-template-resolver/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build from publicly reachable source by default, but allow people to re-build images on
 # top of their own trusted images.
-ARG BUILDER_BASE_IMAGE=golang:1.17
+ARG BUILDER_BASE_IMAGE=golang:1.18
 
 # Build the manager binary
 FROM $BUILDER_BASE_IMAGE as builder

--- a/pkg/v2/tkr/webhook/infra-machine/Dockerfile
+++ b/pkg/v2/tkr/webhook/infra-machine/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build from publicly reachable source by default, but allow people to re-build images on
 # top of their own trusted images.
-ARG BUILDER_BASE_IMAGE=golang:1.17
+ARG BUILDER_BASE_IMAGE=golang:1.18
 
 # Build the manager binary
 FROM $BUILDER_BASE_IMAGE as builder

--- a/pkg/v2/tkr/webhook/tkr-conversion/Dockerfile
+++ b/pkg/v2/tkr/webhook/tkr-conversion/Dockerfile
@@ -3,7 +3,7 @@
 
 # Build from publicly reachable source by default, but allow people to re-build images on
 # top of their own trusted images.
-ARG BUILDER_BASE_IMAGE=golang:1.17
+ARG BUILDER_BASE_IMAGE=golang:1.18
 
 # Build the manager binary
 FROM $BUILDER_BASE_IMAGE as builder

--- a/test/pkg/go.mod
+++ b/test/pkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/test/pkg
 
-go 1.17
+go 1.18
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/tkg/go.mod
+++ b/tkg/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/tkg
 
-go 1.17
+go 1.18
 
 replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli => ../apis/cli

--- a/tkg/hack/tools/go.mod
+++ b/tkg/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware-tanzu/tanzu-framework/tkg/hack/tools
 
-go 1.17
+go 1.18
 
 require golang.org/x/tools v0.1.12
 


### PR DESCRIPTION
### What this PR does / why we need it

This PR updates Tanzu Framework to use Go 1.18

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Update Tanzu Framework to use Go 1.18
```