### PR TITLE
provider: Introduce Pod Security Standard for non-CC and CC based Clusters

### DIFF
--- a/packages/cluster-api-provider-azure/bundle/config/overlay/add-pod-security-namespace-labels.yaml
+++ b/packages/cluster-api-provider-azure/bundle/config/overlay/add-pod-security-namespace-labels.yaml
@@ -1,0 +1,13 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind": "Namespace", "metadata": {"name": "capz-system"}})
+---
+metadata:
+  labels:
+    #@overlay/match missing_ok=True
+    pod-security.kubernetes.io/enforce: privileged
+    #@overlay/match missing_ok=True
+    pod-security.kubernetes.io/warn: privileged
+    #@overlay/match missing_ok=True
+    pod-security.kubernetes.io/audit: privileged

--- a/packages/cluster-api-provider-docker/bundle/config/overlay/add-pod-security-namespace-labels.yaml
+++ b/packages/cluster-api-provider-docker/bundle/config/overlay/add-pod-security-namespace-labels.yaml
@@ -1,0 +1,13 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:overlay", "overlay")
+
+#@overlay/match by=overlay.subset({"kind": "Namespace", "metadata": {"name": "capd-system"}})
+---
+metadata:
+  labels:
+    #@overlay/match missing_ok=True
+    pod-security.kubernetes.io/enforce: privileged
+    #@overlay/match missing_ok=True
+    pod-security.kubernetes.io/warn: privileged
+    #@overlay/match missing_ok=True
+    pod-security.kubernetes.io/audit: privileged

--- a/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-pi.yaml
+++ b/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-pi.yaml
@@ -45,6 +45,7 @@ metadata:
   annotations:
     kapp.k14s.io/change-rule.0: "upsert after upserting tkg-infra-clusterclass-packageinstall/serviceaccount"
     kapp.k14s.io/change-rule.1: "delete before deleting tkg-infra-clusterclass-packageinstall/serviceaccount"
+    ext.packaging.carvel.dev/ytt-paths-from-secret-name.0: tkg-clusterclass-infra-overlays
   labels:
     tkg.tanzu.vmware.com/package-type: "management"
 spec:
