### PR TITLE
Adds last-applied annotation to kapp-controller deployment before upgrade

### DIFF
--- a/tkg/client/upgrade_addon.go
+++ b/tkg/client/upgrade_addon.go
@@ -248,6 +248,13 @@ func (c *TkgClient) DoUpgradeAddon(regionalClusterClient clusterclient.Client, /
 			return errors.Wrap(err, "unable to get cluster configuration")
 		}
 
+		// ensure current kapp-controller deployment has last-applied annotation, which is required for future apply operations
+		if addonName == "addons-management/kapp-controller" {
+			if err := clusterClient.PatchKappControllerLastAppliedAnnotation(options.Namespace); err != nil {
+				return errors.Wrap(err, "unable to add last-applied annotation on kapp-controller")
+			}
+		}
+
 		log.Infof("updating additional components: '%s' ...", addonName)
 
 		err = clusterClient.Apply(string(yaml))

--- a/tkg/client/upgrade_addon_test.go
+++ b/tkg/client/upgrade_addon_test.go
@@ -177,6 +177,19 @@ var _ = Describe("Unit tests for addons upgrade", func() {
 			})
 		})
 
+		Context("When upgrading kapp-controller and it fails to add the last applied annotation", func() {
+			BeforeEach(func() {
+				addonsToBeUpgraded = []string{"addons-management/kapp-controller"}
+				clusterTemplateError = nil
+				regionalClusterClient.PatchKappControllerLastAppliedAnnotationReturns(errors.New("fake-error"))
+			})
+			It("should not returns an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unable to add last-applied annotation on kapp-controller"))
+				Expect(err.Error()).To(ContainSubstring("fake-error"))
+			})
+		})
+
 		Context("When upgrading all addons", func() {
 			BeforeEach(func() {
 				addonsToBeUpgraded = []string{"metadata/tkg", "addons-management/kapp-controller", "addons-management/tanzu-addons-manager", "tkr/tkr-controller"}

--- a/tkg/fakes/clusterclient.go
+++ b/tkg/fakes/clusterclient.go
@@ -886,6 +886,17 @@ type ClusterClient struct {
 	patchK8SVersionToPacificClusterReturnsOnCall map[int]struct {
 		result1 error
 	}
+	PatchKappControllerLastAppliedAnnotationStub        func(string) error
+	patchKappControllerLastAppliedAnnotationMutex       sync.RWMutex
+	patchKappControllerLastAppliedAnnotationArgsForCall []struct {
+		arg1 string
+	}
+	patchKappControllerLastAppliedAnnotationReturns struct {
+		result1 error
+	}
+	patchKappControllerLastAppliedAnnotationReturnsOnCall map[int]struct {
+		result1 error
+	}
 	PatchResourceStub        func(interface{}, string, string, string, types.PatchType, *clusterclient.PollOptions) error
 	patchResourceMutex       sync.RWMutex
 	patchResourceArgsForCall []struct {
@@ -5359,6 +5370,67 @@ func (fake *ClusterClient) PatchK8SVersionToPacificClusterReturnsOnCall(i int, r
 	}{result1}
 }
 
+func (fake *ClusterClient) PatchKappControllerLastAppliedAnnotation(arg1 string) error {
+	fake.patchKappControllerLastAppliedAnnotationMutex.Lock()
+	ret, specificReturn := fake.patchKappControllerLastAppliedAnnotationReturnsOnCall[len(fake.patchKappControllerLastAppliedAnnotationArgsForCall)]
+	fake.patchKappControllerLastAppliedAnnotationArgsForCall = append(fake.patchKappControllerLastAppliedAnnotationArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.PatchKappControllerLastAppliedAnnotationStub
+	fakeReturns := fake.patchKappControllerLastAppliedAnnotationReturns
+	fake.recordInvocation("PatchKappControllerLastAppliedAnnotation", []interface{}{arg1})
+	fake.patchKappControllerLastAppliedAnnotationMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *ClusterClient) PatchKappControllerLastAppliedAnnotationCallCount() int {
+	fake.patchKappControllerLastAppliedAnnotationMutex.RLock()
+	defer fake.patchKappControllerLastAppliedAnnotationMutex.RUnlock()
+	return len(fake.patchKappControllerLastAppliedAnnotationArgsForCall)
+}
+
+func (fake *ClusterClient) PatchKappControllerLastAppliedAnnotationCalls(stub func(string) error) {
+	fake.patchKappControllerLastAppliedAnnotationMutex.Lock()
+	defer fake.patchKappControllerLastAppliedAnnotationMutex.Unlock()
+	fake.PatchKappControllerLastAppliedAnnotationStub = stub
+}
+
+func (fake *ClusterClient) PatchKappControllerLastAppliedAnnotationArgsForCall(i int) string {
+	fake.patchKappControllerLastAppliedAnnotationMutex.RLock()
+	defer fake.patchKappControllerLastAppliedAnnotationMutex.RUnlock()
+	argsForCall := fake.patchKappControllerLastAppliedAnnotationArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *ClusterClient) PatchKappControllerLastAppliedAnnotationReturns(result1 error) {
+	fake.patchKappControllerLastAppliedAnnotationMutex.Lock()
+	defer fake.patchKappControllerLastAppliedAnnotationMutex.Unlock()
+	fake.PatchKappControllerLastAppliedAnnotationStub = nil
+	fake.patchKappControllerLastAppliedAnnotationReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *ClusterClient) PatchKappControllerLastAppliedAnnotationReturnsOnCall(i int, result1 error) {
+	fake.patchKappControllerLastAppliedAnnotationMutex.Lock()
+	defer fake.patchKappControllerLastAppliedAnnotationMutex.Unlock()
+	fake.PatchKappControllerLastAppliedAnnotationStub = nil
+	if fake.patchKappControllerLastAppliedAnnotationReturnsOnCall == nil {
+		fake.patchKappControllerLastAppliedAnnotationReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.patchKappControllerLastAppliedAnnotationReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *ClusterClient) PatchResource(arg1 interface{}, arg2 string, arg3 string, arg4 string, arg5 types.PatchType, arg6 *clusterclient.PollOptions) error {
 	fake.patchResourceMutex.Lock()
 	ret, specificReturn := fake.patchResourceReturnsOnCall[len(fake.patchResourceArgsForCall)]
@@ -7197,6 +7269,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.patchImageRepositoryInKubeProxyDaemonSetMutex.RUnlock()
 	fake.patchK8SVersionToPacificClusterMutex.RLock()
 	defer fake.patchK8SVersionToPacificClusterMutex.RUnlock()
+	fake.patchKappControllerLastAppliedAnnotationMutex.RLock()
+	defer fake.patchKappControllerLastAppliedAnnotationMutex.RUnlock()
 	fake.patchResourceMutex.RLock()
 	defer fake.patchResourceMutex.RUnlock()
 	fake.removeCEIPTelemetryJobMutex.RLock()


### PR DESCRIPTION
### What this PR does / why we need it
- Adds last-applied annotation to `kapp-controller` deployment before upgrade
- This ensures `kapp-controller` manifest merges correctly during upgrade. So `kapp-controller` deployment can be up and run successfully even in some cases `kapp-controller` is created by `kubectl create -f` before upgrade.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #
- Fix issue post upgrade that `kapp-controller` keeps failing due to error 
```
exec: "/kapp-controller-sidecarexec": stat /kapp-controller-sidecarexec: no such file or directory: unknown
```
- The **root cause** is that kubectl merges `kapp-controller` deployment manifest incorrectly during upgrade when source `kapp-controller` version is created by `kubectl create -f` instead of `kubectl apply -f`.

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
- Manually tested on kind cluster that using `kubectl apply set-last-applied` can add last-applied annotation to the `kapp-controller` created with `kubectl create -f`. And kubectl can merge the manifest correctly during the following upgrade. It demonstrates the following workflow can fix the issue:
```
kubectl create -f kapp-before-upgrade.yaml
kubectl apply set-last-applied --create-annotation=true -f kapp-before-upgrade.yaml
kubectl apply -f new-kapp.yaml    <======== upgrade succeeds here
```
- Verified on TKG cluster on AWS using the tanzu CLI built from this branch, and `kapp-controller` is upgraded successfully:
```
# 1. Before upgrade kapp-yaml snippet:
[~] kubectl get deploy kapp-controller -n tkg-system -o yaml
...
metadata:
  annotations:
    kapp-controller.carvel.dev/version: v0.38.4
...
spec:
  template:
    spec:
      containers:
      - command:
        - /kapp-controller-sidecarexec
        env:
        - name: KAPPCTRL_SIDECAREXEC_SOCK
          value: /etc/kappctrl-mem-tmp/sidecarexec.sock

# 2. Run tanzu management-cluster upgrade
# 3. kapp-controller is upgraded successfully
[~] kubectl get deploy kapp-controller -n tkg-system
NAME              READY   UP-TO-DATE   AVAILABLE   AGE
kapp-controller   1/1     1            1           67m
[~] kubectl get pod -n tkg-system
NAME                                                    READY   STATUS    RESTARTS      AGE
kapp-controller-7dbfb5bc58-pnpq8                        2/2     Running   0             2m45s
tanzu-addons-controller-manager-6f7bd84c87-rcnj5        1/1     Running   0             111s
tanzu-capabilities-controller-manager-ff4c7d7f-f2qxb    1/1     Running   1 (10s ago)   2m16s
tanzu-featuregates-controller-manager-bf9ff6466-5cmnn   1/1     Running   0             88s
[~] kubectl get deploy kapp-controller -n tkg-system -o yaml
...
metadata:
  annotations:
    kapp-controller.carvel.dev/version: v0.41.2
...
spec:
  template:
    spec:
      containers:
      - args:
        - --sidecarexec
        env:
        - name: KAPPCTRL_SIDECAREXEC_SOCK

```
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix kapp-controller upgrade issue
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
