### PR TITLE
Add Chocolatey package build script

### DIFF
--- a/cli/core/Makefile
+++ b/cli/core/Makefile
@@ -169,7 +169,7 @@ apt-package: ## Build a debian package to use with APT
 	fi
 
 	@# To call this target, the VERSION variable must be set by the caller.  The version must match an existing release
-	@# of the tanzu CLI on Github. E.g., VERSION=v0.26.0 make apt-package	
+	@# of the tanzu CLI on Github. E.g., VERSION=v0.26.0 make apt-package
 	docker run --rm -e VERSION=$${VERSION} -v $(ROOT_DIR):$(ROOT_DIR) ubuntu $(MODULE_ROOT_DIR)/hack/apt/build_package.sh
 
 .PHONY: rpm-package
@@ -182,6 +182,23 @@ rpm-package: ## Build an RPM package
 	@# To call this target, the VERSION variable must be set by the caller.  The version must match an existing release
 	@# of the tanzu CLI on Github. E.g., VERSION=v0.26.0 make rpm-package
 	docker run --rm -e VERSION=$${VERSION} -v $(ROOT_DIR):$(ROOT_DIR) fedora $(MODULE_ROOT_DIR)/hack/rpm/build_package.sh
+
+.PHONY: choco-package
+choco-package: ## Build a Chocolatey package
+	@if [ "$$(command -v docker)" = "" ]; then \
+		echo "Docker required to build chocolatey package" ;\
+		exit 1 ;\
+	fi
+
+	@# There are only AMD64 images to run chocolatey on docker
+	@if [ "$(GOHOSTARCH)" != "amd64" ]; then \
+		echo "Can only build chocolatey package on an amd64 machine at the moment" ;\
+		exit 1 ;\
+	fi
+
+	@# To call this target, the VERSION variable must be set by the caller.  The version must match an existing release
+	@# of the tanzu CLI on Github. E.g., VERSION=v0.26.0 make choco-package
+	docker run --rm -e VERSION=$${VERSION} -v $(ROOT_DIR):$(ROOT_DIR) chocolatey/choco $(MODULE_ROOT_DIR)/hack/choco/build_package.sh
 
 ## --------------------------------------
 ## Testing

--- a/cli/core/hack/choco/README.md
+++ b/cli/core/hack/choco/README.md
@@ -1,0 +1,53 @@
+# Using Chocolatey to install the Tanzu CLI
+
+This document describes how to build a Chocolatey package for the Tanzu CLI and how to install it.
+
+## Building the Chocolatey package
+
+Executing the `hack/choco/build_package.sh` script will build the Chocolatey package under `cli/core/hack/choco/_output/choco`.
+The `hack/choco/build_package.sh` script is meant to be run on a Linux machine that has `choco` installed.
+This is most easily done using docker.  Note that currently, the docker images for Chocolatey only support an
+`amd64` architecture.  To facilitate building the package, the new `choco-package` Makefile target has been added
+to `cli/core/Makefile`; this Makefile target will first start a docker container and then run the `hack/choco/build_package.sh`
+script.  The `VERSION` environment variable must be set when running the make target.
+
+```bash
+cd tanzu-framework/cli/core
+VERSION=v0.26.0 make choco-package
+```
+
+### Content of Chocolatey package
+
+Currently, we build a Chocolatey package without including the actual Tanzu CLI binary.  Instead, when the
+package is installed, Chocolatey will download the CLI binary from Github.  This has to do with distribution
+rights as we will probably publish the Chocolatey package in the community package repository.
+
+## Installing the Tanzu CLI using the built Chocolatey package
+
+Installing the Tanzu CLI using the newly build Chocolatey package can be done on a Windows machine with `choco`
+installed. First, the Chocolatey package must be uploaded to the Windows machine.
+
+For example, if we upload the package to the Windows machine under `$HOME\tanzu-cli.0.26.0.nupkg`, we can then simply do:
+
+```bash
+choco install -f "$HOME\tanzu-cli.0.26.0.nupkg"
+```
+
+It is also possible to configure a local repository containing the local package:
+
+```bash
+choco source add -n=local -s="file://$HOME"
+choco install tanzu-cli
+```
+
+## Uninstalling the Tanzu CLI
+
+To uninstall the Tanzu CLI after it has been install with Chocolatey:
+
+```bash
+choco uninstall tanzu-cli
+```
+
+## Publishing the package
+
+Once the Tanzu CLI is ready for full availability, we expect to publish our Chocolatey packages to the main Chocolatey community package repository.  This step remains to be properly defined.

