### PR TITLE
Update kctrl Invoke in package plugin

### DIFF
--- a/cmd/cli/plugin/package/kctrl/kctrl.go
+++ b/cmd/cli/plugin/package/kctrl/kctrl.go
@@ -12,15 +12,13 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/cli/runtime/plugin"
 )
 
-func Invoke(p *plugin.Plugin) error {
+func Invoke(p *plugin.Plugin) {
 	writerUI := ui.NewWriterUI(p.Cmd.OutOrStdout(), p.Cmd.ErrOrStderr(), ui.NewNoopLogger())
 	adapterUI := &AdapterUI{WriterUI: *writerUI, outWriter: p.Cmd.OutOrStdout()}
-	confUI := ui.NewWrappingConfUI(adapterUI, ui.NewNoopLogger())
+	confUI := ui.NewWrappingConfUI(ui.NewPaddingUI(adapterUI), ui.NewNoopLogger())
 	defer confUI.Flush()
 
 	kctrlcmd.AttachKctrlPackageCommandTree(p.Cmd, confUI, kctrlcmdcore.PackageCommandTreeOpts{BinaryName: "tanzu", PositionalArgs: true,
 		Color: false, JSON: false})
 	setOutputFormatFlag(p.Cmd, adapterUI)
-
-	return p.Execute()
 }

--- a/cmd/cli/plugin/package/kctrl/kctrl_test.go
+++ b/cmd/cli/plugin/package/kctrl/kctrl_test.go
@@ -1,0 +1,35 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package kctrl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cliapi "github.com/vmware-tanzu/tanzu-framework/cli/runtime/apis/cli/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/cli/runtime/plugin"
+)
+
+func TestKctrlInvoke(t *testing.T) {
+	t.Run("Invoke", func(t *testing.T) {
+		t.Run("add package commands from kctrl", func(t *testing.T) {
+			testPlugin, err := plugin.NewPlugin(&cliapi.PluginDescriptor{
+				Name:        "test",
+				Description: "test",
+				Version:     "v1.0.0",
+				Group:       "test",
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, false, testPlugin.Cmd.HasAvailableSubCommands())
+
+			Invoke(testPlugin)
+
+			assert.Equal(t, true, testPlugin.Cmd.HasAvailableSubCommands())
+			assert.Contains(t, testPlugin.Cmd.UsageString(), "available     Manage available packages")
+			assert.Contains(t, testPlugin.Cmd.UsageString(), "installed     Manage installed packages")
+			assert.Contains(t, testPlugin.Cmd.UsageString(), "repository    Manage package repositories")
+		})
+	})
+}

--- a/cmd/cli/plugin/package/main.go
+++ b/cmd/cli/plugin/package/main.go
@@ -39,7 +39,8 @@ func main() {
 	}
 
 	if config.IsFeatureActivated(config.FeatureFlagPackagePluginKctrlCommandTree) {
-		if err := kctrl.Invoke(p); err != nil {
+		kctrl.Invoke(p)
+		if err := p.Execute(); err != nil {
 			os.Exit(1)
 		}
 		return


### PR DESCRIPTION
### What this PR does / why we need it
- Update kctrl Invoke in package plugin to use padding ui and update the plugin without executing the cmd.
- Add tests for Invoke

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3759 

