### PR TITLE
Ensures kapp-controller deployment has last-applied annotation before upgrade

### DIFF
--- a/tkg/client/delete_region.go
+++ b/tkg/client/delete_region.go
@@ -139,7 +139,7 @@ func (c *TkgClient) DeleteRegion(options DeleteRegionOptions) error { //nolint:f
 
 		// If clusterclass feature flag is enabled then deploy kapp-controller
 		if config.IsFeatureActivated(config.FeatureFlagPackageBasedLCM) {
-			if err = c.InstallOrUpgradeKappController(cleanupClusterKubeconfigPath, ""); err != nil {
+			if err = c.InstallOrUpgradeKappController(cleanupClusterKubeconfigPath, "", constants.OperationTypeInstall); err != nil {
 				return errors.Wrap(err, "unable to install kapp-controller to bootstrap cluster")
 			}
 		}

--- a/tkg/client/init.go
+++ b/tkg/client/init.go
@@ -206,6 +206,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 
 	// If clusterclass feature flag is enabled then deploy kapp-controller
 	if config.IsFeatureActivated(config.FeatureFlagPackageBasedLCM) {
+		log.Info("Installing kapp-controller on bootstrap cluster...")
 		if err = c.InstallOrUpgradeKappController(bootstrapClusterKubeconfigPath, ""); err != nil {
 			return errors.Wrap(err, "unable to install kapp-controller to bootstrap cluster")
 		}
@@ -295,6 +296,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 
 	// If clusterclass feature flag is enabled then deploy kapp-controller
 	if config.IsFeatureActivated(config.FeatureFlagPackageBasedLCM) {
+		log.Info("Installing kapp-controller on management cluster...")
 		if err = c.InstallOrUpgradeKappController(regionalClusterKubeconfigPath, kubeContext); err != nil {
 			return errors.Wrap(err, "unable to install kapp-controller to management cluster")
 		}

--- a/tkg/client/init.go
+++ b/tkg/client/init.go
@@ -207,7 +207,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 	// If clusterclass feature flag is enabled then deploy kapp-controller
 	if config.IsFeatureActivated(config.FeatureFlagPackageBasedLCM) {
 		log.Info("Installing kapp-controller on bootstrap cluster...")
-		if err = c.InstallOrUpgradeKappController(bootstrapClusterKubeconfigPath, ""); err != nil {
+		if err = c.InstallOrUpgradeKappController(bootstrapClusterKubeconfigPath, "", constants.OperationTypeInstall); err != nil {
 			return errors.Wrap(err, "unable to install kapp-controller to bootstrap cluster")
 		}
 	}
@@ -297,7 +297,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 	// If clusterclass feature flag is enabled then deploy kapp-controller
 	if config.IsFeatureActivated(config.FeatureFlagPackageBasedLCM) {
 		log.Info("Installing kapp-controller on management cluster...")
-		if err = c.InstallOrUpgradeKappController(regionalClusterKubeconfigPath, kubeContext); err != nil {
+		if err = c.InstallOrUpgradeKappController(regionalClusterKubeconfigPath, kubeContext, constants.OperationTypeInstall); err != nil {
 			return errors.Wrap(err, "unable to install kapp-controller to management cluster")
 		}
 	}

--- a/tkg/client/management_components.go
+++ b/tkg/client/management_components.go
@@ -22,7 +22,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/tkg/utils"
 )
 
-func (c *TkgClient) InstallOrUpgradeKappController(kubeconfig, kubecontext string) error {
+func (c *TkgClient) InstallOrUpgradeKappController(kubeconfig, kubecontext string, operationType constants.OperationType) error {
 	// Get kapp-controller configuration file
 	kappControllerConfigFile, err := c.getKappControllerConfigFile()
 	if err != nil {
@@ -38,7 +38,7 @@ func (c *TkgClient) InstallOrUpgradeKappController(kubeconfig, kubecontext strin
 		KappControllerConfigFile:       kappControllerConfigFile,
 		KappControllerInstallNamespace: constants.TkgNamespace,
 	}
-	err = managementcomponents.InstallKappController(clusterClient, kappControllerOptions)
+	err = managementcomponents.InstallKappController(clusterClient, kappControllerOptions, operationType)
 
 	// Remove intermediate config files if err is empty
 	if err == nil {

--- a/tkg/client/upgrade_region.go
+++ b/tkg/client/upgrade_region.go
@@ -140,7 +140,7 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 	// If clusterclass feature flag is enabled then deploy management components
 	if config.IsFeatureActivated(config.FeatureFlagPackageBasedLCM) {
 		log.Info("Upgrading kapp-controller...")
-		if err = c.InstallOrUpgradeKappController(currentRegion.SourceFilePath, currentRegion.ContextName); err != nil {
+		if err = c.InstallOrUpgradeKappController(currentRegion.SourceFilePath, currentRegion.ContextName, constants.OperationTypeUpgrade); err != nil {
 			return errors.Wrap(err, "unable to upgrade kapp-controller")
 		}
 		log.Info("Upgrading management components...")

--- a/tkg/clusterclient/clusterclient.go
+++ b/tkg/clusterclient/clusterclient.go
@@ -84,8 +84,9 @@ import (
 )
 
 const (
-	kubectlApplyRetryTimeout  = 30 * time.Second
-	kubectlApplyRetryInterval = 5 * time.Second
+	kubectlApplyRetryTimeout          = 30 * time.Second
+	kubectlApplyRetryInterval         = 5 * time.Second
+	kubectlApplyLastAppliedAnnotation = "kubectl.kubernetes.io/last-applied-configuration"
 	// DefaultKappControllerHostPort is the default kapp-controller port for it's extension apiserver
 	DefaultKappControllerHostPort           = 10100
 	waitPeriodBeforePollingForUpgradeStatus = 60 * time.Second
@@ -2090,6 +2091,10 @@ func (c *client) PatchKappControllerLastAppliedAnnotation(namespace string) erro
 		return errors.Wrap(err, "failed to get kapp-controller deployment from cluster")
 	}
 	kappYaml := result.([]byte)
+	// Skip adding last-applied annotation if already has it
+	if strings.Contains(string(kappYaml), kubectlApplyLastAppliedAnnotation) {
+		return nil
+	}
 
 	f, err := os.CreateTemp("", "kubeapply-")
 	if err != nil {

--- a/tkg/constants/cluster_internal.go
+++ b/tkg/constants/cluster_internal.go
@@ -189,3 +189,10 @@ const (
 	ResourceVSphereClusterTemplate      = "vsphereclustertemplates"
 	ResourceVSphereMachineTemplate      = "vspheremachinetemplates"
 )
+
+type OperationType int
+
+const (
+	OperationTypeInstall OperationType = iota
+	OperationTypeUpgrade
+)

--- a/tkg/managementcomponents/management_component_install.go
+++ b/tkg/managementcomponents/management_component_install.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
@@ -290,14 +291,23 @@ func InstallManagementComponents(mcip *ManagementComponentsInstallOptions) error
 
 // InstallKappController installs kapp-controller to the cluster
 func InstallKappController(clusterClient clusterclient.Client, kappControllerOptions KappControllerOptions) error {
+	// Ensure last-applied annotation is present before kapp-controller upgrade
+	err := clusterClient.GetResource(&appsv1.Deployment{}, constants.KappControllerDeploymentName, kappControllerOptions.KappControllerInstallNamespace, nil, nil)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	if err == nil { // only attempt to add annotation when kapp-controller exists on the cluster
+		log.Infof("Adding last-applied annotation on kapp-controller...")
+		if err := clusterClient.PatchKappControllerLastAppliedAnnotation(kappControllerOptions.KappControllerInstallNamespace); err != nil {
+			return errors.Wrap(err, "error adding last-applied annotation on kapp-controller")
+		}
+	}
 	// Apply kapp-controller configuration
-	err := clusterClient.ApplyFile(kappControllerOptions.KappControllerConfigFile)
-	if err != nil {
+	if err := clusterClient.ApplyFile(kappControllerOptions.KappControllerConfigFile); err != nil {
 		return errors.Wrapf(err, "error installing %s", constants.KappControllerDeploymentName)
 	}
 	// Wait for kapp-controller to be deployed and running
-	err = clusterClient.WaitForDeployment(constants.KappControllerDeploymentName, kappControllerOptions.KappControllerInstallNamespace)
-	if err != nil {
+	if err := clusterClient.WaitForDeployment(constants.KappControllerDeploymentName, kappControllerOptions.KappControllerInstallNamespace); err != nil {
 		return errors.Wrapf(err, "error while waiting for deployment %s", constants.KappControllerDeploymentName)
 	}
 	return nil

--- a/tkg/managementcomponents/management_component_install.go
+++ b/tkg/managementcomponents/management_component_install.go
@@ -290,16 +290,18 @@ func InstallManagementComponents(mcip *ManagementComponentsInstallOptions) error
 }
 
 // InstallKappController installs kapp-controller to the cluster
-func InstallKappController(clusterClient clusterclient.Client, kappControllerOptions KappControllerOptions) error {
-	// Ensure last-applied annotation is present before kapp-controller upgrade
-	err := clusterClient.GetResource(&appsv1.Deployment{}, constants.KappControllerDeploymentName, kappControllerOptions.KappControllerInstallNamespace, nil, nil)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return err
-	}
-	if err == nil { // only attempt to add annotation when kapp-controller exists on the cluster
-		log.Infof("Adding last-applied annotation on kapp-controller...")
-		if err := clusterClient.PatchKappControllerLastAppliedAnnotation(kappControllerOptions.KappControllerInstallNamespace); err != nil {
-			return errors.Wrap(err, "error adding last-applied annotation on kapp-controller")
+func InstallKappController(clusterClient clusterclient.Client, kappControllerOptions KappControllerOptions, operationType constants.OperationType) error {
+	if operationType == constants.OperationTypeUpgrade {
+		// Ensure last-applied annotation is present before kapp-controller upgrade
+		err := clusterClient.GetResource(&appsv1.Deployment{}, constants.KappControllerDeploymentName, kappControllerOptions.KappControllerInstallNamespace, nil, nil)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+		if err == nil { // only attempt to add annotation when kapp-controller exists on the cluster
+			log.Infof("Adding last-applied annotation on kapp-controller...")
+			if err := clusterClient.PatchKappControllerLastAppliedAnnotation(kappControllerOptions.KappControllerInstallNamespace); err != nil {
+				return errors.Wrap(err, "error adding last-applied annotation on kapp-controller")
+			}
 		}
 	}
 	// Apply kapp-controller configuration

--- a/tkg/managementcomponents/management_component_install_test.go
+++ b/tkg/managementcomponents/management_component_install_test.go
@@ -93,11 +93,10 @@ var _ = Describe("Test InstallKappController", func() {
 		kcOptions = KappControllerOptions{KappControllerConfigFile: "", KappControllerInstallNamespace: ""}
 	})
 
-	JustBeforeEach(func() {
-		err = InstallKappController(clusterClient, kcOptions)
-	})
-
-	Context("when getting kapp-controller deployment throws error other than NotFound err", func() {
+	Context("when getting kapp-controller deployment throws error other than NotFound err, while upgrading kapp controller", func() {
+		JustBeforeEach(func() {
+			err = InstallKappController(clusterClient, kcOptions, constants.OperationTypeUpgrade)
+		})
 		BeforeEach(func() {
 			clusterClient.GetResourceReturns(errors.New("fake error getting resource"))
 		})
@@ -107,7 +106,10 @@ var _ = Describe("Test InstallKappController", func() {
 		})
 	})
 
-	Context("when adding last-applied annotation on kapp-controller throws error", func() {
+	Context("when adding last-applied annotation on kapp-controller throws error, while upgrading kapp controller", func() {
+		JustBeforeEach(func() {
+			err = InstallKappController(clusterClient, kcOptions, constants.OperationTypeUpgrade)
+		})
 		BeforeEach(func() {
 			clusterClient.GetResourceReturns(nil)
 			clusterClient.PatchKappControllerLastAppliedAnnotationReturns(errors.New("fake error adding annotation"))
@@ -119,7 +121,10 @@ var _ = Describe("Test InstallKappController", func() {
 		})
 	})
 
-	Context("when applying kapp-controller config throws error", func() {
+	Context("when applying kapp-controller config throws error, while upgrading kapp controller", func() {
+		JustBeforeEach(func() {
+			err = InstallKappController(clusterClient, kcOptions, constants.OperationTypeUpgrade)
+		})
 		BeforeEach(func() {
 			clusterClient.GetResourceReturns(notFoundError)
 			clusterClient.ApplyFileReturns(errors.New("fake error applyfile"))
@@ -131,7 +136,10 @@ var _ = Describe("Test InstallKappController", func() {
 		})
 	})
 
-	Context("when WaitForDeployment config throws error", func() {
+	Context("when WaitForDeployment config throws error, while upgrading kapp controller", func() {
+		JustBeforeEach(func() {
+			err = InstallKappController(clusterClient, kcOptions, constants.OperationTypeUpgrade)
+		})
 		BeforeEach(func() {
 			clusterClient.GetResourceReturns(notFoundError)
 			clusterClient.ApplyFileReturns(nil)
@@ -144,7 +152,10 @@ var _ = Describe("Test InstallKappController", func() {
 		})
 	})
 
-	Context("when kapp-controller is deployed successfully", func() {
+	Context("when kapp-controller is deployed successfully, while upgrading kapp controller", func() {
+		JustBeforeEach(func() {
+			err = InstallKappController(clusterClient, kcOptions, constants.OperationTypeUpgrade)
+		})
 		BeforeEach(func() {
 			clusterClient.GetResourceReturns(notFoundError)
 			clusterClient.ApplyFileReturns(nil)
@@ -155,6 +166,50 @@ var _ = Describe("Test InstallKappController", func() {
 		})
 	})
 
+	Context("when applying kapp-controller throws error, while installing kapp controller", func() {
+		JustBeforeEach(func() {
+			err = InstallKappController(clusterClient, kcOptions, constants.OperationTypeInstall)
+		})
+		BeforeEach(func() {
+			clusterClient.GetResourceReturns(notFoundError)
+			clusterClient.ApplyFileReturns(errors.New("fake error applyfile"))
+		})
+		It("should return error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("fake error applyfile"))
+			Expect(err.Error()).To(ContainSubstring("error installing %s", constants.KappControllerDeploymentName))
+		})
+	})
+
+	Context("when WaitForDeployment config throws error, while installing kapp controller", func() {
+		JustBeforeEach(func() {
+			err = InstallKappController(clusterClient, kcOptions, constants.OperationTypeInstall)
+		})
+		BeforeEach(func() {
+			clusterClient.GetResourceReturns(notFoundError)
+			clusterClient.ApplyFileReturns(nil)
+			clusterClient.WaitForDeploymentReturns(errors.New("fake error waitfordeployment"))
+		})
+		It("should return error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("fake error waitfordeployment"))
+			Expect(err.Error()).To(ContainSubstring("error while waiting for deployment %s", constants.KappControllerDeploymentName))
+		})
+	})
+
+	Context("when kapp-controller is deployed successfully, while installing kapp controller", func() {
+		JustBeforeEach(func() {
+			err = InstallKappController(clusterClient, kcOptions, constants.OperationTypeInstall)
+		})
+		BeforeEach(func() {
+			clusterClient.GetResourceReturns(notFoundError)
+			clusterClient.ApplyFileReturns(nil)
+			clusterClient.WaitForDeploymentReturns(nil)
+		})
+		It("should return error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
 })
 
 var _ = Describe("Test WaitForManagementPackages", func() {


### PR DESCRIPTION
### What this PR does / why we need it
- Ensures `kapp-controller` deployment has last-applied annotation before upgrade when `package-based-lcm` feature flag is on.
- Same fix as #3631 but this one is for flow when package-based-lcm feature flag is on. Context about why we need the fix can be referred at PR above.
- Skips adding last-applied annotation to `kapp-controller` if it already has one

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #
- Fix the same issue mentioned in PR https://github.com/vmware-tanzu/tanzu-framework/pull/3631, but for the case when package-based-lcm feature flag is on.

### Describe testing done for PR
1. Manually verified that creating Classy Cluster based management cluster is successful on AWS.
2. Verified on TKG cluster on AWS using the tanzu CLI built from this branch, and kapp-controller is upgraded successfully when package-based-lcm feature flag is on:

- Before upgrade, `kapp-controller` yaml snippet:
```
[~] kubectl get deploy kapp-controller -n tkg-system -o yaml
...
metadata:
  annotations:
    kapp-controller.carvel.dev/version: v0.38.4
...
spec:
  template:
    spec:
      containers:
      - command:
        - /kapp-controller-sidecarexec
        env:
        - name: KAPPCTRL_SIDECAREXEC_SOCK
          value: /etc/kappctrl-mem-tmp/sidecarexec.sock
```

- Upgrade management cluster:
```
[~] tanzu config set features.global.package-based-lcm-beta true
[~] tanzu mc upgrade
```

- `kapp-controller` is upgraded successfully:
```
[~] kubectl get deploy kapp-controller -n tkg-system
NAME              READY   UP-TO-DATE   AVAILABLE   AGE
kapp-controller   1/1     1            1           4m
[~] kubectl get pod -n tkg-system
NAME                                                     READY   STATUS    RESTARTS      AGE
kapp-controller-8494db94cc-xsptn                         2/2     Running   0             40s
tanzu-addons-controller-manager-6f7bd84c87-rcnj5         1/1     Running   0             5d18h
tanzu-capabilities-controller-manager-858569d99c-6k992   1/1     Running   3 (83s ago)   7m47s
tanzu-featuregates-controller-manager-6cc7c6c496-h9vnj   1/1     Running   0             7m27s
[~] kubectl get deploy kapp-controller -n tkg-system -o yaml
...
metadata:
  annotations:
    kapp-controller.carvel.dev/version: v0.41.2
...
spec:
  template:
    spec:
      containers:
      - args:
        - --sidecarexec
        env:
        - name: KAPPCTRL_SIDECAREXEC_SOCK
           value: /etc/kappctrl-mem-tmp/sidecarexec.sock
```

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix kapp-controller upgrade issue when package-based-lcm feature flag is on
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
