### PR TITLE
Run Go tests for admin plugins

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,7 +105,7 @@ jobs:
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v3
       with:
-        files: ./coverage1.txt,./coverage2.txt,./coverage3.txt,./addons/coverage.txt,./pinniped-components/post-deploy/coverage.txt,./pinniped-components/tanzu-auth-controller-manager/coverage.txt,./cli/core/coverage.txt,./cli/runtime/coverage.txt,./tkg/coverage.txt,./featuregates/client/cover.out,./featuregates/controller/cover.out,./capabilities/client/cover.out,./capabilities/controller/cover.out
+        files: ./coverage1.txt,./coverage2.txt,./coverage3.txt,./addons/coverage.txt,./pinniped-components/post-deploy/coverage.txt,./pinniped-components/tanzu-auth-controller-manager/coverage.txt,./cli/core/coverage.txt,./cli/runtime/coverage.txt,./tkg/coverage.txt,./featuregates/client/cover.out,./featuregates/controller/cover.out,./capabilities/client/cover.out,./capabilities/controller/cover.out,./cmd/cli/plugin-admin/builder/cover.out,./cmd/cli/plugin-admin/codegen/cover.out,./cmd/cli/plugin-admin/test/cover.out
 
   check:
     name: Lint

--- a/.github/workflows/release_staging.yaml
+++ b/.github/workflows/release_staging.yaml
@@ -69,7 +69,7 @@ jobs:
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v3
       with:
-        files: ./coverage1.txt,./coverage2.txt,./coverage3.txt,./addons/coverage.txt,./pinniped-components/post-deploy/coverage.txt,./pinniped-components/tanzu-auth-controller-manager/coverage.txt,./cli/core/coverage.txt,./cli/runtime/coverage.txt,./tkg/coverage.txt,./featuregates/client/cover.out,./featuregates/controller/cover.out,./capabilities/client/cover.out,./capabilities/controller/cover.out
+        files: ./coverage1.txt,./coverage2.txt,./coverage3.txt,./addons/coverage.txt,./pinniped-components/post-deploy/coverage.txt,./pinniped-components/tanzu-auth-controller-manager/coverage.txt,./cli/core/coverage.txt,./cli/runtime/coverage.txt,./tkg/coverage.txt,./featuregates/client/cover.out,./featuregates/controller/cover.out,./capabilities/client/cover.out,./capabilities/controller/cover.out,./cmd/cli/plugin-admin/builder/cover.out,./cmd/cli/plugin-admin/codegen/cover.out,./cmd/cli/plugin-admin/test/cover.out
 
     - id: upload-cli-artifacts
       # do not upload unsigned/untested artifacts to GCP bucket

--- a/Makefile
+++ b/Makefile
@@ -517,6 +517,15 @@ test: generate manifests build-cli-mocks ## Run tests
 	# Test capabilities
 	$(MAKE) test -C capabilities
 
+	# Test builder plugin
+	cd cmd/cli/plugin-admin/builder && $(GO) test ./... -coverprofile cover.out
+
+	# Test codegen plugin
+	cd cmd/cli/plugin-admin/codegen && $(GO) test ./... -coverprofile cover.out
+
+	# Test test plugin
+	cd cmd/cli/plugin-admin/test && $(GO) test ./... -coverprofile cover.out
+	
 .PHONY: test-cli
 test-cli: build-cli-mocks ## Run tests
 	$(GO) test  ./pkg/v1/auth/... ./pkg/v1/builder/...  ./pkg/v1/encoding/... ./pkg/v1/grpc/...


### PR DESCRIPTION
### What this PR does / why we need it

Run Go tests for admin plugins.
After the refactoring, we forgot to explicitly run the Go tests (which include code coverage) for the admin plugins.

Note that we decided not to have a `Makefile` for those plugins at the moment, so the Go tests are triggered explicitly from the main `Makefile`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3531

### Describe testing done for PR

Ran `make test` locally and saw go tests being run for the three admin plugins as well as the creating of `cover.txt` files.

Checked new CI output of this PR to see that the following strings were now present:
1. `github.com/vmware-tanzu/tanzu-framework/codegen/plugin`
1. `github.com/vmware-tanzu/tanzu-framework/plugin/builder`
1. `github.com/vwmare-tanzu/tanzu-framework/plugin/test` (see #3535 for fixing the typo)
