### PR TITLE
Support prodcc plan on vSphere classy cluster

### DIFF
--- a/providers/infrastructure-vsphere/v1.3.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.3.1/yttcc/overlay.yaml
@@ -56,7 +56,11 @@ spec:
       - class: tkg-worker
         name: md-0
         #@overlay/match missing_ok=True
+        #@ if data.values.CLUSTER_PLAN == "prodcc":
+        replicas: #@ data.values.WORKER_MACHINE_COUNT_0
+        #@ else:
         replicas: #@ data.values.WORKER_MACHINE_COUNT
+        #@ end
         #@overlay/match missing_ok=True
         metadata:
           annotations:

--- a/providers/infrastructure-vsphere/yttcc/vsphere-overlay.yaml
+++ b/providers/infrastructure-vsphere/yttcc/vsphere-overlay.yaml
@@ -11,26 +11,3 @@
 
 #@ bomDataForK8sVersion = get_bom_data_for_tkr_name()
 
-#@ if data.values.CLUSTER_PLAN == "prodcc" and not data.values.IS_WINDOWS_WORKLOAD_CLUSTER:
-#@overlay/match by=overlay.subset({"kind": "Cluster"})
----
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
-spec:
-  topology:
-    workers:
-      machineDeployments:
-      #@overlay/match by=overlay.index(0)
-      - replicas: #@ data.values.WORKER_MACHINE_COUNT_0
-        #@overlay/match missing_ok=True
-        failureDomain: #@ data.values.VSPHERE_AZ_0
-      #@overlay/append
-      - class: tkg-worker
-        name: tkg-md-1
-        replicas: #@ data.values.WORKER_MACHINE_COUNT_1
-        failureDomain: #@ data.values.VSPHERE_AZ_1
-      - class: tkg-worker
-        name: tkg-md-2
-        replicas: #@ data.values.WORKER_MACHINE_COUNT_2
-        failureDomain: #@ data.values.VSPHERE_AZ_2
-#@ end

