### PR TITLE
Run Go tests for refactored plugins

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,7 +105,7 @@ jobs:
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v3
       with:
-        files: ./coverage1.txt,./coverage2.txt,./coverage3.txt,./addons/coverage.txt,./pinniped-components/post-deploy/coverage.txt,./pinniped-components/tanzu-auth-controller-manager/coverage.txt,./cli/core/coverage.txt,./cli/runtime/coverage.txt,./tkg/coverage.txt,./featuregates/client/cover.out,./featuregates/controller/cover.out,./capabilities/client/cover.out,./capabilities/controller/cover.out,./cmd/cli/plugin-admin/builder/cover.out,./cmd/cli/plugin-admin/codegen/cover.out,./cmd/cli/plugin-admin/test/cover.out,./apis/config/cover.out,./apis/run/cover.out,./packageclients/cover.out,./apis/addonconfigs/cover.out,./apis/cli/cover.out,./apis/core/cover.out
+        files: ./coverage1.txt,./coverage2.txt,./coverage3.txt,./addons/coverage.txt,./pinniped-components/post-deploy/coverage.txt,./pinniped-components/tanzu-auth-controller-manager/coverage.txt,./cli/core/coverage.txt,./cli/runtime/coverage.txt,./tkg/coverage.txt,./featuregates/client/cover.out,./featuregates/controller/cover.out,./capabilities/client/cover.out,./capabilities/controller/cover.out,./cmd/cli/plugin-admin/builder/cover.out,./cmd/cli/plugin-admin/codegen/cover.out,./cmd/cli/plugin-admin/test/cover.out,./apis/config/cover.out,./apis/run/cover.out,./packageclients/cover.out,./apis/addonconfigs/cover.out,./apis/cli/cover.out,./apis/core/cover.out,./cmd/cli/plugin/feature/cover.out,./cmd/cli/plugin/login/cover.out,./cmd/cli/plugin/package/cover.out,./cmd/cli/plugin/pinniped-auth/cover.out,./cmd/cli/plugin/secret/cover.out
 
   check:
     name: Lint

--- a/.github/workflows/release_staging.yaml
+++ b/.github/workflows/release_staging.yaml
@@ -69,7 +69,7 @@ jobs:
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v3
       with:
-        files: ./coverage1.txt,./coverage2.txt,./coverage3.txt,./addons/coverage.txt,./pinniped-components/post-deploy/coverage.txt,./pinniped-components/tanzu-auth-controller-manager/coverage.txt,./cli/core/coverage.txt,./cli/runtime/coverage.txt,./tkg/coverage.txt,./featuregates/client/cover.out,./featuregates/controller/cover.out,./capabilities/client/cover.out,./capabilities/controller/cover.out,./cmd/cli/plugin-admin/builder/cover.out,./cmd/cli/plugin-admin/codegen/cover.out,./cmd/cli/plugin-admin/test/cover.out,./apis/config/cover.out,./apis/run/cover.out,./packageclients/cover.out,./apis/addonconfigs/cover.out,./apis/cli/cover.out,./apis/core/cover.out
+        files: ./coverage1.txt,./coverage2.txt,./coverage3.txt,./addons/coverage.txt,./pinniped-components/post-deploy/coverage.txt,./pinniped-components/tanzu-auth-controller-manager/coverage.txt,./cli/core/coverage.txt,./cli/runtime/coverage.txt,./tkg/coverage.txt,./featuregates/client/cover.out,./featuregates/controller/cover.out,./capabilities/client/cover.out,./capabilities/controller/cover.out,./cmd/cli/plugin-admin/builder/cover.out,./cmd/cli/plugin-admin/codegen/cover.out,./cmd/cli/plugin-admin/test/cover.out,./apis/config/cover.out,./apis/run/cover.out,./packageclients/cover.out,./apis/addonconfigs/cover.out,./apis/cli/cover.out,./apis/core/cover.out,./cmd/cli/plugin/feature/cover.out,./cmd/cli/plugin/login/cover.out,./cmd/cli/plugin/package/cover.out,./cmd/cli/plugin/pinniped-auth/cover.out,./cmd/cli/plugin/secret/cover.out
 
     - id: upload-cli-artifacts
       # do not upload unsigned/untested artifacts to GCP bucket

--- a/Makefile
+++ b/Makefile
@@ -526,15 +526,20 @@ test: generate manifests build-cli-mocks ## Run tests
 	cd apis/cli && $(GO) test ./... -coverprofile cover.out
 	cd apis/core && $(GO) test ./... -coverprofile cover.out
 
-	# Test builder plugin
+	# Test admin plugins
 	cd cmd/cli/plugin-admin/builder && $(GO) test ./... -coverprofile cover.out
-
-	# Test codegen plugin
 	cd cmd/cli/plugin-admin/codegen && $(GO) test ./... -coverprofile cover.out
-
-	# Test test plugin
 	cd cmd/cli/plugin-admin/test && $(GO) test ./... -coverprofile cover.out
-	
+
+	# Test plugins
+	cd cmd/cli/plugin/feature && $(GO) test ./... -coverprofile cover.out
+	cd cmd/cli/plugin/login && $(GO) test ./... -coverprofile cover.out
+	cd cmd/cli/plugin/pinniped-auth && $(GO) test ./... -coverprofile cover.out
+	cd cmd/cli/plugin/secret && $(GO) test ./... -coverprofile cover.out
+
+	# Test package plugin but skip package/test which are e2e tests run separately in CI
+	cd cmd/cli/plugin/package && $(GO) test -coverprofile cover.out -v `go list ./... | grep -v github.com/vmware-tanzu/tanzu-framework/cmd/cli/plugin/package/test`
+
 .PHONY: test-cli
 test-cli: build-cli-mocks ## Run tests
 	$(GO) test  ./pkg/v1/auth/... ./pkg/v1/builder/...  ./pkg/v1/encoding/... ./pkg/v1/grpc/...


### PR DESCRIPTION
### What this PR does / why we need it

Run Go tests for the refactored plugins.
After the refactoring, we forgot to explicitly run the Go tests (which include code coverage) for the refactored plugins.

Note that we decided not to have a `Makefile` for those plugins at the moment, so the Go tests are triggered explicitly from the main `Makefile`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3533

### Describe testing done for PR

Ran `make test` locally and saw go tests being run for the refactored plugins as well as the creating of `cover.txt` files.
Actually, the tests failed for the `package` plugin.  I will follow-up on that once CI runs.

Check CI output of this PR for the strings:
1. `github.com/vmware-tanzu/tanzu-framework/featuregate/plugin`
1. `github.com/vmware-tanzu/tanzu-framework/plugin/login`
1. `github.com/vmware-tanzu/tanzu-framework/cmd/cli/plugin/package`
1. `github.com/vmware-tanzu/tanzu-framework/plugin/pinniped-auth`
1. `github.com/vmware-tanzu/tanzu-framework/cmd/cli/plugin/secret` 
