### PR TITLE
Add unit tests for capabilities to increase test coverage

### DIFF
--- a/capabilities/client/go.mod
+++ b/capabilities/client/go.mod
@@ -5,6 +5,7 @@ go 1.18
 replace github.com/vmware-tanzu/tanzu-framework/apis/run => ../../apis/run
 
 require (
+	github.com/google/gnostic v0.5.7-v3refs
 	github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-00010101000000-000000000000
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.2
@@ -35,7 +36,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/capabilities/client/pkg/discovery/cluster_test.go
+++ b/capabilities/client/pkg/discovery/cluster_test.go
@@ -39,6 +39,9 @@ var testGVR = Group("carpResource", testapigroup.SchemeGroupVersion.Group).
 	WithVersions(testapigroup.SchemeGroupVersion.Version).
 	WithResource("carps")
 
+var testPartialSchemaNotFound = Schema("partialSchemaQuery", "partial schema")
+var testPartialSchemaFound = Schema("partialSchemaQuery", "example schema for test")
+
 var testObjects = []runtime.Object{
 	&testapigroup.Carp{
 		ObjectMeta: metav1.ObjectMeta{
@@ -75,6 +78,11 @@ func queryClientWithNoResources() (*ClusterQueryClient, error) {
 func queryClientWithResourcesAndNoObjects() (*ClusterQueryClient, error) {
 	scheme, _ := apitest.TestScheme()
 	return NewFakeClusterQueryClient(apiResources, scheme, []runtime.Object{})
+}
+
+func queryClientWithSchema() (*ClusterQueryClient, error) {
+	scheme, _ := apitest.TestScheme()
+	return NewFakeClusterQueryClientWithSchema(nil, scheme, nil)
 }
 
 func TestClusterQueries(t *testing.T) {
@@ -118,6 +126,20 @@ func TestClusterQueries(t *testing.T) {
 			queryTargets:      []QueryTarget{testGVR, testObject, Object("carpObj", &carp)},
 			want:              false,
 			err:               "query target names must be unique",
+		},
+		{
+			description:       "partial schema query not found",
+			discoveryClientFn: queryClientWithSchema,
+			queryTargets:      []QueryTarget{testPartialSchemaNotFound},
+			want:              false,
+			err:               "",
+		},
+		{
+			description:       "partial schema query found",
+			discoveryClientFn: queryClientWithSchema,
+			queryTargets:      []QueryTarget{testPartialSchemaFound},
+			want:              true,
+			err:               "",
 		},
 	}
 

--- a/capabilities/client/pkg/discovery/fake.go
+++ b/capabilities/client/pkg/discovery/fake.go
@@ -4,6 +4,7 @@
 package discovery
 
 import (
+	openapi_v2 "github.com/google/gnostic/openapiv2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakediscovery "k8s.io/client-go/discovery/fake"
@@ -18,5 +19,38 @@ func NewFakeClusterQueryClient(resources []*metav1.APIResourceList, scheme *runt
 		Fake: &k8stesting.Fake{
 			Resources: resources,
 		}}
+	return NewClusterQueryClient(fakeDynamicClient, fakeDiscoveryClient)
+}
+
+// fakeWithSchema is the same as fakediscovery.FakeDiscovery except it has a
+// different OPenAPISchema() method.
+type fakeWithSchema struct {
+	*fakediscovery.FakeDiscovery
+}
+
+func (fws fakeWithSchema) OpenAPISchema() (*openapi_v2.Document, error) {
+	schema := `swagger: '2.0'
+info:
+  title: 'example schema for test'
+  version: '1.3'
+paths:
+  - '/test/path'
+  - '/another/path'
+`
+	return openapi_v2.ParseDocument([]byte(schema))
+}
+
+// NewFakeClusterQueryClient returns a fake ClusterQueryClient for use in tests.
+func NewFakeClusterQueryClientWithSchema(resources []*metav1.APIResourceList, scheme *runtime.Scheme, objs []runtime.Object) (*ClusterQueryClient, error) {
+	fakeDynamicClient := dynamicFake.NewSimpleDynamicClient(scheme, objs...)
+
+	fakeDiscWithSchema := fakeWithSchema{
+		&fakediscovery.FakeDiscovery{
+			Fake: &k8stesting.Fake{
+				Resources: nil,
+			},
+		},
+	}
+	fakeDiscoveryClient := &fakeDiscWithSchema
 	return NewClusterQueryClient(fakeDynamicClient, fakeDiscoveryClient)
 }

--- a/capabilities/client/pkg/discovery/generate.go
+++ b/capabilities/client/pkg/discovery/generate.go
@@ -10,7 +10,8 @@ import (
 	runv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
 )
 
-// QueryTargetsToCapabilityResource is a helper function to generate a Capability v1alpha1 resource from a slice of QueryTarget.
+// QueryTargetsToCapabilityResource is a helper function to generate a
+// Capability v1alpha1 resource from a slice of QueryTarget.
 func QueryTargetsToCapabilityResource(queryTargets []QueryTarget) (*runv1alpha1.Capability, error) {
 	var (
 		gvrQueries           []runv1alpha1.QueryGVR

--- a/capabilities/client/pkg/discovery/generate_test.go
+++ b/capabilities/client/pkg/discovery/generate_test.go
@@ -1,0 +1,143 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package discovery
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	testapigroup "k8s.io/apimachinery/pkg/apis/testapigroup/v1"
+
+	runv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha1"
+)
+
+// Create an unknownQueryType that implements QueryTarget interface to ensure
+// the correct error is triggered in one of table test cases.
+type unknownQueryType string
+
+func (unk unknownQueryType) Name() string {
+	return ""
+}
+func (unk unknownQueryType) Run(conf *clusterQueryClientConfig) (bool, error) {
+	return false, nil
+}
+func (unk unknownQueryType) Reason() string {
+	return ""
+}
+
+func TestQueryTargetsToCapabilityResource(t *testing.T) {
+	clusterGVR := Group("pondQuery", testapigroup.SchemeGroupVersion.Group).
+		WithVersions(testapigroup.SchemeGroupVersion.Version).
+		WithResource("carps")
+
+	koi := corev1.ObjectReference{
+		Kind:       "Carp",
+		Name:       "koi",
+		Namespace:  "koi-pond",
+		APIVersion: testapigroup.SchemeGroupVersion.String(),
+	}
+	annotations := map[string]string{
+		"cluster.x-k8s.io/provider": "infrastructure-fake",
+	}
+	clusterObject := Object("pondQuery", &koi).WithAnnotations(annotations)
+
+	clusterSchema := Schema("pondQuery", "partial schema")
+
+	testCases := []struct {
+		description  string
+		queryTargets []QueryTarget
+		want         runv1alpha1.Capability
+		err          error
+	}{
+		{
+			description:  "one of each query target type (gvr, object, and partial schema)",
+			queryTargets: []QueryTarget{clusterGVR, clusterObject, clusterSchema},
+			want: runv1alpha1.Capability{
+				Spec: runv1alpha1.CapabilitySpec{
+					Queries: []runv1alpha1.Query{
+						{
+							GroupVersionResources: []runv1alpha1.QueryGVR{
+								{
+									Group:    testapigroup.SchemeGroupVersion.Group,
+									Resource: "carps",
+									Versions: []string{testapigroup.SchemeGroupVersion.Version},
+								},
+							},
+							Objects: []runv1alpha1.QueryObject{
+								{
+									ObjectReference:    koi,
+									WithAnnotations:    annotations,
+									WithoutAnnotations: map[string]string{},
+								},
+							},
+							PartialSchemas: []runv1alpha1.QueryPartialSchema{
+								{
+									PartialSchema: "partial schema",
+								},
+							},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			description:  "unknown query type",
+			queryTargets: []QueryTarget{unknownQueryType("shark")},
+			err:          fmt.Errorf("unknown QueryTarget type: %T", unknownQueryType("shark")),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			got, err := QueryTargetsToCapabilityResource(tc.queryTargets)
+
+			if tc.err == nil {
+				// Check QueryGVR fields.
+				if len(got.Spec.Queries[0].GroupVersionResources[0].Name) == 0 {
+					t.Errorf("QueryGVR name: got: %s, but want: a non-empty string", got.Spec.Queries[0].GroupVersionResources[0].Name)
+				}
+				if got.Spec.Queries[0].GroupVersionResources[0].Group != tc.want.Spec.Queries[0].GroupVersionResources[0].Group {
+					t.Errorf("QueryGVR resource group: got: %s, but want: %s", got.Spec.Queries[0].GroupVersionResources[0].Group, tc.want.Spec.Queries[0].GroupVersionResources[0].Group)
+				}
+				if !reflect.DeepEqual(got.Spec.Queries[0].GroupVersionResources[0].Versions, tc.want.Spec.Queries[0].GroupVersionResources[0].Versions) {
+					t.Errorf("QueryGVR versions: got: %+v, but want: %+v", got.Spec.Queries[0].GroupVersionResources[0].Versions, tc.want.Spec.Queries[0].GroupVersionResources[0].Versions)
+				}
+
+				// Check QueryObject fields.
+				if len(got.Spec.Queries[0].Objects[0].Name) == 0 {
+					t.Errorf("QueryObject name: got: %s, but want: a non-empty string", got.Spec.Queries[0].Objects[0].Name)
+				}
+				if got.Spec.Queries[0].Objects[0].ObjectReference != tc.want.Spec.Queries[0].Objects[0].ObjectReference {
+					t.Errorf("QueryObject object reference: got: %+v, but want: %+v", got.Spec.Queries[0].Objects[0].ObjectReference, tc.want.Spec.Queries[0].Objects[0].ObjectReference)
+				}
+				if !reflect.DeepEqual(got.Spec.Queries[0].Objects[0].WithAnnotations, tc.want.Spec.Queries[0].Objects[0].WithAnnotations) {
+					t.Errorf("QueryGVR versions: got: %+v, but want: %+v", got.Spec.Queries[0].Objects[0].WithAnnotations, tc.want.Spec.Queries[0].Objects[0].WithAnnotations)
+				}
+				if !reflect.DeepEqual(got.Spec.Queries[0].Objects[0].WithoutAnnotations, tc.want.Spec.Queries[0].Objects[0].WithoutAnnotations) {
+					t.Errorf("QueryGVR versions: got: %+v, but want: %+v", got.Spec.Queries[0].Objects[0].WithoutAnnotations, tc.want.Spec.Queries[0].Objects[0].WithoutAnnotations)
+				}
+
+				// Check QueryPartialSchema fields.
+				if len(got.Spec.Queries[0].PartialSchemas[0].Name) == 0 {
+					t.Errorf("QueryPartialSchema name: got: %s, but want: a non-empty string", got.Spec.Queries[0].PartialSchemas[0].Name)
+				}
+				if got.Spec.Queries[0].PartialSchemas[0].PartialSchema != tc.want.Spec.Queries[0].PartialSchemas[0].PartialSchema {
+					t.Errorf("QueryPartialSchema partial schema: got: %s, but want: %s", got.Spec.Queries[0].PartialSchemas[0].PartialSchema, tc.want.Spec.Queries[0].PartialSchemas[0].PartialSchema)
+				}
+			}
+
+			if tc.err != nil {
+				if err.Error() != tc.err.Error() {
+					t.Errorf("want error: %s but got: %s", tc.err, err)
+				}
+				if got != nil {
+					t.Errorf("expected nil Capability object, but got: %+v", got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: F. Gold <fgold@vmware.com>

### What this PR does / why we need it

Increase test coverage of capabilities functions. It is needed because at Codecov shows the capabilities component a Tanzu Framework top directory has less than 70% test coverage.

Before this PR, the coverage was 66.19% for capabilities:

![codecov-capabilities](https://user-images.githubusercontent.com/17328443/195214781-eb192344-bff6-4fdd-9a2d-501317d650bc.png)

This PR creates unit tests for two files that have zero test coverage: `generate.go` and `cluster_schema.go`.

![codecov-capabilties-discovery](https://user-images.githubusercontent.com/17328443/195215200-52f94e63-64f4-4b45-aa9a-6bbaabc4fc27.png)

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

After this PR, Codecov showed higher coverage numbers for both `generate.go` (100%) and `cluster_schema.go` (84.21%) files when it processed my branch.

![after_generate_cluster-schema](https://user-images.githubusercontent.com/17328443/197320424-50376d7c-f727-4d2f-b318-3c2e133f3361.png)

The overall coverage for capabilities increased to 79.39%, which surpasses the goal of a minimum 70% coverage:

![after_capabilities](https://user-images.githubusercontent.com/17328443/197320452-10fe1457-9629-497c-a190-eef6fad56b77.png)


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
