### PR TITLE
Customization for nameserver/searchDomain/ntpServer for vSphere cc mode

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -405,6 +405,11 @@ spec:
                 items:
                   type: string
                 default: []
+              searchDomains:
+                type: array
+                items:
+                  type: string
+                default: []
   - name: worker
     required: true
     schema:
@@ -431,6 +436,11 @@ spec:
                 items:
                   type: string
                 default: []
+              searchDomains:
+                type: array
+                items:
+                  type: string
+                default: []
   - name: nodePoolLabels
     required: false
     schema:
@@ -443,6 +453,14 @@ spec:
               type: string
             value:
               type: string
+        default: []
+  - name: ntpServers
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: string
         default: []
   - name: TKR_DATA
     required: false
@@ -743,8 +761,14 @@ spec:
             devices:
             - networkName: {{ .vcenter.network }}
               {{ if .controlPlane.network.nameservers -}}
-                nameservers:
+              nameservers:
                 {{- range .controlPlane.network.nameservers }}
+              - {{ . }}
+                {{- end }}
+              {{- end }}
+              {{ if .controlPlane.network.searchDomains -}}
+              searchDomains:
+                {{- range .controlPlane.network.searchDomains }}
               - {{ . }}
                 {{- end }}
               {{- end }}
@@ -766,8 +790,14 @@ spec:
             devices:
             - networkName: {{ .vcenter.network }}
               {{ if .worker.network.nameservers -}}
-                nameservers:
+              nameservers:
                 {{- range .worker.network.nameservers }}
+              - {{ . }}
+                {{- end }}
+              {{- end }}
+              {{ if .controlPlane.network.searchDomains -}}
+              searchDomains:
+                {{- range .controlPlane.network.searchDomains }}
               - {{ . }}
                 {{- end }}
               {{- end }}
@@ -1547,3 +1577,38 @@ spec:
               - ' {{- . -}} '
               {{- end }}
               sudo: ALL=(ALL) NOPASSWD:ALL
+  - name: ntpServers
+    enabledIf: '{{ not (empty .ntpServers) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/ntp
+        valueFrom:
+          template: |
+            enabled: true
+            servers:
+              {{- range .ntpServers }}
+            - {{ . }}
+              {{- end }}
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/ntp
+        valueFrom:
+          template: |
+            enabled: true
+            servers:
+              {{- range .ntpServers }}
+            - {{ . }}
+              {{- end }}

--- a/providers/config_default.yaml
+++ b/providers/config_default.yaml
@@ -459,6 +459,9 @@ DISABLE_TMC_CLOUD_PERMISSIONS: false
 #! Node Nameservers (currently only supports the vSphere provider)
 CONTROL_PLANE_NODE_NAMESERVERS:
 WORKER_NODE_NAMESERVERS:
+#! Node SearchDomains
+CONTROL_PLANE_NODE_SEARCH_DOMAINS:
+WORKER_NODE_SEARCH_DOMAINS:
 
 #! Audit Logging settings
 ENABLE_AUDIT_LOGGING: false
@@ -487,6 +490,8 @@ OS_ARCH: ""
 
 USE_TOPOLOGY_CATEGORIES: false
 
+#! NTP server customization (Only support vSphere provider)
+NTP_SERVERS:
 
 
 #! ---------------------------------------------------------------------

--- a/providers/infrastructure-vsphere/v1.3.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.3.1/cconly/base.yaml
@@ -405,6 +405,11 @@ spec:
                 items:
                   type: string
                 default: []
+              searchDomains:
+                type: array
+                items:
+                  type: string
+                default: []
   - name: worker
     required: true
     schema:
@@ -431,6 +436,11 @@ spec:
                 items:
                   type: string
                 default: []
+              searchDomains:
+                type: array
+                items:
+                  type: string
+                default: []
   - name: nodePoolLabels
     required: false
     schema:
@@ -443,6 +453,14 @@ spec:
               type: string
             value:
               type: string
+        default: []
+  - name: ntpServers
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: string
         default: []
   - name: TKR_DATA
     required: false
@@ -743,8 +761,14 @@ spec:
             devices:
             - networkName: {{ .vcenter.network }}
               {{ if .controlPlane.network.nameservers -}}
-                nameservers:
+              nameservers:
                 {{- range .controlPlane.network.nameservers }}
+              - {{ . }}
+                {{- end }}
+              {{- end }}
+              {{ if .controlPlane.network.searchDomains -}}
+              searchDomains:
+                {{- range .controlPlane.network.searchDomains }}
               - {{ . }}
                 {{- end }}
               {{- end }}
@@ -766,8 +790,14 @@ spec:
             devices:
             - networkName: {{ .vcenter.network }}
               {{ if .worker.network.nameservers -}}
-                nameservers:
+              nameservers:
                 {{- range .worker.network.nameservers }}
