### PR TITLE
Updated TKR version to match what is in the next TKG Bom

### DIFF
--- a/pkg/v1/providers/infrastructure-docker/v1.1.5/yttcc/base-template.yaml
+++ b/pkg/v1/providers/infrastructure-docker/v1.1.5/yttcc/base-template.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ${CLUSTER_NAME}
   labels:
     tkg.tanzu.vmware.com/cluster-name: '${ CLUSTER_NAME }'
-    run.tanzu.vmware.com/tkr: v1.23.8---vmware.2-tkg.1-zshippable
+    run.tanzu.vmware.com/tkr: v1.23.8---vmware.2-tkg.2-zshippable
   annotations:
     run.tanzu.vmware.com/resolve-tkr: ""
 spec:

--- a/pkg/v1/providers/infrastructure-docker/v1.1.5/yttcc/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-docker/v1.1.5/yttcc/overlay.yaml
@@ -20,12 +20,12 @@ metadata:
   name: #@ data.values.CLUSTER_NAME
   labels:
     tkg.tanzu.vmware.com/cluster-name: #@ data.values.CLUSTER_NAME
-    run.tanzu.vmware.com/tkr: v1.23.8---vmware.2-tkg.1-zshippable
+    run.tanzu.vmware.com/tkr: v1.23.8---vmware.2-tkg.2-zshippable
 spec:
   topology:
     class: #@ data.values.CLUSTER_CLASS
     #! VVV TODO(vui) compute
-    version: #@ "{}-tkg.1-zshippable".format(data.values.KUBERNETES_VERSION)
+    version: #@ "{}-tkg.2-zshippable".format(data.values.KUBERNETES_VERSION)
     #@overlay/match missing_ok=True
     controlPlane:
       replicas: #@ data.values.CONTROL_PLANE_MACHINE_COUNT
@@ -62,4 +62,4 @@ spec:
             os-type: linux
             os-arch: amd64
             os-version: "2004"
-            run.tanzu.vmware.com/tkr: v1.23.8---vmware.2-tkg.1-zshippable
+            run.tanzu.vmware.com/tkr: v1.23.8---vmware.2-tkg.2-zshippable

--- a/tkg/test/framework/utils.go
+++ b/tkg/test/framework/utils.go
@@ -64,6 +64,24 @@ func WaitForNodes(proxy *ClusterProxy, desiredCount int) {
 	Fail(fmt.Sprintf("Timed out waiting for nodes count to reach %q", desiredCount))
 }
 
+// WaitForNodesDuringScaleUp waits for desiredCount number of nodes to be ready
+func WaitForNodesDuringScaleUp(proxy *ClusterProxy, desiredCount int) {
+	const timeout = 10 * time.Minute
+
+	start := time.Now()
+	for time.Since(start) < timeout {
+		count := len(proxy.GetClusterNodes())
+		_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Node count for cluster %q: %d\n", proxy.name, count)))
+		if count >= desiredCount {
+			return
+		}
+
+		time.Sleep(30 * time.Second) // nolint:gomnd
+	}
+
+	Fail(fmt.Sprintf("Timed out waiting for nodes count to reach %q", desiredCount))
+}
+
 // GetClusterClass returns ClusterClass used by the Cluster
 func GetClusterClass(proxy *ClusterProxy, clusterName string, namespace string) (string, error) {
 	var err error

--- a/tkg/test/tkgctl/shared/autoscaler.go
+++ b/tkg/test/tkgctl/shared/autoscaler.go
@@ -118,7 +118,7 @@ func E2EAutoscalerSpec(context context.Context, inputGetter func() E2EAutoscaler
 		}
 
 		By("Scaling up workload cluster")
-		framework.WaitForNodes(framework.NewClusterProxy(clusterName, "", contextName), 3)
+		framework.WaitForNodesDuringScaleUp(framework.NewClusterProxy(clusterName, "", contextName), 3)
 
 		By("Deleting workload which should trigger a scale down")
 		kubectlCmd = exec.NewCommand(

--- a/tkg/test/tkgctl/shared/constants.go
+++ b/tkg/test/tkgctl/shared/constants.go
@@ -28,7 +28,7 @@ apiVersion: run.tanzu.vmware.com/v1alpha3
 kind: ClusterBootstrap
 metadata:
   annotations:
-    tkg.tanzu.vmware.com/add-missing-fields-from-tkr: v1.23.8---vmware.2-tkg.1-zshippable
+    tkg.tanzu.vmware.com/add-missing-fields-from-tkr: v1.23.8---vmware.2-tkg.2-zshippable
   name: %s
   namespace: %s
 spec:


### PR DESCRIPTION
### What this PR does / why we need it
The CI pipelines have been failing ever since we started using the 1.7.0 TKG BOM. This is likely because the 1.7.0 TKG BOM is using `v1.23.8.vmware.2-tkg.2-zshippable` and not `v1.23.8.vmware.2-tkg.1-zshippable`. 

This was causing the integration tests to fail. This PR changes the TKR version to `v1.23.8.vmware.2-tkg.2-zshippable` in order to get the CI tests passing


This PR also adds a helper function to the integration tests which waits for the number of scaled up nodes to be greater than / equal to a target number of nodes, as opposed to being exactly equal to the target number of nodes. This was done because the autoscaler tests were failing when the number of cluster nodes was 4, but the expected number was 3

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
1. Relying on the CI checks to pass before merging this PR

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
