### PR TITLE
Bumping TKr zshippable for 2

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -278,6 +278,7 @@ spec:
         - resourcePool
         - server
   - name: VSPHERE_WINDOWS_TEMPLATE
+    required: false
     schema:
       openAPIV3Schema:
         type: string

--- a/pkg/v1/providers/infrastructure-vsphere/v1.3.1/yttcc/overlay.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.3.1/yttcc/overlay.yaml
@@ -42,7 +42,7 @@ spec:
     #! VVV TODO(vui) compute
     #! version: #@ data.values.KUBERNETES_VERSION
     #! hack to match up tkr
-    version: #@ "{}-tkg.1-zshippable".format(data.values.KUBERNETES_VERSION)
+    version: #@ "{}-tkg.2-zshippable".format(data.values.KUBERNETES_VERSION)
     controlPlane:
       replicas: #@ data.values.CONTROL_PLANE_MACHINE_COUNT
       #@overlay/match missing_ok=True


### PR DESCRIPTION
### What this PR does / why we need it

Missing bumping TKr zshippable for vsphere provider, this raises an error from the mutation webhook.
Moving to the latest TKr `v1.23.8+vmware.2-tkg.1-zshippable`

```
Error from server (could not resolve TKR/OSImage for controlPlane, machineDeployments: [md-0], query: {controlPlane: {k8sVersionPrefix: 'v1.23.8+vmware.2-tkg.1-zshippable',..
```

The required field is missing the spec.variables templates (VSPHERE_WINDOWS_TEMPLATE)

```
error: error validating "/tmp/kubeapply-2955250273": error validating data: ValidationError(ClusterClass.spec.variables[1]): missing required field "required" in io.x-k8s.cluster.v1beta1.ClusterClass.spec.variables; if you choose to ignore these errors, turn validation off with --validate=false 
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
<!-- Example: Created vSphere workload cluster to verify change. -->
Manual CLI usage and mc creation.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```
