### PR TITLE
Removing useExperimentalRetryJoin from Windows templates

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -1410,6 +1410,8 @@ spec:
             names:
             - tkg-worker-windows
       jsonPatches:
+      - op: remove
+        path: /spec/template/spec/useExperimentalRetryJoin
       - op: add
         path: /spec/template/spec/joinConfiguration/nodeRegistration/criSocket
         value: npipe:////./pipe/containerd-containerd

--- a/pkg/v1/providers/infrastructure-vsphere/v1.3.1/cconly/base.yaml
+++ b/pkg/v1/providers/infrastructure-vsphere/v1.3.1/cconly/base.yaml
@@ -1410,6 +1410,8 @@ spec:
             names:
             - tkg-worker-windows
       jsonPatches:
+      - op: remove
+        path: /spec/template/spec/useExperimentalRetryJoin
       - op: add
         path: /spec/template/spec/joinConfiguration/nodeRegistration/criSocket
         value: npipe:////./pipe/containerd-containerd


### PR DESCRIPTION
### What this PR does / why we need it
Windows nodes do not allow the usage of useExperimentalRetryJoin option. This PR removes using json in-line patching.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/3607

### Describe testing done for PR
Created a Windows cluster with the patch and had the node joining
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```