@@ -72,3 +73,177 @@ metadata:
 type: Opaque
 stringData:
   values.yaml: #@ yaml.encode(data.values.clusterclassInfraPackageValues.configValues)
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tkg-clusterclass-infra-overlays
+  namespace: #@ data.values.namespaceForPackageInstallation
+  annotations:
+    kapp.k14s.io/change-rule.0: "upsert after upserting tkg-infra-clusterclass-packageinstall/serviceaccount"
+    kapp.k14s.io/change-rule.1: "delete before deleting tkg-infra-clusterclass-packageinstall/serviceaccount"
+type: Opaque
+stringData:
+  kcp-empty-array-ovleray.yaml: |
+    #! This overlay is adds a patch as first element in the patches to create empty
+    #! arrays inside the KCP object. With this other patches are able to append to the
+    #! now empty array.
+    #! Otherwise the arrays would not exist and the patches would fail.
+    #! Empty arrays get dropped due to omitEmpty set at the CRD level.
+    #@ load("@ytt:overlay", "overlay")
+    #@ load("@ytt:data", "data")
+
+    #@overlay/match by=overlay.subset({"kind":"ClusterClass"})
+    ---
+    spec:
+      patches:
+      #@overlay/match by=overlay.index(0)
+      #@overlay/insert before=True
+      - definitions:
+        - jsonPatches:
+          - op: add
+            path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes
+            value: []
+          selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            kind: KubeadmControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+        name: KCP_INIT_EMPTY_ARRAYS
+
+  pod-security-overlay.yaml: |
+    #@ load("@ytt:overlay", "overlay")
+    #@ load("@ytt:data", "data")
+
+    #@overlay/match by=overlay.subset({"kind":"ClusterClass"})
+    ---
+    apiVersion: cluster.x-k8s.io/v1beta1
+    kind: ClusterClass
+    spec:
+      #@overlay/match missing_ok=True
+      variables:
+      #@overlay/remove
+      #@overlay/match by=overlay.map_key("name"),missing_ok=True
+      - name: podSecurityStandard
+      #@overlay/append
+      - name: podSecurityStandard
+        required: false
+        schema:
+          openAPIV3Schema:
+            type: object
+            default: {}
+            properties:
+              deactivated:
+                type: boolean
+                description: "deactivated disables the patches for Pod Security Standard via AdmissionConfiguration."
+              enforce:
+                type: string
+                enum: ["", "privileged", "baseline", "restricted"]
+                description: "enforce sets the level for the enforce PodSecurityConfiguration mode. One of \"\", privileged, baseline, restricted."
+                nullable: true
+              enforceVersion:
+                type: string
+                #! Version defaults to v1.23 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
+                #! by a defaulting webhook instead for extended logic.
+                default: "v1.23"
+                description: "enforceVersion sets the version for the enforce PodSecurityConfiguration mode."
+              audit:
+                type: string
+                enum: ["", "privileged", "baseline", "restricted"]
+                description: "audit sets the level for the audit PodSecurityConfiguration mode. One of \"\", privileged, baseline, restricted."
+                nullable: true
+              auditVersion:
+                type: string
+                #! Version defaults to v1.23 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
+                #! by a defaulting webhook instead for extended logic.
+                default: "v1.23"
+                description: "auditVersion sets the version for the audit PodSecurityConfiguration mode."
+              warn:
+                type: string
+                enum: ["", "privileged", "baseline", "restricted"]
+                description: "warn sets the level for the warn PodSecurityConfiguration mode. One of \"\", privileged, baseline, restricted."
+                nullable: true
+              warnVersion:
+                type: string
+                #! Version defaults to v1.23 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
+                #! by a defaulting webhook instead for extended logic.
+                default: "v1.23"
+                description: "warnVersion sets the version for the warn PodSecurityConfiguration mode."
+              exemptions:
+                type: object
+                description: "exemption configuration for the PodSecurityConfiguration."
+                properties:
+                  namespaces:
+                    type: array
+                    items:
+                      type: string
+                    description: "namespaces excluded to apply PodSecurityConfiguration Admission."
+      #@overlay/match missing_ok=True
+      patches:
+      #@overlay/remove
+      #@overlay/match by=overlay.map_key("name"),missing_ok=True
+      - name: podSecurityStandard
+      #@overlay/append
+      - name: podSecurityStandard
+        description: "Adds an admission configuration for PodSecurity to the kube-apiserver."
+        definitions:
+        - selector:
+            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+            kind: KubeadmControlPlaneTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+          - op: add
+            path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/admission-control-config-file"
+            value: "/etc/kubernetes/kube-apiserver-admission-pss.yaml"
+          - op: add
+            path: "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes/-"
+            value:
+              name: admission-pss
+              hostPath: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+              mountPath: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+              readOnly: true
+              pathType: "File"
+          - op: add
+            path: "/spec/template/spec/kubeadmConfigSpec/files/-"
+            valueFrom:
+              template: |-
+                content: |-
+                  {{ $namespace_exemptions := printf "%q, %q" "kube-system" "tkg-system" -}}
+                  {{ $defaultWarnAudit := "baseline" }}
+                  {{- if .podSecurityStandard.exemptions.namespaces -}}
+                    {{ range $namespace := .podSecurityStandard.exemptions.namespaces -}}
+                      {{ $namespace_exemptions = printf "%s, %q" $namespace_exemptions $namespace -}}
+                    {{- end -}}
+                  {{- end -}}
+                  apiVersion: apiserver.config.k8s.io/v1
+                  kind: AdmissionConfiguration
+                  plugins:
+                  - name: PodSecurity
+                    configuration:
+                      apiVersion: pod-security.admission.config.k8s.io/v1beta1
+                      kind: PodSecurityConfiguration
+                      defaults:
+                        enforce: "{{ if .podSecurityStandard.enforce -}}
+                            {{ .podSecurityStandard.enforce }}
+                          {{- end }}"
+                        enforce-version: "{{ .podSecurityStandard.enforceVersion -}}"
+                        audit: "{{ if .podSecurityStandard.audit -}}
+                            {{ .podSecurityStandard.audit }}
+                          {{- else -}}
+                            {{ $defaultWarnAudit }}
+                          {{- end }}"
+                        audit-version: "{{ .podSecurityStandard.auditVersion -}}"
+                        warn: "{{ if .podSecurityStandard.warn -}}
+                            {{ .podSecurityStandard.warn }}
+                          {{- else -}}
+                            {{ $defaultWarnAudit }}
+                          {{- end }}"
+                        warn-version: "{{ .podSecurityStandard.warnVersion -}}"
+                      exemptions:
+                        usernames: []
+                        runtimeClasses: []
+                        namespaces: [{{ $namespace_exemptions }}]
+                path: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+        enabledIf: '{{ and (not .podSecurityStandard.deactivated) (semverCompare ">= v1.23" .builtin.controlPlane.version) }}'

