### PR TITLE
Update nodepool cc to default top level variable

### DIFF
--- a/cmd/cli/plugin/managementcluster/go.mod
+++ b/cmd/cli/plugin/managementcluster/go.mod
@@ -201,6 +201,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/packageclients v0.0.0-20220908202723-7a1ddb97efab // indirect
 	github.com/vmware-tanzu/tanzu-framework/tkr v0.0.0-00010101000000-000000000000 // indirect
+	github.com/vmware-tanzu/tanzu-framework/util v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware/govmomi v0.27.1 // indirect
 	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0 // indirect
 	go.mongodb.org/mongo-driver v1.5.1 // indirect

--- a/cmd/cli/plugin/package/go.mod
+++ b/cmd/cli/plugin/package/go.mod
@@ -208,6 +208,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/cli/core v0.0.0-20220914003300-5b2ed024556a // indirect
 	github.com/vmware-tanzu/tanzu-framework/tkr v0.0.0-00010101000000-000000000000 // indirect
+	github.com/vmware-tanzu/tanzu-framework/util v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware/govmomi v0.27.1 // indirect
 	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0 // indirect
 	go.mongodb.org/mongo-driver v1.5.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -214,6 +214,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/cli/core v0.0.0-20220914003300-5b2ed024556a // indirect
 	github.com/vmware-tanzu/tanzu-framework/packageclients v0.0.0-00010101000000-000000000000 // indirect
+	github.com/vmware-tanzu/tanzu-framework/util v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware/govmomi v0.27.1 // indirect
 	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0 // indirect
 	go.mongodb.org/mongo-driver v1.5.1 // indirect

--- a/tkg/client/machine_deployment_cc.go
+++ b/tkg/client/machine_deployment_cc.go
@@ -11,6 +11,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/pkg/errors"
+
 	"github.com/vmware-tanzu/tanzu-framework/tkg/clusterclient"
 	"github.com/vmware-tanzu/tanzu-framework/util/topology"
 )

--- a/tkg/client/machine_deployment_cc.go
+++ b/tkg/client/machine_deployment_cc.go
@@ -6,13 +6,18 @@ package client
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 
-	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 
+	"github.com/pkg/errors"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/clusterclient"
+	"github.com/vmware-tanzu/tanzu-framework/util/topology"
+)
+
+const (
+	NodePoolLabelsName string = "nodePoolLabels"
+	NodePoolTaintsName string = "nodePoolTaints"
 )
 
 //nolint:funlen,gocyclo
@@ -24,26 +29,11 @@ func DoSetMachineDeploymentCC(clusterClient clusterclient.Client, cluster *capi.
 		return errors.New("cluster topology workers are not set. please repair your cluster before trying again")
 	}
 
