### PR TITLE
[Tooling] Remove use of -compat flag for go mod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ ensure-pinniped-repo: ## Clone Pinniped
 .PHONY: prep-build-cli
 prep-build-cli: ensure-pinniped-repo  ## Prepare for building the CLI
 	$(GO) mod download
-	$(GO) mod tidy -compat=${GOVERSION}
+	$(GO) mod tidy
 	EMBED_PROVIDERS_TAG=embedproviders
 ifeq "${BUILD_TAGS}" "${EMBED_PROVIDERS_TAG}"
 	make -C pkg/v1/providers -f Makefile generate-provider-bundle-zip
@@ -603,7 +603,7 @@ modules: ## Runs go mod to ensure modules are up to date.
 	@for i in $(GO_MODULES); do \
 		echo "-- Tidying $$i --"; \
 		pushd $${i}; \
-		$(GO) mod tidy -compat=${GOVERSION} || exit 1; \
+		$(GO) mod tidy || exit 1; \
 		popd; \
 	done
 
@@ -822,7 +822,7 @@ create-package: ## Stub out new package directories and manifests. Usage: make c
 
 .PHONY: prep-package-tools
 prep-package-tools:
-	cd hack/packages/package-tools && $(GO) mod tidy -compat=${GOVERSION}
+	cd hack/packages/package-tools && $(GO) mod tidy
 
 .PHONY: package-bundle
 package-bundle: tools prep-package-tools ## Build one specific tar bundle package, needs PACKAGE_NAME VERSION

--- a/common.mk
+++ b/common.mk
@@ -5,7 +5,6 @@ GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 GOHOSTOS ?= $(shell go env GOHOSTOS)
 GOHOSTARCH ?= $(shell go env GOHOSTARCH)
-GOVERSION ?= 1.18
 
 ROOT_DIR := $(shell git rev-parse --show-toplevel)
 RELATIVE_ROOT ?= .


### PR DESCRIPTION
### What this PR does / why we need it

Stop using the go mod `-compat` flag which was only useful when using Go 1.17.

When we were using go 1.17, we decided to use the `-compat=1.17` flag of `go mod` so as to use the pruned Go module graph introduced by Go 1.17.  Details can be found in this [Stack Overflow answer](https://stackoverflow.com/a/71974997) and in the [Go documentation](https://go.dev/ref/mod#graph-pruning).

Now that we are running Go 1.18 thanks to #3577, `go mod` will build the dependency graph for go 1.18 and 1.17, which both use the pruned graph.

We therefore don't need to use the `-compat=1.17` flag anymore.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3569 

### Describe testing done for PR

Make sure to be running Go 1.18.
Apply this PR and run `make modules` and see that no files are changed.