--- a/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-pi.yaml
+++ b/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-pi.yaml
@@ -144,9 +144,9 @@ stringData:
                 nullable: true
               enforceVersion:
                 type: string
-                #! Version defaults to v1.24 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
+                #! Version defaults to v1.23 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
                 #! by a defaulting webhook instead for extended logic.
-                default: "v1.24"
+                default: "v1.23"
                 description: "enforceVersion sets the version for the enforce PodSecurityConfiguration mode."
               audit:
                 type: string
@@ -155,9 +155,9 @@ stringData:
                 nullable: true
               auditVersion:
                 type: string
-                #! Version defaults to v1.24 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
+                #! Version defaults to v1.23 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
                 #! by a defaulting webhook instead for extended logic.
-                default: "v1.24"
+                default: "v1.23"
                 description: "auditVersion sets the version for the audit PodSecurityConfiguration mode."
               warn:
                 type: string
@@ -166,9 +166,9 @@ stringData:
                 nullable: true
               warnVersion:
                 type: string
-                #! Version defaults to v1.24 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
+                #! Version defaults to v1.23 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
                 #! by a defaulting webhook instead for extended logic.
-                default: "v1.24"
+                default: "v1.23"
                 description: "warnVersion sets the version for the warn PodSecurityConfiguration mode."
               exemptions:
                 type: object
@@ -246,4 +246,4 @@ stringData:
                         runtimeClasses: []
                         namespaces: [{{ $namespace_exemptions }}]
                 path: /etc/kubernetes/kube-apiserver-admission-pss.yaml
-        enabledIf: '{{ and (not .podSecurityStandard.deactivated) (semverCompare ">= v1.24" .builtin.controlPlane.version) }}'
+        enabledIf: '{{ and (not .podSecurityStandard.deactivated) (semverCompare ">= v1.23" .builtin.controlPlane.version) }}'

--- a/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-pi.yaml
+++ b/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-pi.yaml
@@ -85,7 +85,7 @@ metadata:
     kapp.k14s.io/change-rule.1: "delete before deleting tkg-infra-clusterclass-packageinstall/serviceaccount"
 type: Opaque
 stringData:
-  kcp-empty-array-ovleray.yaml: |
+  kcp-empty-array-overlay.yaml: |
     #! This overlay is adds a patch as first element in the patches to create empty
     #! arrays inside the KCP object. With this other patches are able to append to the
     #! now empty array.

--- a/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-pi.yaml
+++ b/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-pi.yaml
@@ -144,9 +144,9 @@ stringData:
                 nullable: true
               enforceVersion:
                 type: string
-                #! Version defaults to v1.23 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
+                #! Version defaults to v1.24 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
                 #! by a defaulting webhook instead for extended logic.
-                default: "v1.23"
+                default: "v1.24"
                 description: "enforceVersion sets the version for the enforce PodSecurityConfiguration mode."
               audit:
                 type: string
@@ -155,9 +155,9 @@ stringData:
                 nullable: true
               auditVersion:
                 type: string
