### PR TITLE
Add BOM ConfigMaps to tkr-system if configured

### DIFF
--- a/packages/tkg/bundle/config/values.yaml
+++ b/packages/tkg/bundle/config/values.yaml
@@ -78,6 +78,7 @@ tkrSourceControllerPackage:
   versionConstraints:
   tkrSourceControllerPackageValues:
     namespace: tkg-system
+    legacyNamespace: tkr-system
     bomImagePath:
     bomMetadataImagePath:
     tkrRepoImagePath:

--- a/packages/tkr-source-controller/bundle/config/upstream/tkr-source-controller-deployment.yaml
+++ b/packages/tkr-source-controller/bundle/config/upstream/tkr-source-controller-deployment.yaml
@@ -30,6 +30,7 @@ spec:
         - --metrics-bind-addr=0
         - --sa-name=tkr-source-controller-manager-sa
         - #@ "--namespace={}".format(data.values.namespace)
+        - #@ "--legacy-namespace={}".format(data.values.legacyNamespace)
         - #@ "--bom-image-path={}".format(data.values.bomImagePath)
         - #@ "--bom-metadata-image-path={}".format(data.values.bomMetadataImagePath)
         - #@ "--tkr-repo-image-path={}".format(data.values.tkrRepoImagePath)

--- a/packages/tkr-source-controller/bundle/config/values.yaml
+++ b/packages/tkr-source-controller/bundle/config/values.yaml
@@ -2,6 +2,7 @@
 #@overlay/match-child-defaults missing_ok=True
 ---
 namespace: tkg-system
+legacyNamespace: tkr-system
 bomImagePath:
 bomMetadataImagePath:
 tkrRepoImagePath:

--- a/tkg/test/tkgctl/aws_cc/aws_cc_suite_test.go
+++ b/tkg/test/tkgctl/aws_cc/aws_cc_suite_test.go
@@ -110,11 +110,6 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	// create management cluster
 	if !e2eConfig.UseExistingCluster {
-		// TODO(vuil): Remove this temporary workaround (to populate the TKr  BOM config map in tkr-system namespace)
-		// once https://github.com/vmware-tanzu/tanzu-framework/issues/2891 is fixed
-		tkrURLToApply := "https://gist.githubusercontent.com/vuil/c10295e438b6b7c7232192999dac2cd8/raw/e592364eecde64ab941eed71af7239ce9c8295b7/v1.23.5---vmware.1-tkg.1-zshippable-configmap.yaml"
-		os.Setenv("_ADDITIONAL_MANAGEMENT_COMPONENT_CONFIGURATION_FILE", tkrURLToApply)
-
 		err := cli.Init(tkgctl.InitRegionOptions{
 			ClusterConfigFile: e2eConfig.TkgClusterConfigPath,
 
@@ -146,7 +141,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 		mcClusterClient, err = clusterclient.NewClient(mcKubeconfigFile, mcKubecontext, clusterclient.Options{})
 		Expect(err).To(BeNil())
 
-		//Should verify management cluster is created using default ClusterClass
+		// Should verify management cluster is created using default ClusterClass
 		clusterInfo := mcClusterClient.GetClusterStatusInfo(e2eConfig.ManagementClusterName, "tkg-system", nil)
 		Expect(clusterInfo.ClusterObject).NotTo(BeNil())
 		Expect(clusterInfo.ClusterObject.Spec.Topology).NotTo(BeNil())

--- a/tkr/controller/tkr-source/fetcher/fetcher.go
+++ b/tkr/controller/tkr-source/fetcher/fetcher.go
@@ -47,6 +47,7 @@ type Fetcher struct {
 // Config contains the controller manager context.
 type Config struct {
 	TKRNamespace         string
+	LegacyTKRNamespace   string
 	BOMImagePath         string
 	BOMMetadataImagePath string
 	TKRRepoImagePath     string
@@ -145,21 +146,31 @@ func (f *Fetcher) fetchTKRCompatibilityCM(ctx context.Context) error {
 		return err
 	}
 
+	for _, ns := range []string{f.Config.TKRNamespace, f.Config.LegacyTKRNamespace} {
+		if ns != "" {
+			if err := f.saveTKRCompatibilityCM(ctx, ns, metadataContent); err != nil {
+				return errors.Wrap(err, "error creating or updating BOM metadata ConfigMap")
+			}
+		}
+	}
+	return nil
+}
+
+func (f *Fetcher) saveTKRCompatibilityCM(ctx context.Context, ns string, metadataContent []byte) error {
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: f.Config.TKRNamespace,
+			Namespace: ns,
 			Name:      constants.BOMMetadataConfigMapName,
 		},
 	}
-
-	_, err = controllerutil.CreateOrUpdate(ctx, f.Client, cm, func() error {
+	f.Log.Info("Creating/updating TKR compatibility ConfigMap", "ns", ns, "name", constants.BOMMetadataConfigMapName)
+	_, err := controllerutil.CreateOrUpdate(ctx, f.Client, cm, func() error {
 		cm.BinaryData = map[string][]byte{
 			constants.BOMMetadataCompatibilityKey: metadataContent,
 		}
 		return nil
 	})
-
-	return errors.Wrap(err, "error creating or updating BOM metadata ConfigMap")
+	return err
 }
 
 func (f *Fetcher) fetchCompatibilityMetadata() (*tkrv1.CompatibilityMetadata, error) {
@@ -272,6 +283,17 @@ func (f *Fetcher) createBOMConfigMap(ctx context.Context, tag string) error {
 
 	name := strings.ReplaceAll(releaseName, "+", "---")
 
+	for _, ns := range []string{f.Config.TKRNamespace, f.Config.LegacyTKRNamespace} {
+		if ns != "" {
+			if err := f.saveBOMConfigMap(ctx, ns, name, tag, bomContent); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *Fetcher) saveBOMConfigMap(ctx context.Context, ns string, name string, tag string, bomContent []byte) error {
 	// label the ConfigMap with image tag and tkr name
 	ls := make(map[string]string)
 	ls[constants.BomConfigMapTKRLabel] = name
@@ -285,13 +307,14 @@ func (f *Fetcher) createBOMConfigMap(ctx context.Context, tag string) error {
 	cm := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Namespace:   f.Config.TKRNamespace,
+			Namespace:   ns,
 			Labels:      ls,
 			Annotations: annotations,
 		},
 		BinaryData: binaryData,
 	}
 
+	f.Log.Info("Creating BOM ConfigMap", "ns", ns, "name", name)
 	if err := f.Client.Create(ctx, &cm); err != nil && !apierrors.IsAlreadyExists(err) {
 		return errors.Wrapf(err, "could not create ConfigMap: name='%s'", cm.Name)
 	}

--- a/tkr/controller/tkr-source/main.go
+++ b/tkr/controller/tkr-source/main.go
@@ -142,9 +142,12 @@ func main() {
 	setupWithManager(mgr, []managedComponent{
 		registryInstance,
 		fetcherInstance,
-		pkgcrReconciler,
-		compatibilityReconciler,
+		// pkgcrReconciler,
+		// compatibilityReconciler,
 	})
+	if pkgcrReconciler == nil || compatibilityReconciler == nil {
+		// TODO(imikushin) uncomment above and remove
+	}
 
 	startManager(ctx, mgr)
 }

--- a/tkr/controller/tkr-source/main.go
+++ b/tkr/controller/tkr-source/main.go
@@ -47,6 +47,7 @@ func init() {
 var (
 	metricsAddr               string
 	tkrNamespace              string
+	legacyTKRNamespace        string
 	tkrPkgServiceAccountName  string
 	bomImagePath              string
 	bomMetadataImagePath      string
@@ -59,6 +60,7 @@ var (
 func init() {
 	flag.StringVar(&metricsAddr, "metrics-bind-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&tkrNamespace, "namespace", "tkg-system", "Namespace for TKR related resources")
+	flag.StringVar(&legacyTKRNamespace, "legacy-namespace", "", "Legacy namespace for TKR BOM ConfigMaps")
 	flag.StringVar(&tkrPkgServiceAccountName, "sa-name", "tkr-source-controller-manager-sa", "ServiceAccount name used by TKR PackageInstalls")
 	flag.StringVar(&bomImagePath, "bom-image-path", "", "The BOM image path.")
 	flag.StringVar(&bomMetadataImagePath, "bom-metadata-image-path", "", "The BOM compatibility metadata image path.")
@@ -76,6 +78,7 @@ func init() {
 	}
 	fetcherConfig = fetcher.Config{
 		TKRNamespace:         tkrNamespace,
+		LegacyTKRNamespace:   legacyTKRNamespace,
 		BOMImagePath:         bomImagePath,
 		BOMMetadataImagePath: bomMetadataImagePath,
 		TKRRepoImagePath:     tkrRepoImagePath,

--- a/tkr/controller/tkr-source/main.go
+++ b/tkr/controller/tkr-source/main.go
@@ -142,12 +142,9 @@ func main() {
 	setupWithManager(mgr, []managedComponent{
 		registryInstance,
 		fetcherInstance,
-		// pkgcrReconciler,
-		// compatibilityReconciler,
+		pkgcrReconciler,
+		compatibilityReconciler,
 	})
-	if pkgcrReconciler == nil || compatibilityReconciler == nil {
-		// TODO(imikushin) uncomment above and remove
-	}
 
 	startManager(ctx, mgr)
 }


### PR DESCRIPTION

### What this PR does / why we need it

New namespace for all things TKG is `tkg-system`. This includes TKR BOM ConfigMaps. Legacy style cluster operations in the tanzu CLI expect these in `tkr-system` though. This change makes sure these ConfigMaps get saved to both the new and legacy namespaces (if configured).

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #2891

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Manual testing done: BOM ConfigMaps appear in both `tag-system` and `tkr-system` when `--legacy-namespace=tkr-system` is set on tkr-source-controller.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
