### PR TITLE
Removes requirement adddon configs match cluster name

### DIFF
--- a/addons/README.md
+++ b/addons/README.md
@@ -289,7 +289,7 @@ metadata:
    name: my-cluster
    namespace: my-ns
    annotations:
-      tkg.tanzu.vmware.com/add-missing-fields-from-tkr:v1.22.4
+      tkg.tanzu.vmware.com/add-missing-fields-from-tkr: v1.22.4
 spec:
    cni:
       refName: calico*

--- a/addons/controllers/antreaconfig_controller_test.go
+++ b/addons/controllers/antreaconfig_controller_test.go
@@ -4,30 +4,44 @@
 package controllers
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	cutil "github.com/vmware-tanzu/tanzu-framework/addons/controllers/utils"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
 	"github.com/vmware-tanzu/tanzu-framework/addons/test/testutil"
 	cniv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/addonconfigs/cni/v1alpha1"
+	runtanzuv1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
 )
 
 var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 	var (
+		clusterName             string
+		clusterNamespace        string
 		configCRName            string
+		configName              string
 		clusterResourceFilePath string
 		err                     error
 		f                       *os.File
+		tkrString               string
+		newDefaultMTU           string
+		clusterBootstrap        *runtanzuv1alpha3.ClusterBootstrap
+		clusterBoostrapFile     string
+		clusterInfraName        string
 	)
 
 	const (
+		waitTimeout                            = waitTimeout //use this to change test speed when debugging
 		antreaManifestsTestFile1               = "testdata/antrea-test-1.yaml"
 		antreaTemplateConfigManifestsTestFile1 = "testdata/antrea-test-template-config-1.yaml"
 		antreaTestCluster1                     = "test-cluster-4"
@@ -74,26 +88,32 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 	Context("Reconcile AntreaConfig for management cluster", func() {
 
 		BeforeEach(func() {
-			configCRName = antreaTestCluster1
+			clusterName = antreaTestCluster1
+			clusterNamespace = defaultString
+			configCRName = util.GeneratePackageSecretName(clusterName, constants.AntreaDefaultRefName)
 			clusterResourceFilePath = antreaManifestsTestFile1
 		})
 
 		It("Should reconcile AntreaConfig and create data value secret on management cluster", func() {
 
-			key := client.ObjectKey{
-				Namespace: "default",
+			clusterKey := client.ObjectKey{
+				Namespace: clusterNamespace,
+				Name:      clusterName,
+			}
+			configKey := client.ObjectKey{
+				Namespace: clusterNamespace,
 				Name:      configCRName,
 			}
 
 			cluster := &clusterapiv1beta1.Cluster{}
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, key, cluster)
+				err := k8sClient.Get(ctx, clusterKey, cluster)
 				return err == nil
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 
 			config := &cniv1alpha1.AntreaConfig{}
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, key, config)
+				err := k8sClient.Get(ctx, configKey, config)
 				if err != nil {
 					return false
 				}
@@ -104,7 +124,7 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 				}
 
 				Expect(len(config.OwnerReferences)).Should(Equal(1))
-				Expect(config.OwnerReferences[0].Name).Should(Equal(configCRName))
+				Expect(config.OwnerReferences[0].Name).Should(Equal(clusterName))
 
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.TrafficEncapMode).Should(Equal("encap"))
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.AntreaTraceflow).Should(Equal(false))
@@ -119,7 +139,7 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 
 			Eventually(func() bool {
 				cluster := &clusterapiv1beta1.Cluster{}
-				err := k8sClient.Get(ctx, key, cluster)
+				err := k8sClient.Get(ctx, clusterKey, cluster)
 				if err != nil {
 					return false
 				}
@@ -145,8 +165,8 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 
 			Eventually(func() bool {
 				secretKey := client.ObjectKey{
-					Namespace: "default",
-					Name:      util.GenerateDataValueSecretName(configCRName, constants.AntreaAddonName),
+					Namespace: clusterNamespace,
+					Name:      util.GenerateDataValueSecretName(clusterName, constants.AntreaAddonName),
 				}
 				secret := &v1.Secret{}
 				err := k8sClient.Get(ctx, secretKey, secret)
@@ -173,12 +193,11 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 			Eventually(func() bool {
 				// Check status.secretRef after reconciliation
 				config := &cniv1alpha1.AntreaConfig{}
-				err := k8sClient.Get(ctx, key, config)
+				err := k8sClient.Get(ctx, configKey, config)
 				if err != nil {
 					return false
 				}
-				Expect(config.Status.SecretRef).Should(Equal(util.GenerateDataValueSecretName(configCRName, constants.AntreaAddonName)))
-				return true
+				return config.Status.SecretRef == util.GenerateDataValueSecretName(clusterName, constants.AntreaAddonName)
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 
 		})
@@ -188,7 +207,8 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 	Context("Reconcile AntreaConfig used as template", func() {
 
 		BeforeEach(func() {
-			configCRName = antreaTestCluster1
+			clusterName = antreaTestCluster1
+			configCRName = util.GeneratePackageSecretName(clusterName, constants.AntreaDefaultRefName)
 			clusterResourceFilePath = antreaTemplateConfigManifestsTestFile1
 		})
 
@@ -209,14 +229,16 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 	Context("Mutating webhooks for AntreaConfig", func() {
 
 		BeforeEach(func() {
-			configCRName = antreaTestCluster1
+			clusterName = antreaTestCluster1
+			clusterNamespace = defaultString
+			configCRName = util.GeneratePackageSecretName(clusterName, constants.AntreaDefaultRefName)
 			clusterResourceFilePath = antreaManifestsTestFile1
 		})
 
 		It("Should fail mutating webhooks for immutable field for AntreaConfig", func() {
 
 			key := client.ObjectKey{
-				Namespace: "default",
+				Namespace: clusterNamespace,
 				Name:      configCRName,
 			}
 			config := &cniv1alpha1.AntreaConfig{}
@@ -227,4 +249,211 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 			Expect(k8sClient.Update(ctx, config)).ToNot(Succeed())
 		})
 	})
+
+	When("antrea config is precreated with name {CLUSTER_NAME}-{package-short-name}-package", func() {
+
+		BeforeEach(func() {
+			clusterName = "antrea-custom-cb-cluster"
+			clusterNamespace = "antrea-custom-cb-ns"
+			configName = util.GeneratePackageSecretName(clusterName, constants.AntreaDefaultRefName)
+			tkrString = "v1.23.1"
+			clusterResourceFilePath = "testdata/antrea-custom-tkg-system.yaml"
+			clusterInfraName = "custom-cb-docker-cluster"
+			newDefaultMTU = "8901"
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterNamespace,
+				},
+			}
+			err := k8sClient.Create(ctx, ns)
+			if err != nil {
+				Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
+			}
+
+		})
+
+		It("should add cluster as owner reference to antrea config", func() {
+			// define custom resources in cluster namespace
+			f, err := os.Open("testdata/antrea-custom-cb-ns.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			err = testutil.CreateResources(f, cfg, dynamicClient)
+			Expect(err).ToNot(HaveOccurred())
+			f.Close()
+
+			By("Create antrea config in the cluster's namespace with expected name pattern", func() {
+				datavalues := &cniv1alpha1.AntreaConfigDataValue{DefaultMTU: newDefaultMTU}
+				antreaConfig := genearateAntreaConfig(configName, clusterNamespace, datavalues)
+				err := k8sClient.Create(ctx, antreaConfig)
+				Expect(err).ToNot(HaveOccurred())
+				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(antreaConfig), antreaConfig)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("Create the cluster", func() {
+				cluster := generateDockerCluster(clusterName, clusterNamespace, tkrString, clusterInfraName)
+				err := k8sClient.Create(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
+				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)
+				Expect(err).ToNot(HaveOccurred())
+
+			})
+
+			By("Verify after reconciliation clusterBootstrap ProviderRef.Name points to pre-created antrea config", func() {
+				clusterBootstrap = &runtanzuv1alpha3.ClusterBootstrap{}
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKey{Namespace: clusterNamespace, Name: clusterName}, clusterBootstrap)
+					return err == nil
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+
+				Eventually(func() bool {
+					return clusterBootstrap.Spec.CNI.ValuesFrom.ProviderRef.Name == configName
+
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+			})
+
+			By("Verify contents of resulting antrea config", func() {
+				antreaConfig := &cniv1alpha1.AntreaConfig{}
+				key := client.ObjectKey{Name: clusterBootstrap.Spec.CNI.ValuesFrom.ProviderRef.Name, Namespace: clusterNamespace}
+				err := k8sClient.Get(ctx, key, antreaConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cutil.VerifyOwnerRef(antreaConfig, clusterName, constants.ClusterKind)).To(BeTrue())
+				Expect(antreaConfig.Spec.Antrea.AntreaConfigDataValue.DefaultMTU).Should(Equal(newDefaultMTU))
+			})
+
+		})
+
+	})
+
+	When("custom clusterbootstrap points to precreated antrea config", func() {
+		BeforeEach(func() {
+			clusterName = "custom-cb-2-cluster"
+			clusterNamespace = "custom-cb-2-namespace"
+			configName = "antrea-config-custom-2"
+			clusterBoostrapFile = "testdata/antrea-custom-cb.yaml"
+			clusterInfraName = "custom-cb-docker-cluster-2"
+			tkrString = "v1.23.2"
+			clusterResourceFilePath = "testdata/antrea-custom-cb-2-resources.yaml"
+			newDefaultMTU = "8902"
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterNamespace,
+				},
+			}
+			err := k8sClient.Create(ctx, ns)
+			if err != nil {
+				Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
+			}
+
+		})
+		It("should add cluster as owner reference to precreated antrea config", func() {
+			By("check resources like the kapp-controller config have been created", func() {
+				kappConfig := &runtanzuv1alpha3.KappControllerConfig{}
+				kappConfigKey := client.ObjectKey{Name: "test-cluster-custom-cb-2-kapp-controller-config",
+					Namespace: addonNamespace}
+				err := k8sClient.Get(ctx, kappConfigKey, kappConfig)
+				Expect(err).ToNot(HaveOccurred())
+
+			})
+
+			By("Create antrea config in the cluster's namespace with random name", func() {
+				datavalues := &cniv1alpha1.AntreaConfigDataValue{DefaultMTU: newDefaultMTU}
+				antreaConfig := genearateAntreaConfig(configName, clusterNamespace, datavalues)
+				err := k8sClient.Create(ctx, antreaConfig)
+				Expect(err).ToNot(HaveOccurred())
+				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(antreaConfig), antreaConfig)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			By("Create custom clusterbootstrap in clusters namespace", func() {
+				f, err := os.Open(clusterBoostrapFile)
+				Expect(err).ToNot(HaveOccurred())
+				defer f.Close()
+				Expect(testutil.CreateResources(f, cfg, dynamicClient)).To(Succeed())
+
+			})
+
+			By("Create the cluster", func() {
+				cluster := generateDockerCluster(clusterName, clusterNamespace, tkrString, clusterInfraName)
+				err := k8sClient.Create(ctx, cluster)
+				Expect(err).ToNot(HaveOccurred())
+				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), cluster)
+				Expect(err).ToNot(HaveOccurred())
+
+			})
+
+			By("Verify contents of resulting antrea config", func() {
+				// eventually the secret ref to the data values should be updated
+				antreaConfig := &cniv1alpha1.AntreaConfig{}
+				Eventually(func() error {
+					configKey := client.ObjectKey{
+						Namespace: clusterNamespace,
+						Name:      configName,
+					}
+					if err := k8sClient.Get(ctx, configKey, antreaConfig); err != nil {
+						return fmt.Errorf("failed to get antrea config '%v': '%v'", configKey, err)
+					}
+					if antreaConfig.Status.SecretRef == "" {
+						return fmt.Errorf("antrea config status not yet updated: %v", configKey)
+					}
+					Expect(antreaConfig.Status.SecretRef).To(Equal(fmt.Sprintf("%s-%s-data-values", clusterName, constants.AntreaAddonName)))
+					return nil
+				}, waitTimeout, pollingInterval).Should(Succeed())
+
+				antreaConfig = &cniv1alpha1.AntreaConfig{}
+				key := client.ObjectKey{Name: configName, Namespace: clusterNamespace}
+				err := k8sClient.Get(ctx, key, antreaConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cutil.VerifyOwnerRef(antreaConfig, clusterName, constants.ClusterKind)).To(BeTrue())
+				Expect(antreaConfig.Spec.Antrea.AntreaConfigDataValue.DefaultMTU).Should(Equal(newDefaultMTU))
+			})
+
+		})
+	})
 })
+
+func genearateAntreaConfig(name, namespace string, datavalues *cniv1alpha1.AntreaConfigDataValue) *cniv1alpha1.AntreaConfig {
+	config := &cniv1alpha1.AntreaConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: cniv1alpha1.AntreaConfigSpec{
+			Antrea: cniv1alpha1.Antrea{
+				AntreaConfigDataValue: *datavalues,
+			},
+		},
+	}
+	return config
+}
+
+func generateDockerCluster(name, namespace, tkr, infraName string) *clusterapiv1beta1.Cluster {
+	labels := map[string]string{}
+	labels["tkg.tanzu.vmware.com/cluster-name"] = name
+	labels["run.tanzu.vmware.com/tkr"] = tkr
+
+	pods := &clusterapiv1beta1.NetworkRanges{CIDRBlocks: []string{"192.168.0.0/16"}}
+	services := &clusterapiv1beta1.NetworkRanges{CIDRBlocks: []string{"192.168.0.0/16", "fd00:100:96::/48"}}
+	clusterNetworks := &clusterapiv1beta1.ClusterNetwork{
+		Services: services,
+		Pods:     pods,
+	}
+	clusterSpecs := clusterapiv1beta1.ClusterSpec{
+		ClusterNetwork: clusterNetworks,
+		InfrastructureRef: &v1.ObjectReference{
+			Kind:       "DockerCluster",
+			Name:       infraName,
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+		}}
+
+	cluster := &clusterapiv1beta1.Cluster{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec:   clusterSpecs,
+		Status: clusterapiv1beta1.ClusterStatus{},
+	}
+	return cluster
+}

--- a/addons/controllers/calicoconfig_controller_test.go
+++ b/addons/controllers/calicoconfig_controller_test.go
@@ -8,13 +8,21 @@ import (
 	"os"
 	"strings"
 
+	cutil "github.com/vmware-tanzu/tanzu-framework/addons/controllers/utils"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	runtanzuv1alpha3 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha3"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
 	"github.com/vmware-tanzu/tanzu-framework/addons/test/testutil"
 	cniv1alpha1 "github.com/vmware-tanzu/tanzu-framework/apis/addonconfigs/cni/v1alpha1"
 )
@@ -25,11 +33,15 @@ const (
 	testDataCalico1               = "testdata/test-calico-1.yaml"
 	testDataCalico2               = "testdata/test-calico-2.yaml"
 	testDataCalicoTemplateConfig1 = "testdata/test-calico-template-config-1.yaml"
+	calicoCarvelPkgRefName        = "calico.tanzu.vmware.com"
+	calicoCustomTKGSystemFile     = "testdata/calico-custom-tkg-system.yaml"
 )
 
 var _ = Describe("CalicoConfig Reconciler and Webhooks", func() {
 	var (
 		clusterName             string
+		clusterNamespace        string
+		configName              string
 		clusterResourceFilePath string
 	)
 
@@ -72,14 +84,21 @@ var _ = Describe("CalicoConfig Reconciler and Webhooks", func() {
 
 	Context("reconcile default CalicoConfig for management cluster on dual-stack CIDR", func() {
 		BeforeEach(func() {
+			clusterNamespace = addonNamespace
 			clusterName = testClusterCalico1
+			configName = util.GeneratePackageSecretName(clusterName, calicoCarvelPkgRefName)
 			clusterResourceFilePath = testDataCalico1
 		})
 
 		It("Should reconcile CalicoConfig and create data values secret for CalicoConfig on management cluster", func() {
 			key := client.ObjectKey{
-				Namespace: "default",
-				Name:      testClusterCalico1,
+				Namespace: clusterNamespace,
+				Name:      clusterName,
+			}
+
+			configKey := client.ObjectKey{
+				Namespace: clusterNamespace,
+				Name:      configName,
 			}
 
 			cluster := &clusterapiv1beta1.Cluster{}
@@ -92,56 +111,44 @@ var _ = Describe("CalicoConfig Reconciler and Webhooks", func() {
 
 			config := &cniv1alpha1.CalicoConfig{}
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, key, config); err != nil {
+				if err := k8sClient.Get(ctx, configKey, config); err != nil {
 					return false
 				}
-
-				// check spec values
-				Expect(config.Spec.Calico.Config.VethMTU).Should(Equal(int64(0)))
-				Expect(config.Spec.Calico.Config.SkipCNIBinaries).Should(BeTrue())
-
 				// check owner reference
-				if len(config.OwnerReferences) == 0 {
-					return false
-				}
-				Expect(len(config.OwnerReferences)).Should(Equal(1))
-				Expect(config.OwnerReferences[0].Name).Should(Equal(testClusterCalico1))
-
-				return true
+				return cutil.VerifyOwnerRef(config, clusterName, constants.ClusterKind)
 			}, waitTimeout, pollingInterval).Should(BeTrue())
+			// check spec values
+			Expect(config.Spec.Calico.Config.VethMTU).Should(Equal(int64(7)))
+			Expect(config.Spec.Calico.Config.SkipCNIBinaries).Should(BeTrue())
 
+			secret := &v1.Secret{}
 			Eventually(func() bool {
 				secretKey := client.ObjectKey{
-					Namespace: "default",
+					Namespace: clusterNamespace,
 					Name:      fmt.Sprintf("%s-%s-data-values", clusterName, constants.CalicoAddonName),
 				}
-				secret := &v1.Secret{}
 				if err := k8sClient.Get(ctx, secretKey, secret); err != nil {
 					return false
 				}
-
-				// check data values secret contents
-				Expect(secret.Type).Should(Equal(v1.SecretTypeOpaque))
-				secretData := string(secret.Data["values.yaml"])
-				Expect(strings.Contains(secretData, "infraProvider: vsphere")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "ipFamily: ipv4,ipv6")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "clusterCIDR: 192.168.0.0/16,fd00:100:96::/48")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "vethMTU: \"0\"")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "skipCNIBinaries: true")).Should(BeTrue())
-
-				return true
+				return cutil.VerifyOwnerRef(secret, clusterName, constants.ClusterKind)
 			}, waitTimeout, pollingInterval).Should(BeTrue())
-
+			// check data values secret contents
+			Expect(secret.Type).Should(Equal(v1.SecretTypeOpaque))
+			secretData := string(secret.Data["values.yaml"])
+			Expect(strings.Contains(secretData, "infraProvider: vsphere")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "ipFamily: ipv4,ipv6")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "clusterCIDR: 192.168.0.0/16,fd00:100:96::/48")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "vethMTU: \"7\"")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "skipCNIBinaries: true")).Should(BeTrue())
 			Eventually(func() bool {
 				config := &cniv1alpha1.CalicoConfig{}
-				err := k8sClient.Get(ctx, key, config)
+				err := k8sClient.Get(ctx, configKey, config)
 				if err != nil {
 					return false
 				}
 				// Check status.secretName after reconciliation
-				Expect(config.Status.SecretRef).Should(Equal(fmt.Sprintf("%s-%s-data-values", clusterName, constants.CalicoAddonName)))
+				return config.Status.SecretRef == util.GenerateDataValueSecretName(clusterName, constants.CalicoAddonName)
 
-				return true
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
@@ -149,13 +156,20 @@ var _ = Describe("CalicoConfig Reconciler and Webhooks", func() {
 	Context("reconcile mtu customized and cni binaries installation skipped CalicoConfig for management cluster on ipv4 CIDR", func() {
 		BeforeEach(func() {
 			clusterName = testClusterCalico2
+			clusterNamespace = addonNamespace
+			configName = util.GeneratePackageSecretName(clusterName, constants.CalicoDefaultRefName)
 			clusterResourceFilePath = testDataCalico2
 		})
 
 		It("Should reconcile CalicoConfig and create data values secret for CalicoConfig on management cluster", func() {
 			key := client.ObjectKey{
-				Namespace: "default",
-				Name:      testClusterCalico2,
+				Namespace: clusterNamespace,
+				Name:      clusterName,
+			}
+
+			configKey := client.ObjectKey{
+				Namespace: clusterNamespace,
+				Name:      configName,
 			}
 
 			cluster := &clusterapiv1beta1.Cluster{}
@@ -168,28 +182,222 @@ var _ = Describe("CalicoConfig Reconciler and Webhooks", func() {
 
 			config := &cniv1alpha1.CalicoConfig{}
 			Eventually(func() bool {
-				if err := k8sClient.Get(ctx, key, config); err != nil {
+				if err := k8sClient.Get(ctx, configKey, config); err != nil {
 					return false
 				}
+				return cutil.VerifyOwnerRef(config, clusterName, constants.ClusterKind)
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 
-				// check spec values
-				Expect(config.Spec.Calico.Config.VethMTU).Should(Equal(int64(1420)))
-				Expect(config.Spec.Calico.Config.SkipCNIBinaries).Should(BeFalse())
+			// check spec values
+			Expect(config.Spec.Calico.Config.VethMTU).Should(Equal(int64(1420)))
+			Expect(config.Spec.Calico.Config.SkipCNIBinaries).Should(BeFalse())
 
-				// check owner reference
-				if len(config.OwnerReferences) == 0 {
+			secret := &v1.Secret{}
+			Eventually(func() bool {
+				secretKey := client.ObjectKey{
+					Namespace: clusterNamespace,
+					Name:      util.GenerateDataValueSecretName(clusterName, constants.CalicoAddonName),
+				}
+				if err := k8sClient.Get(ctx, secretKey, secret); err != nil {
 					return false
 				}
-				Expect(len(config.OwnerReferences)).Should(Equal(1))
-				Expect(config.OwnerReferences[0].Name).Should(Equal(testClusterCalico2))
+				return cutil.VerifyOwnerRef(secret, clusterName, constants.ClusterKind)
+			}, waitTimeout, pollingInterval).Should(BeTrue())
+			// check data values secret contents
+			Expect(secret.Type).Should(Equal(v1.SecretTypeOpaque))
+			secretData := string(secret.Data["values.yaml"])
+			Expect(strings.Contains(secretData, "infraProvider: docker")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "ipFamily: ipv4")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "clusterCIDR: 192.168.0.0/16")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "vethMTU: \"1420\"")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "skipCNIBinaries: false")).Should(BeTrue())
 
+			Eventually(func() bool {
+				config := &cniv1alpha1.CalicoConfig{}
+				err := k8sClient.Get(ctx, configKey, config)
+				if err != nil {
+					return false
+				}
+				// Check status.secretName after reconciliation
+				expectedName := util.GenerateDataValueSecretName(clusterName, constants.CalicoAddonName)
+				return config.Status.SecretRef == expectedName
+			}, waitTimeout, pollingInterval).Should(BeTrue())
+		})
+	})
+
+	Context("Reconcile CalicoConfig used as template", func() {
+
+		BeforeEach(func() {
+			clusterName = testClusterCalico1
+			clusterResourceFilePath = testDataCalicoTemplateConfig1
+			configName = util.GeneratePackageSecretName(clusterName, constants.CalicoDefaultRefName)
+		})
+
+		It("Should skip the reconciliation", func() {
+
+			configKey := client.ObjectKey{
+				Namespace: addonNamespace,
+				Name:      configName,
+			}
+			config := &cniv1alpha1.CalicoConfig{}
+			Expect(k8sClient.Get(ctx, configKey, config)).To(Succeed())
+
+			By("OwnerReferences is not set")
+			Expect(len(config.OwnerReferences)).Should(Equal(0))
+		})
+	})
+
+	When("calico config is for management cluster", func() {
+
+		BeforeEach(func() {
+			clusterName = "mgmt-cluster"
+			clusterNamespace = "tkg-system"
+			configName = util.GeneratePackageSecretName(clusterName, calicoCarvelPkgRefName)
+			clusterResourceFilePath = calicoCustomTKGSystemFile
+
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterNamespace,
+				},
+			}
+			err := k8sClient.Create(ctx, ns)
+			if err != nil {
+				Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
+			}
+		})
+
+		It("should add cluster as owner reference to calico config and name config {CLUSTER_NAME}-{short-package-name}-package", func() {
+			By("Creating cluster", func() {
+				f, err := os.Open("testdata/calico-management-cluster.yaml")
+				Expect(err).ToNot(HaveOccurred())
+				err = testutil.CreateResources(f, cfg, dynamicClient)
+				Expect(err).ToNot(HaveOccurred())
+				f.Close()
+			})
+			clusterKey := client.ObjectKey{
+				Namespace: clusterNamespace,
+				Name:      clusterName,
+			}
+
+			configKey := client.ObjectKey{
+				Namespace: clusterNamespace,
+				Name:      configName,
+			}
+			cluster := &clusterapiv1beta1.Cluster{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, clusterKey, cluster); err != nil {
+					return false
+				}
 				return true
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 
+			By("Verify new config has owner reference", func() {
+				config := &cniv1alpha1.CalicoConfig{}
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, configKey, config); err != nil {
+						return false
+					}
+					return cutil.VerifyOwnerRef(config, clusterName, constants.ClusterKind)
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+			})
+
+			By("Verify new config points to the correct secret ref", func() {
+				Eventually(func() bool {
+					config := &cniv1alpha1.CalicoConfig{}
+					err := k8sClient.Get(ctx, configKey, config)
+					if err != nil {
+						return false
+					}
+					// Check status.secretName after reconciliation
+					expectedName := util.GenerateDataValueSecretName(clusterName, constants.CalicoAddonName)
+					return config.Status.SecretRef == expectedName
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+			})
+		})
+	})
+
+	When("calico config is precreated with {CLUSTER_NAME}-{package-short-name}-package in cluster namespace", func() {
+
+		BeforeEach(func() {
+			clusterName = "calico-custom-config-cluster"
+			clusterNamespace = "calico-custom-config-ns"
+			configName = util.GeneratePackageSecretName(clusterName, calicoCarvelPkgRefName)
+			clusterResourceFilePath = calicoCustomTKGSystemFile
+
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterNamespace,
+				},
+			}
+			err := k8sClient.Create(ctx, ns)
+			if err != nil {
+				Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
+			}
+		})
+
+		It("should add cluster as owner reference to calico config", func() {
+			By("Creating cluster and CalicoConfig resources", func() {
+				f, err := os.Open("testdata/calico-custom-config-ns.yaml")
+				Expect(err).ToNot(HaveOccurred())
+				err = testutil.CreateResources(f, cfg, dynamicClient)
+				Expect(err).ToNot(HaveOccurred())
+				f.Close()
+			})
+
+			By("Verify clusterBootstrap points to pre-created calico config", func() {
+				clusterBootstrap := &runtanzuv1alpha3.ClusterBootstrap{}
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKey{Namespace: clusterNamespace, Name: clusterName}, clusterBootstrap)
+					if err != nil {
+						return false
+					}
+					if clusterBootstrap.Spec.CNI.ValuesFrom.ProviderRef.Name == configName {
+						return true
+					}
+					return false
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+			})
+
+			key := client.ObjectKey{
+				Namespace: clusterNamespace,
+				Name:      clusterName,
+			}
+
+			configKey := client.ObjectKey{
+				Namespace: clusterNamespace,
+				Name:      configName,
+			}
+			cluster := &clusterapiv1beta1.Cluster{}
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, key, cluster); err != nil {
+					return false
+				}
+				return true
+			}, waitTimeout, pollingInterval).Should(BeTrue())
+
+			key = client.ObjectKey{
+				Namespace: clusterNamespace,
+				Name:      configName,
+			}
+			config := &cniv1alpha1.CalicoConfig{}
+
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, configKey, config); err != nil {
+					return false
+				}
+
+				// check owner reference
+				return cutil.VerifyOwnerRef(config, clusterName, constants.ClusterKind)
+
+			}, waitTimeout, pollingInterval).Should(BeTrue())
+
+			// check spec values
+			Expect(config.Spec.Calico.Config.VethMTU).Should(Equal(int64(1420)))
+			Expect(config.Spec.Calico.Config.SkipCNIBinaries).Should(BeFalse())
 			Eventually(func() bool {
 				secretKey := client.ObjectKey{
-					Namespace: "default",
-					Name:      fmt.Sprintf("%s-%s-data-values", clusterName, constants.CalicoAddonName),
+					Namespace: clusterNamespace,
+					Name:      util.GenerateDataValueSecretName(clusterName, constants.CalicoAddonName),
 				}
 				secret := &v1.Secret{}
 				if err := k8sClient.Get(ctx, secretKey, secret); err != nil {
@@ -210,36 +418,145 @@ var _ = Describe("CalicoConfig Reconciler and Webhooks", func() {
 
 			Eventually(func() bool {
 				config := &cniv1alpha1.CalicoConfig{}
-				err := k8sClient.Get(ctx, key, config)
+				err := k8sClient.Get(ctx, configKey, config)
 				if err != nil {
 					return false
 				}
 				// Check status.secretName after reconciliation
-				Expect(config.Status.SecretRef).Should(Equal(fmt.Sprintf("%s-%s-data-values", clusterName, constants.CalicoAddonName)))
-
-				return true
+				expectedName := util.GenerateDataValueSecretName(clusterName, constants.CalicoAddonName)
+				return config.Status.SecretRef == expectedName
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 		})
 	})
 
-	Context("Reconcile CalicoConfig used as template", func() {
-
+	When("custom clusterbootstrap points to precreated calico config in cluster namespace", func() {
 		BeforeEach(func() {
-			clusterName = testClusterCalico1
-			clusterResourceFilePath = testDataCalicoTemplateConfig1
-		})
+			clusterName = "calico-custom-cb-cluster"
+			clusterNamespace = "calico-custom-cb-ns"
+			configName = "calico-custom-config"
+			clusterResourceFilePath = calicoCustomTKGSystemFile
 
-		It("Should skip the reconciliation", func() {
-
-			key := client.ObjectKey{
-				Namespace: addonNamespace,
-				Name:      clusterName,
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterNamespace,
+				},
 			}
-			config := &cniv1alpha1.CalicoConfig{}
-			Expect(k8sClient.Get(ctx, key, config)).To(Succeed())
+			err := k8sClient.Create(ctx, ns)
+			if err != nil {
+				Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
+			}
 
-			By("OwnerReferences is not set")
-			Expect(len(config.OwnerReferences)).Should(Equal(0))
+		})
+		It("values from custom config should override those of template", func() {
+
+			// define custom resources in cluster namespace
+			f, err := os.Open("testdata/calico-custom-cb-ns.yaml")
+			Expect(err).ToNot(HaveOccurred())
+			err = testutil.CreateResources(f, cfg, dynamicClient)
+			Expect(err).ToNot(HaveOccurred())
+			f.Close()
+
+			By("Verify contents of resulting calico config", func() {
+				// eventually the secret ref to the data values should be updated
+				calicoConfig := &cniv1alpha1.CalicoConfig{}
+				configKey := client.ObjectKey{Name: configName, Namespace: clusterNamespace}
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, configKey, calicoConfig); err != nil {
+						return false
+					}
+					return cutil.VerifyOwnerRef(calicoConfig, clusterName, constants.ClusterKind)
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, configKey, calicoConfig); err != nil {
+						return false
+					}
+					expectedSecretRef := util.GenerateDataValueSecretName(clusterName, constants.CalicoDefaultRefName)
+					return calicoConfig.Status.SecretRef != "" && calicoConfig.Status.SecretRef == expectedSecretRef
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+
+				Expect(k8sClient.Get(ctx, configKey, calicoConfig)).To(Succeed())
+
+				Expect(calicoConfig.Spec.Calico.Config.VethMTU).Should(Equal(int64(1420)))
+				//  why  int64??  that would make it architecture specific, as oposed to why not just int?
+				// (defined in apis/addonconfigs/cni/v1alpha1/calicoconfig_types.go)
+				// seems to also have forced part of this fix: https://github.com/vmware-tanzu/tanzu-framework/pull/2164
+			})
+
+		})
+	})
+
+	When("custom clusterbootstrap uses wild card to point to precreated calico config", func() {
+		BeforeEach(func() {
+			clusterName = "calico-wildcard-cb-cluster"
+			clusterNamespace = "calico-wildcard-cb-ns"
+			configName = "calico-wildcard-config"
+			clusterResourceFilePath = calicoCustomTKGSystemFile
+
+			ns := &v1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterNamespace,
+				},
+			}
+			err := k8sClient.Create(ctx, ns)
+			if err != nil {
+				Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
+			}
+
+		})
+		It("values from custom config should override those of template", func() {
+
+			By("define cluster namespace resources", func() {
+				f, err := os.Open("testdata/calico-wildcard-cb-ns.yaml")
+				Expect(err).ToNot(HaveOccurred())
+				err = testutil.CreateResources(f, cfg, dynamicClient)
+				Expect(err).ToNot(HaveOccurred())
+				f.Close()
+			})
+
+			By("define clusterboostrap with widlcard, config and clsuter", func() {
+				// define custom resources in cluster namespace
+				f, err := os.Open("testdata/calico-wildcard-user-input.yaml")
+				Expect(err).ToNot(HaveOccurred())
+				err = testutil.CreateResources(f, cfg, dynamicClient)
+				Expect(err).ToNot(HaveOccurred())
+				f.Close()
+			})
+			By("Verify package refName has been updated correctly in the clusterboostrap", func() {
+				clusterBootstrap := &runtanzuv1alpha3.ClusterBootstrap{}
+				Eventually(func() bool {
+					cbKey := client.ObjectKey{Name: clusterName, Namespace: clusterNamespace}
+					if err := k8sClient.Get(ctx, cbKey, clusterBootstrap); err != nil {
+						return false
+					}
+					return true
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+				Expect(clusterBootstrap.Spec.CNI.RefName).Should(Equal("calico.tanzu.vmware.com.1.2.5--vmware.12-tkg.1"))
+
+			})
+			By("Verify owner reference of resulting config", func() {
+				Eventually(func() bool {
+					calicoConfig := &cniv1alpha1.CalicoConfig{}
+					configKey := client.ObjectKey{Name: configName, Namespace: clusterNamespace}
+					if err := k8sClient.Get(ctx, configKey, calicoConfig); err != nil {
+						return false
+					}
+					// check owner reference
+					return cutil.VerifyOwnerRef(calicoConfig, clusterName, constants.ClusterKind)
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+			})
+			By("Verify contents of resulting calico config", func() {
+				// eventually the secret ref to the data values should be updated
+				calicoConfig := &cniv1alpha1.CalicoConfig{}
+				configKey := client.ObjectKey{Name: configName, Namespace: clusterNamespace}
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, configKey, calicoConfig); err != nil {
+						return false
+					}
+					return calicoConfig.Spec.Calico.Config.VethMTU == 1420 && !calicoConfig.Spec.Calico.Config.SkipCNIBinaries
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+
+			})
 		})
 	})
 })

--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -186,6 +186,14 @@ func (r *ClusterBootstrapReconciler) reconcileNormal(cluster *clusterapiv1beta1.
 		return ctrl.Result{}, nil
 	}
 
+	clusterBootstrapHelper := clusterbootstrapclone.NewHelper(
+		r.context, r.Client, r.aggregatedAPIResourcesClient, r.dynamicClient, r.gvrHelper, r.Log)
+
+	if err := clusterBootstrapHelper.AddClusterOwnerRefToExistingProviders(cluster, clusterBootstrap); err != nil {
+		log.Error(err, "could not add cluster as owner to existing providers")
+		return ctrl.Result{}, err
+	}
+
 	// reconcile the proxy settings of the cluster
 	if err := r.reconcileClusterProxyAndNetworkSettings(cluster, log); err != nil {
 		return ctrl.Result{}, err

--- a/addons/controllers/cpi/vspherecpiconfig_utils.go
+++ b/addons/controllers/cpi/vspherecpiconfig_utils.go
@@ -382,6 +382,7 @@ func (r *VSphereCPIConfigReconciler) mapCPIConfigToProviderServiceAccountSpec(vs
 	}
 }
 
+//nolint:unused
 // getOwnerCluster verifies that the VSphereCPIConfig has a cluster as its owner reference,
 // and returns the cluster. It tries to read the cluster name from the VSphereCPIConfig's owner reference objects.
 // If not there, we assume the owner cluster and VSphereCPIConfig always has the same name.

--- a/addons/controllers/csi/vspherecsiconfig_utils.go
+++ b/addons/controllers/csi/vspherecsiconfig_utils.go
@@ -201,6 +201,7 @@ func (r *VSphereCSIConfigReconciler) mapVSphereCSIConfigToDataValuesNonParavirtu
 	return dvs, nil
 }
 
+//nolint:unused
 // getOwnerCluster verifies that the VSphereCSIConfig has a cluster as its owner reference,
 // and returns the cluster. It tries to read the cluster name from the VSphereCSIConfig's owner reference objects.
 // If not there, we assume the owner cluster and VSphereCSIConfig always has the same name.

--- a/addons/controllers/kappcontrollerconfig_controller_test.go
+++ b/addons/controllers/kappcontrollerconfig_controller_test.go
@@ -14,6 +14,7 @@ import (
 	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	cutil "github.com/vmware-tanzu/tanzu-framework/addons/controllers/utils"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
 	"github.com/vmware-tanzu/tanzu-framework/addons/test/testutil"
@@ -26,6 +27,7 @@ const (
 
 var _ = Describe("KappControllerConfig Reconciler", func() {
 	var (
+		clusterName             string
 		kappConfigCRName        string
 		clusterResourceFilePath string
 	)
@@ -51,14 +53,19 @@ var _ = Describe("KappControllerConfig Reconciler", func() {
 	Context("reconcile KappControllerConfig for management cluster", func() {
 
 		BeforeEach(func() {
-			kappConfigCRName = testKappController1
+			clusterName = testKappController1
+			kappConfigCRName = util.GeneratePackageSecretName(clusterName, constants.KappControllerDefaultRefName)
 			clusterResourceFilePath = "testdata/test-kapp-controller-1.yaml"
 		})
 
 		It("Should reconcile KappControllerConfig and create data value secret on management cluster", func() {
 
 			key := client.ObjectKey{
-				Namespace: "default",
+				Namespace: defaultString,
+				Name:      clusterName,
+			}
+			configKey := client.ObjectKey{
+				Namespace: defaultString,
 				Name:      kappConfigCRName,
 			}
 
@@ -68,60 +75,57 @@ var _ = Describe("KappControllerConfig Reconciler", func() {
 				return err == nil
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 
+			config := &runv1alpha3.KappControllerConfig{}
 			Eventually(func() bool {
-				config := &runv1alpha3.KappControllerConfig{}
-				err := k8sClient.Get(ctx, key, config)
+				err := k8sClient.Get(ctx, configKey, config)
 				if err != nil {
 					return false
 				}
 				// check owner reference
-				if len(config.OwnerReferences) == 0 {
-					return false
-				}
-				Expect(len(config.OwnerReferences)).Should(Equal(1))
-				Expect(config.OwnerReferences[0].Name).Should(Equal(kappConfigCRName))
+				return cutil.VerifyOwnerRef(config, clusterName, constants.ClusterKind)
 
-				// check spec values
-				Expect(config.Spec.Namespace).Should(Equal("test-ns"))
-				Expect(config.Spec.KappController.CreateNamespace).Should(Equal(true))
-				Expect(config.Spec.KappController.GlobalNamespace).Should(Equal("tanzu-package-repo-global"))
-				Expect(config.Spec.KappController.Deployment.Concurrency).Should(Equal(4))
-				Expect(config.Spec.KappController.Deployment.HostNetwork).Should(Equal(true))
-				Expect(config.Spec.KappController.Deployment.PriorityClassName).Should(Equal("system-cluster-critical"))
-				Expect(config.Spec.KappController.Deployment.APIPort).Should(Equal(10100))
-				Expect(config.Spec.KappController.Deployment.MetricsBindAddress).Should(Equal("0"))
-				Expect(config.Spec.KappController.Deployment.Tolerations).ShouldNot(BeNil())
-
-				return true
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 
+			// check spec values
+			Expect(config.Spec.Namespace).Should(Equal("test-ns"))
+			Expect(config.Spec.KappController.CreateNamespace).Should(Equal(true))
+			Expect(config.Spec.KappController.GlobalNamespace).Should(Equal("tanzu-package-repo-global"))
+			Expect(config.Spec.KappController.Deployment.Concurrency).Should(Equal(4))
+			Expect(config.Spec.KappController.Deployment.HostNetwork).Should(Equal(true))
+			Expect(config.Spec.KappController.Deployment.PriorityClassName).Should(Equal("system-cluster-critical"))
+			Expect(config.Spec.KappController.Deployment.APIPort).Should(Equal(10100))
+			Expect(config.Spec.KappController.Deployment.MetricsBindAddress).Should(Equal("0"))
+			Expect(config.Spec.KappController.Deployment.Tolerations).ShouldNot(BeNil())
+
+			secret := &v1.Secret{}
 			Eventually(func() bool {
 				secretKey := client.ObjectKey{
-					Namespace: "default",
+					Namespace: defaultString,
 					Name:      util.GenerateDataValueSecretName(cluster.Name, constants.KappControllerAddonName),
 				}
-				secret := &v1.Secret{}
 				err := k8sClient.Get(ctx, secretKey, secret)
 				if err != nil {
 					return false
 				}
-				Expect(secret.Type).Should(Equal(v1.SecretTypeOpaque))
+				return secret.Type == v1.SecretTypeOpaque
+			}, waitTimeout, pollingInterval).Should(BeTrue())
 
-				// check data value secret contents
-				secretData := string(secret.Data["values.yaml"])
-				Expect(strings.Contains(secretData, "createNamespace: true")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "globalNamespace: tanzu-package-repo-global")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "concurrency: 4")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "hostNetwork: true")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "coreDNSIP: 100.64.0.10")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "- key: CriticalAddonsOnly")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "node-role.kubernetes.io/control-plane: \"\"")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "key: node.kubernetes.io/not-ready")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "key: node.cloudprovider.kubernetes.io/uninitialized")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "apiPort: 10100")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "metricsBindAddress: \"0\"")).Should(BeTrue())
-				Expect(strings.Contains(secretData, "key: node-role.kubernetes.io/control-plane")).Should(BeTrue())
+			// check data value secret contents
+			secretData := string(secret.Data["values.yaml"])
+			Expect(strings.Contains(secretData, "createNamespace: true")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "globalNamespace: tanzu-package-repo-global")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "concurrency: 4")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "hostNetwork: true")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "coreDNSIP: 100.64.0.10")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "- key: CriticalAddonsOnly")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "node-role.kubernetes.io/control-plane: \"\"")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "key: node.kubernetes.io/not-ready")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "key: node.cloudprovider.kubernetes.io/uninitialized")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "apiPort: 10100")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "metricsBindAddress: \"0\"")).Should(BeTrue())
+			Expect(strings.Contains(secretData, "key: node-role.kubernetes.io/control-plane")).Should(BeTrue())
 