-                #! Version defaults to v1.23 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
+                #! Version defaults to v1.24 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
                 #! by a defaulting webhook instead for extended logic.
-                default: "v1.23"
+                default: "v1.24"
                 description: "auditVersion sets the version for the audit PodSecurityConfiguration mode."
               warn:
                 type: string
@@ -166,9 +166,9 @@ stringData:
                 nullable: true
               warnVersion:
                 type: string
-                #! Version defaults to v1.23 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
+                #! Version defaults to v1.24 for now. When v1.25 is part of tanzu-framework, the defaulting should be done
                 #! by a defaulting webhook instead for extended logic.
-                default: "v1.23"
+                default: "v1.24"
                 description: "warnVersion sets the version for the warn PodSecurityConfiguration mode."
               exemptions:
                 type: object
@@ -246,4 +246,4 @@ stringData:
                         runtimeClasses: []
                         namespaces: [{{ $namespace_exemptions }}]
                 path: /etc/kubernetes/kube-apiserver-admission-pss.yaml
-        enabledIf: '{{ and (not .podSecurityStandard.deactivated) (semverCompare ">= v1.23" .builtin.controlPlane.version) }}'
+        enabledIf: '{{ and (not .podSecurityStandard.deactivated) (semverCompare ">= v1.24" .builtin.controlPlane.version) }}'

--- a/providers/config_default.yaml
+++ b/providers/config_default.yaml
@@ -493,6 +493,12 @@ USE_TOPOLOGY_CATEGORIES: false
 #! NTP server customization (Only support vSphere provider)
 NTP_SERVERS:
 
+#! Disables pod security standards in kube-apiserver.
+POD_SECURITY_STANDARD_DEACTIVATED: false
+
+POD_SECURITY_STANDARD_AUDIT: "baseline"
+POD_SECURITY_STANDARD_WARN: "baseline"
+POD_SECURITY_STANDARD_ENFORCE: ""
 
 #! ---------------------------------------------------------------------
 #! Autoscaler related configuration

--- a/providers/infrastructure-azure/v1.5.3/infrastructure-components.yaml
+++ b/providers/infrastructure-azure/v1.5.3/infrastructure-components.yaml
@@ -3,6 +3,9 @@ kind: Namespace
 metadata:
   labels:
     cluster.x-k8s.io/provider: infrastructure-azure
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged
   name: capz-system
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/providers/infrastructure-docker/v1.2.4/infrastructure-components.yaml
+++ b/providers/infrastructure-docker/v1.2.4/infrastructure-components.yaml
@@ -4,6 +4,9 @@ metadata:
   labels:
     cluster.x-k8s.io/provider: infrastructure-docker
     control-plane: controller-manager
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/audit: privileged
   name: capd-system
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/providers/tests/clustergen/param_models/cluster_optional.model
+++ b/providers/tests/clustergen/param_models/cluster_optional.model
@@ -104,6 +104,13 @@ TKG_IP_FAMILY: "NA", "", "ipv4", "ipv6"
 ENABLE_AUDIT_LOGGING: "true", "false"
 OS_NAME: "photon", "ubuntu", "amazon"
 
+# pod security standards
+POD_SECURITY_STANDARD_DEACTIVATED: "true", "false"
+
+POD_SECURITY_STANDARD_AUDIT: "", "baseline", "restricted", "enforce"
+POD_SECURITY_STANDARD_WARN: "", "baseline", "restricted", "enforce"
+POD_SECURITY_STANDARD_ENFORCE: "", "baseline", "restricted", "enforce"
+
 # autoscaler
 AUTOSCALER_MIN_SIZE_0: "NA", "2"
 AUTOSCALER_MAX_SIZE_0: "NA", "5"

--- a/providers/ytt/03_customizations/pod_security_admission.yaml
+++ b/providers/ytt/03_customizations/pod_security_admission.yaml
@@ -15,11 +15,11 @@ plugins:
     kind: PodSecurityConfiguration
     defaults:
       enforce: #@ data.values.POD_SECURITY_STANDARD_ENFORCE
