### PR TITLE
Turn on context-target functionality for release-0.25

### DIFF
--- a/docs/cli/cli-architecture.md
+++ b/docs/cli/cli-architecture.md
@@ -91,8 +91,6 @@ This will list all versions of the plugin along with its description.
 
 Context is an isolated scope of relevant client-side configurations for a combination of user identity and server identity. There can be multiple contexts for the same combination of `(user, server)`. Previously, this was referred to as `Server` in the Tanzu CLI. Going forward we shall refer to them as `Context` to be explicit. Also, the context can be managed at one place using the `tanzu context` command. Earlier, this was distributed between the `tanzu login` command and `tanzu config server` command.
 
-Note: This is currently behind a feature flag. To enable the flag please run `tanzu config set features.global.context-target true`
-
 Create a new context:
 
 ```sh

--- a/pkg/v1/cli/command/core/root.go
+++ b/pkg/v1/cli/command/core/root.go
@@ -66,19 +66,18 @@ func NewRootCmd() (*cobra.Command, error) {
 		genAllDocsCmd,
 	)
 
-	// If the context and target feature is enabled, add the corresponding commands under root.
-	if config.IsFeatureActivated(config.FeatureContextCommand) {
-		RootCmd.AddCommand(
-			contextCmd,
-			k8sCmd,
-			tmcCmd,
-		)
-		if err := addCtxPlugins(k8sCmd, configv1alpha1.CtxTypeK8s); err != nil {
-			return nil, err
-		}
-		if err := addCtxPlugins(tmcCmd, configv1alpha1.CtxTypeTMC); err != nil {
-			return nil, err
-		}
+	// Now that the context and target features are activated, add the
+	// corresponding commands under root unconditionally.
+	RootCmd.AddCommand(
+		contextCmd,
+		k8sCmd,
+		tmcCmd,
+	)
+	if err := addCtxPlugins(k8sCmd, configv1alpha1.CtxTypeK8s); err != nil {
+		return nil, err
+	}
+	if err := addCtxPlugins(tmcCmd, configv1alpha1.CtxTypeTMC); err != nil {
+		return nil, err
 	}
 
 	plugins, err := getAvailablePlugins()

--- a/pkg/v1/config/clientconfig.go
+++ b/pkg/v1/config/clientconfig.go
@@ -53,8 +53,6 @@ const (
 	// to use the new context-aware Plugin API based plugin discovery mechanism
 	// Users can set this featureflag so that we can have context-aware plugin discovery be opt-in for now.
 	FeatureContextAwareCLIForPlugins = "features.global.context-aware-cli-for-plugins"
-	// FeatureContextCommand determines whether to surface the context command. This is disabled by default.
-	FeatureContextCommand = "features.global.context-target"
 	// DualStack feature flags determine whether it is permitted to create
 	// clusters with a dualstack TKG_IP_FAMILY.  There are separate flags for
 	// each primary, "ipv4,ipv6" vs "ipv6,ipv4", and flags for management vs
@@ -107,7 +105,6 @@ const (
 var (
 	DefaultCliFeatureFlags = map[string]bool{
 		FeatureContextAwareCLIForPlugins:                      common.ContextAwareDiscoveryEnabled(),
-		FeatureContextCommand:                                 false,
 		"features.management-cluster.import":                  false,
 		"features.management-cluster.export-from-confirm":     true,
 		"features.management-cluster.standalone-cluster-mode": false,


### PR DESCRIPTION
This change eliminates the cli feature flag
`globals.features.context-target` and enables the functionality unconditionally.

This is a cherry-pick of https://github.com/vmware-tanzu/tanzu-framework/pull/3658

Note that the `tanzu login` and `tanzu config server ...` commands (which the context commands will eventually replace) will still be supported, and will be deprecated at some point in the future.

Signed-off-by: Vui Lam <vui@vmware.com>

### What this PR does / why we need it

### Which issue(s) this PR fixes

Fixes #3653

### Describe testing done for PR

```
tanzu config unset features.global.context-target
tanzu
```
and verified that context and target usage is available and commands invocable.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Turned on 'tanzu context' and 'tanzu <target> ...' functionality by default 
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