-	var nodePoolVarFound bool
-	for i := range cluster.Spec.Topology.Variables {
-		if cluster.Spec.Topology.Variables[i].Name == "nodePoolLabels" {
-			nodePoolVarFound = true
-		}
-	}
-
-	if !nodePoolVarFound && options.Labels != nil {
-		output, _ := json.Marshal([]map[string]string{})
-		cluster.Spec.Topology.Variables = append(cluster.Spec.Topology.Variables, capi.ClusterVariable{
-			Name: "nodePoolLabels",
-			Value: v1.JSON{
-				Raw: output,
-			},
-		})
-	}
-
+	mdIndex := -1
 	for i := range cluster.Spec.Topology.Workers.MachineDeployments {
 		if cluster.Spec.Topology.Workers.MachineDeployments[i].Name == options.Name {
 			update = &cluster.Spec.Topology.Workers.MachineDeployments[i]
+			mdIndex = i
 		}
 		if cluster.Spec.Topology.Workers.MachineDeployments[i].Name == options.BaseMachineDeployment {
 			base = cluster.Spec.Topology.Workers.MachineDeployments[i].DeepCopy()
@@ -73,6 +63,7 @@ func DoSetMachineDeploymentCC(clusterClient clusterclient.Client, cluster *capi.
 
 		cluster.Spec.Topology.Workers.MachineDeployments = append(cluster.Spec.Topology.Workers.MachineDeployments, *base)
 		base = &cluster.Spec.Topology.Workers.MachineDeployments[len(cluster.Spec.Topology.Workers.MachineDeployments)-1]
+		mdIndex = len(cluster.Spec.Topology.Workers.MachineDeployments) - 1
 	}
 
 	base.Name = options.Name
@@ -98,19 +89,10 @@ func DoSetMachineDeploymentCC(clusterClient clusterclient.Client, cluster *capi.
 	}
 
 	if options.Labels != nil {
-		nodeLabelsVar := getClusterVariableByName("nodePoolLabels", base.Variables.Overrides)
-		if nodeLabelsVar == nil {
-			nodeLabelsVar = &capi.ClusterVariable{
-				Name:  "nodePoolLabels",
-				Value: v1.JSON{},
-			}
-			base.Variables.Overrides = append(base.Variables.Overrides, *nodeLabelsVar)
-			nodeLabelsVar = &base.Variables.Overrides[len(base.Variables.Overrides)-1]
-		}
-
 		var labels []map[string]string
-		// ignore nodePoolLabels not existing
-		_ = json.NewDecoder(bytes.NewBuffer(nodeLabelsVar.Value.Raw)).Decode(&labels)
+		if err := topology.GetMDVariable(cluster, mdIndex, NodePoolLabelsName, &labels); err != nil {
+			return errors.Errorf("unable to find or marshal variable with name %s", NodePoolLabelsName)
+		}
 
 		for k, v := range *options.Labels {
 			labels = append(labels, map[string]string{
@@ -119,23 +101,15 @@ func DoSetMachineDeploymentCC(clusterClient clusterclient.Client, cluster *capi.
 			})
 		}
 
-		output, _ := json.Marshal(labels)
-		nodeLabelsVar.Value.Raw = output
+		if err := topology.SetMDVariable(cluster, mdIndex, NodePoolLabelsName, labels); err != nil {
+			return errors.Errorf("unable to set variable with name %s", NodePoolLabelsName)
+		}
 	}
 
 	if options.Taints != nil {
-		nodeTaintsVar := getClusterVariableByName("nodePoolTaints", base.Variables.Overrides)
-		if nodeTaintsVar == nil {
-			nodeTaintsVar = &capi.ClusterVariable{
-				Name:  "nodePoolTaints",
-				Value: v1.JSON{},
-			}
-			base.Variables.Overrides = append(base.Variables.Overrides, *nodeTaintsVar)
-			nodeTaintsVar = &base.Variables.Overrides[len(base.Variables.Overrides)-1]
+		if err := topology.SetMDVariable(cluster, mdIndex, NodePoolTaintsName, &options.Taints); err != nil {
+			return errors.Errorf("unable to set variable with name %s", NodePoolTaintsName)
 		}
-
-		output, _ := json.Marshal(options.Taints)
-		nodeTaintsVar.Value.Raw = output
 	}
 
 	if update != nil {

--- a/tkg/client/machine_deployment_cc.go
+++ b/tkg/client/machine_deployment_cc.go
@@ -24,6 +24,23 @@ func DoSetMachineDeploymentCC(clusterClient clusterclient.Client, cluster *capi.
 		return errors.New("cluster topology workers are not set. please repair your cluster before trying again")
 	}
 
+	var nodePoolVarFound bool
+	for i := range cluster.Spec.Topology.Variables {
+		if cluster.Spec.Topology.Variables[i].Name == "nodePoolLabels" {
+			nodePoolVarFound = true
+		}
+	}
+
+	if !nodePoolVarFound && options.Labels != nil {
+		output, _ := json.Marshal([]map[string]string{})
+		cluster.Spec.Topology.Variables = append(cluster.Spec.Topology.Variables, capi.ClusterVariable{
+			Name: "nodePoolLabels",
+			Value: v1.JSON{
+				Raw: output,
+			},
+		})
+	}
+
 	for i := range cluster.Spec.Topology.Workers.MachineDeployments {
 		if cluster.Spec.Topology.Workers.MachineDeployments[i].Name == options.Name {
 			update = &cluster.Spec.Topology.Workers.MachineDeployments[i]

--- a/tkg/client/machine_deployment_cc_test.go
+++ b/tkg/client/machine_deployment_cc_test.go
@@ -286,7 +286,7 @@ var _ = Describe("GetMachineDeploymentCC", func() {
 	})
 })
 
-var _ = Describe("GetMachineDeploymentCC", func() {
+var _ = Describe("DeleteMachineDeploymentCC", func() {
 	var (
 		err                   error
 		regionalClusterClient *fakes.ClusterClient
@@ -501,6 +501,8 @@ var _ = Describe("SetMachineDeploymentCC", func() {
 				clusterInterface, _, _, _ := regionalClusterClient.UpdateResourceArgsForCall(0)
 				actual, ok := clusterInterface.(*capi.Cluster)
 				Expect(ok).To(BeTrue())
+				Expect(len(actual.Spec.Topology.Variables)).To(Equal(2))
+				Expect(actual.Spec.Topology.Variables[1].Name).To(Equal("nodePoolLabels"))
 				Expect(len(actual.Spec.Topology.Workers.MachineDeployments)).To(Equal(3))
 				Expect(actual.Spec.Topology.Workers.MachineDeployments[2].Variables.Overrides[0].Value.Raw).To(Equal(expected))
 			})


### PR DESCRIPTION
This change adds a top level empty array for the nodePoolLabels variable so that any nodePoolLabels override in machineDeployments will not fail with a 'no top-level variable found' error.

### What this PR does / why we need it
Fixes a regression where node pool cli feature would fail for clusterclass based clusters if the cluster topology did not define a top level variable for `nodePoolLabels`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