-      enforce-version: "v1.23"
+      enforce-version: "v1.24"
       audit: #@ data.values.POD_SECURITY_STANDARD_AUDIT
-      audit-version: "v1.23"
+      audit-version: "v1.24"
       warn: #@ data.values.POD_SECURITY_STANDARD_WARN
-      warn-version: "v1.23"
+      warn-version: "v1.24"
     exemptions:
       usernames: []
       runtimeClasses: []

--- a/providers/ytt/03_customizations/pod_security_admission.yaml
+++ b/providers/ytt/03_customizations/pod_security_admission.yaml
@@ -1,0 +1,57 @@
+#@ load("@ytt:overlay", "overlay")
+#@ load("@ytt:data", "data")
+#@ load("@ytt:base64", "base64")
+#@ load("@ytt:yaml", "yaml")
+#@ load("@ytt:version", "version")
+#@ load("/lib/helpers.star", "activate_pod_security_standard")
+
+#@ def kube_apiserver_admission_pss():
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: PodSecurity
+  configuration:
+    apiVersion: pod-security.admission.config.k8s.io/v1beta1
+    kind: PodSecurityConfiguration
+    defaults:
+      enforce: #@ data.values.POD_SECURITY_STANDARD_ENFORCE
+      enforce-version: "v1.23"
+      audit: #@ data.values.POD_SECURITY_STANDARD_AUDIT
+      audit-version: "v1.23"
+      warn: #@ data.values.POD_SECURITY_STANDARD_WARN
+      warn-version: "v1.23"
+    exemptions:
+      usernames: []
+      runtimeClasses: []
+      namespaces: ["kube-system","tkg-system"]
+#@ end
+
+#@ if activate_pod_security_standard():
+#@overlay/match by=overlay.subset({"kind":"KubeadmControlPlane"})
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        #@overlay/match missing_ok=True
+        extraArgs:
+          #@overlay/match missing_ok=True
+          admission-control-config-file: "/etc/kubernetes/kube-apiserver-admission-pss.yaml"
+        #@overlay/match missing_ok=True
+        extraVolumes:
+        #@overlay/append
+        - name: admission-pss
+          hostPath: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+          mountPath: /etc/kubernetes/kube-apiserver-admission-pss.yaml
+          readOnly: true
+          pathType: "File"
+    #@overlay/match missing_ok=True
+    files:
+    #@overlay/append
+    - path: "/etc/kubernetes/kube-apiserver-admission-pss.yaml"
+      content: #@ base64.encode("{}".format(yaml.encode(kube_apiserver_admission_pss())))
+      encoding: "base64"
+      permissions: "0444"
+#@ end

--- a/providers/ytt/03_customizations/pod_security_admission.yaml
+++ b/providers/ytt/03_customizations/pod_security_admission.yaml
@@ -15,11 +15,11 @@ plugins:
     kind: PodSecurityConfiguration
     defaults:
       enforce: #@ data.values.POD_SECURITY_STANDARD_ENFORCE
-      enforce-version: "v1.24"
+      enforce-version: "v1.23"
       audit: #@ data.values.POD_SECURITY_STANDARD_AUDIT
-      audit-version: "v1.24"
+      audit-version: "v1.23"
       warn: #@ data.values.POD_SECURITY_STANDARD_WARN
-      warn-version: "v1.24"
+      warn-version: "v1.23"
     exemptions:
       usernames: []
       runtimeClasses: []

--- a/providers/ytt/lib/helpers.star
+++ b/providers/ytt/lib/helpers.star
@@ -373,7 +373,7 @@ def activate_pod_security_standard():
     return False
   end
   tkrVersion = get_tkr_version_from_tkr_name(data.values.KUBERNETES_RELEASE)
-  if compare_semver_versions(tkrVersion, "v1.24.0") >= 0:
+  if compare_semver_versions(tkrVersion, "v1.23.0") >= 0:
      return True
   end
   return False

