### PR TITLE
Remove controlPlaneEndpoint and identityRef in VSphereClusterTemplate

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -10,12 +10,6 @@ metadata:
 spec:
   template:
     spec:
-      controlPlaneEndpoint:
-        host: '#@ data.values.VSPHERE_CONTROL_PLANE_ENDPOINT'
-        port: 6443
-      identityRef:
-        kind: Secret
-        name: '${ CLUSTER_NAME }'
       server: #@ data.values.VSPHERE_SERVER
       thumbprint: #@ data.values.VSPHERE_TLS_THUMBPRINT
 ---
@@ -170,15 +164,6 @@ spec:
         - #@ data.values.VSPHERE_SSH_AUTHORIZED_KEY
         sudo: ALL=(ALL) NOPASSWD:ALL
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: #@ data.values.CLUSTER_NAME
-  namespace: #@ data.values.NAMESPACE
-stringData:
-  username: #@ data.values.VSPHERE_USERNAME
-  password: #@ data.values.VSPHERE_PASSWORD
----
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
@@ -278,6 +263,7 @@ spec:
         - resourcePool
         - server
   - name: VSPHERE_WINDOWS_TEMPLATE
+    required: false
     schema:
       openAPIV3Schema:
         type: string
@@ -477,10 +463,12 @@ spec:
         matchResources:
           infrastructureCluster: true
       jsonPatches:
-      - op: replace
-        path: /spec/template/spec/controlPlaneEndpoint/host
+      - op: add
+        path: /spec/template/spec/controlPlaneEndpoint
         valueFrom:
-          variable: apiServerEndpoint
+          template: |
+            host: '{{ .apiServerEndpoint }}'
+            port: 6443
       - op: replace
         path: /spec/template/spec/thumbprint
         valueFrom:
@@ -489,10 +477,12 @@ spec:
         path: /spec/template/spec/server
         valueFrom:
           variable: vcenter.server
-      - op: replace
-        path: /spec/template/spec/identityRef/name
+      - op: add
+        path: /spec/template/spec/identityRef
         valueFrom:
-          template: '{{ .builtin.cluster.name }}'
+          template: |
+            kind: Secret
+            name: '{{ .builtin.cluster.name }}'
   - name: controlPlaneMachineTemplate
     definitions:
     - selector:

--- a/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
@@ -10,12 +10,6 @@ metadata:
 spec:
   template:
     spec:
-      controlPlaneEndpoint:
-        host: '#@ data.values.VSPHERE_CONTROL_PLANE_ENDPOINT'
-        port: 6443
-      identityRef:
-        kind: Secret
-        name: '${ CLUSTER_NAME }'
       server: #@ data.values.VSPHERE_SERVER
       thumbprint: #@ data.values.VSPHERE_TLS_THUMBPRINT
 ---
@@ -170,15 +164,6 @@ spec:
         - #@ data.values.VSPHERE_SSH_AUTHORIZED_KEY
         sudo: ALL=(ALL) NOPASSWD:ALL
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: #@ data.values.CLUSTER_NAME
-  namespace: #@ data.values.NAMESPACE
-stringData:
-  username: #@ data.values.VSPHERE_USERNAME
-  password: #@ data.values.VSPHERE_PASSWORD
----
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
@@ -278,6 +263,7 @@ spec:
         - resourcePool
         - server
   - name: VSPHERE_WINDOWS_TEMPLATE
+    required: false
     schema:
       openAPIV3Schema:
         type: string
@@ -477,10 +463,12 @@ spec:
         matchResources:
           infrastructureCluster: true
       jsonPatches:
-      - op: replace
-        path: /spec/template/spec/controlPlaneEndpoint/host
+      - op: add
+        path: /spec/template/spec/controlPlaneEndpoint
         valueFrom:
-          variable: apiServerEndpoint
+          template: |
+            host: '{{ .apiServerEndpoint }}'
+            port: 6443
       - op: replace
         path: /spec/template/spec/thumbprint
         valueFrom:
@@ -489,10 +477,12 @@ spec:
         path: /spec/template/spec/server
         valueFrom:
           variable: vcenter.server
-      - op: replace
-        path: /spec/template/spec/identityRef/name
+      - op: add
+        path: /spec/template/spec/identityRef
         valueFrom:
-          template: '{{ .builtin.cluster.name }}'
+          template: |
+            kind: Secret
+            name: '{{ .builtin.cluster.name }}'
   - name: controlPlaneMachineTemplate
     definitions:
     - selector:


### PR DESCRIPTION
'#@ data.values.VSPHERE_CONTROL_PLANE_ENDPOINT' and ${ CLUSTER_NAME } are not interpolated after the ClusterClass package is installed. The secret for identityRef causes a Carvel adoption error after it is migrated from the bootstrap cluster to the management cluster.

The fields controlPlaneEndpoint and identityRef should be empty in VSphereClusterTemplate and use a json patch to set them during the cluster creation phrase.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
