### PR TITLE
[TKG-13275] package tkr-vsphere-template webhook for vsphere-cc

### DIFF
--- a/.github/workflows/tkg_integration_tests_clusterclass.yaml
+++ b/.github/workflows/tkg_integration_tests_clusterclass.yaml
@@ -172,7 +172,7 @@ jobs:
       env:
         NUM: ${{ github.run_id }}
         OCI_REGISTRY: ${{ steps.set_registry.outputs.registry }}/tanzu_framework/github-actions/${{ steps.extract_reg_dir.outputs.regdir }}
-        COMPONENTS: "tkr/controller/tkr-source tkr/controller/tkr-status featuregates addons capabilities tkr/webhook/tkr-conversion tkr/webhook/cluster/tkr-resolver pinniped-components/tanzu-auth-controller-manager object-propagation"
+        COMPONENTS: "tkr/controller/tkr-source tkr/controller/tkr-status featuregates addons capabilities tkr/webhook/tkr-conversion tkr/webhook/cluster/tkr-resolver tkg/vsphere-template-resolver pinniped-components/tanzu-auth-controller-manager object-propagation"
         BUILD_VERSION: "v0.21.0"
         IMG_VERSION_OVERRIDE: latest
       run: |
@@ -183,7 +183,7 @@ jobs:
       env:
         NUM: ${{ github.run_number }}
         OCI_REGISTRY: ${{ steps.set_registry.outputs.registry }}/tanzu_framework/github-actions/${{ steps.extract_reg_dir.outputs.regdir }}
-        COMPONENTS: "tkr/controller/tkr-source tkr/controller/tkr-status featuregates addons capabilities tkr/webhook/tkr-conversion tkr/webhook/cluster/tkr-resolver pinniped-components/tanzu-auth-controller-manager object-propagation"
+        COMPONENTS: "tkr/controller/tkr-source tkr/controller/tkr-status featuregates addons capabilities tkr/webhook/tkr-conversion tkr/webhook/cluster/tkr-resolver tkg/vsphere-template-resolver pinniped-components/tanzu-auth-controller-manager object-propagation"
         BUILD_VERSION: "v0.21.0"
         IMG_VERSION_OVERRIDE: latest
       run: |

--- a/Makefile
+++ b/Makefile
@@ -790,6 +790,7 @@ COMPONENTS ?=  \
   capabilities \
   tkr/webhook/tkr-conversion \
   tkr/webhook/cluster/tkr-resolver \
+  tkg/vsphere-template-resolver \
   pinniped-components/tanzu-auth-controller-manager \
   object-propagation
 