--- a/providers/ytt/lib/helpers.star
+++ b/providers/ytt/lib/helpers.star
@@ -367,6 +367,18 @@ def enable_csi_driver():
   return False
 end
 
+def activate_pod_security_standard():
+  # disable if pod security is explicitly disabled
+  if data.values.POD_SECURITY_STANDARD_DEACTIVATED:
+    return False
+  end
+  tkrVersion = get_tkr_version_from_tkr_name(data.values.KUBERNETES_RELEASE)
+  if compare_semver_versions(tkrVersion, "v1.23.0") >= 0:
+     return True
+  end
+  return False
+end
+
 def map(f, list):
     return [f(x) for x in list]
 end

--- a/providers/ytt/lib/helpers.star
+++ b/providers/ytt/lib/helpers.star
@@ -373,7 +373,7 @@ def activate_pod_security_standard():
     return False
   end
   tkrVersion = get_tkr_version_from_tkr_name(data.values.KUBERNETES_RELEASE)
-  if compare_semver_versions(tkrVersion, "v1.23.0") >= 0:
+  if compare_semver_versions(tkrVersion, "v1.24.0") >= 0:
      return True
   end
   return False

--- a/tkg/client/admission_upgrade_helper.go
+++ b/tkg/client/admission_upgrade_helper.go
@@ -22,9 +22,9 @@ plugins:
       enforce: ""
       enforce-version: ""
       audit: "baseline"
-      audit-version: "v1.24"
+      audit-version: "v1.23"
       warn: "baseline"
-      warn-version: "v1.24"
+      warn-version: "v1.23"
     exemptions:
       usernames: []
       runtimeClasses: []

--- a/tkg/client/admission_upgrade_helper.go
+++ b/tkg/client/admission_upgrade_helper.go
@@ -1,0 +1,93 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	capibootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+)
+
+const (
+	admissionPodSecurityConfigFilePath = "/etc/kubernetes/kube-apiserver-admission-pss.yaml"
+	admissionPodSecurityConfigFileData = `apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+- name: PodSecurity
+  configuration:
+    apiVersion: pod-security.admission.config.k8s.io/v1beta1
+    kind: PodSecurityConfiguration
+    defaults:
+      enforce: ""
+      enforce-version: ""
+      audit: "baseline"
+      audit-version: "v1.23"
+      warn: "baseline"
+      warn-version: "v1.23"
+    exemptions:
+      usernames: []
+      runtimeClasses: []
+      namespaces: ["kube-system","tkg-system"]
+`
+	admissionPodSecurityConfigFlagName = "admission-control-config-file"
+)
+
+func (c *TkgClient) configurePodSecurityStandard(old *controlplanev1.KubeadmControlPlane) *controlplanev1.KubeadmControlPlane {
+
+	fileExists := false
+	for _, f := range old.Spec.KubeadmConfigSpec.Files {
+		if f.Path == admissionPodSecurityConfigFilePath {
+			fileExists = true
+			break
+		}
+	}
+
+	volumeMountExists := false
+	if old.Spec.KubeadmConfigSpec.ClusterConfiguration != nil {
+		for _, m := range old.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraVolumes {
+			if m.HostPath == admissionPodSecurityConfigFilePath {
+				volumeMountExists = true
+				break
+			}
+		}
+	}
+
+	if fileExists && volumeMountExists && old.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs[admissionPodSecurityConfigFlagName] == admissionPodSecurityConfigFilePath {
+		return old
+	}
+
+	kcp := old.DeepCopy()
+
+	if !fileExists {
+		kcp.Spec.KubeadmConfigSpec.Files = append(kcp.Spec.KubeadmConfigSpec.Files,
+			capibootstrapv1.File{
+				Path:    admissionPodSecurityConfigFilePath,
+				Content: admissionPodSecurityConfigFileData,
+			},
+		)
+	}
+
+	if !volumeMountExists {
+		if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration == nil {
+			kcp.Spec.KubeadmConfigSpec.ClusterConfiguration = &capibootstrapv1.ClusterConfiguration{}
+		}
+
+		kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraVolumes = append(kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraVolumes,
+			capibootstrapv1.HostPathMount{
+				Name:      "admission-pss",
+				HostPath:  admissionPodSecurityConfigFilePath,
+				MountPath: admissionPodSecurityConfigFilePath,
+				ReadOnly:  true,
+				PathType:  corev1.HostPathFile,
+			},
+		)
+	}
+
+	if kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs == nil {
+		kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs = map[string]string{}
+	}
+	kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs[admissionPodSecurityConfigFlagName] = admissionPodSecurityConfigFilePath
+
+	return kcp
+}

