### PR TITLE
remove ipv6 workaround from post kubeadm

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -880,18 +880,6 @@ spec:
         path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs
         value:
           node-ip: "::"
-  - name: ipv6Hack
-    enabledIf: '{{ .builtin.cluster.network.ipFamily | eq "IPv6" }}'
-    definitions:
-    - selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-        kind: KubeadmControlPlaneTemplate
-        matchResources:
-          controlPlane: true
-      jsonPatches:
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/postKubeadmCommands/-
-        value: sed -i '/listen-client-urls/ s/$/,https:\/\/127.0.0.1:2379/' /etc/kubernetes/manifests/etcd.yaml
   - name: nodeLabels
     definitions:
     - selector:

--- a/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
@@ -880,18 +880,6 @@ spec:
         path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs
         value:
           node-ip: "::"
-  - name: ipv6Hack
-    enabledIf: '{{ .builtin.cluster.network.ipFamily | eq "IPv6" }}'
-    definitions:
-    - selector:
-        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-        kind: KubeadmControlPlaneTemplate
-        matchResources:
-          controlPlane: true
-      jsonPatches:
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/postKubeadmCommands/-
-        value: sed -i '/listen-client-urls/ s/$/,https:\/\/127.0.0.1:2379/' /etc/kubernetes/manifests/etcd.yaml
   - name: nodeLabels
     definitions:
     - selector:

--- a/providers/infrastructure-vsphere/v1.4.1/ytt/overlay-windows.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/ytt/overlay-windows.yaml
@@ -277,13 +277,6 @@ spec:
       sshAuthorizedKeys:
       - #@ data.values.VSPHERE_SSH_AUTHORIZED_KEY
       sudo: ALL=(ALL) NOPASSWD:ALL
-    #! TODO: we can remove this block once we are consuming a version of containerd with this change: https://github.com/containerd/containerd/pull/5145
-    #@ if data.values.TKG_IP_FAMILY == "ipv6":
-    #@overlay/match missing_ok=True
-    postKubeadmCommands:
-    #@overlay/append
-    - sed -i '/listen-client-urls/ s/$/,https:\/\/127.0.0.1:2379/' /etc/kubernetes/manifests/etcd.yaml
-    #@ end
   replicas: #@ data.values.CONTROL_PLANE_MACHINE_COUNT
   version: #@ data.values.KUBERNETES_VERSION
 

--- a/providers/infrastructure-vsphere/v1.4.1/ytt/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/ytt/overlay.yaml
@@ -393,13 +393,6 @@ spec:
       sshAuthorizedKeys:
       - #@ data.values.VSPHERE_SSH_AUTHORIZED_KEY
       sudo: ALL=(ALL) NOPASSWD:ALL
-    #! TODO: we can remove this block once we are consuming a version of containerd with this change: https://github.com/containerd/containerd/pull/5145
-    #@ if data.values.TKG_IP_FAMILY == "ipv6":
-    #@overlay/match missing_ok=True
-    postKubeadmCommands:
-    #@overlay/append
-    - sed -i '/listen-client-urls/ s/$/,https:\/\/127.0.0.1:2379/' /etc/kubernetes/manifests/etcd.yaml
-    #@ end
     #! When using kube-vip as the control plane endpoint provider with IPv6 as
     #! the primary IP family, set --node-ip on kubelet so that host network pods
     #! do not get the kube-vip address as their pod IP.


### PR DESCRIPTION
### What this PR does / why we need it
all current versions of tanzu are using a new-enough version of containerd (v1.5.0 or greater) that we can remove this workaround

the issue this addressed was fixed in
https://github.com/containerd/containerd/pull/5145

### Describe testing done for PR
Created a cluster to verify it comes up without this workaround

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
N/A
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