--- a/cli/core/hack/choco/build_package.sh
+++ b/cli/core/hack/choco/build_package.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+if [ "$(command -v choco)" = "" ]; then
+   echo "This script must be run on a system that has 'choco' installed"
+   exit 1
+fi
+
+# VERSION should be set when calling this script
+if [ -z "${VERSION}" ]; then
+   echo "\$VERSION must be set before calling this script"
+   exit 1
+fi
+
+# Strip 'v' prefix to be consistent with our other package names
+VERSION=${VERSION#v}
+
+BASE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
+OUTPUT_DIR=${BASE_DIR}/_output/choco
+
+mkdir -p ${OUTPUT_DIR}/
+# Remove the nupkg file made by `choco pack` in the working dir
+rm -f ${OUTPUT_DIR}/*.nupkg
+
+# Obtain SHA
+SHA=$(curl -sL https://github.com/vmware-tanzu/tanzu-framework/releases/download/v${VERSION}/tanzu-framework-executables-checksums.txt | grep tanzu-cli-windows-amd64.zip |cut -f1 -d" ")
+if [ -z "$SHA" ]; then
+   echo "Unable to determine SHA for package of version $VERSION"
+   exit 1
+fi
+
+# Prepare install script
+sed -e s,__CLI_VERSION__,v${VERSION}, -e s,__CLI_SHA__,${SHA}, \
+   ${BASE_DIR}/chocolateyInstall.ps1.tmpl > ${OUTPUT_DIR}/chocolateyInstall.ps1
+chmod a+x ${OUTPUT_DIR}/chocolateyInstall.ps1
+
+# Bundle the powershell scripts and nuspec into a nupkg file
+choco pack ${BASE_DIR}/tanzu-cli-release.nuspec --out ${OUTPUT_DIR} "cliVersion=${VERSION}"
+
+# Upload the nupkg file to the registry
+# DON'T DO THIS YET
+# choco push --source https://push.chocolatey.org/ --api-key .......

--- a/cli/core/hack/choco/chocolateyInstall.ps1.tmpl
+++ b/cli/core/hack/choco/chocolateyInstall.ps1.tmpl
@@ -1,0 +1,35 @@
+# Copyright 2022 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+$ErrorActionPreference = 'Stop';
+$releaseVersion = '__CLI_VERSION__'
+$packageName = 'tanzu-cli'
+$packagePath = "${releaseVersion}"
+$scriptsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url64 = "https://github.com/vmware-tanzu/tanzu-framework/releases/download/${releaseVersion}/tanzu-cli-windows-amd64.zip"
+$checksum64 = '__CLI_SHA__'
+$checksumType64 = 'sha256'
+
+$packageArgs = @{
+    packageName    = $packageName
+    unzipLocation  = $scriptsDir
+    url64bit       = $url64
+
+    softwareName   = 'tanzu-cli'
+
+    checksum64     = $checksum64
+    checksumType64 = $checksumType64
+}
+
+function Install-TanzuEnvironment {
+    # Rename CLI
+    # Note that we use the scriptsDir path because chocolatey doesn't put
+    # binaries on the $PATH until _after_ the install script runs.
+    $tanzuExe = "${scriptsDir}\${packagePath}\tanzu.exe"
+    Move-Item "${scriptsDir}\${packagePath}\tanzu-core-windows_amd64.exe" "${tanzuExe}"
+}
+
+# this is a built-in function, read https://docs.chocolatey.org/en-us/create/functions/install-chocolateyzippackage
+Install-ChocolateyZipPackage @packageArgs
+
+Install-TanzuEnvironment

--- a/cli/core/hack/choco/tanzu-cli-release.nuspec
+++ b/cli/core/hack/choco/tanzu-cli-release.nuspec
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>tanzu-cli</id>
+    <version>$cliVersion$</version>
+    <owners>VMware</owners>
+    <title>Tanzu CLI</title>
+    <authors>VMware Tanzu</authors>
+    <projectUrl>https://github.com/vmware-tanzu/tanzu-framework</projectUrl>
+    <packageSourceUrl>https://github.com/vmware-tanzu/tanzu-framework/blob/main/cli/core/hack/choco</packageSourceUrl>
+    <!-- TODO:
+    <iconUrl></iconUrl>
+    -->
+    <licenseUrl>https://github.com/vmware-tanzu/tanzu-framework/blob/main/LICENSE</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/vmware-tanzu/tanzu-framework</projectSourceUrl>
+    <docsUrl>https://github.com/vmware-tanzu/tanzu-framework/blob/main/README.md</docsUrl>
+    <bugTrackerUrl>https://github.com/vmware-tanzu/tanzu-framework/issues</bugTrackerUrl>
+    <tags>tanzu cli kubernetes</tags>
+    <summary>CLI tool to create and manage Tanzu Kubernetes clusters</summary>
+    <description>The Tanzu CLI is the starting point to create and manage Tanzu Kubernetes clusters.</description>
+    <releaseNotes>Release notes are available at https://github.com/vmware-tanzu/tanzu-framework/releases</releaseNotes>
+  </metadata>
+  <files>
+    <file src="_output/choco/chocolateyInstall.ps1" target="scripts" />
+  </files>
+</package>


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds a script to build a chocolatey package to install the Tanzu CLI.

### Which issue(s) this PR fixes

Part of #3
Other package managers have to be included before we can completely resolve this issue.

### Describe testing done for PR

On an ubuntu machine with `amd64` architecture:
First clone the `tanzu-framework` repo and checkout the PR.  Then:
 
```
$ cd tanzu-framework
$ cd cli/core
$ VERSION=0.26.0 make choco-package
$ ls hack/choco/_output/choco
```
Then upload the build package to a Windows machine under `$HOME\tanzu-cli.0.26.0.nupkg` and run
```
$ tanzu
# Notice tanzu is not installed
$ choco install -y -f "$HOME\tanzu-cli.0.26.0.nupkg"
$ tanzu
# Notice tanzu is installed
```

### Additional information

This PR only allows to build the Chocolatey package but it does not officially publish it.

At the moment, it looks like the best option is to publish the package to the main community Chocolatey repo.  This is the approach used by TCE: https://community.chocolatey.org/packages/tanzu-community-edition

#### Special notes for your reviewer

It may be possible to include the actual CLI binary into the Chocolatey package.  However, if we publish to the main community repository, it is probably better to not include the binary to avoid any legal questions.