--- a/tkg/client/admission_upgrade_helper.go
+++ b/tkg/client/admission_upgrade_helper.go
@@ -22,9 +22,9 @@ plugins:
       enforce: ""
       enforce-version: ""
       audit: "baseline"
-      audit-version: "v1.23"
+      audit-version: "v1.24"
       warn: "baseline"
-      warn-version: "v1.23"
+      warn-version: "v1.24"
     exemptions:
       usernames: []
       runtimeClasses: []

--- a/tkg/client/admission_upgrade_helper_test.go
+++ b/tkg/client/admission_upgrade_helper_test.go
@@ -1,0 +1,72 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	capibootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
+	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+)
+
+func TestTkgClient_configurePodSecurityStandard(t *testing.T) {
+	c := &TkgClient{}
+
+	kcp := &controlplanev1.KubeadmControlPlane{
+		Spec: controlplanev1.KubeadmControlPlaneSpec{
+			KubeadmConfigSpec: capibootstrapv1.KubeadmConfigSpec{
+				ClusterConfiguration: &capibootstrapv1.ClusterConfiguration{
+					APIServer: capibootstrapv1.APIServer{
+						ControlPlaneComponent: capibootstrapv1.ControlPlaneComponent{
+							ExtraArgs: map[string]string{
+								admissionPodSecurityConfigFlagName: admissionPodSecurityConfigFilePath,
+							},
+							ExtraVolumes: []capibootstrapv1.HostPathMount{
+								{
+									Name:      "admission-pss",
+									HostPath:  admissionPodSecurityConfigFilePath,
+									MountPath: admissionPodSecurityConfigFilePath,
+									ReadOnly:  true,
+									PathType:  corev1.HostPathFile,
+								},
+							},
+						},
+					},
+				},
+				Files: []capibootstrapv1.File{
+					{
+						Path:    admissionPodSecurityConfigFilePath,
+						Content: admissionPodSecurityConfigFileData,
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		old  *controlplanev1.KubeadmControlPlane
+		want *controlplanev1.KubeadmControlPlane
+	}{
+		{
+			"nil pointer check",
+			&controlplanev1.KubeadmControlPlane{},
+			kcp.DeepCopy(),
+		},
+		{
+			"no-op",
+			kcp.DeepCopy(),
+			kcp.DeepCopy(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := c.configurePodSecurityStandard(tt.old); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("TkgClient.configurePodSecurityStandard() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tkg/client/upgrade_cluster.go
+++ b/tkg/client/upgrade_cluster.go
@@ -1103,7 +1103,7 @@ func (c *TkgClient) PatchKubernetesVersionToKubeadmControlPlane(regionalClusterC
 		}
 	}
 
-	if semver.Compare(clusterUpgradeConfig.UpgradeComponentInfo.KubernetesVersion, "v1.24.0") >= 0 {
+	if semver.Compare(clusterUpgradeConfig.UpgradeComponentInfo.KubernetesVersion, "v1.23.0") >= 0 {
 		newKCP := c.configurePodSecurityStandard(currentKCP)
 		if newKCP != nil {
 			log.Infof("Enabling Pod Security Standard for KCP")

--- a/tkg/client/upgrade_cluster.go
+++ b/tkg/client/upgrade_cluster.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/mod/semver"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -1099,6 +1100,14 @@ func (c *TkgClient) PatchKubernetesVersionToKubeadmControlPlane(regionalClusterC
 		}
 		for k, v := range clusterUpgradeConfig.UpgradeComponentInfo.EtcdExtraArgs {
 			currentKCP.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ExtraArgs[k] = v
+		}
+	}
+
+	if semver.Compare(clusterUpgradeConfig.UpgradeComponentInfo.KubernetesVersion, "v1.23.0") >= 0 {
+		newKCP := c.configurePodSecurityStandard(currentKCP)
+		if newKCP != nil {
+			log.Infof("Enabling Pod Security Standard for KCP")
+			currentKCP = newKCP
 		}
 	}
 

--- a/tkg/client/upgrade_cluster.go
+++ b/tkg/client/upgrade_cluster.go
@@ -1103,7 +1103,7 @@ func (c *TkgClient) PatchKubernetesVersionToKubeadmControlPlane(regionalClusterC
 		}
 	}
 
-	if semver.Compare(clusterUpgradeConfig.UpgradeComponentInfo.KubernetesVersion, "v1.23.0") >= 0 {
+	if semver.Compare(clusterUpgradeConfig.UpgradeComponentInfo.KubernetesVersion, "v1.24.0") >= 0 {
 		newKCP := c.configurePodSecurityStandard(currentKCP)
 		if newKCP != nil {
 			log.Infof("Enabling Pod Security Standard for KCP")

--- a/tkg/constants/clusterclass_mapping.go
+++ b/tkg/constants/clusterclass_mapping.go
@@ -35,6 +35,11 @@ var ClusterAttributesToLegacyVariablesMapCommon = map[string]string{
 	"spec.topology.variables.trust.imageRepository": ConfigVariableCustomImageRepositoryCaCertificate, // TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE
 
 	"spec.topology.variables.apiServerPort": ConfigVariableClusterAPIServerPort, // CLUSTER_API_SERVER_PORT
+
+	"spec.topology.variables.podSecurityStandard.deactivated": PodSecurityStandardDeactivated, // POD_SECURITY_STANDARD_DEACTIVATED
+	"spec.topology.variables.podSecurityStandard.audit":       PodSecurityStandardAudit,       // POD_SECURITY_STANDARD_AUDIT
+	"spec.topology.variables.podSecurityStandard.warn":        PodSecurityStandardWarn,        // POD_SECURITY_STANDARD_WARN
+	"spec.topology.variables.podSecurityStandard.enforce":     PodSecurityStandardEnforce,     // POD_SECURITY_STANDARD_ENFORCE
 }
 
 // ClusterAttributesHigherPrecedenceToLowerMap has cluster class input attributes which

--- a/tkg/constants/config_variables.go
+++ b/tkg/constants/config_variables.go
@@ -192,6 +192,11 @@ const (
 	EnableAuditLogging  = "ENABLE_AUDIT_LOGGING"
 	TKGIPFamily         = "TKG_IP_FAMILY"
 
+	PodSecurityStandardDeactivated = "POD_SECURITY_STANDARD_DEACTIVATED"
+	PodSecurityStandardAudit       = "POD_SECURITY_STANDARD_AUDIT"
+	PodSecurityStandardWarn        = "POD_SECURITY_STANDARD_WARN"
+	PodSecurityStandardEnforce     = "POD_SECURITY_STANDARD_ENFORCE"
+
 	ConfigVariableOSName    = "OS_NAME"
 	ConfigVariableOSVersion = "OS_VERSION"
 	ConfigVariableOSArch    = "OS_ARCH"


### PR DESCRIPTION
### What this PR does / why we need it

Introduces:
* Overlay for ClusterClasses to enable and configure Pod Security Standard for v1.23 clusters
* Overlay for non-ClusterClass clusters to enable and configure Pod Security Standard for v1.23 clusters
* Migration code for non-ClusterClass clusters to enable Pod Security Standard when upgrading to v1.23

Follow-up PR: raise the bar to v1.24 clusters instead of v1.23 clusters, as soon as v1.24 is available in tanzu-framework.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Enable pod security admission per default for Cluster in audit and warn mode. Also introduces variables to the ClusterClasses to make it configurable for ClusterClass based clusters.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
