### PR TITLE
TKR webhook should not reject a paused cluster.

### DIFF
--- a/tkr/webhook/cluster/tkr-resolver/cluster/cluster.go
+++ b/tkr/webhook/cluster/tkr-resolver/cluster/cluster.go
@@ -65,6 +65,10 @@ func (cw *Webhook) Handle(ctx context.Context, req admission.Request) admission.
 }
 
 func (cw *Webhook) getClusterClass(ctx context.Context, cluster *clusterv1.Cluster) (*clusterv1.ClusterClass, *admission.Response) {
+	if cluster.Spec.Paused {
+		return nil, respPtr(admission.Allowed("Doing nothing. Cluster is paused."))
+	}
+
 	if !cluster.GetDeletionTimestamp().IsZero() {
 		return nil, respPtr(admission.Allowed("Doing nothing. Cluster is being deleted"))
 	}

--- a/tkr/webhook/cluster/tkr-resolver/cluster/cluster_test.go
+++ b/tkr/webhook/cluster/tkr-resolver/cluster/cluster_test.go
@@ -97,6 +97,17 @@ var _ = Describe("cluster.Webhook", func() {
 	const strNonExistent = "non-existent"
 
 	Context("getClusterClass()", func() {
+
+		When("Cluster is paused", func() {
+			It("should allow the request to pass", func() {
+				cluster.Spec.Paused = true
+				cc, resp := cw.getClusterClass(context.Background(), cluster)
+				Expect(cc).To(BeNil())
+				Expect(resp).ToNot(BeNil())
+				Expect(resp.Allowed).To(BeTrue())
+			})
+		})
+
 		When("Cluster has deletionTimestamp set", func() {
 			It("should allow the request to pass", func() {
 				cluster.DeletionTimestamp = &metav1.Time{Time: time.Now()}


### PR DESCRIPTION
### What this PR does / why we need it

A fix cherrypicked from https://github.com/vmware-tanzu/tanzu-framework/pull/3557

Generally, the webhook should always admit a Cluster resource that is paused.

_**Oracle MC deletion is blocked without this change**_

When deleting a management cluster, the CAPI Cluster resource will be first paused an moved to the bootstrap kind cluster. During this process, we can not guarantee that the cluster's metadata is resolve-able, because its  corresponding TKR might not be there yet.

In fact, the webhook is rejecting the Cluster CR when deleting the MC, if that MC created was using `--additional-manifests <some-tkr-url>`. This TKR from manifests won't be presented in the Bootstrap Kind cluster during deletion.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Webhook unit test

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
TKR webhook should not reject a paused cluster.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