--- a/packages/tkg-clusterclass-vsphere/README.md
+++ b/packages/tkg-clusterclass-vsphere/README.md
@@ -4,6 +4,8 @@ This package provides << awesome functionality >> using [tkg-clusterclass-vspher
 
 ## Components
 
+* tkr-vsphere-cluster-webhook
+
 ## Configuration
 
 The following configuration values can be set to customize the tkg-clusterclass-vsphere installation.

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -522,10 +522,6 @@ spec:
         valueFrom:
           variable: vcenter.network
       - op: replace
-        path: /spec/template/spec/template
-        valueFrom:
-          variable: vcenter.template
-      - op: replace
         path: /spec/template/spec/datacenter
         valueFrom:
           variable: vcenter.datacenter
@@ -584,11 +580,6 @@ spec:
         path: /spec/template/spec/network
         valueFrom:
           variable: vcenter.network
-      #! TODO: move this patch elsewhere
-      - op: replace
-        path: /spec/template/spec/template
-        valueFrom:
-          variable: vcenter.template
       - op: replace
         path: /spec/template/spec/datacenter
         valueFrom:

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/certificates.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/certificates.yaml
@@ -1,0 +1,31 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+  name: tkr-vsphere-resolver-service-selfsigned-issuer
+  namespace: #@ data.values.NAMESPACE
+  annotations:
+    kapp.k14s.io/change-group: "tkr-vsphere-resolver.tanzu.vmware.com/issuer"
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+  name: tkr-vsphere-resolver-webhook-serving-cert
+  namespace: #@ data.values.NAMESPACE
+  annotations:
+    kapp.k14s.io/change-group: "tkr-vsphere-resolver.tanzu.vmware.com/certificate"
+    kapp.k14s.io/change-rule.0: "upsert after upserting tkr-vsphere-resolver.tanzu.vmware.com/issuer"
+    kapp.k14s.io/change-rule.1: "delete before deleting tkr-vsphere-resolver.tanzu.vmware.com/issuer"
+spec:
+  dnsNames:
+  - #@ "tkr-vsphere-resolver-webhook-service.{}.svc".format(data.values.NAMESPACE)
+  - #@ "tkr-vsphere-resolver-webhook-service-cert.{}.svc.cluster.local".format(data.values.NAMESPACE)
+  issuerRef:
+    kind: Issuer
+    name: tkr-vsphere-resolver-service-selfsigned-issuer
+  secretName: tkr-vsphere-resolver-webhook-service-cert

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/rbac.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/rbac.yaml
@@ -1,0 +1,98 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tkr-vsphere-resolver-webhook
+  name: tkr-vsphere-resolver-manager-sa
+  namespace: #@ data.values.NAMESPACE
+  annotations:
+    kapp.k14s.io/change-group: "tkr-vsphere-resolver.tanzu.vmware.com/serviceaccount"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tkr-vsphere-resolver-manager-role
+  annotations:
+    kapp.k14s.io/change-group: "tkr-vsphere-resolver.tanzu.vmware.com/serviceaccount"
+rules:
+- apiGroups:
+  - run.tanzu.vmware.com
+  resources:
+  - tanzukubernetesreleases
+  - osimages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - run.tanzu.vmware.com
+  resources:
+  - tanzukubernetesreleases/status
+  - osimages/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusterclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tkr-vsphere-resolver-manager-clusterrolebinding
+  annotations:
+    kapp.k14s.io/change-group: "tkr-vsphere-resolver.tanzu.vmware.com/ClusterRoleBinding"
+    kapp.k14s.io/change-rule.0: "upsert after upserting tkr-vsphere-resolver.tanzu.vmware.com/serviceaccount"
+    kapp.k14s.io/change-rule.1: "delete before deleting tkr-vsphere-resolver.tanzu.vmware.com/serviceaccount"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tkr-vsphere-resolver-manager-role
+subjects:
+- kind: ServiceAccount
+  name: tkr-vsphere-resolver-manager-sa
+  namespace: #@ data.values.NAMESPACE

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/service.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/service.yaml
@@ -1,0 +1,14 @@
+#@ load("@ytt:data", "data")
+#! tkr-vsphere-resolver-webhook
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tkr-vsphere-resolver-webhook-service
+  namespace: #@ data.values.NAMESPACE
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    app: tkr-vsphere-resolver-webhook

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/vsphere-template-resolver-cluster-webhook-deployment.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/vsphere-template-resolver-cluster-webhook-deployment.yaml
@@ -1,0 +1,66 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tkr-vsphere-resolver-webhook
+  name: tkr-vsphere-resolver-webhook-manager
+  namespace: #@ data.values.NAMESPACE
+  annotations:
+    kapp.k14s.io/change-rule.0: "upsert after upserting tkr-vsphere-resolver.tanzu.vmware.com/ClusterRoleBinding"
+    kapp.k14s.io/change-rule.1: "delete before deleting tkr-vsphere-resolver.tanzu.vmware.com/ClusterRoleBinding"
+    kapp.k14s.io/change-rule.2: "upsert after upserting tkr-vsphere-resolver.tanzu.vmware.com/certificate"
+    kapp.k14s.io/change-rule.3: "delete before deleting tkr-vsphere-resolver.tanzu.vmware.com/certificate"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tkr-vsphere-resolver-webhook
+  template:
+    metadata:
+      labels:
+        app: tkr-vsphere-resolver-webhook
+    spec:
+      containers:
+      - image: tkr-vsphere-cluster-webhook:latest
+        imagePullPolicy: IfNotPresent
+        name: manager
+        command:
+        - /manager
+        args:
+        - --metrics-bind-addr=0
+        - #@ "--webhook-server-port={}".format(data.values.deployment.tkrVsphereResolverWebhookServerPort)
+        resources:
+          limits:
+            cpu: 100m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: #@ data.values.deployment.tkrVsphereResolverWebhookServerPort
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccount: tkr-vsphere-resolver-manager-sa
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          secretName: tkr-vsphere-resolver-webhook-service-cert
+      #@ if hasattr(data.values, 'deployment') and hasattr(data.values.deployment, 'hostNetwork') and data.values.deployment.hostNetwork:
+      #@overlay/match missing_ok=True
+      hostNetwork: true
+      #@ end
+      #@ if hasattr(data.values, 'deployment') and hasattr(data.values.deployment, 'tolerations') and data.values.deployment.tolerations:
+      #@overlay/match missing_ok=True
+      tolerations: #@ data.values.deployment.tolerations
+      #@ end
+      #@ if hasattr(data.values, 'deployment') and hasattr(data.values.deployment, 'nodeSelector') and data.values.deployment.nodeSelector:
+      #@overlay/match missing_ok=True
+      nodeSelector: #@ data.values.deployment.nodeSelector
+      #@ end

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/webhook.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/webhook.yaml
@@ -1,0 +1,33 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: #@ "{}/tkr-vsphere-resolver-webhook-serving-cert".format(data.values.NAMESPACE)
+  name: tkr-vsphere-resolver-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: tkr-vsphere-resolver-webhook-service
+      namespace: #@ data.values.NAMESPACE
+      path: /resolve-template
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: tkr-vsphere-resolver-webhook.tanzu.vmware.com
+  reinvocationPolicy: IfNeeded
+  rules:
+  - apiGroups: ["cluster.x-k8s.io"]
+    apiVersions:
+    - v1
+    - v1beta1
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - "clusters"
+  sideEffects: None

--- a/packages/tkg-clusterclass-vsphere/bundle/config/values.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/values.yaml
@@ -36,3 +36,10 @@ VSPHERE_WORKER_MEM_MIB: 4096
 VSPHERE_CLONE_MODE: "fullClone"
 
 CLUSTER_NAME: management-cluster
+
+deployment:
+  hostNetwork: false
+  nodeSelector: null
+  tolerations: []
+  #! If hostNetwork is set to true the below two ports should be different
+  tkrVsphereResolverWebhookServerPort: 9443

--- a/packages/tkg-clusterclass-vsphere/kbld-config.yaml
+++ b/packages/tkg-clusterclass-vsphere/kbld-config.yaml
@@ -1,0 +1,5 @@
+apiVersion: kbld.k14s.io/v1alpha1
+kind: Config
+overrides:
+- image: tkr-vsphere-cluster-webhook:latest
+  newImage: ""

--- a/packages/tkg-clusterclass-vsphere/vendir.lock.yml
+++ b/packages/tkg-clusterclass-vsphere/vendir.lock.yml
@@ -1,3 +1,19 @@
 apiVersion: vendir.k14s.io/v1alpha1
-directories: null
+directories:
+- contents:
+  - manual: {}
+    path: base.yaml
+  - manual: {}
+    path: overlay.yaml
+  - manual: {}
+    path: certificates.yaml
+  - manual: {}
+    path: rbac.yaml
+  - manual: {}
+    path: service.yaml
+  - manual: {}
+    path: vsphere-template-resolver-cluster-webhook-deployment.yaml
+  - manual: {}
+    path: webhook.yaml
+  path: bundle/config/upstream
 kind: LockConfig

--- a/packages/tkg-clusterclass-vsphere/vendir.yml
+++ b/packages/tkg-clusterclass-vsphere/vendir.yml
@@ -1,3 +1,20 @@
 apiVersion: vendir.k14s.io/v1alpha1
 kind: Config
 minimumRequiredVersion: 0.12.0
+directories:
+  - path: bundle/config/upstream
+    contents:
+      - path: base.yaml
+        manual: {}
+      - path: overlay.yaml
+        manual: {}
+      - path: certificates.yaml
+        manual: {}
+      - path: rbac.yaml
+        manual: {}
+      - path: service.yaml
+        manual: {}
+      - path: vsphere-template-resolver-cluster-webhook-deployment.yaml
+        manual: {}
+      - path: webhook.yaml
+        manual: {}

--- a/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-service-account.yaml
+++ b/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-service-account.yaml
@@ -29,6 +29,41 @@ rules:
       - get
       - list
       - delete
+      - watch
+  - apiGroups:
+    - run.tanzu.vmware.com
+    resources:
+    - tanzukubernetesreleases
+    - osimages
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - run.tanzu.vmware.com
+    resources:
+    - tanzukubernetesreleases/status
+    - osimages/status
+    verbs:
+    - get
+    - patch
+    - update
+  - apiGroups:
+    - cluster.x-k8s.io
+    resources:
+    - clusters
+    - clusters/status
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
   - apiGroups:
       - cluster.x-k8s.io
     resources:
@@ -39,6 +74,7 @@ rules:
       - get
       - list
       - delete
+      - watch
   - apiGroups:
       - bootstrap.cluster.x-k8s.io
     resources:
@@ -91,6 +127,45 @@ rules:
     resources:
       - clusterroles
       - clusterrolebindings
+    verbs:
+      - create
+      - update
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - update
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - issuers
+      - certificates
+    verbs:
+      - create
+      - update
+      - get
+      - list
+      - delete
+  - apiGroups:
+    - coordination.k8s.io
+    resources:
+    - leases
+    verbs:
+    - create
+    - get
+    - update
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
     verbs:
       - create
       - update

--- a/providers/infrastructure-vsphere/v1.3.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.3.1/cconly/base.yaml
@@ -522,10 +522,6 @@ spec:
         valueFrom:
           variable: vcenter.network
       - op: replace
-        path: /spec/template/spec/template
-        valueFrom:
-          variable: vcenter.template
-      - op: replace
         path: /spec/template/spec/datacenter
         valueFrom:
           variable: vcenter.datacenter
@@ -584,11 +580,6 @@ spec:
         path: /spec/template/spec/network
         valueFrom:
           variable: vcenter.network
-      #! TODO: move this patch elsewhere
-      - op: replace
-        path: /spec/template/spec/template
-        valueFrom:
-          variable: vcenter.template
       - op: replace
         path: /spec/template/spec/datacenter
         valueFrom:

--- a/providers/infrastructure-vsphere/v1.3.1/cconly/certificates.yaml
+++ b/providers/infrastructure-vsphere/v1.3.1/cconly/certificates.yaml
@@ -1,0 +1,31 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+  name: tkr-vsphere-resolver-service-selfsigned-issuer
+  namespace: #@ data.values.NAMESPACE
+  annotations:
+    kapp.k14s.io/change-group: "tkr-vsphere-resolver.tanzu.vmware.com/issuer"
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+  name: tkr-vsphere-resolver-webhook-serving-cert
+  namespace: #@ data.values.NAMESPACE
+  annotations:
+    kapp.k14s.io/change-group: "tkr-vsphere-resolver.tanzu.vmware.com/certificate"
+    kapp.k14s.io/change-rule.0: "upsert after upserting tkr-vsphere-resolver.tanzu.vmware.com/issuer"
+    kapp.k14s.io/change-rule.1: "delete before deleting tkr-vsphere-resolver.tanzu.vmware.com/issuer"
+spec:
+  dnsNames:
+  - #@ "tkr-vsphere-resolver-webhook-service.{}.svc".format(data.values.NAMESPACE)
+  - #@ "tkr-vsphere-resolver-webhook-service-cert.{}.svc.cluster.local".format(data.values.NAMESPACE)
+  issuerRef:
+    kind: Issuer
+    name: tkr-vsphere-resolver-service-selfsigned-issuer
+  secretName: tkr-vsphere-resolver-webhook-service-cert

--- a/providers/infrastructure-vsphere/v1.3.1/cconly/rbac.yaml
+++ b/providers/infrastructure-vsphere/v1.3.1/cconly/rbac.yaml
@@ -1,0 +1,98 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: tkr-vsphere-resolver-webhook
+  name: tkr-vsphere-resolver-manager-sa
+  namespace: #@ data.values.NAMESPACE
+  annotations:
+    kapp.k14s.io/change-group: "tkr-vsphere-resolver.tanzu.vmware.com/serviceaccount"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tkr-vsphere-resolver-manager-role
+  annotations:
+    kapp.k14s.io/change-group: "tkr-vsphere-resolver.tanzu.vmware.com/serviceaccount"
+rules:
+- apiGroups:
+  - run.tanzu.vmware.com
+  resources:
+  - tanzukubernetesreleases
+  - osimages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - run.tanzu.vmware.com
+  resources:
+  - tanzukubernetesreleases/status
+  - osimages/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusterclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - delete
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tkr-vsphere-resolver-manager-clusterrolebinding
+  annotations:
+    kapp.k14s.io/change-group: "tkr-vsphere-resolver.tanzu.vmware.com/ClusterRoleBinding"
+    kapp.k14s.io/change-rule.0: "upsert after upserting tkr-vsphere-resolver.tanzu.vmware.com/serviceaccount"
+    kapp.k14s.io/change-rule.1: "delete before deleting tkr-vsphere-resolver.tanzu.vmware.com/serviceaccount"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tkr-vsphere-resolver-manager-role
+subjects:
+- kind: ServiceAccount
+  name: tkr-vsphere-resolver-manager-sa
+  namespace: #@ data.values.NAMESPACE

--- a/providers/infrastructure-vsphere/v1.3.1/cconly/service.yaml
+++ b/providers/infrastructure-vsphere/v1.3.1/cconly/service.yaml
@@ -1,0 +1,14 @@
+#@ load("@ytt:data", "data")
+#! tkr-vsphere-resolver-webhook
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tkr-vsphere-resolver-webhook-service
+  namespace: #@ data.values.NAMESPACE
+spec:
+  ports:
+  - port: 443
+    targetPort: webhook-server
+  selector:
+    app: tkr-vsphere-resolver-webhook

--- a/providers/infrastructure-vsphere/v1.3.1/cconly/vsphere-template-resolver-cluster-webhook-deployment.yaml
+++ b/providers/infrastructure-vsphere/v1.3.1/cconly/vsphere-template-resolver-cluster-webhook-deployment.yaml
@@ -1,0 +1,66 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: tkr-vsphere-resolver-webhook
+  name: tkr-vsphere-resolver-webhook-manager
+  namespace: #@ data.values.NAMESPACE
+  annotations:
+    kapp.k14s.io/change-rule.0: "upsert after upserting tkr-vsphere-resolver.tanzu.vmware.com/ClusterRoleBinding"
+    kapp.k14s.io/change-rule.1: "delete before deleting tkr-vsphere-resolver.tanzu.vmware.com/ClusterRoleBinding"
+    kapp.k14s.io/change-rule.2: "upsert after upserting tkr-vsphere-resolver.tanzu.vmware.com/certificate"
+    kapp.k14s.io/change-rule.3: "delete before deleting tkr-vsphere-resolver.tanzu.vmware.com/certificate"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tkr-vsphere-resolver-webhook
+  template:
+    metadata:
+      labels:
+        app: tkr-vsphere-resolver-webhook
+    spec:
+      containers:
+      - image: tkr-vsphere-cluster-webhook:latest
+        imagePullPolicy: IfNotPresent
+        name: manager
+        command:
+        - /manager
+        args:
+        - --metrics-bind-addr=0
+        - #@ "--webhook-server-port={}".format(data.values.deployment.tkrVsphereResolverWebhookServerPort)
+        resources:
+          limits:
+            cpu: 100m
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: #@ data.values.deployment.tkrVsphereResolverWebhookServerPort
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      serviceAccount: tkr-vsphere-resolver-manager-sa
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          secretName: tkr-vsphere-resolver-webhook-service-cert
+      #@ if hasattr(data.values, 'deployment') and hasattr(data.values.deployment, 'hostNetwork') and data.values.deployment.hostNetwork:
+      #@overlay/match missing_ok=True
+      hostNetwork: true
+      #@ end
+      #@ if hasattr(data.values, 'deployment') and hasattr(data.values.deployment, 'tolerations') and data.values.deployment.tolerations:
+      #@overlay/match missing_ok=True
+      tolerations: #@ data.values.deployment.tolerations
+      #@ end
+      #@ if hasattr(data.values, 'deployment') and hasattr(data.values.deployment, 'nodeSelector') and data.values.deployment.nodeSelector:
+      #@overlay/match missing_ok=True
+      nodeSelector: #@ data.values.deployment.nodeSelector
+      #@ end

--- a/providers/infrastructure-vsphere/v1.3.1/cconly/webhook.yaml
+++ b/providers/infrastructure-vsphere/v1.3.1/cconly/webhook.yaml
@@ -1,0 +1,33 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: #@ "{}/tkr-vsphere-resolver-webhook-serving-cert".format(data.values.NAMESPACE)
+  name: tkr-vsphere-resolver-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: tkr-vsphere-resolver-webhook-service
+      namespace: #@ data.values.NAMESPACE
+      path: /resolve-template
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: tkr-vsphere-resolver-webhook.tanzu.vmware.com
+  reinvocationPolicy: IfNeeded
+  rules:
+  - apiGroups: ["cluster.x-k8s.io"]
+    apiVersions:
+    - v1
+    - v1beta1
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - "clusters"
+  sideEffects: None

--- a/providers/infrastructure-vsphere/v1.3.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.3.1/yttcc/overlay.yaml
@@ -39,10 +39,7 @@ spec:
       cidrBlocks: #@ data.values.SERVICE_CIDR.split(",")
   topology:
     class: #@ data.values.CLUSTER_CLASS
-    #! VVV TODO(vui) compute
-    #! version: #@ data.values.KUBERNETES_VERSION
-    #! hack to match up tkr
-    version: #@ "{}-tkg.1-zshippable".format(data.values.KUBERNETES_VERSION)
+    version: #@ data.values.KUBERNETES_VERSION
     controlPlane:
       replicas: #@ data.values.CONTROL_PLANE_MACHINE_COUNT
       #@overlay/match missing_ok=True

--- a/tkg/vsphere-template-resolver/Makefile
+++ b/tkg/vsphere-template-resolver/Makefile
@@ -43,7 +43,8 @@ docker-publish: ## Publish docker image
 
 .PHONY: kbld-image-replace
 kbld-image-replace: ## Add newImage in kbld-config.yaml
-	cd ../../hack/packages/kbld-image-replace && $(MAKE) run IMAGE=$(IMG_DEFAULT_NAME_TAG) NEW_IMAGE=$(IMG)
+	cd ../../hack/packages/kbld-image-replace && \
+	  go run main.go -kbld-config ../../../packages/tkg-clusterclass-vsphere/kbld-config.yaml $(IMG_DEFAULT_NAME_TAG) $(IMG)
 
 .PHONY: docker-image-names
 docker-image-names:


### PR DESCRIPTION
package tkr-vsphere-template webhook in tkg-clusterclass-vsphere pkg

add corresponding rules for tanzu-infra-clusterclass-package-cluster-role

update makefile for building tkr-vsphere-template image

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/3726

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

tested on local env.
vsphere resolver manager works
```
kubo@UWF9unoTO8zSw:~/kubeconfigs$ k -n tkg-system logs tkr-vsphere-resolver-webhook-manager-5f58c6b8d7-bbbp7
1.666017839321263e+09	INFO	setup	Version	{"version": "v0.28.0-dev", "buildDate": "2022-10-17", "sha": "eeb44d68-dirty"}
1.6660178393213103e+09	INFO	setup	setting up manager
I1017 14:44:00.374250       1 request.go:601] Waited for 1.037620136s due to client-side throttling, not priority and fairness, request: GET:https://100.64.0.1:443/apis/controlplane.cluster.x-k8s.io/v1alpha3?timeout=32s
1.6660178406260228e+09	INFO	setup	setting up webhook server
1.6660178406260667e+09	INFO	setup	registering webhooks to the webhook server
1.6660178406284528e+09	INFO	controller-runtime.webhook	Registering webhook	{"path": "/resolve-template"}
1.666017840628638e+09	INFO	setup	registering webhooks to the webhook server
1.6660178406286545e+09	INFO	setup	starting manager
1.6660178406289191e+09	INFO	controller-runtime.webhook.webhooks	Starting webhook server
1.6660178406291919e+09	INFO	controller-runtime.certwatcher	Updated current TLS certificate
1.6660178406296694e+09	INFO	controller-runtime.webhook	Serving webhook server	{"host": "", "port": 9443}
1.666017840629843e+09	INFO	controller-runtime.certwatcher	Starting certificate watcher
1.6660179125250592e+09	DEBUG	controller-runtime.webhook.webhooks	received request	{"webhook": "/resolve-template", "UID": "ba6fc9b3-63ea-478c-9d6d-b6865c2cd031", "kind": "cluster.x-k8s.io/v1beta1, Kind=Cluster", "resource": {"group":"cluster.x-k8s.io","version":"v1beta1","resource":"clusters"}}
1.666017912526086e+09	INFO	webhook.vsphere-template-resolver	Getting secret for VC Client	{"key": "tkg-system/mgmt"}
1.666017912628607e+09	INFO	webhook.vsphere-template-resolver	Successfully retrieved vSphere context	{"Server": "10.191.189.223", "datacenter": "/dc0", "tlsthumbprint": ""}
1.6660179126286654e+09	INFO	webhook.vsphere-template-resolver	Creating client with endpoint: https://10.191.189.223/sdk
1.6660179126367881e+09	INFO	webhook.vsphere-template-resolver	Logging into vSphere
1.666017912960742e+09	INFO	webhook.vsphere-template-resolver	Template resolution query	{"query": "{ovaTemplateQueries: map[{v1.23.8+vmware.2-tkg.2-81d1a7892ad39f017fbaf59f9907cbe7 { photon 3 amd64}}:{}]}"}
1.6660179131368515e+09	INFO	webhook.vsphere-template-resolver	Template resolution result	{"result": "{ovaTemplates: map[{v1.23.8+vmware.2-tkg.2-81d1a7892ad39f017fbaf59f9907cbe7 { photon 3 amd64}}:{TemplatePath: '/dc0/vm/photon-3-kube-v1.23.8+vmware.2', TemplateMOID: 'vm-60'}], usefulErrorMessage:''}"}
1.666017913137088e+09	INFO	webhook.vsphere-template-resolver	template resolution result processing complete for Control Plane topology
1.6660179131372411e+09	INFO	webhook.vsphere-template-resolver	template resolution result processing complete for machine deployments in topology
1.6660179131382957e+09	DEBUG	controller-runtime.webhook.webhooks	wrote response	{"webhook": "/resolve-template", "code": 200, "reason": "", "UID": "ba6fc9b3-63ea-478c-9d6d-b6865c2cd031", "allowed": true}
1.666017913277912e+09	DEBUG	controller-runtime.webhook.webhooks	received request	{"webhook": "/resolve-template", "UID": "100ac7d4-07c2-442f-a16e-b6daf7363052", "kind": "cluster.x-k8s.io/v1beta1, Kind=Cluster", "resource": {"group":"cluster.x-k8s.io","version":"v1beta1","resource":"clusters"}}
1.6660179132784038e+09	DEBUG	controller-runtime.webhook.webhooks	wrote response	{"webhook": "/resolve-template", "code": 200, "reason": "no queries to resolve, no-op", "UID": "100ac7d4-07c2-442f-a16e-b6daf7363052", "allowed": true}
1.6660179132892509e+09	DEBUG	controller-runtime.webhook.webhooks	received request	{"webhook": "/resolve-template", "UID": "72f0debd-ad7c-436a-85f4-ad806505317e", "kind": "cluster.x-k8s.io/v1beta1, Kind=Cluster", "resource": {"group":"cluster.x-k8s.io","version":"v1beta1","resource":"clusters"}}
1.6660179132898617e+09	DEBUG	controller-runtime.webhook.webhooks	wrote response	{"webhook": "/resolve-template", "code": 200, "reason": "no queries to resolve, no-op", "UID": "72f0debd-ad7c-436a-85f4-ad806505317e", "allowed": true}
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
