### PR TITLE
[cherry-pick] Fix NSX ALB service engine group & network validation failure when duplicate resource names in different clouds

### DIFF
--- a/pkg/v1/tkg/client/validate.go
+++ b/pkg/v1/tkg/client/validate.go
@@ -1960,13 +1960,13 @@ func (c *TkgClient) ValidateAviCloud(aviClient avi.Client) error {
 	return nil
 }
 
-// ValidateAVIManagementClusterServiceEngineGroup validates if configured service engine group exists or not
+// ValidateAVIServiceEngineGroup validates if configured service engine group exists or not
 func (c *TkgClient) ValidateAviServiceEngineGroup(aviClient avi.Client) error {
 	aviServiceEngineGroup, err := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviServiceEngineGroup)
 	if err != nil {
 		return err
 	}
-	if _, err = aviClient.GetServiceEngineGroupByName(aviServiceEngineGroup); err != nil {
+	if _, err = aviClient.GetServiceEngineGroupByName(aviServiceEngineGroup); err != nil && !isAviResourceDuplicatedNameError(err) {
 		return err
 	}
 	return nil
@@ -1977,14 +1977,14 @@ func (c *TkgClient) ValidateAviManagementClusterServiceEngineGroup(aviClient avi
 	aviManagementClusterSEG, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviManagementClusterServiceEngineGroup)
 	// this field is optional, only validates if it has value
 	if aviManagementClusterSEG != "" {
-		if _, err := aviClient.GetServiceEngineGroupByName(aviManagementClusterSEG); err != nil {
+		if _, err := aviClient.GetServiceEngineGroupByName(aviManagementClusterSEG); err != nil && !isAviResourceDuplicatedNameError(err) {
 			return err
 		}
 	}
 	return nil
 }
 
-// ValidateAVIControlPlaneNetwork validates if workload clusters' data plane vip network is valid or not
+// ValidateAVIDataPlaneNetwork validates if workload clusters' data plane vip network is valid or not
 func (c *TkgClient) ValidateAviDataPlaneNetwork(aviClient avi.Client) error {
 	aviDataNetworkName, err := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviDataPlaneNetworkName)
 	if err != nil {
@@ -2042,7 +2042,7 @@ func (c *TkgClient) ValidateAviManagementClusterControlPlaneNetwork(aviClient av
 // ValidateAVINetwork validates if the network can be found in AVI controller or not and the subnet CIDR format is correct or not
 func (c *TkgClient) ValidateAviNetwork(networkName, networkCIDR string, aviClient avi.Client) error {
 	_, err := aviClient.GetVipNetworkByName(networkName)
-	if err != nil {
+	if err != nil && !isAviResourceDuplicatedNameError(err) {
 		return err
 	}
 	_, _, err = net.ParseCIDR(networkCIDR)
@@ -2120,6 +2120,10 @@ func (c *TkgClient) checkIPFamilyFeatureFlags(ipFamily, clusterRole string) erro
 	}
 
 	return nil
+}
+
+func isAviResourceDuplicatedNameError(err error) bool {
+	return strings.Contains(err.Error(), "More than one object of type ")
 }
 
 func dualStackFeatureFlagError(ipFamily, featureFlag string) error {


### PR DESCRIPTION
Signed-off-by: Xudong Liu <xudongl@vmware.com>


This PR is cherry-pick fix of https://github.com/vmware-tanzu/tanzu-framework/pull/3602

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