+			Eventually(func() bool {
 				if !strings.Contains(secretData, "caCerts: dummyCertificate") ||
 					!strings.Contains(secretData, "httpsProxy: bar.com") ||
 					!strings.Contains(secretData, "noProxy: foobar.com") ||
@@ -140,12 +144,11 @@ var _ = Describe("KappControllerConfig Reconciler", func() {
 			Eventually(func() bool {
 				// Check status.secretRef after reconciliation
 				config := &runv1alpha3.KappControllerConfig{}
-				err := k8sClient.Get(ctx, key, config)
+				err := k8sClient.Get(ctx, configKey, config)
 				if err != nil {
 					return false
 				}
-				Expect(config.Status.SecretRef).Should(Equal(util.GenerateDataValueSecretName(cluster.Name, constants.KappControllerAddonName)))
-				return true
+				return config.Status.SecretRef == util.GenerateDataValueSecretName(cluster.Name, constants.KappControllerAddonName)
 			}, waitTimeout, pollingInterval).Should(BeTrue())
 
 		})
@@ -155,18 +158,19 @@ var _ = Describe("KappControllerConfig Reconciler", func() {
 	Context("Reconcile KappControllerConfig used as template", func() {
 
 		BeforeEach(func() {
-			kappConfigCRName = testKappController1
+			clusterName = testKappController1
+			kappConfigCRName = util.GeneratePackageSecretName(clusterName, constants.KappControllerDefaultRefName)
 			clusterResourceFilePath = "testdata/test-kapp-controller-template-config-1.yaml"
 		})
 
 		It("Should skip the reconciliation", func() {
 
-			key := client.ObjectKey{
+			configKey := client.ObjectKey{
 				Namespace: addonNamespace,
 				Name:      kappConfigCRName,
 			}
 			config := &runv1alpha3.KappControllerConfig{}
-			Expect(k8sClient.Get(ctx, key, config)).To(Succeed())
+			Expect(k8sClient.Get(ctx, configKey, config)).To(Succeed())
 
 			By("OwnerReferences is not set")
 			Expect(len(config.OwnerReferences)).Should(Equal(0))

--- a/addons/controllers/testdata/antrea-custom-cb-2-resources.yaml
+++ b/addons/controllers/testdata/antrea-custom-cb-2-resources.yaml
@@ -1,0 +1,266 @@
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: TanzuKubernetesRelease
+metadata:
+  name: v1.23.2
+spec:
+  version: v1.23.2
+  kubernetes:
+    version: v1.23.2
+    imageRepository: foo
+  osImages: []
+  bootstrapPackages: []
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: ClusterBootstrapTemplate
+metadata:
+  name: v1.23.2
+  namespace: tkg-system
+spec:
+  kapp:
+    refName: kapp-controller.tanzu.vmware.com.0.31.2
+    valuesFrom:
+      providerRef:
+        apiGroup: run.tanzu.vmware.com
+        kind: KappControllerConfig
+        name: test-cluster-custom-cb-2-kapp-controller-config
+  cni:
+    refName: antrea.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
+    valuesFrom:
+      providerRef:
+        apiGroup: cni.tanzu.vmware.com
+        kind: AntreaConfig
+        name: antrea-config-template-2
+---
+apiVersion: cni.tanzu.vmware.com/v1alpha1
+kind: AntreaConfig
+metadata:
+  name: antrea-config-template-2
+  namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
+spec:
+  antrea:
+    config:
+      trafficEncapMode: encap
+      defaultMTU:       "8900"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DockerCluster
+metadata:
+  name: custom-cb-docker-cluster-2
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-cluster-custom-cb
+  namespace: custom-cb-2-namespace
+data:
+  password: QWRtaW4hMjM= # Admin!23
+  username: YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs # administrator@vsphere.local
+---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: kapp-controller.tanzu.vmware.com.0.31.2
+  namespace: tkg-system
+spec:
+  refName: kapp-controller.tanzu.vmware.com
+  version: 0.31.0
+  releaseNotes: kapp-controller 0.30.0 https://github.com/vmware-tanzu/carvel-kapp-controller
+  licenses:
+    - 'VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)'
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/kapp-controller:v0.30.0_vmware.1-tkg.1
+      template:
+        - ytt:
+            paths:
+              - config/
+            ignoreUnknownComments: true
+        - kbld:
+            paths:
+              - '-'
+              - .imgpkg/images.yml
+      deploy:
+        - kapp:
+            rawOptions:
+              - --wait-timeout=30s
+              - --kube-api-qps=20
+              - --kube-api-burst=30
+  releasedAt: "2021-12-30T10:59:32Z"
+  valuesSchema:
+    openAPIv3:
+      title: kapp-controller.tanzu.vmware.com.0.31.2+vmware.1-tkg.1 values schema
+---
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: antrea.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
+  namespace: tkg-system
+spec:
+  refName: antrea.tanzu.vmware.com
+  version: 1.2.5+vmware.1-tkg.1
+  releaseNotes: antrea 1.2.3 https://github.com/antrea-io/antrea/releases/tag/v1.2.3
+  licenses:
+    - 'VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)'
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/antrea:v1.2.3_vmware.1-tkg.1
+      template:
+        - ytt:
+            paths:
+              - config/
+            ignoreUnknownComments: true
+        - kbld:
+            paths:
+              - '-'
+              - .imgpkg/images.yml
+      deploy:
+        - kapp:
+            rawOptions:
+              - --wait-timeout=30s
+              - --kube-api-qps=20
+              - --kube-api-burst=30
+  releasedAt: "2021-12-20T10:59:32Z"
+  valuesSchema:
+    openAPIv3:
+      title: antrea.tanzu.vmware.com.1.2.5+vmware.1-tkg.1 values schema
+---
+# manually sync package to required namespace (done by kapp-controller on a real cluster)
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: kapp-controller.tanzu.vmware.com.0.31.2
+  namespace: custom-cb-2-namespace
+spec:
+  refName: kapp-controller.tanzu.vmware.com
+  version: 0.31.0
+  releaseNotes: kapp-controller 0.30.0 https://github.com/vmware-tanzu/carvel-kapp-controller
+  licenses:
+    - 'VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)'
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/kapp-controller:v0.30.0_vmware.1-tkg.1
+      template:
+        - ytt:
+            paths:
+              - config/
+            ignoreUnknownComments: true
+        - kbld:
+            paths:
+              - '-'
+              - .imgpkg/images.yml
+      deploy:
+        - kapp:
+            rawOptions:
+              - --wait-timeout=30s
+              - --kube-api-qps=20
+              - --kube-api-burst=30
+  releasedAt: "2021-12-30T10:59:32Z"
+  valuesSchema:
+    openAPIv3:
+      title: kapp-controller.tanzu.vmware.com.0.31.2+vmware.1-tkg.1 values schema
+---
+# manually sync package to required namespace (done by kapp-controller on a real cluster)
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: antrea.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
+  namespace: custom-cb-2-namespace
+spec:
+  refName: antrea.tanzu.vmware.com
+  version: 1.2.5+vmware.1-tkg.1
+  releaseNotes: antrea 1.2.3 https://github.com/antrea-io/antrea/releases/tag/v1.2.3
+  licenses:
+    - 'VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)'
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/antrea:v1.2.3_vmware.1-tkg.1
+      template:
+        - ytt:
+            paths:
+              - config/
+            ignoreUnknownComments: true
+        - kbld:
+            paths:
+              - '-'
+              - .imgpkg/images.yml
+      deploy:
+        - kapp:
+            rawOptions:
+              - --wait-timeout=30s
+              - --kube-api-qps=20
+              - --kube-api-burst=30
+  releasedAt: "2021-12-20T10:59:32Z"
+  valuesSchema:
+    openAPIv3:
+      title: antrea.tanzu.vmware.com.1.2.5+vmware.1-tkg.1 values schema
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: KappControllerConfig
+metadata:
+  name: test-cluster-custom-cb-2-kapp-controller-config
+  namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
+spec:
+  namespace: test-ns
+  kappController:
+    createNamespace: true
+    globalNamespace: tanzu-package-repo-global
+    deployment:
+      concurrency: 4
+      hostNetwork: true
+      priorityClassName: system-cluster-critical
+      apiPort: 10100
+      metricsBindAddress: "0"
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: KappControllerConfig
+metadata:
+  name: test-cluster-custom-cb-2-kapp-controller-config
+  namespace: custom-cb-2-namespace
+spec:
+  namespace: test-ns
+  kappController:
+    createNamespace: true
+    globalNamespace: tanzu-package-repo-global
+    deployment:
+      concurrency: 4
+      hostNetwork: true
+      priorityClassName: system-cluster-critical
+      apiPort: 10100
+      metricsBindAddress: "0"
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"

--- a/addons/controllers/testdata/antrea-custom-cb-ns.yaml
+++ b/addons/controllers/testdata/antrea-custom-cb-ns.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-cluster-custom-cb
+  namespace: antrea-custom-cb-ns
+data:
+  password: QWRtaW4hMjM= # Admin!23
+  username: YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs # administrator@vsphere.local
+---
+# manually sync package to required namespace (done by kapp-controller on a real cluster)
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: kapp-controller.tanzu.vmware.com.0.31.1
+  namespace: antrea-custom-cb-ns
+spec:
+  refName: kapp-controller.tanzu.vmware.com
+  version: 0.31.0
+  releaseNotes: kapp-controller 0.30.0 https://github.com/vmware-tanzu/carvel-kapp-controller
+  licenses:
+    - 'VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)'
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/kapp-controller:v0.30.0_vmware.1-tkg.1
+      template:
+        - ytt:
+            paths:
+              - config/
+            ignoreUnknownComments: true
+        - kbld:
+            paths:
+              - '-'
+              - .imgpkg/images.yml
+      deploy:
+        - kapp:
+            rawOptions:
+              - --wait-timeout=30s
+              - --kube-api-qps=20
+              - --kube-api-burst=30
+  releasedAt: "2021-12-30T10:59:32Z"
+  valuesSchema:
+    openAPIv3:
+      title: kapp-controller.tanzu.vmware.com.0.31.1+vmware.1-tkg.1 values schema
+---
+# manually sync package to required namespace (done by kapp-controller on a real cluster)
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: antrea.tanzu.vmware.com.1.2.5--vmware.11-tkg.1
+  namespace: antrea-custom-cb-ns
+spec:
+  refName: antrea.tanzu.vmware.com
+  version: 1.2.5+vmware.1-tkg.1
+  releaseNotes: antrea 1.2.3 https://github.com/antrea-io/antrea/releases/tag/v1.2.3
+  licenses:
+    - 'VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)'
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/antrea:v1.2.3_vmware.1-tkg.1
+      template:
+        - ytt:
+            paths:
+              - config/
+            ignoreUnknownComments: true
+        - kbld:
+            paths:
+              - '-'
+              - .imgpkg/images.yml
+      deploy:
+        - kapp:
+            rawOptions:
+              - --wait-timeout=30s
+              - --kube-api-qps=20
+              - --kube-api-burst=30
+  releasedAt: "2021-12-20T10:59:32Z"
+  valuesSchema:
+    openAPIv3:
+      title: antrea.tanzu.vmware.com.1.2.5+vmware.1-tkg.1 values schema

--- a/addons/controllers/testdata/antrea-custom-cb.yaml
+++ b/addons/controllers/testdata/antrea-custom-cb.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: ClusterBootstrap
+metadata:
+  name: custom-cb-2-cluster
+  namespace: custom-cb-2-namespace
+spec:
+  kapp:
+    refName: kapp-controller.tanzu.vmware.com.0.31.2
+    valuesFrom:
+      providerRef:
+        apiGroup: run.tanzu.vmware.com
+        kind: KappControllerConfig
+        name: test-cluster-custom-cb-2-kapp-controller-config
+  cni:
+    refName: antrea.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
+    valuesFrom:
+      providerRef:
+        apiGroup: cni.tanzu.vmware.com
+        kind: AntreaConfig
+        name: antrea-config-custom-2

--- a/addons/controllers/testdata/antrea-custom-tkg-system.yaml
+++ b/addons/controllers/testdata/antrea-custom-tkg-system.yaml
@@ -2,74 +2,58 @@
 apiVersion: run.tanzu.vmware.com/v1alpha3
 kind: TanzuKubernetesRelease
 metadata:
-  name: v1.23.2
+  name: v1.23.1
 spec:
-  version: v1.23.2
+  version: v1.23.1
   kubernetes:
-    version: v1.23.2
+    version: v1.23.1
     imageRepository: foo
   osImages: []
-  bootstrapPackages:
-    - name: calico.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
+  bootstrapPackages: []
 ---
 apiVersion: run.tanzu.vmware.com/v1alpha3
 kind: ClusterBootstrapTemplate
 metadata:
-  name: v1.23.2
+  name: v1.23.1
   namespace: tkg-system
 spec:
   kapp:
-    refName: kapp-controller.tanzu.vmware.com.0.31.2
+    refName: kapp-controller.tanzu.vmware.com.0.31.1
     valuesFrom:
       providerRef:
         apiGroup: run.tanzu.vmware.com
         kind: KappControllerConfig
-        name: c-kapp-config-template-3
+        name: kapp-config-template
   cni:
-    refName: calico.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
+    refName: antrea.tanzu.vmware.com.1.2.5--vmware.11-tkg.1
     valuesFrom:
       providerRef:
         apiGroup: cni.tanzu.vmware.com
-        kind: CalicoConfig
-        name: calico-config-template-3
+        kind: AntreaConfig
+        name: antrea-config-template
 ---
 apiVersion: cni.tanzu.vmware.com/v1alpha1
-kind: CalicoConfig
+kind: AntreaConfig
 metadata:
-  name: calico-config-template-3
+  name: antrea-config-template
   namespace: tkg-system
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:
-  calico:
+  antrea:
     config:
-      vethMTU: 0
-      skipCNIBinaries: true
----
-apiVersion: run.tanzu.vmware.com/v1alpha3
-kind: KappControllerConfig
-metadata:
-  name: c-kapp-config-template-3
-  namespace: tkg-system
-  annotations:
-    tkg.tanzu.vmware.com/template-config: "true"
-spec:
-  namespace: test-ns
-  kappController:
-    createNamespace: true
-    globalNamespace: tanzu-package-repo-global
-
+      trafficEncapMode: encap
+      defaultMTU:       "8900"
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DockerCluster
 metadata:
   name: custom-cb-docker-cluster
-
 ---
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: kapp-controller.tanzu.vmware.com.0.31.2
+  name: kapp-controller.tanzu.vmware.com.0.31.1
   namespace: tkg-system
 spec:
   refName: kapp-controller.tanzu.vmware.com
@@ -100,24 +84,24 @@ spec:
   releasedAt: "2021-12-30T10:59:32Z"
   valuesSchema:
     openAPIv3:
-      title: kapp-controller.tanzu.vmware.com.0.31.2+vmware.1-tkg.1 values schema
+      title: kapp-controller.tanzu.vmware.com.0.31.1+vmware.1-tkg.1 values schema
 ---
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: calico.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
+  name: antrea.tanzu.vmware.com.1.2.5--vmware.11-tkg.1
   namespace: tkg-system
 spec:
-  refName: calico.tanzu.vmware.com
+  refName: antrea.tanzu.vmware.com
   version: 1.2.5+vmware.1-tkg.1
-  releaseNotes: calico 1.2.3 https://github.com/calico-io/calico/releases/tag/v1.2.3
+  releaseNotes: antrea 1.2.3 https://github.com/antrea-io/antrea/releases/tag/v1.2.3
   licenses:
     - 'VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)'
   template:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/calico:v1.2.3_vmware.1-tkg.1
+            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/antrea:v1.2.3_vmware.1-tkg.1
       template:
         - ytt:
             paths:
@@ -136,32 +120,35 @@ spec:
   releasedAt: "2021-12-20T10:59:32Z"
   valuesSchema:
     openAPIv3:
-      title: calico.tanzu.vmware.com.1.2.5+vmware.1-tkg.1 values schema
-
+      title: antrea.tanzu.vmware.com.1.2.5+vmware.1-tkg.1 values schema
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: KappControllerConfig
 metadata:
-  name: test-cluster-calico-1
+  name: kapp-config-template
   namespace: tkg-system
-  labels:
-    "tkg.tanzu.vmware.com/cluster-name": test-cluster-calico-1
-    "run.tanzu.vmware.com/tkr": v1.23.2
-    cluster-role.tkg.tanzu.vmware.com/management: ""
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
-  infrastructureRef:
-    kind: VSphereCluster
-  clusterNetwork:
-    pods:
-      cidrBlocks: [ "192.168.0.0/16","fd00:100:96::/48" ]
----
-apiVersion: cni.tanzu.vmware.com/v1alpha1
-kind: CalicoConfig
-metadata:
-  name: test-cluster-calico-1-calico-package
-  namespace: tkg-system
-spec:
-  calico:
-    config:
-      vethMTU: 7
-      skipCNIBinaries: true
+  namespace: test-ns
+  kappController:
+    createNamespace: true
+    globalNamespace: tanzu-package-repo-global
+    deployment:
+      concurrency: 4
+      hostNetwork: true
+      priorityClassName: system-cluster-critical
+      apiPort: 10100
+      metricsBindAddress: "0"
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"

--- a/addons/controllers/testdata/antrea-test-1.yaml
+++ b/addons/controllers/testdata/antrea-test-1.yaml
@@ -23,8 +23,15 @@ metadata:
 apiVersion: cni.tanzu.vmware.com/v1alpha1
 kind: AntreaConfig
 metadata:
-  name: test-cluster-4
+  name: test-cluster-4-antrea-package
   namespace: default
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test-cluster-4
+      uid: cbd29b10-c190-422e-86f1-a0321d1aab7d
 spec:
   antrea:
     config:

--- a/addons/controllers/testdata/antrea-test-template-config-1.yaml
+++ b/addons/controllers/testdata/antrea-test-template-config-1.yaml
@@ -2,7 +2,7 @@
 apiVersion: cni.tanzu.vmware.com/v1alpha1
 kind: AntreaConfig
 metadata:
-  name: test-cluster-4
+  name: test-cluster-4-antrea-package
   namespace: tkg-system
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"

--- a/addons/controllers/testdata/calico-custom-cb-ns.yaml
+++ b/addons/controllers/testdata/calico-custom-cb-ns.yaml
@@ -1,76 +1,19 @@
 ---
-apiVersion: run.tanzu.vmware.com/v1alpha3
-kind: TanzuKubernetesRelease
+apiVersion: v1
+kind: Secret
 metadata:
-  name: v1.23.2
-spec:
-  version: v1.23.2
-  kubernetes:
-    version: v1.23.2
-    imageRepository: foo
-  osImages: []
-  bootstrapPackages:
-    - name: calico.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
+  name: calico-custom-cb-ns
+  namespace: calico-custom-cb-ns
+data:
+  password: QWRtaW4hMjM= # Admin!23
+  username: YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs # administrator@vsphere.local
 ---
-apiVersion: run.tanzu.vmware.com/v1alpha3
-kind: ClusterBootstrapTemplate
-metadata:
-  name: v1.23.2
-  namespace: tkg-system
-spec:
-  kapp:
-    refName: kapp-controller.tanzu.vmware.com.0.31.2
-    valuesFrom:
-      providerRef:
-        apiGroup: run.tanzu.vmware.com
-        kind: KappControllerConfig
-        name: c-kapp-config-template-3
-  cni:
-    refName: calico.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
-    valuesFrom:
-      providerRef:
-        apiGroup: cni.tanzu.vmware.com
-        kind: CalicoConfig
-        name: calico-config-template-3
----
-apiVersion: cni.tanzu.vmware.com/v1alpha1
-kind: CalicoConfig
-metadata:
-  name: calico-config-template-3
-  namespace: tkg-system
-  annotations:
-    tkg.tanzu.vmware.com/template-config: "true"
-spec:
-  calico:
-    config:
-      vethMTU: 0
-      skipCNIBinaries: true
----
-apiVersion: run.tanzu.vmware.com/v1alpha3
-kind: KappControllerConfig
-metadata:
-  name: c-kapp-config-template-3
-  namespace: tkg-system
-  annotations:
-    tkg.tanzu.vmware.com/template-config: "true"
-spec:
-  namespace: test-ns
-  kappController:
-    createNamespace: true
-    globalNamespace: tanzu-package-repo-global
-
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: DockerCluster
-metadata:
-  name: custom-cb-docker-cluster
-
----
+# manually sync package to required namespace (done by kapp-controller on a real cluster)
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: kapp-controller.tanzu.vmware.com.0.31.2
-  namespace: tkg-system
+  namespace: calico-custom-cb-ns
 spec:
   refName: kapp-controller.tanzu.vmware.com
   version: 0.31.0
@@ -102,11 +45,12 @@ spec:
     openAPIv3:
       title: kapp-controller.tanzu.vmware.com.0.31.2+vmware.1-tkg.1 values schema
 ---
+# manually sync package to required namespace (done by kapp-controller on a real cluster)
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: calico.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
-  namespace: tkg-system
+  namespace: calico-custom-cb-ns
 spec:
   refName: calico.tanzu.vmware.com
   version: 1.2.5+vmware.1-tkg.1
@@ -137,30 +81,80 @@ spec:
   valuesSchema:
     openAPIv3:
       title: calico.tanzu.vmware.com.1.2.5+vmware.1-tkg.1 values schema
+
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: KappControllerConfig
+metadata:
+  name: kapp-config-custom
+  namespace: calico-custom-cb-ns
+spec:
+  namespace: test-ns
+  kappController:
+    createNamespace: true
+    globalNamespace: tanzu-package-repo-global
+    deployment:
+      concurrency: 4
+      hostNetwork: true
+      priorityClassName: system-cluster-critical
+      apiPort: 10100
+      metricsBindAddress: "0"
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+---
+apiVersion: cni.tanzu.vmware.com/v1alpha1
+kind: CalicoConfig
+metadata:
+  name: calico-custom-config
+  namespace: calico-custom-cb-ns
+spec:
+  calico:
+    config:
+      vethMTU: 1420
+      skipCNIBinaries: false
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: ClusterBootstrap
+metadata:
+  name: calico-custom-cb-cluster
+  namespace: calico-custom-cb-ns
+spec:
+  kapp:
+    refName: kapp-controller.tanzu.vmware.com.0.31.2
+    valuesFrom:
+      providerRef:
+        apiGroup: run.tanzu.vmware.com
+        kind: KappControllerConfig
+        name: kapp-config-custom
+  cni:
+    refName: calico.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
+    valuesFrom:
+      providerRef:
+        apiGroup: cni.tanzu.vmware.com
+        kind: CalicoConfig
+        name: calico-custom-config
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: test-cluster-calico-2
-  namespace: tkg-system
+  name: calico-custom-cb-cluster
+  namespace: calico-custom-cb-ns
   labels:
-    "tkg.tanzu.vmware.com/cluster-name": calico-wildcard-cb-cluster
+    "tkg.tanzu.vmware.com/cluster-name": calico-custom-cb-cluster
     "run.tanzu.vmware.com/tkr": v1.23.2
-    cluster-role.tkg.tanzu.vmware.com/management: ""
 spec:
   infrastructureRef:
     kind: DockerCluster
   clusterNetwork:
     pods:
       cidrBlocks: [ "192.168.0.0/16"]
----
-apiVersion: cni.tanzu.vmware.com/v1alpha1
-kind: CalicoConfig
-metadata:
-  name: test-cluster-calico-2-calico-package
-  namespace: tkg-system
-spec:
-  calico:
-    config:
-      vethMTU: 1420
-      skipCNIBinaries: false

--- a/addons/controllers/testdata/calico-custom-config-ns.yaml
+++ b/addons/controllers/testdata/calico-custom-config-ns.yaml
@@ -1,76 +1,19 @@
 ---
-apiVersion: run.tanzu.vmware.com/v1alpha3
-kind: TanzuKubernetesRelease
+apiVersion: v1
+kind: Secret
 metadata:
-  name: v1.23.2
-spec:
-  version: v1.23.2
-  kubernetes:
-    version: v1.23.2
-    imageRepository: foo
-  osImages: []
-  bootstrapPackages:
-    - name: calico.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
+  name: calico-custom-config-ns
+  namespace: calico-custom-config-ns
+data:
+  password: QWRtaW4hMjM= # Admin!23
+  username: YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs # administrator@vsphere.local
 ---
-apiVersion: run.tanzu.vmware.com/v1alpha3
-kind: ClusterBootstrapTemplate
-metadata:
-  name: v1.23.2
-  namespace: tkg-system
-spec:
-  kapp:
-    refName: kapp-controller.tanzu.vmware.com.0.31.2
-    valuesFrom:
-      providerRef:
-        apiGroup: run.tanzu.vmware.com
-        kind: KappControllerConfig
-        name: c-kapp-config-template-3
-  cni:
-    refName: calico.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
-    valuesFrom:
-      providerRef:
-        apiGroup: cni.tanzu.vmware.com
-        kind: CalicoConfig
-        name: calico-config-template-3
----
-apiVersion: cni.tanzu.vmware.com/v1alpha1
-kind: CalicoConfig
-metadata:
-  name: calico-config-template-3
-  namespace: tkg-system
-  annotations:
-    tkg.tanzu.vmware.com/template-config: "true"
-spec:
-  calico:
-    config:
-      vethMTU: 0
-      skipCNIBinaries: true
----
-apiVersion: run.tanzu.vmware.com/v1alpha3
-kind: KappControllerConfig
-metadata:
-  name: c-kapp-config-template-3
-  namespace: tkg-system
-  annotations:
-    tkg.tanzu.vmware.com/template-config: "true"
-spec:
-  namespace: test-ns
-  kappController:
-    createNamespace: true
-    globalNamespace: tanzu-package-repo-global
-
----
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: DockerCluster
-metadata:
-  name: custom-cb-docker-cluster
-
----
+# manually sync package to required namespace (done by kapp-controller on a real cluster)
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: kapp-controller.tanzu.vmware.com.0.31.2
-  namespace: tkg-system
+  namespace: calico-custom-config-ns
 spec:
   refName: kapp-controller.tanzu.vmware.com
   version: 0.31.0
@@ -102,11 +45,12 @@ spec:
     openAPIv3:
       title: kapp-controller.tanzu.vmware.com.0.31.2+vmware.1-tkg.1 values schema
 ---
+# manually sync package to required namespace (done by kapp-controller on a real cluster)
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: calico.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
-  namespace: tkg-system
+  namespace: calico-custom-config-ns
 spec:
   refName: calico.tanzu.vmware.com
   version: 1.2.5+vmware.1-tkg.1
@@ -139,29 +83,57 @@ spec:
       title: calico.tanzu.vmware.com.1.2.5+vmware.1-tkg.1 values schema
 
 ---
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: KappControllerConfig
 metadata:
-  name: test-cluster-calico-1
-  namespace: tkg-system
-  labels:
-    "tkg.tanzu.vmware.com/cluster-name": test-cluster-calico-1
-    "run.tanzu.vmware.com/tkr": v1.23.2
-    cluster-role.tkg.tanzu.vmware.com/management: ""
+  name: kapp-config-custom
+  namespace: calico-custom-config-ns
 spec:
-  infrastructureRef:
-    kind: VSphereCluster
-  clusterNetwork:
-    pods:
-      cidrBlocks: [ "192.168.0.0/16","fd00:100:96::/48" ]
+  namespace: test-ns
+  kappController:
+    createNamespace: true
+    globalNamespace: tanzu-package-repo-global
+    deployment:
+      concurrency: 4
+      hostNetwork: true
+      priorityClassName: system-cluster-critical
+      apiPort: 10100
+      metricsBindAddress: "0"
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
 ---
 apiVersion: cni.tanzu.vmware.com/v1alpha1
 kind: CalicoConfig
 metadata:
-  name: test-cluster-calico-1-calico-package
-  namespace: tkg-system
+  name: calico-custom-config-cluster-calico-package
+  namespace: calico-custom-config-ns
 spec:
   calico:
     config:
-      vethMTU: 7
-      skipCNIBinaries: true
+      vethMTU: 1420
+      skipCNIBinaries: false
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: calico-custom-config-cluster
+  namespace: calico-custom-config-ns
+  labels:
+    "tkg.tanzu.vmware.com/cluster-name": calico-custom-config-cluster
+    "run.tanzu.vmware.com/tkr": v1.23.2
+spec:
+  infrastructureRef:
+    kind: DockerCluster
+  clusterNetwork:
+    pods:
+      cidrBlocks: [ "192.168.0.0/16"]

--- a/addons/controllers/testdata/calico-custom-config.yaml
+++ b/addons/controllers/testdata/calico-custom-config.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: test-cluster-calico-2
+  namespace: default
+spec:
+  infrastructureRef:
+    kind: DockerCluster
+  clusterNetwork:
+    pods:
+      cidrBlocks: [ "192.168.0.0/16"]
+---
+apiVersion: cni.tanzu.vmware.com/v1alpha1
+kind: CalicoConfig
+metadata:
+  name: test-cluster-calico-2-calico-package
+  namespace: default
+spec:
+  calico:
+    config:
+      vethMTU: 1420
+      skipCNIBinaries: false

--- a/addons/controllers/testdata/calico-custom-tkg-system.yaml
+++ b/addons/controllers/testdata/calico-custom-tkg-system.yaml
@@ -138,30 +138,3 @@ spec:
     openAPIv3:
       title: calico.tanzu.vmware.com.1.2.5+vmware.1-tkg.1 values schema
 
----
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
-metadata:
-  name: test-cluster-calico-1
-  namespace: tkg-system
-  labels:
-    "tkg.tanzu.vmware.com/cluster-name": test-cluster-calico-1
-    "run.tanzu.vmware.com/tkr": v1.23.2
-    cluster-role.tkg.tanzu.vmware.com/management: ""
-spec:
-  infrastructureRef:
-    kind: VSphereCluster
-  clusterNetwork:
-    pods:
-      cidrBlocks: [ "192.168.0.0/16","fd00:100:96::/48" ]
----
-apiVersion: cni.tanzu.vmware.com/v1alpha1
-kind: CalicoConfig
-metadata:
-  name: test-cluster-calico-1-calico-package
-  namespace: tkg-system
-spec:
-  calico:
-    config:
-      vethMTU: 7
-      skipCNIBinaries: true

--- a/addons/controllers/testdata/calico-management-cluster.yaml
+++ b/addons/controllers/testdata/calico-management-cluster.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: mgmt-cluster
+  namespace: tkg-system
+  labels:
+    "tkg.tanzu.vmware.com/cluster-name": mgmt-cluster
+    "run.tanzu.vmware.com/tkr": v1.23.2
+    "cluster-role.tkg.tanzu.vmware.com/management": ""
+spec:
+  infrastructureRef:
+    kind: DockerCluster
+  clusterNetwork:
+    pods:
+      cidrBlocks: [ "192.168.0.0/16"]

--- a/addons/controllers/testdata/calico-wildcard-cb-ns.yaml
+++ b/addons/controllers/testdata/calico-wildcard-cb-ns.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: calico-wildcard-cb-ns
+  namespace: calico-wildcard-cb-ns
+data:
+  password: QWRtaW4hMjM= # Admin!23
+  username: YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs # administrator@vsphere.local
+---
+# manually sync package to required namespace (done by kapp-controller on a real cluster)
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: kapp-controller.tanzu.vmware.com.0.31.2
+  namespace: calico-wildcard-cb-ns
+spec:
+  refName: kapp-controller.tanzu.vmware.com
+  version: 0.31.0
+  releaseNotes: kapp-controller 0.30.0 https://github.com/vmware-tanzu/carvel-kapp-controller
+  licenses:
+    - 'VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)'
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/kapp-controller:v0.30.0_vmware.1-tkg.1
+      template:
+        - ytt:
+            paths:
+              - config/
+            ignoreUnknownComments: true
+        - kbld:
+            paths:
+              - '-'
+              - .imgpkg/images.yml
+      deploy:
+        - kapp:
+            rawOptions:
+              - --wait-timeout=30s
+              - --kube-api-qps=20
+              - --kube-api-burst=30
+  releasedAt: "2021-12-30T10:59:32Z"
+  valuesSchema:
+    openAPIv3:
+      title: kapp-controller.tanzu.vmware.com.0.31.2+vmware.1-tkg.1 values schema
+---
+# manually sync package to required namespace (done by kapp-controller on a real cluster)
+apiVersion: data.packaging.carvel.dev/v1alpha1
+kind: Package
+metadata:
+  name: calico.tanzu.vmware.com.1.2.5--vmware.12-tkg.1
+  namespace: calico-wildcard-cb-ns
+spec:
+  refName: calico.tanzu.vmware.com
+  version: 1.2.5+vmware.1-tkg.1
+  releaseNotes: calico 1.2.3 https://github.com/calico-io/calico/releases/tag/v1.2.3
+  licenses:
+    - 'VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)'
+  template:
+    spec:
+      fetch:
+        - imgpkgBundle:
+            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/calico:v1.2.3_vmware.1-tkg.1
+      template:
+        - ytt:
+            paths:
+              - config/
+            ignoreUnknownComments: true
+        - kbld:
+            paths:
+              - '-'
+              - .imgpkg/images.yml
+      deploy:
+        - kapp:
+            rawOptions:
+              - --wait-timeout=30s
+              - --kube-api-qps=20
+              - --kube-api-burst=30
+  releasedAt: "2021-12-20T10:59:32Z"
+  valuesSchema:
+    openAPIv3:
+      title: calico.tanzu.vmware.com.1.2.5+vmware.1-tkg.1 values schema
+
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: KappControllerConfig
+metadata:
+  name: kapp-config-custom
+  namespace: calico-wildcard-cb-ns
+spec:
+  namespace: test-ns
+  kappController:
+    createNamespace: true
+    globalNamespace: tanzu-package-repo-global
+    deployment:
+      concurrency: 4
+      hostNetwork: true
+      priorityClassName: system-cluster-critical
+      apiPort: 10100
+      metricsBindAddress: "0"
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+

--- a/addons/controllers/testdata/calico-wildcard-user-input.yaml
+++ b/addons/controllers/testdata/calico-wildcard-user-input.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: cni.tanzu.vmware.com/v1alpha1
+kind: CalicoConfig
+metadata:
+  name: calico-wildcard-config
+  namespace: calico-wildcard-cb-ns
+spec:
+  calico:
+    config:
+      vethMTU: 1420
+      skipCNIBinaries: false
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: ClusterBootstrap
+metadata:
+  name: calico-wildcard-cb-cluster
+  namespace: calico-wildcard-cb-ns
+  annotations:
+    tkg.tanzu.vmware.com/add-missing-fields-from-tkr: v1.23.2
+spec:
+  kapp:
+    refName: kapp-controller.tanzu.vmware.com.0.31.2
+    valuesFrom:
+      providerRef:
+        apiGroup: run.tanzu.vmware.com
+        kind: KappControllerConfig
+        name: kapp-config-custom
+  cni:
+    refName: calico*
+    valuesFrom:
+      providerRef:
+        apiGroup: cni.tanzu.vmware.com
+        kind: CalicoConfig
+        name: calico-wildcard-config
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: calico-wildcard-cb-cluster
+  namespace: calico-wildcard-cb-ns
+  labels:
+    "tkg.tanzu.vmware.com/cluster-name": calico-wildcard-cb-cluster
+    "run.tanzu.vmware.com/tkr": v1.23.2
+spec:
+  infrastructureRef:
+    kind: DockerCluster
+  clusterNetwork:
+    pods:
+      cidrBlocks: [ "192.168.0.0/16"]

--- a/addons/controllers/testdata/test-calico-template-config-1.yaml
+++ b/addons/controllers/testdata/test-calico-template-config-1.yaml
@@ -2,7 +2,7 @@
 apiVersion: cni.tanzu.vmware.com/v1alpha1
 kind: CalicoConfig
 metadata:
-  name: test-cluster-calico-1
+  name: test-cluster-calico-1-calico-package
   namespace: tkg-system
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"

--- a/addons/controllers/testdata/test-kapp-controller-1.yaml
+++ b/addons/controllers/testdata/test-kapp-controller-1.yaml
@@ -23,8 +23,15 @@ spec:
 apiVersion: run.tanzu.vmware.com/v1alpha3
 kind: KappControllerConfig
 metadata:
-  name: test-kapp-controller-1
+  name: test-kapp-controller-1-kapp-controller-package
   namespace: default
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test-kapp-controller-1
+      uid: cbd29b10-c190-422e-86f1-a0321d1aab7d
 spec:
   namespace: test-ns
   kappController:

--- a/addons/controllers/testdata/test-kapp-controller-template-config-1.yaml
+++ b/addons/controllers/testdata/test-kapp-controller-template-config-1.yaml
@@ -2,7 +2,7 @@
 apiVersion: run.tanzu.vmware.com/v1alpha3
 kind: KappControllerConfig
 metadata:
-  name: test-kapp-controller-1
+  name: test-kapp-controller-1-kapp-controller-package
   namespace: tkg-system
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"

--- a/addons/controllers/testdata/test-tkg-system-ns-resources.yaml
+++ b/addons/controllers/testdata/test-tkg-system-ns-resources.yaml
@@ -154,6 +154,8 @@ kind: CalicoConfig
 metadata:
   name: test-cluster-tcbt
   namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   calico:
     config:
@@ -164,6 +166,8 @@ kind: AntreaConfig
 metadata:
   name: test-cluster-tcbt
   namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   antrea:
     config:
@@ -174,6 +178,8 @@ kind: KappControllerConfig
 metadata:
   name: test-cluster-tcbt-kapp-controller-config
   namespace: tkg-system
+  annotations:
+    tkg.tanzu.vmware.com/template-config: "true"
 spec:
   namespace: test-ns
   kappController:

--- a/addons/controllers/testdata/test-vsphere-cpi-non-paravirtual-multi-tenancy.yaml
+++ b/addons/controllers/testdata/test-vsphere-cpi-non-paravirtual-multi-tenancy.yaml
@@ -108,8 +108,15 @@ data:
 apiVersion: cpi.tanzu.vmware.com/v1alpha1
 kind: VSphereCPIConfig
 metadata:
-  name: test-cluster-cpi-multi-tenancy
+  name: test-cluster-cpi-multi-tenancy-vsphere-cpi-package
   namespace: default
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test-cluster-cpi-multi-tenancy
+      uid: cbd29b10-c190-422e-86f1-a0321d1aab7d
 spec:
   vsphereCPI:
     mode: vsphereCPI

--- a/addons/controllers/testdata/test-vsphere-cpi-non-paravirtual.yaml
+++ b/addons/controllers/testdata/test-vsphere-cpi-non-paravirtual.yaml
@@ -106,8 +106,15 @@ data:
 apiVersion: cpi.tanzu.vmware.com/v1alpha1
 kind: VSphereCPIConfig
 metadata:
-  name: test-cluster-cpi
+  name: test-cluster-cpi-vsphere-cpi-package
   namespace: default
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test-cluster-cpi
+      uid: cbd29b10-c190-422e-86f1-a0321d1aab7d
 spec:
   vsphereCPI:
     mode: vsphereCPI

--- a/addons/controllers/testdata/test-vsphere-cpi-paravirtual-clusters-same-name.yaml
+++ b/addons/controllers/testdata/test-vsphere-cpi-paravirtual-clusters-same-name.yaml
@@ -16,8 +16,15 @@ spec:
 apiVersion: cpi.tanzu.vmware.com/v1alpha1
 kind: VSphereCPIConfig
 metadata:
-  name: test-cluster-cpi-paravirtual-same-name
+  name: test-cluster-cpi-paravirtual-same-name-vsphere-cpi-package
   namespace: default
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test-cluster-cpi-paravirtual-same-name
+      uid: cbd29b10-c190-422e-86f1-a0321d1aab7d
 spec:
   vsphereCPI:
     mode: vsphereParavirtualCPI

--- a/addons/controllers/testdata/test-vsphere-cpi-paravirtual-with-endpoint.yaml
+++ b/addons/controllers/testdata/test-vsphere-cpi-paravirtual-with-endpoint.yaml
@@ -13,8 +13,15 @@ spec:
 apiVersion: cpi.tanzu.vmware.com/v1alpha1
 kind: VSphereCPIConfig
 metadata:
-  name: test-cluster-cpi-paravirtual-with-endpoint
+  name: test-cluster-cpi-paravirtual-with-endpoint-vsphere-cpi-package
   namespace: default
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test-cluster-cpi-paravirtual-with-endpoint
+      uid: cbd29b10-c190-422e-86f1-a0321d1aab7d
 spec:
   vsphereCPI:
     mode: vsphereParavirtualCPI

--- a/addons/controllers/testdata/test-vsphere-cpi-paravirtual.yaml
+++ b/addons/controllers/testdata/test-vsphere-cpi-paravirtual.yaml
@@ -13,8 +13,15 @@ spec:
 apiVersion: cpi.tanzu.vmware.com/v1alpha1
 kind: VSphereCPIConfig
 metadata:
-  name: test-cluster-cpi-paravirtual
+  name: test-cluster-cpi-paravirtual-vsphere-cpi-package
   namespace: default
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test-cluster-cpi-paravirtual
+      uid: cbd29b10-c190-422e-86f1-a0321d1aab7d
 spec:
   vsphereCPI:
     mode: vsphereParavirtualCPI

--- a/addons/controllers/testdata/test-vsphere-cpi-template-config.yaml
+++ b/addons/controllers/testdata/test-vsphere-cpi-template-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: cpi.tanzu.vmware.com/v1alpha1
 kind: VSphereCPIConfig
 metadata:
-  name: test-cluster-cpi-template
+  name: test-cluster-cpi-config-template
   namespace: tkg-system
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"

--- a/addons/controllers/testdata/test-vsphere-csi-non-paravirtual-minimal.yaml
+++ b/addons/controllers/testdata/test-vsphere-csi-non-paravirtual-minimal.yaml
@@ -91,8 +91,15 @@ spec:
 apiVersion: csi.tanzu.vmware.com/v1alpha1
 kind: VSphereCSIConfig
 metadata:
-  name: test-cluster-csi-minimal
+  name: test-cluster-csi-minimal-vsphere-csi-package
   namespace: default
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test-cluster-csi-minimal
+      uid: cbd29b10-c190-422e-86f1-a0321d1aab7d
 spec:
   vsphereCSI:
     mode: vsphereCSI

--- a/addons/controllers/testdata/test-vsphere-csi-non-paravirtual.yaml
+++ b/addons/controllers/testdata/test-vsphere-csi-non-paravirtual.yaml
@@ -95,8 +95,15 @@ data:
 apiVersion: csi.tanzu.vmware.com/v1alpha1
 kind: VSphereCSIConfig
 metadata:
-  name: test-cluster-csi
+  name: test-cluster-csi-vsphere-csi-package
   namespace: default
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test-cluster-csi
+      uid: cbd29b10-c190-422e-86f1-a0321d1aab7d
 spec:
   vsphereCSI:
     mode: vsphereCSI

--- a/addons/controllers/testdata/test-vsphere-csi-paravirtual.yaml
+++ b/addons/controllers/testdata/test-vsphere-csi-paravirtual.yaml
@@ -30,8 +30,15 @@ spec:
 apiVersion: csi.tanzu.vmware.com/v1alpha1
 kind: VSphereCSIConfig
 metadata:
-  name: test-cluster-pv-csi
+  name: test-cluster-pv-csi-vsphere-csi-package
   namespace: default
+  ownerReferences:
+    - apiVersion: cluster.x-k8s.io/v1beta1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Cluster
+      name: test-cluster-pv-csi
+      uid: cbd29b10-c190-422e-86f1-a0321d1aab7d
 spec:
   vsphereCSI:
     mode: vsphereParavirtualCSI

--- a/addons/controllers/testdata/test-vsphere-csi-template-config.yaml
+++ b/addons/controllers/testdata/test-vsphere-csi-template-config.yaml
@@ -2,7 +2,7 @@
 apiVersion: csi.tanzu.vmware.com/v1alpha1
 kind: VSphereCSIConfig
 metadata:
-  name: test-cluster-csi-template
+  name: test-cluster-csi-template-config
   namespace: tkg-system
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"

--- a/addons/controllers/utils/suite_test.go
+++ b/addons/controllers/utils/suite_test.go
@@ -1,0 +1,37 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+const ()
+
+var ()
+
+func TestAddonControllerUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Addon Controller Utils Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	Expect(true).To(BeTrue())
+})

--- a/addons/controllers/utils/utils_test.go
+++ b/addons/controllers/utils/utils_test.go
@@ -1,0 +1,156 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
+)
+
+var _ = Describe("AddonsControllerUtils", func() {
+
+	const (
+		MISSINGCLUSTERNAME = "missing_cluster"
+		PRESENTCLUSTERNAME = "present_cluster"
+		NAMESPACE          = "cluster_name_space"
+		PACKAGEREFNAME     = "somepackage.tanzu.vmware.com"
+	)
+	var (
+		presentClusterUUID = uuid.NewUUID()
+		scheme             = runtime.NewScheme()
+		fakeClient         client.Client
+		objectMeta         metav1.ObjectMeta
+	)
+	BeforeEach(func() {
+		presentCluster := &clusterapiv1beta1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      PRESENTCLUSTERNAME,
+				Namespace: NAMESPACE,
+				UID:       presentClusterUUID,
+			},
+		}
+		err := clientgoscheme.AddToScheme(scheme)
+		Expect(err).ToNot(HaveOccurred())
+		err = clusterapiv1beta1.AddToScheme(scheme)
+		Expect(err).ToNot(HaveOccurred())
+		fakeClient = fake.NewClientBuilder().WithScheme(scheme).WithObjects(presentCluster).Build()
+	})
+
+	When("cluser is listed as owner reference", func() {
+		BeforeEach(func() {
+			objectMeta = metav1.ObjectMeta{
+				Name:      "randoName",
+				Namespace: NAMESPACE,
+			}
+		})
+		It("VerifyOwnerRef should return true", func() {
+
+			clusterOwnerRef := metav1.OwnerReference{
+				Kind: constants.ClusterKind,
+				Name: PRESENTCLUSTERNAME,
+			}
+			objectMeta.OwnerReferences = []metav1.OwnerReference{clusterOwnerRef}
+			k8sObject := corev1.Secret{
+				ObjectMeta: objectMeta,
+			}
+			Expect(VerifyOwnerRef(&k8sObject, PRESENTCLUSTERNAME, constants.ClusterKind)).To(BeTrue())
+
+		})
+		Context(" cannot be fetched", func() {
+			It("GetOnwerCluster should return cluster with name and namespace and err", func() {
+
+				clusterOwnerRef := metav1.OwnerReference{
+					Kind: constants.ClusterKind,
+					Name: MISSINGCLUSTERNAME,
+				}
+				objectMeta.OwnerReferences = []metav1.OwnerReference{clusterOwnerRef}
+				k8sObject := corev1.Secret{
+					ObjectMeta: objectMeta,
+				}
+				fakeBrokenClient := fake.NewClientBuilder().Build()
+				cluster, err := GetOwnerCluster(context.TODO(), fakeBrokenClient, &k8sObject, NAMESPACE, PACKAGEREFNAME)
+				Expect(cluster).NotTo(BeNil())
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsNotFound(err)).ToNot(BeTrue())
+				Expect(cluster.Name).To(Equal(MISSINGCLUSTERNAME))
+				Expect(cluster.Namespace).To(Equal(NAMESPACE))
+			})
+		})
+		Context(" is not found ", func() {
+			It("GetOnwerCluster should return cluster with name and namespace and not found error", func() {
+
+				clusterOwnerRef := metav1.OwnerReference{
+					Kind: constants.ClusterKind,
+					Name: MISSINGCLUSTERNAME,
+				}
+				objectMeta.OwnerReferences = []metav1.OwnerReference{clusterOwnerRef}
+				k8sObject := corev1.Secret{
+					ObjectMeta: objectMeta,
+				}
+
+				cluster, err := GetOwnerCluster(context.TODO(), fakeClient, &k8sObject, NAMESPACE, PACKAGEREFNAME)
+				Expect(cluster).NotTo(BeNil())
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				Expect(cluster.Name).To(Equal(MISSINGCLUSTERNAME))
+				Expect(cluster.Namespace).To(Equal(NAMESPACE))
+			})
+		})
+		Context(" is found", func() {
+			It("GetOnwerCluster should return cluster with detaisl and no error", func() {
+
+				clusterOwnerRef := metav1.OwnerReference{
+					Kind: constants.ClusterKind,
+					Name: PRESENTCLUSTERNAME,
+				}
+				objectMeta.OwnerReferences = []metav1.OwnerReference{clusterOwnerRef}
+				k8sObject := corev1.Secret{
+					ObjectMeta: objectMeta,
+				}
+				cluster, err := GetOwnerCluster(context.TODO(), fakeClient, &k8sObject, NAMESPACE, PACKAGEREFNAME)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cluster.Name).To(Equal(PRESENTCLUSTERNAME))
+				Expect(cluster.Namespace).To(Equal(NAMESPACE))
+				Expect(cluster.UID).To(Equal(presentClusterUUID))
+			})
+		})
+
+	})
+
+	When(" a cluster is not listed as owner reference", func() {
+		It("VerifyOwnerRef should return false", func() {
+
+			clusterOwnerRef := metav1.OwnerReference{
+				Kind: constants.ClusterKind,
+				Name: PRESENTCLUSTERNAME,
+			}
+			objectMeta.OwnerReferences = []metav1.OwnerReference{clusterOwnerRef}
+			k8sObject := corev1.Secret{
+				ObjectMeta: objectMeta,
+			}
+			Expect(VerifyOwnerRef(&k8sObject, MISSINGCLUSTERNAME, constants.ClusterKind)).To(BeFalse())
+
+		})
+		It("GetOnwerCluster  should return cluster=nil and error", func() {
+			k8sObject := corev1.Secret{}
+			cluster, err := GetOwnerCluster(context.TODO(), fakeClient, &k8sObject, NAMESPACE, PACKAGEREFNAME)
+			Expect(cluster).To(BeNil())
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -26,14 +26,23 @@ const (
 	// CalicoAddonName is name of the Calico addon
 	CalicoAddonName = "calico"
 
+	// CalicoDefaultRefName is default refname for Calico addon
+	CalicoDefaultRefName = CalicoAddonName + ".tanzu.vmware.com"
+
 	// CPIAddonName is name of the cloud-provider-vsphere addon
 	CPIAddonName = "vsphere-cpi"
+
+	// CPIDefaultRefName is default refname for cloud-provider-vsphere addon addon
+	CPIDefaultRefName = CPIAddonName + ".tanzu.vmware.com"
 
 	// PVCSIAddonName is name of the vsphere-pv-csi addon
 	PVCSIAddonName = "vsphere-pv-csi"
 
 	// CSIAddonName is name of the vsphere-csi addon
 	CSIAddonName = "vsphere-csi"
+
+	// CSIDefaultRefName is default refname for vsphere-csi addon
+	CSIDefaultRefName = CSIAddonName + ".tanzu.vmware.com"
 
 	// AwsEbsCSIAddonName is name of the aws-ebs-csi addon
 	AwsEbsCSIAddonName = "aws-ebs-csi"
@@ -166,8 +175,14 @@ const (
 	// AntreaAddonName is the name of Antrea Addon Controller
 	AntreaAddonName = "antrea"
 
+	// AntreaDefaultRefName is default refname for Antrea addon
+	AntreaDefaultRefName = AntreaAddonName + ".tanzu.vmware.com"
+
 	// KappControllerAddonName is the addon name of Kapp Controller
 	KappControllerAddonName = "kapp-controller"
+
+	// KappControllerDefaultRefName is default refname for Kapp Controller addon
+	KappControllerDefaultRefName = KappControllerAddonName + ".tanzu.vmware.com"
 
 	// SecretNameLogKey is the log key for Secrets
 	SecretNameLogKey = "secret-name"

--- a/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
+++ b/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
@@ -379,12 +379,42 @@ func (h *Helper) HandleExistingClusterBootstrap(clusterBootstrap *runtanzuv1alph
 			packagesToBeCloned = append(packagesToBeCloned, nonEmptyInlinePackages...)
 			packages = packagesToBeCloned
 		}
+	} else {
+		// packages with values from inline need to be cloned for two cases:
+		//
+		// 1. When no Clusterbootstrap is given by user and clusterbootstraptemplate
+		//    is cloned as clusterbootstrap but resolved tkr is not set - In this
+		//   case the providers are already cloned so providers do not have to be cloned again
+		//
+		// 2. When full clusterbootstrap without tkr annotation is given by user.
+		//    In this case we only want to handle inline packages for creating
+		//    secret. The providers are expected to be present in the
+		//   clusternamespace, created by user before clusterbootstrap is created.
+		var nonEmptyInlinePackages []*runtanzuv1alpha3.ClusterBootstrapPackage
+		for _, cbPackage := range packages {
+			if cbPackage != nil && cbPackage.ValuesFrom != nil && cbPackage.ValuesFrom.Inline != nil {
+				nonEmptyInlinePackages = append(nonEmptyInlinePackages, cbPackage)
+			}
+		}
+		var packagesToBeCloned []*runtanzuv1alpha3.ClusterBootstrapPackage
+		packagesToBeCloned = append(packagesToBeCloned, nonEmptyInlinePackages...)
+		packages = packagesToBeCloned
 	}
 
-	secrets, providers, err := h.CloneReferencedObjectsFromCBPackages(cluster, packages, systemNamespace)
+	secrets, _, err := h.CloneReferencedObjectsFromCBPackages(cluster, packages, systemNamespace)
 	if err != nil {
 		h.Logger.Error(err, "unable to clone secrets or providers")
 		return nil, err
+	}
+
+	// We need to verify that all the listed prvoiders in the clusterbootstrap with fromRef exist
+	providers, err := h.verifyProvidersFromRefExist(clusterBootstrap)
+	if err != nil {
+		h.Logger.Error(err, "could not verify all providers listed with providerRef in clusterbootstrap exists")
+		return nil, err
+	}
+	if err := h.AddClusterOwnerRef(cluster, providers, nil, nil); err != nil {
+		h.Logger.Error(err, fmt.Sprintf("unable to add cluster %s/%s as owner reference to providers", cluster.Namespace, cluster.Name))
 	}
 
 	clusterBootstrap.OwnerReferences = []metav1.OwnerReference{
@@ -405,14 +435,56 @@ func (h *Helper) HandleExistingClusterBootstrap(clusterBootstrap *runtanzuv1alph
 		return nil, err
 	}
 
-	// ensure ownerRef of clusterBootstrap on created secrets and providers, this can only be done after
-	// clusterBootstrap is created
+	// all providers have the clusterboostrap added as controller owner reference.
 	if err := h.EnsureOwnerRef(clusterBootstrap, secrets, providers); err != nil {
 		h.Logger.Error(err, fmt.Sprintf("unable to ensure ClusterBootstrap %s/%s as a ownerRef on created secrets and providers", clusterBootstrap.Namespace, clusterBootstrap.Name))
 		return nil, err
 	}
 
 	return clusterBootstrap, nil
+}
+func (h *Helper) verifyProvidersFromRefExist(clusterBootstrap *runtanzuv1alpha3.ClusterBootstrap) ([]*unstructured.Unstructured, error) {
+
+	providers := []*unstructured.Unstructured{}
+	cbPkgs, err := h.getListOfPkgsWithProviderRefNames(clusterBootstrap)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pkg := range cbPkgs {
+		gvr, err := h.GVRHelper.GetGVR(schema.GroupKind{Group: *pkg.ValuesFrom.ProviderRef.APIGroup, Kind: pkg.ValuesFrom.ProviderRef.Kind})
+		if err != nil {
+			h.Logger.Error(err, "failed to getGVR")
+			return nil, err
+		}
+		provider, err := h.DynamicClient.Resource(*gvr).Namespace(clusterBootstrap.Namespace).Get(h.Ctx, pkg.ValuesFrom.ProviderRef.Name, metav1.GetOptions{})
+		if err != nil {
+			h.Logger.Error(err, fmt.Sprintf("unable to fetch provider %s/%s", clusterBootstrap.Namespace, pkg.ValuesFrom.ProviderRef.Name), "gvr", gvr)
+			return nil, err
+		}
+		providers = append(providers, provider)
+	}
+	return providers, nil
+}
+
+func (h *Helper) getListOfPkgsWithProviderRefNames(clusterBootstrap *runtanzuv1alpha3.ClusterBootstrap) ([]*runtanzuv1alpha3.ClusterBootstrapPackage, error) {
+
+	cbPkgs := []*runtanzuv1alpha3.ClusterBootstrapPackage{}
+
+	possiblePackages := append([]*runtanzuv1alpha3.ClusterBootstrapPackage{
+		clusterBootstrap.Spec.CNI,
+		clusterBootstrap.Spec.CPI,
+		clusterBootstrap.Spec.CSI,
+		clusterBootstrap.Spec.Kapp,
+	}, clusterBootstrap.Spec.AdditionalPackages...)
+	for _, pkg := range possiblePackages {
+		if pkg == nil || pkg.ValuesFrom == nil || pkg.ValuesFrom.ProviderRef == nil {
+			continue
+		}
+		cbPkgs = append(cbPkgs, pkg)
+	}
+
+	return cbPkgs, nil
 }
 
 // CreateClusterBootstrapFromTemplate does the following:
@@ -827,6 +899,69 @@ func (h *Helper) cloneEmbeddedLocalObjectRef(cluster *clusterapiv1beta1.Cluster,
 	return nil
 }
 
+// AddClusterOwnerRef adds cluster as an owner reference to the children with given controller and blockownerdeletion settings
+func (h *Helper) AddClusterOwnerRef(cluster *clusterapiv1beta1.Cluster, children []*unstructured.Unstructured, controller, blockownerdeletion *bool) error {
+	ownerRef := metav1.OwnerReference{
+		APIVersion:         clusterapiv1beta1.GroupVersion.String(),
+		Kind:               cluster.Kind, // kind is empty after create
+		Name:               cluster.Name,
+		UID:                cluster.UID,
+		Controller:         controller,
+		BlockOwnerDeletion: blockownerdeletion,
+	}
+	// check that none of the children is owned by another cluster
+	for _, child := range children {
+		differentClusterName := ownedByDifferentCluster(child, cluster)
+		if differentClusterName != "" {
+			err := fmt.Errorf("%s/%s is already owned by %s", child.GetNamespace(), child.GetName(), differentClusterName)
+			return err
+		}
+	}
+	return h.setOwnerRef(&ownerRef, children)
+}
+
+// Returns the name of any other cluster that owns the object, besides "cluster".
+func ownedByDifferentCluster(k8SObject *unstructured.Unstructured, cluster *clusterapiv1beta1.Cluster) string {
+	for _, reference := range k8SObject.GetOwnerReferences() {
+		if reference.Kind == constants.ClusterKind && reference.Name != cluster.Name {
+			return reference.Name
+		}
+	}
+	return ""
+}
+
+func (h *Helper) setOwnerRef(ownerRef *metav1.OwnerReference, children []*unstructured.Unstructured) error {
+	for _, child := range children {
+		gvr, err := h.GVRHelper.GetGVR(child.GroupVersionKind().GroupKind())
+		if err != nil {
+			h.Logger.Error(err, fmt.Sprintf("unable to get GVR of %s/%s", child.GetNamespace(), child.GetName()))
+			return err
+		}
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			// We need to get and update, otherwise there could have concurrency issue: ["the object has been modified; please
+			// apply your changes to the latest version and try again"]
+			newChild, errGetProvider := h.DynamicClient.Resource(*gvr).Namespace(child.GetNamespace()).Get(h.Ctx, child.GetName(), metav1.GetOptions{})
+			if errGetProvider != nil {
+				h.Logger.Error(errGetProvider, fmt.Sprintf("unable to get %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName()))
+				return errGetProvider
+			}
+			newChild = newChild.DeepCopy()
+			newChild.SetOwnerReferences(clusterapiutil.EnsureOwnerRef(newChild.GetOwnerReferences(), *ownerRef))
+			_, errUpdateProvider := h.DynamicClient.Resource(*gvr).Namespace(newChild.GetNamespace()).Update(h.Ctx, newChild, metav1.UpdateOptions{})
+			if errUpdateProvider != nil {
+				h.Logger.Error(errUpdateProvider, fmt.Sprintf("unable to update %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName()))
+				return errUpdateProvider
+			}
+			return nil
+		})
+		if err != nil {
+			h.Logger.Error(err, fmt.Sprintf("unable to update the OwnerRefrences for %s %s/%s", child.GetKind(), child.GetNamespace(), child.GetName()))
+			return err
+		}
+	}
+	return nil
+}
+
 // EnsureOwnerRef will ensure the provided OwnerReference onto the secrets and provider objects
 func (h *Helper) EnsureOwnerRef(clusterBootstrap *runtanzuv1alpha3.ClusterBootstrap, secrets []*corev1.Secret, providers []*unstructured.Unstructured) error {
 	ownerRef := metav1.OwnerReference{
@@ -864,7 +999,7 @@ func (h *Helper) EnsureOwnerRef(clusterBootstrap *runtanzuv1alpha3.ClusterBootst
 				return errGetProvider
 			}
 			newProvider = newProvider.DeepCopy()
-			newProvider.SetOwnerReferences(clusterapiutil.EnsureOwnerRef(provider.GetOwnerReferences(), ownerRef))
+			newProvider.SetOwnerReferences(clusterapiutil.EnsureOwnerRef(newProvider.GetOwnerReferences(), ownerRef)) // This change was probably a bug. It was using provider owner references. provider owner references are set outside the retryonconflict thus they are probably stale
 			_, errUpdateProvider := h.DynamicClient.Resource(*gvr).Namespace(newProvider.GetNamespace()).Update(h.Ctx, newProvider, metav1.UpdateOptions{})
 			if errUpdateProvider != nil {
 				h.Logger.Error(errUpdateProvider, fmt.Sprintf("unable to update provider %s/%s", provider.GetNamespace(), provider.GetName()))

--- a/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone_test.go
+++ b/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone_test.go
@@ -112,6 +112,53 @@ var _ = Describe("ClusterbootstrapClone", func() {
 		})
 	})
 
+	Context("Verify AddClusterOwnerRef()", func() {
+		BeforeEach(func() {
+			fakeDynamicClient = dynamicfake.NewSimpleDynamicClient(scheme, constructFakeAntreaConfig(),
+				constructFakeAntreaConfigWithClusterOwner("same-cluster-config", "same-cluster"),
+			)
+			helper.DynamicClient = fakeDynamicClient
+		})
+		It("should succeed on adding cluster as owner to orphan config", func() {
+			fakeCluster := constructFakeCluster()
+			fakeConfig := constructFakeAntreaConfig()
+			fakeProvider := convertToUnstructured(fakeConfig)
+			children := []*unstructured.Unstructured{fakeProvider}
+			err := helper.AddClusterOwnerRef(fakeCluster, children, nil, nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should succeed on adding cluster as owner to config which already lists same cluster as owner", func() {
+			fakeCluster := constructNamespacedFakeCluster("same-cluster", "fake-cluster-ns")
+			fakeConfig := constructFakeAntreaConfigWithClusterOwner("same-cluster-config", fakeCluster.Name)
+			fakeProvider := convertToUnstructured(fakeConfig)
+			children := []*unstructured.Unstructured{fakeProvider}
+			err := helper.AddClusterOwnerRef(fakeCluster, children, nil, nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should throw error if children has different cluster owner", func() {
+			fakeCluster := constructNamespacedFakeCluster("same-cluster", "fake-cluster-ns")
+			fakeConfig := constructFakeAntreaConfigWithClusterOwner("other-other-config", "other-cluster")
+			fakeProvider := convertToUnstructured(fakeConfig)
+			children := []*unstructured.Unstructured{fakeProvider}
+			err := helper.AddClusterOwnerRef(fakeCluster, children, nil, nil)
+			Expect(err).To(HaveOccurred())
+		})
+		It("should throw error if any of the children has different cluster owner", func() {
+			fakeCluster := constructNamespacedFakeCluster("same-cluster", "fake-cluster-ns")
+			fakeConfig := constructFakeAntreaConfigWithClusterOwner("same-cluster-config", fakeCluster.Name)
+			fakeProvider := convertToUnstructured(fakeConfig)
+
+			fakeConfig2 := constructFakeAntreaConfigWithClusterOwner("another-cluster-config", "some-other-cluster")
+			fakeProvider2 := convertToUnstructured(fakeConfig2)
+
+			children := []*unstructured.Unstructured{fakeProvider, fakeProvider2}
+			err := helper.AddClusterOwnerRef(fakeCluster, children, nil, nil)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Context("Verify cloneEmbeddedLocalObjectRef()", func() {
 		BeforeEach(func() {
 			fakeDynamicClient = dynamicfake.NewSimpleDynamicClient(scheme, constructFakeAntreaConfig(), constructFakeVSphereCPIConfig(), constructFakeSecret())
@@ -854,6 +901,17 @@ func constructFakeCluster() *clusterapiv1beta1.Cluster {
 	}
 }
 
+func constructNamespacedFakeCluster(name, namespace string) *clusterapiv1beta1.Cluster {
+	return &clusterapiv1beta1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			UID:       "uid",
+		},
+		Spec: clusterapiv1beta1.ClusterSpec{},
+	}
+}
+
 func constructFakeSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -913,6 +971,35 @@ func constructFakeAntreaConfig() *antreaconfigv1alpha1.AntreaConfig {
 			Annotations: map[string]string{
 				constants.TKGAnnotationTemplateConfig: "true",
 			},
+		},
+		Spec: antreaconfigv1alpha1.AntreaConfigSpec{
+			Antrea: antreaconfigv1alpha1.Antrea{
+				AntreaConfigDataValue: antreaconfigv1alpha1.AntreaConfigDataValue{TrafficEncapMode: "encap"},
+			},
+		},
+	}
+}
+
+func constructFakeAntreaConfigWithClusterOwner(configName, clusterName string) *antreaconfigv1alpha1.AntreaConfig {
+	ownerRef := metav1.OwnerReference{
+		APIVersion: "",
+		Kind:       constants.ClusterKind,
+		Name:       clusterName,
+		UID:        "",
+	}
+	return &antreaconfigv1alpha1.AntreaConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "AntreaConfig",
+			APIVersion: antreaconfigv1alpha1.GroupVersion.String(),
+		},
+
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configName,
+			Namespace: "fake-ns",
+			Annotations: map[string]string{
+				constants.TKGAnnotationTemplateConfig: "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
 		},
 		Spec: antreaconfigv1alpha1.AntreaConfigSpec{
 			Antrea: antreaconfigv1alpha1.Antrea{


### PR DESCRIPTION
allowing the name of addons config to be anything

controllers changed in this patch

- Calico CNI
- Antrea CNI
- CSI
- CPI
- Kapp Controller

scenario logic:
- no customization
  user does nothing
  **addonsNS/config-template**   is cloned to **clusterNS/{CLUSTER_NAME}-{pacakge-short-name}-package**
  **CLUSTER_NAME** will be added  the owner references of **clusterNS/{CLUSTER_NAME}-{pacakge-short-name}-package**
   data value secrets is created


- customize based on template:
   create clusterNS/addonconfig withname **clusterNS/{CLUSTER_NAMEW}-{package-short-name}-pacakge**
   then
   **clusterNS/{CLUSTER_NAME}-{pacakge-short-name}-package += addonsNS/config-template** 

    The resulting addon config is a merged of template with user defined config addon
    The values from user defined addon config take precedence over the values from template config
    and **CLUSTER_NAME** will be added  the owner references of **clusterNS/{CLUSTER_NAME}-{pacakge-short-name}- 
    package**
    data value secrets is created

-  customized  based custom clusterboostrap and custom addonconfig:
   create clusterNS/addonconfig withname **clusterNS/{Any-name-for-addon-config}**
   webhook adds all undefined necessary fields.
   create clusterbootsrap **clusterNS/{CLUSTER_NAME}** pointing to **clusterNS/{Any-name-for-addon-config}**
   **CLUSTER_NAME** will be added  the owner references of **clusterNS/{Any-name-for-addon-config}**
   data value secrets is created

-  customized  based custom clusterboostrap and custom addonconfig with wildcard:
   create clusterNS/addonconfig withname **clusterNS/{Any-name-for-addon-config}**
   webhook adds all undefined necessary fields.
   create clusterbootsrap **clusterNS/{CLUSTER_NAME}** pointing to **clusterNS/{Any-name-for-addon-config}**
   **CLUSTER_NAME** will be added  the owner references of **clusterNS/{Any-name-for-addon-config}**
   data value secrets is created

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
scenarios described have been added as tests using eventest library
unit tests defined

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Remove requirements that user defined addon config match cluster name. 
Addon configs can be based on addonConfig templates plus user defined values by using predefined name for addon config
User defined addon configs must be used in conjunction with user defined clusterboostrap

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