+              - {{ . }}
+                {{- end }}
+              {{- end }}
+              {{ if .controlPlane.network.searchDomains -}}
+              searchDomains:
+                {{- range .controlPlane.network.searchDomains }}
               - {{ . }}
                 {{- end }}
               {{- end }}
@@ -1547,3 +1577,38 @@ spec:
               - ' {{- . -}} '
               {{- end }}
               sudo: ALL=(ALL) NOPASSWD:ALL
+  - name: ntpServers
+    enabledIf: '{{ not (empty .ntpServers) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/ntp
+        valueFrom:
+          template: |
+            enabled: true
+            servers:
+              {{- range .ntpServers }}
+            - {{ . }}
+              {{- end }}
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/ntp
+        valueFrom:
+          template: |
+            enabled: true
+            servers:
+              {{- range .ntpServers }}
+            - {{ . }}
+              {{- end }}

--- a/providers/infrastructure-vsphere/v1.3.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.3.1/yttcc/overlay.yaml
@@ -130,7 +130,7 @@ spec:
     variables:
     #@ vars = get_vsphere_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "TKR_DATA"]:
+    #@  if vars[configVariable] != None and configVariable in ["apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/providers/yttcc/lib/config_variable_association.star
+++ b/providers/yttcc/lib/config_variable_association.star
@@ -791,7 +791,10 @@ def get_vsphere_vars():
 
     network = {}
     if data.values["CONTROL_PLANE_NODE_NAMESERVERS"] != None:
-        network["nameservers"] = data.values["CONTROL_PLANE_NODE_NAMESERVERS"]
+        network["nameservers"] = data.values["CONTROL_PLANE_NODE_NAMESERVERS"].replace(" ", "").split(",")
+    end
+    if data.values["CONTROL_PLANE_NODE_SEARCH_DOMAINS"] != None:
+        network["searchDomains"] = data.values["CONTROL_PLANE_NODE_SEARCH_DOMAINS"].replace(" ", "").split(",")
     end
     if network != {}:
         controlPlane["network"] = network
@@ -820,13 +823,20 @@ def get_vsphere_vars():
 
     network = {}
     if data.values["WORKER_NODE_NAMESERVERS"] != None:
-        network["nameservers"] = data.values["WORKER_NODE_NAMESERVERS"]
+        network["nameservers"] = data.values["WORKER_NODE_NAMESERVERS"].replace(" ", "").split(",")
+    end
+    if data.values["WORKER_NODE_SEARCH_DOMAINS"] != None:
+        network["searchDomains"] = data.values["WORKER_NODE_SEARCH_DOMAINS"].replace(" ", "").split(",")
     end
     if network != {}:
         worker["network"] = network
     end
     if worker != {}:
         vars["worker"] = worker
+    end
+
+    if data.values["NTP_SERVERS"] != None:
+        vars["ntpServers"] = data.values["NTP_SERVERS"].replace(" ", "").split(",")
     end
 
     return vars


### PR DESCRIPTION
### What this PR does / why we need it

We need to support officially documented ytt overlay customization in CC mode. This PR address 3 of them:

* Nameservers on vSphere  (This one is just a fix, add indentation and support multiple nameserver)
* Resolve .local Domain
* Configuring NTP without DHCP Option 42


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Part of #3616 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Manually create CC cluster with customization.

### Release note

```
Support customization for nameserver/searchDomain/ntpServer when creating CC based cluster on vSphere
```

<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->

### Doc

#### Nameservers on vSphere

1. Enable custom-nameservers flag:
tanzu config set features.management-cluster.custom-nameservers true
2. Add below variable in config file to customize name server on control plane and worker nodes, for example:
```
CONTROL_PLANE_NODE_NAMESERVERS: 10.132.7.1, 10.142.7.1
WORKER_NODE_NAMESERVERS: 10.132.7.1, 10.142.7.1
```

Validate whether it's set successfully, login into the control plane or worker node vm:
```
$ cat /etc/systemd/network/10-cloud-init-eth0.network
[Network]
DHCP=ipv4
DNS=10.132.7.1 10.142.7.1
```


#### Resolve .local Domain

Add below variable in config file to customize search domain:
```
CONTROL_PLANE_NODE_SEARCH_DOMAINS: eng.vmware.com, vmware.com
WORKER_NODE_SEARCH_DOMAINS: eng.vmware.com, vmware.com
```

Validate whether it's set successfully, login into the control plane or worker node vm:
```
$ cat /etc/systemd/network/10-cloud-init-eth0.network
[Network]
DHCP=ipv4
Domains=eng.vmware.com vmware.com
```

#### Configuring NTP without DHCP Option 42 (vSphere)

Add below variable in config file to customize ntp servers:
```
NTP_SERVERS: time.google.com
```

Validate whether it's set successfully, login into the control plane or worker node vm:
```
$ cat /etc/chrony.conf
# Use public servers from the pool.ntp.org project.
# Please consider joining the pool (http://www.pool.ntp.org/join.html).
# servers
server time.google.com iburst
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
