### PR TITLE
Run Go tests for refactored modules

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -105,7 +105,7 @@ jobs:
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v3
       with:
-        files: ./coverage1.txt,./coverage2.txt,./coverage3.txt,./addons/coverage.txt,./pinniped-components/post-deploy/coverage.txt,./pinniped-components/tanzu-auth-controller-manager/coverage.txt,./cli/core/coverage.txt,./cli/runtime/coverage.txt,./tkg/coverage.txt,./featuregates/client/cover.out,./featuregates/controller/cover.out,./capabilities/client/cover.out,./capabilities/controller/cover.out,./cmd/cli/plugin-admin/builder/cover.out,./cmd/cli/plugin-admin/codegen/cover.out,./cmd/cli/plugin-admin/test/cover.out
+        files: ./coverage1.txt,./coverage2.txt,./coverage3.txt,./addons/coverage.txt,./pinniped-components/post-deploy/coverage.txt,./pinniped-components/tanzu-auth-controller-manager/coverage.txt,./cli/core/coverage.txt,./cli/runtime/coverage.txt,./tkg/coverage.txt,./featuregates/client/cover.out,./featuregates/controller/cover.out,./capabilities/client/cover.out,./capabilities/controller/cover.out,./cmd/cli/plugin-admin/builder/cover.out,./cmd/cli/plugin-admin/codegen/cover.out,./cmd/cli/plugin-admin/test/cover.out,./apis/config/cover.out,./apis/run/cover.out,./packageclients/cover.out,./apis/addonconfigs/cover.out,./apis/cli/cover.out,./apis/core/cover.out
 
   check:
     name: Lint

--- a/.github/workflows/release_staging.yaml
+++ b/.github/workflows/release_staging.yaml
@@ -69,7 +69,7 @@ jobs:
     - name: Upload coverage reports to Codecov with GitHub Action
       uses: codecov/codecov-action@v3
       with:
-        files: ./coverage1.txt,./coverage2.txt,./coverage3.txt,./addons/coverage.txt,./pinniped-components/post-deploy/coverage.txt,./pinniped-components/tanzu-auth-controller-manager/coverage.txt,./cli/core/coverage.txt,./cli/runtime/coverage.txt,./tkg/coverage.txt,./featuregates/client/cover.out,./featuregates/controller/cover.out,./capabilities/client/cover.out,./capabilities/controller/cover.out,./cmd/cli/plugin-admin/builder/cover.out,./cmd/cli/plugin-admin/codegen/cover.out,./cmd/cli/plugin-admin/test/cover.out
+        files: ./coverage1.txt,./coverage2.txt,./coverage3.txt,./addons/coverage.txt,./pinniped-components/post-deploy/coverage.txt,./pinniped-components/tanzu-auth-controller-manager/coverage.txt,./cli/core/coverage.txt,./cli/runtime/coverage.txt,./tkg/coverage.txt,./featuregates/client/cover.out,./featuregates/controller/cover.out,./capabilities/client/cover.out,./capabilities/controller/cover.out,./cmd/cli/plugin-admin/builder/cover.out,./cmd/cli/plugin-admin/codegen/cover.out,./cmd/cli/plugin-admin/test/cover.out,./apis/config/cover.out,./apis/run/cover.out,./packageclients/cover.out,./apis/addonconfigs/cover.out,./apis/cli/cover.out,./apis/core/cover.out
 
     - id: upload-cli-artifacts
       # do not upload unsigned/untested artifacts to GCP bucket

--- a/Makefile
+++ b/Makefile
@@ -517,6 +517,15 @@ test: generate manifests build-cli-mocks ## Run tests
 	# Test capabilities
 	$(MAKE) test -C capabilities
 
+	# Test other modules.
+	# TODO: This should be a call to a "test" target in that module's Makefile
+	cd apis/config && $(GO) test ./... -coverprofile cover.out
+	cd apis/run && $(GO) test ./... -coverprofile cover.out
+	cd packageclients && $(GO) test ./... -coverprofile cover.out
+	cd apis/addonconfigs && $(GO) test ./... -coverprofile cover.out
+	cd apis/cli && $(GO) test ./... -coverprofile cover.out
+	cd apis/core && $(GO) test ./... -coverprofile cover.out
+
 	# Test builder plugin
 	cd cmd/cli/plugin-admin/builder && $(GO) test ./... -coverprofile cover.out
 


### PR DESCRIPTION
### What this PR does / why we need it

Run Go tests for the refactored modules that were missed.
After the refactoring, we forgot to explicitly run the Go tests (which include code coverage) for certain modules.

For the sake of efficiency, it was agree that this PR would trigger the go tests from the root `Makefile`.
Adding a `test` target to each module's `Makefile` is something that can be done later.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3544

### Describe testing done for PR

Ran `make test` locally and saw go tests being run for the refactored plugins as well as the creating of `cover.out` files.

Check CI output of this PR for the strings:
- `github.com/vmware-tanzu/tanzu-framework/apis/config`
- `github.com/vmware-tanzu/tanzu-framework/apis/run`
- `github.com/vmware-tanzu/tanzu-framework/packageclients`
- `github.com/vmware-tanzu/tanzu-framework/apis/addonconfigs`
- `github.com/vmware-tanzu/tanzu-framework/apis/cli`
- `github.com/vmware-tanzu/tanzu-framework/apis/core`
