### PR TITLE
Add support for completions in fish and powershell

### DIFF
--- a/cli/core/pkg/command/completion.go
+++ b/cli/core/pkg/command/completion.go
@@ -20,6 +20,8 @@ var (
 	completionShells = []string{
 		"bash",
 		"zsh",
+		"fish",
+		"powershell",
 	}
 
 	completionLongDesc = dedent.Dedent(`
@@ -28,8 +30,7 @@ var (
 		The shell completion code must be evaluated to provide completion. See Examples
 		for how to perform this for your given shell.
 
-		Note for bash users: make sure the bash-completions package has been installed.
-		Note for zsh users: zsh >= 5.2 is required for command completion.`)
+		Note for bash users: make sure the bash-completions package has been installed.`)
 
 	completionExamples = dedent.Dedent(`
 		# Bash instructions:
@@ -45,9 +46,30 @@ var (
 
 		# Zsh instructions:
 
+		  ## Load only for current session:
+		  autoload -U compinit; compinit
+		  source <(tanzu completion zsh)
+		  compdef _tanzu tanzu
+
 		  ## Load for all new sessions:
 		  echo "autoload -U compinit; compinit" >> ~/.zshrc
-		  tanzu completion zsh > "${fpath[1]}/_tanzu"`)
+		  tanzu completion zsh > "${fpath[1]}/_tanzu"
+
+		# Fish instructions:
+
+		  ## Load only for current session:
+		  tanzu completion fish | source
+
+		  ## Load for all new sessions:
+		  tanzu completion fish > ~/.config/fish/completions/tanzu.fish
+
+		# Powershell instructions:
+
+		  ## Load only for current session:
+		  tanzu completion powershell | Out-String | Invoke-Expression
+
+		  ## Load for all new sessions:
+		  Add the output of the above command to your powershell profile.`)
 )
 
 // completionCmd represents the completion command
@@ -78,6 +100,10 @@ func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
 		return cmd.Root().GenBashCompletion(out)
 	case "zsh":
 		return cmd.Root().GenZshCompletion(out)
+	case "fish":
+		return cmd.Root().GenFishCompletion(out, true)
+	case "powershell", "pwsh":
+		return cmd.Root().GenPowerShellCompletionWithDesc(out)
 	default:
 		return errors.New("unrecognized shell type specified")
 	}

--- a/cli/core/pkg/command/completion_test.go
+++ b/cli/core/pkg/command/completion_test.go
@@ -75,7 +75,7 @@ func Test_runCompletion_Bash(t *testing.T) {
 	// Check for a snippet of the bash completion output
 	// TODO make this test less brittle
 	if !strings.Contains(out.String(), "if [[ -z \"${BASH_VERSION:-}\" || \"${BASH_VERSINFO[0]:-}\" -gt 3 ]]; then") {
-		t.Errorf("Unexpected error returned for invalid shell argument: %s", out.String())
+		t.Errorf("Unexpected output for the bash shell script: %s", out.String())
 	}
 }
 
@@ -90,6 +90,36 @@ func Test_runCompletion_Zsh(t *testing.T) {
 
 	// Check for a snippet of the zsh completion output
 	if !strings.Contains(out.String(), "# For zsh, when completing a flag with an = (e.g., completion -n=<TAB>)") {
-		t.Errorf("Unexpected error returned for invalid shell argument: %s", out.String())
+		t.Errorf("Unexpected output for the zsh shell script: %s", out.String())
+	}
+}
+
+// Test_runCompletion_Fish validates functionality for fish shell completion.
+func Test_runCompletion_Fish(t *testing.T) {
+	var out bytes.Buffer
+	args := []string{"fish"}
+	err := runCompletion(&out, completionCmd, args)
+	if err != nil {
+		t.Errorf("Unexpected error for valid shell: %v", err)
+	}
+
+	// Check for a snippet of the fish completion output
+	if !strings.Contains(out.String(), "# For Fish, when completing a flag with an = (e.g., <program> -n=<TAB>)") {
+		t.Errorf("Unexpected output for the fish shell script: %s", out.String())
+	}
+}
+
+// Test_runCompletion_Pwsh validates functionality for powershell completion.
+func Test_runCompletion_Pwsh(t *testing.T) {
+	var out bytes.Buffer
+	args := []string{"powershell"}
+	err := runCompletion(&out, completionCmd, args)
+	if err != nil {
+		t.Errorf("Unexpected error for valid shell: %v", err)
+	}
+
+	// Check for a snippet of the powershell completion output
+	if !strings.Contains(out.String(), "# PowerShell supports three different completion modes") {
+		t.Errorf("Unexpected output for the powershell script: %s", out.String())
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it

This PR allows tanzu users to use shell completion for `fish` or `powershell`.
This is directly supported by Cobra and all this PR does is give access to the scripts.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3158

### Describe testing done for PR

Powershell:
```
$ pwsh
PS /Users/kmarc/git/tanzu-framework> ./tanzu <TAB>
# File completion is triggered.  This is not correct.

# Source the new completion script for powershell
PS /Users/kmarc/git/tanzu-framework> ./tanzu completion powershell | Out-String | Invoke-Expression
PS /Users/kmarc/git/tanzu-framework> ./tanzu <TAB>
completion  (Output shell completion code)                     init        (Initialize the CLI)
config      (Configuration for the CLI)                        plugin      (Manage CLI plugins)
context     (Configure and manage contexts for the Tanzu CLI)  update      (Update the CLI)
help        (Help about any command)                           version     (Version information)
```

Fish
```
$ fish
Welcome to fish, the friendly interactive shell
Type help for instructions on how to use fish
kmarc@kmarc-a01 ~/g/tanzu-framework (feat/compFish)> ./tanzu <TAB>
# File completion is triggered.  This is not correct.

# Source the new completion script for fish
kmarc@kmarc-a01 ~/g/tanzu-framework (feat/compFish)> ./tanzu completion fish | source
kmarc@kmarc-a01 ~/g/tanzu-framework (feat/compFish)> ./tanzu <TAB>
completion                  (Output shell completion code)  help  (Help about any command)  update        (Update the CLI)
config                         (Configuration for the CLI)  init      (Initialize the CLI)  version  (Version information)
context  (Configure and manage contexts for the Tanzu CLI)  plugin    (Manage CLI plugins)
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
The Tanzu CLI now supports shell completion for the fish shell and powershell.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

You can install powershell on Mac.

#### Special notes for your reviewer

Note also that with Cobra 1.5, it is no longer necessary to have zsh >= 5.2 (see https://github.com/spf13/cobra/pull/1665).
So I have update the help text.


