### PR TITLE
Clean up runner space for release workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,18 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+    - name: Free some disk space on runner
+      run: |
+        df -h
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/share/boost
+        sudo rm -rf /usr/lib/jvm
+        sudo rm -rf /usr/lib/firefox
+        sudo rm -rf /opt/microsoft/powershell
+        sudo rm -rf /opt/hostedtoolcache
+        echo "free space after cleanup:"
+        df -h
 
     - name: Set up Go 1.x
       uses: actions/setup-go@v3

--- a/.github/workflows/release_staging.yaml
+++ b/.github/workflows/release_staging.yaml
@@ -10,6 +10,18 @@ jobs:
     name: Release Staging
     runs-on: ubuntu-latest
     steps:
+    - name: Free some disk space on runner
+      run: |
+        df -h
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/share/boost
+        sudo rm -rf /usr/lib/jvm
+        sudo rm -rf /usr/lib/firefox
+        sudo rm -rf /opt/microsoft/powershell
+        sudo rm -rf /opt/hostedtoolcache
+        echo "free space after cleanup:"
+        df -h
 
     - name: Set up Go 1.x
       uses: actions/setup-go@v3


### PR DESCRIPTION
The standard github runners ran out of space during builds for the release workflows. Cleaning up some unused directories to see if situation improves.

Signed-off-by: Vui Lam <vui@vmware.com>

### What this PR does / why we need it
standard github runners are running out of space, likely due to golang bump and related growth in go cache.
e.g. https://github.com/vmware-tanzu/tanzu-framework/actions/runs/3192148672/jobs/5209301585

### Which issue(s) this PR fixes

Fixes #N/A

### Describe testing done for PR

Need to merge to trigger the release job to verify if the issue is indeed addressed.

### Release note

```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
