### PR TITLE
Remove pinniped from Codecov yaml ignore list

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -19,7 +19,7 @@ coverage:
     changes: false
 ignore:
   - "vendor"
-  - "pinniped"
+  - "pinniped/**/*"
   - "provider-bundle"
   - "providers.zip"
   - "providers.tar.gz"


### PR DESCRIPTION
### What this PR does / why we need it

I can't see unit test coverage for files inside the `pinniped-components` directory.

This PR gets those test coverage reports to show up on the [Codecov dashboard](https://app.codecov.io/gh/vmware-tanzu/tanzu-framework).

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

After replacing "pinniped" with "pinniped/**/*" in the ignore section of [.codecov.yaml](https://github.com/vmware-tanzu/tanzu-framework/blob/main/.codecov.yaml), and after the build completed successfully by GitHub Action, I was able to see pinniped-components show up in Codecov dashboard.

![pinniped-codecov-as-of-oct-5](https://user-images.githubusercontent.com/17328443/194172025-9049a9bc-c70e-4904-834c-b71b124391c6.png)


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
