### PR TITLE
Skip adding last applied annotation to kapp-controller on workload cluster

### DIFF
--- a/tkg/client/upgrade_addon.go
+++ b/tkg/client/upgrade_addon.go
@@ -248,8 +248,8 @@ func (c *TkgClient) DoUpgradeAddon(regionalClusterClient clusterclient.Client, /
 			return errors.Wrap(err, "unable to get cluster configuration")
 		}
 
-		// ensure current kapp-controller deployment has last-applied annotation, which is required for future apply operations
-		if addonName == "addons-management/kapp-controller" {
+		// ensure current kapp-controller deployment on the management cluster has last-applied annotation, which is required for future apply operations
+		if addonName == "addons-management/kapp-controller" && options.IsRegionalCluster {
 			if err := clusterClient.PatchKappControllerLastAppliedAnnotation(options.Namespace); err != nil {
 				return errors.Wrap(err, "unable to add last-applied annotation on kapp-controller")
 			}


### PR DESCRIPTION
### What this PR does / why we need it
- Let the logic only works on management cluster when the feature flag is off.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #
- Fix the bug observed in downstream pipelines that when feature flag is off, workload cluster fails to be upgraded due to error in adding last-applied annotation to `kapp-controller`, which actually should **not** run on workload cluster.


### Describe testing done for PR
Verified on TKG cluster on AWS using the tanzu CLI built from this branch, and `kapp-controller` is upgraded successfully.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix kapp-controller upgrade issue on workload cluster when package-based-lcm feature flag is off
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
