### PR TITLE
set minimum tls version to 1.2 for webhook servers

### DIFF
--- a/addons/main.go
+++ b/addons/main.go
@@ -106,6 +106,7 @@ type addonFlags struct {
 	featureGatePackageInstallStatus bool
 	enablePprof                     bool
 	pprofBindAddress                string
+	tlsMinVersion                   string
 }
 
 func parseAddonFlags(addonFlags *addonFlags) {
@@ -148,6 +149,7 @@ func parseAddonFlags(addonFlags *addonFlags) {
 	flag.BoolVar(&addonFlags.featureGatePackageInstallStatus, "feature-gate-package-install-status", false, "Feature gate to enable packageinstallstatus controller")
 	flag.BoolVar(&addonFlags.enablePprof, "enable-pprof", false, "Enable pprof web server")
 	flag.StringVar(&addonFlags.pprofBindAddress, "pprof-bind-addr", ":18318", "Bind address of pprof web server if enabled")
+	flag.StringVar(&addonFlags.tlsMinVersion, "tls-min-version", "1.2", "minimum TLS version in use by the webhook server. Recommended values are \"1.2\" and \"1.3\".")
 
 	flag.Parse()
 }
@@ -213,6 +215,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	mgr.GetWebhookServer().TLSMinVersion = flags.tlsMinVersion
 	addonReconciler := &controllers.AddonReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("Addon"),

--- a/featuregates/controller/main.go
+++ b/featuregates/controller/main.go
@@ -34,7 +34,9 @@ func init() {
 
 func main() {
 	var webhookServerPort int
+	var tlsMinVersion string
 	flag.IntVar(&webhookServerPort, "webhook-server-port", 9443, "The port that the webhook server serves at.")
+	flag.StringVar(&tlsMinVersion, "tls-min-version", "1.2", "minimum TLS version in use by the webhook server. Recommended values are \"1.2\" and \"1.3\".")
 
 	opts := zap.Options{
 		Development: true,
@@ -53,6 +55,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	mgr.GetWebhookServer().TLSMinVersion = tlsMinVersion
 	if err = (&featuregate.FeatureGateReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("FeatureGate"),

--- a/tkr/webhook/cluster/tkr-resolver/main.go
+++ b/tkr/webhook/cluster/tkr-resolver/main.go
@@ -39,10 +39,12 @@ func main() {
 	var metricsAddr string
 	var webhookServerPort int
 	var customImageRepositoryCCVar string
+	var tlsMinVersion string
 	flag.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/", "Webhook cert directory.")
 	flag.StringVar(&metricsAddr, "metrics-bind-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&customImageRepositoryCCVar, "custom-image-repository-cc-var", "imageRepository", "Custom imageRepository ClusterClass variable")
 	flag.IntVar(&webhookServerPort, "webhook-server-port", 9443, "The port that the webhook server serves at.")
+	flag.StringVar(&tlsMinVersion, "tls-min-version", "1.2", "minimum TLS version in use by the webhook server. Recommended values are \"1.2\" and \"1.3\".")
 
 	opts := zap.Options{
 		Development: true,
@@ -67,6 +69,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	mgr.GetWebhookServer().TLSMinVersion = tlsMinVersion
 	tkrResolver := resolver.New()
 
 	if err := (&cache.Reconciler{

--- a/tkr/webhook/tkr-conversion/main.go
+++ b/tkr/webhook/tkr-conversion/main.go
@@ -36,10 +36,11 @@ func main() {
 	var webhookCertDir string
 	var metricsAddr string
 	var webhookServerPort int
+	var tlsMinVersion string
 	flag.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs/", "Webhook cert directory.")
 	flag.StringVar(&metricsAddr, "metrics-bind-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.IntVar(&webhookServerPort, "webhook-server-port", 9443, "The port that the webhook server serves at.")
-
+	flag.StringVar(&tlsMinVersion, "tls-min-version", "1.2", "minimum TLS version in use by the webhook server. Recommended values are \"1.2\" and \"1.3\".")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -63,6 +64,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	mgr.GetWebhookServer().TLSMinVersion = tlsMinVersion
 	setupWebhooks(mgr)
 
 	setupLog.Info("starting manager")


### PR DESCRIPTION
### What this PR does / why we need it
This PR makes tls version configurable. It is needed to set the tls minimum version to 1.2 by default.

### Which issue(s) this PR fixes 
Fixes #3630

### Describe testing done for PR
tasking is done downstream using pysslscan to ensure only TLSv12 is accepted. 