--- a/tkg/client/client_suite_test.go
+++ b/tkg/client/client_suite_test.go
@@ -658,7 +658,7 @@ var _ = Describe("ValidateAWSConfig", func() {
 	JustBeforeEach(func() {
 		tkgClient, cerr := CreateTKGClient(tkgConfigPath, testingDir, bomFile, 2*time.Second)
 		Expect(cerr).ToNot(HaveOccurred())
-		err = tkgClient.ConfigureAndValidateAwsConfig(tkrVersion, false, false, 1, false, false)
+		err = tkgClient.ConfigureAndValidateAwsConfig(tkrVersion, 1, false)
 	})
 
 	Context("When the AWS_REGION is not found from tkg config or environment variable", func() {

--- a/tkg/client/utils.go
+++ b/tkg/client/utils.go
@@ -377,16 +377,12 @@ func (c *TkgClient) getDefaultMachineCountForMC(plan string) (int, int) {
 	controlPlaneMachineCount = constants.DefaultDevControlPlaneMachineCount
 	workerMachineCount = constants.DefaultDevWorkerMachineCount
 
-	switch plan {
-	case constants.PlanDev, constants.PlanDevCC:
-		// use the defaults already set above
-	case constants.PlanProd, constants.PlanProdCC:
+	if IsProdPlan(plan) {
 		// update controlplane count for prod plan
 		controlPlaneMachineCount = constants.DefaultProdControlPlaneMachineCount
 		workerMachineCount = constants.DefaultProdWorkerMachineCount
-	default:
-		// do nothing. If config overrides are provided, they'll get overridden in the calling function
 	}
+
 	return controlPlaneMachineCount, workerMachineCount
 }
 
@@ -429,6 +425,10 @@ func getCCPlanFromLegacyPlan(plan string) (string, error) {
 		return constants.PlanProdCC, nil
 	}
 	return "", errors.Errorf("unknown plan '%v'", plan)
+}
+
+func IsProdPlan(plan string) bool {
+	return plan == constants.PlanProd || plan == constants.PlanProdCC
 }
 
 // Sets the appropriate CAPI ClusterTopology configuration unless it has been explicitly overridden

--- a/tkg/client/utils.go
+++ b/tkg/client/utils.go
@@ -378,9 +378,9 @@ func (c *TkgClient) getDefaultMachineCountForMC(plan string) (int, int) {
 	workerMachineCount = constants.DefaultDevWorkerMachineCount
 
 	switch plan {
-	case constants.PlanDev:
+	case constants.PlanDev, constants.PlanDevCC:
 		// use the defaults already set above
-	case constants.PlanProd:
+	case constants.PlanProd, constants.PlanProdCC:
 		// update controlplane count for prod plan
 		controlPlaneMachineCount = constants.DefaultProdControlPlaneMachineCount
 		workerMachineCount = constants.DefaultProdWorkerMachineCount

--- a/tkg/client/validate_test.go
+++ b/tkg/client/validate_test.go
@@ -1418,9 +1418,13 @@ var _ = Describe("Validate", func() {
 			clusterClient        *fakes.ClusterClient
 		)
 		BeforeEach(func() {
+			workerMachineCount := int64(3)
 			createClusterOptions = &client.CreateClusterOptions{
 				VsphereControlPlaneEndpoint: "foo.bar",
 				Edition:                     "tkg",
+				ClusterConfigOptions: client.ClusterConfigOptions{
+					WorkerMachineCount: &workerMachineCount,
+				},
 			}
 			createClusterOptions.ProviderRepositorySource = &clusterctl.ProviderRepositorySourceOptions{
 				InfrastructureProvider: "vsphere",

--- a/tkg/fakes/clusterclient.go
+++ b/tkg/fakes/clusterclient.go
@@ -1170,6 +1170,18 @@ type ClusterClient struct {
 	waitForClusterReadyReturnsOnCall map[int]struct {
 		result1 error
 	}
+	WaitForControlPlaneAvailableStub        func(string, string) error
+	waitForControlPlaneAvailableMutex       sync.RWMutex
+	waitForControlPlaneAvailableArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	waitForControlPlaneAvailableReturns struct {
+		result1 error
+	}
+	waitForControlPlaneAvailableReturnsOnCall map[int]struct {
+		result1 error
+	}
 	WaitForDeploymentStub        func(string, string) error
 	waitForDeploymentMutex       sync.RWMutex
 	waitForDeploymentArgsForCall []struct {
@@ -6754,6 +6766,68 @@ func (fake *ClusterClient) WaitForClusterReadyReturnsOnCall(i int, result1 error
 	}{result1}
 }
 
+func (fake *ClusterClient) WaitForControlPlaneAvailable(arg1 string, arg2 string) error {
+	fake.waitForControlPlaneAvailableMutex.Lock()
+	ret, specificReturn := fake.waitForControlPlaneAvailableReturnsOnCall[len(fake.waitForControlPlaneAvailableArgsForCall)]
+	fake.waitForControlPlaneAvailableArgsForCall = append(fake.waitForControlPlaneAvailableArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.WaitForControlPlaneAvailableStub
+	fakeReturns := fake.waitForControlPlaneAvailableReturns
+	fake.recordInvocation("WaitForControlPlaneAvailable", []interface{}{arg1, arg2})
+	fake.waitForControlPlaneAvailableMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *ClusterClient) WaitForControlPlaneAvailableCallCount() int {
+	fake.waitForControlPlaneAvailableMutex.RLock()
+	defer fake.waitForControlPlaneAvailableMutex.RUnlock()
+	return len(fake.waitForControlPlaneAvailableArgsForCall)
+}
+
+func (fake *ClusterClient) WaitForControlPlaneAvailableCalls(stub func(string, string) error) {
+	fake.waitForControlPlaneAvailableMutex.Lock()
+	defer fake.waitForControlPlaneAvailableMutex.Unlock()
+	fake.WaitForControlPlaneAvailableStub = stub
+}
+
+func (fake *ClusterClient) WaitForControlPlaneAvailableArgsForCall(i int) (string, string) {
+	fake.waitForControlPlaneAvailableMutex.RLock()
+	defer fake.waitForControlPlaneAvailableMutex.RUnlock()
+	argsForCall := fake.waitForControlPlaneAvailableArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *ClusterClient) WaitForControlPlaneAvailableReturns(result1 error) {
+	fake.waitForControlPlaneAvailableMutex.Lock()
+	defer fake.waitForControlPlaneAvailableMutex.Unlock()
+	fake.WaitForControlPlaneAvailableStub = nil
+	fake.waitForControlPlaneAvailableReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ClusterClient) WaitForControlPlaneAvailableReturnsOnCall(i int, result1 error) {
+	fake.waitForControlPlaneAvailableMutex.Lock()
+	defer fake.waitForControlPlaneAvailableMutex.Unlock()
+	fake.WaitForControlPlaneAvailableStub = nil
+	if fake.waitForControlPlaneAvailableReturnsOnCall == nil {
+		fake.waitForControlPlaneAvailableReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.waitForControlPlaneAvailableReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *ClusterClient) WaitForDeployment(arg1 string, arg2 string) error {
 	fake.waitForDeploymentMutex.Lock()
 	ret, specificReturn := fake.waitForDeploymentReturnsOnCall[len(fake.waitForDeploymentArgsForCall)]
@@ -7313,6 +7387,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.waitForClusterInitializedMutex.RUnlock()
 	fake.waitForClusterReadyMutex.RLock()
 	defer fake.waitForClusterReadyMutex.RUnlock()
+	fake.waitForControlPlaneAvailableMutex.RLock()
+	defer fake.waitForControlPlaneAvailableMutex.RUnlock()
 	fake.waitForDeploymentMutex.RLock()
 	defer fake.waitForDeploymentMutex.RUnlock()
 	fake.waitForPacificClusterMutex.RLock()

--- a/tkg/test/tkgctl/shared/node_pools.go
+++ b/tkg/test/tkgctl/shared/node_pools.go
@@ -107,7 +107,7 @@ func E2ENodePoolSpec(context context.Context, inputGetter func() E2ENodePoolSpec
 		Expect(err).To(BeNil())
 
 		if strings.Contains(input.Plan, "prod") {
-			expectedNodes = 4
+			expectedNodes = 6
 		} else {
 			expectedNodes = 2
 		}

--- a/tkg/tkgctl/create_cluster.go
+++ b/tkg/tkgctl/create_cluster.go
@@ -372,7 +372,7 @@ func (t *tkgctl) configureCreateClusterOptionsFromConfigFile(cc *CreateClusterOp
 			cc.ControlPlaneMachineCount = cpmc
 		} else {
 			cc.ControlPlaneMachineCount = constants.DefaultDevControlPlaneMachineCount
-			if cc.Plan == constants.PlanProd {
+			if cc.Plan == constants.PlanProd || cc.Plan == constants.PlanProdCC {
 				cc.ControlPlaneMachineCount = constants.DefaultProdControlPlaneMachineCount
 			}
 		}
@@ -388,7 +388,7 @@ func (t *tkgctl) configureCreateClusterOptionsFromConfigFile(cc *CreateClusterOp
 			cc.WorkerMachineCount = wmc
 		} else {
 			cc.WorkerMachineCount = constants.DefaultDevWorkerMachineCount
-			if cc.Plan == constants.PlanProd {
+			if cc.Plan == constants.PlanProd || cc.Plan == constants.PlanProdCC {
 				cc.WorkerMachineCount = constants.DefaultProdWorkerMachineCount
 			}
 		}

--- a/tkg/tkgctl/create_cluster.go
+++ b/tkg/tkgctl/create_cluster.go
@@ -372,7 +372,7 @@ func (t *tkgctl) configureCreateClusterOptionsFromConfigFile(cc *CreateClusterOp
 			cc.ControlPlaneMachineCount = cpmc
 		} else {
 			cc.ControlPlaneMachineCount = constants.DefaultDevControlPlaneMachineCount
-			if cc.Plan == constants.PlanProd || cc.Plan == constants.PlanProdCC {
+			if client.IsProdPlan(cc.Plan) {
 				cc.ControlPlaneMachineCount = constants.DefaultProdControlPlaneMachineCount
 			}
 		}
@@ -388,7 +388,7 @@ func (t *tkgctl) configureCreateClusterOptionsFromConfigFile(cc *CreateClusterOp
 			cc.WorkerMachineCount = wmc
 		} else {
 			cc.WorkerMachineCount = constants.DefaultDevWorkerMachineCount
-			if cc.Plan == constants.PlanProd || cc.Plan == constants.PlanProdCC {
+			if client.IsProdPlan(cc.Plan) {
 				cc.WorkerMachineCount = constants.DefaultProdWorkerMachineCount
 			}
 		}


### PR DESCRIPTION
### What this PR does / why we need it

* The overlay in `pkg/v1/providers/infrastructure-vsphere/yttcc/vsphere-overlay.yaml` miss `run.tanzu.vmware.com/resolve-os-image` annotation and is duplicate with overlay in `pkg/v1/providers/infrastructure-vsphere/v1.3.1/yttcc/overlay.yaml`. Missing `run.tanzu.vmware.com/resolve-os-image` annotation will cause tkr/os-image resolve error, adding it will make it duplicate with existing overlay, so just remove it.  The `data.values.WORKER_MACHINE_COUNT_0` logic is moved to `pkg/v1/providers/infrastructure-vsphere/v1.3.1/yttcc/overlay.yaml`.
* Set default control plane machine count and worker machine count when its variable is not set in CC mode
* Install kapp-controller right after control plane is available (means API server is ready to receive requests), because control plane scaling up depends on CPI setting providerID for node, and CPI can only be installed after kapp-controller is installed, so the kapp-controller needs to be deployed as soon as API Server is available to speed up the cluster creation process. This only affects management cluster creation, since addon-controller will install kapp-controller for workload cluster after its control plane is available. 
* Distribute md workers for vSphere to keep consistent with AWS/Azure and also legacy mode
* Added a function to check whether current plan is prod

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #3601 .

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3601 
Fixes #3701 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Manual create vSphere classy cluster with prodcc plan, for both management and workload cluster.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support prodcc plan on vSphere classy cluster
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
