### PR TITLE
revert version bump, which cause downstream pipeline failure

### DIFF
--- a/tkg/tkgconfighelper/tkgconfighelper_test.go
+++ b/tkg/tkgconfighelper/tkgconfighelper_test.go
@@ -131,7 +131,7 @@ var _ = Describe("ValidateK8sVersionSupport", func() {
 			})
 			It("should return error", func() {
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("only [v1.0 v1.1 v1.2 v1.3 v1.4 v1.5 v1.6 v1.7] management cluster versions are supported with current version of TKG CLI. Please upgrade TKG CLI to latest version if you are using it on latest version of management cluster."))
+				Expect(err.Error()).To(ContainSubstring("only [v1.0 v1.1 v1.2 v1.3 v1.4 v1.5 v1.6 v1.7 v2.1] management cluster versions are supported with current version of TKG CLI. Please upgrade TKG CLI to latest version if you are using it on latest version of management cluster."))
 			})
 		})
 	})

--- a/tkg/tkgconfighelper/tkgconfighelper_test.go
+++ b/tkg/tkgconfighelper/tkgconfighelper_test.go
@@ -131,7 +131,7 @@ var _ = Describe("ValidateK8sVersionSupport", func() {
 			})
 			It("should return error", func() {
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("only [v1.0 v1.1 v1.2 v1.3 v1.4 v1.5 v1.6 v1.7 v2.1] management cluster versions are supported with current version of TKG CLI. Please upgrade TKG CLI to latest version if you are using it on latest version of management cluster."))
+				Expect(err.Error()).To(ContainSubstring("only [v1.0 v1.1 v1.2 v1.3 v1.4 v1.5 v1.6 v1.7] management cluster versions are supported with current version of TKG CLI. Please upgrade TKG CLI to latest version if you are using it on latest version of management cluster."))
 			})
 		})
 	})

--- a/tkg/tkgconfighelper/validate.go
+++ b/tkg/tkgconfighelper/validate.go
@@ -23,6 +23,7 @@ var ManagementClusterVersionToK8sVersionSupportMatrix = map[string][]string{
 	"v1.5": {"v1.19", "v1.20", "v1.21", "v1.22"},
 	"v1.6": {"v1.20", "v1.21", "v1.22", "v1.23"},
 	"v1.7": {"v1.21", "v1.22", "v1.23", "v1.24"},
+	"v2.1": {"v1.21", "v1.22", "v1.23", "v1.24"},
 }
 
 // ValidateK8sVersionSupport validates the k8s version is supported on management cluster or not

--- a/tkg/tkgconfighelper/validate.go
+++ b/tkg/tkgconfighelper/validate.go
@@ -22,8 +22,7 @@ var ManagementClusterVersionToK8sVersionSupportMatrix = map[string][]string{
 	"v1.4": {"v1.17", "v1.18", "v1.19", "v1.20", "v1.21"},
 	"v1.5": {"v1.19", "v1.20", "v1.21", "v1.22"},
 	"v1.6": {"v1.20", "v1.21", "v1.22", "v1.23"},
-	"v1.7": {"v1.22", "v1.23", "v1.24"},
-	"v2.1": {"v1.22", "v1.23", "v1.24"},
+	"v1.7": {"v1.21", "v1.22", "v1.23", "v1.24"},
 }
 
 // ValidateK8sVersionSupport validates the k8s version is supported on management cluster or not


### PR DESCRIPTION
### What this PR does / why we need it

### Which issue(s) this PR fixes
Previously, 1.21 support is removed, which cause all downstream multi-version pipelines failed, after discussion with downstream team, an agreement is made to add 1.21 back to support list. bolt team will info tanzu-framework when 1.24 is ready.

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
