### PR TITLE
Add RPM package build script

### DIFF
--- a/cli/core/Makefile
+++ b/cli/core/Makefile
@@ -172,6 +172,17 @@ apt-package: ## Build a debian package to use with APT
 	@# of the tanzu CLI on Github. E.g., VERSION=v0.26.0 make apt-package	
 	docker run --rm -e VERSION=$${VERSION} -v $(ROOT_DIR):$(ROOT_DIR) ubuntu $(MODULE_ROOT_DIR)/hack/apt/build_package.sh
 
+.PHONY: rpm-package
+rpm-package: ## Build an RPM package
+	@if [ "$$(command -v docker)" == "" ]; then \
+		echo "Docker required to build rpm package" ;\
+		exit 1 ;\
+	fi
+
+	@# To call this target, the VERSION variable must be set by the caller.  The version must match an existing release
+	@# of the tanzu CLI on Github. E.g., VERSION=v0.26.0 make rpm-package
+	docker run --rm -e VERSION=$${VERSION} -v $(ROOT_DIR):$(ROOT_DIR) fedora $(MODULE_ROOT_DIR)/hack/rpm/build_package.sh
+
 ## --------------------------------------
 ## Testing
 ## --------------------------------------

--- a/cli/core/hack/rpm/README.md
+++ b/cli/core/hack/rpm/README.md
@@ -1,0 +1,69 @@
+# Using YUM/DNF to install the Tanzu CLI
+
+YUM and DNF (the replacement for YUM) use RPM packages for installation.  This document describes how to
+build such packages for the Tanzu CLI, how to push them to a public repository and how to install the CLI
+from that repository.
+
+## Building the RPM package
+
+Executing the `hack/rpm/build_package.sh` script will build the RPM packages under `cli/core/hack/rpm/_output`.
+The `hack/rpm/build_package.sh` script is meant to be run on a Linux machine that has `dnf` or `yum` installed.
+This can be done in docker using the `fedora` image.  To facilitate this operation, the new `rpm-package`
+Makefile target has been added to `cli/core/Makefile`; this Makefile target will first start a docker
+container and then run the `hack/rpm/build_package.sh` script.
+
+```bash
+cd tanzu-framework/cli/core
+make rpm-package
+```
+
+Note that two packages will be built, one for AMD64 and one for ARM64.
+Also, a repository will be generated as a directory called `_output/rpm` which will contain the two
+built packages as well as some metadata.  Please see the section on publishing the repository for more details.
+
+## Testing the installation of the Tanzu CLI locally
+
+We can install the Tanzu CLI using the newly built RPM repository locally on a Linux machine with `yum` or `dnf`
+installed or using a docker container.  For example, using `yum`:
+
+```bash
+cd tanzu-framework
+docker run --rm -it -v $(pwd)/cli/core/hack/rpm/_output/rpm:/tmp/rpm fedora
+cat << EOF | sudo tee /etc/yum.repos.d/tanzu-cli.repo
+[tanzu-cli]
+name=Tanzu CLI
+baseurl=file:///tmp/rpm
+enabled=1
+gpgcheck=0
+EOF
+yum install -y tanzu-cli
+tanzu
+```
+
+Note that the repository isn't signed at the moment, so you may see warnings during installation.
+
+## Publishing the package to GCloud
+
+We have a GCloud bucket dedicated to hosting the Tanzu CLI OS packages.  That bucket can be controlled from:
+`https://console.cloud.google.com/storage/browser/tanzu-cli-os-packages`.
+
+To publish the repository containing the new rpm packages for the Tanzu CLI, we must upload the entire `rpm`
+directory to the root of the bucket.  You can do this manually.  Once uploaded, the Tanzu CLI can be installed
+publicly as described in the next section.
+
+## Installing the Tanzu CLI
+
+Currently, the repo is not signed but will be in the future; you may get warnings during installation.
+To install from an insecure repo:
+
+```bash
+docker run --rm -it fedora
+cat << EOF | sudo tee /etc/yum.repos.d/tanzu-cli.repo
+[tanzu-cli]
+name=Tanzu CLI
+baseurl=https://storage.googleapis.com/tanzu-cli-os-packages/rpm
+enabled=1
+gpgcheck=0
+EOF
+yum install -y tanzu-cli
+```

--- a/cli/core/hack/rpm/build_package.sh
+++ b/cli/core/hack/rpm/build_package.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+if [ $(uname) != "Linux" ]; then
+   echo "This script must be run on a Linux system"
+   exit 1
+fi
+
+# Use DNF and if it is not installed fallback to YUM
+DNF=$(command -v dnf || command -v yum || true)
+if [ -z "$DNF" ]; then
+   echo "This script requires the presence of either DNF or YUM package manager"
+   exit 1
+fi
+
+# VERSION should be set when calling this script
+if [ -z "${VERSION}" ]; then
+   echo "\$VERSION must be set before calling this script"
+   exit 1
+fi
+
+# Strip 'v' prefix as an rpm package version must start with an integer
+VERSION=${VERSION#v}
+
+BASE_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
+OUTPUT_DIR=${BASE_DIR}/_output/rpm
+
+# Install build dependencies
+$DNF install -y rpmdevtools rpmlint createrepo
+
+rpmlint ${BASE_DIR}/tanzu-cli.spec
+
+# We must create the sources directory ourselves in the below location
+mkdir -p ${HOME}/rpmbuild/SOURCES
+
+# Create the .rpm packages
+rm -rf ${OUTPUT_DIR}
+mkdir -p ${OUTPUT_DIR}
+rpmbuild --define "cli_version ${VERSION}" -bb ${BASE_DIR}/tanzu-cli.spec --target amd64
+mv ${HOME}/rpmbuild/RPMS/amd64/* ${OUTPUT_DIR}/
+rpmbuild --define "cli_version ${VERSION}" -bb ${BASE_DIR}/tanzu-cli.spec --target aarch64
+mv ${HOME}/rpmbuild/RPMS/aarch64/* ${OUTPUT_DIR}/
+
+# Create the repository metadata
+createrepo ${OUTPUT_DIR}

--- a/cli/core/hack/rpm/tanzu-cli.spec
+++ b/cli/core/hack/rpm/tanzu-cli.spec
@@ -1,0 +1,46 @@
+Name:       tanzu-cli
+Version:    %{cli_version}
+Release:    1
+License:    Apache 2.0
+URL:        https://github.com/vmware-tanzu/tanzu-cli/
+Vendor:     VMware
+Summary:    The Tanzu CLI
+Provides:   tanzu-cli
+Obsoletes:  tanzu-cli  < %{cli_version}
+
+%ifarch amd64
+%define arch amd64
+%endif
+
+%ifarch aarch64
+# TODO For now, we use the amd64 build for arm64
+%define arch amd64
+%endif
+
+%undefine _disable_source_fetch
+Source0:    https://github.com/vmware-tanzu/tanzu-framework/releases/download/v%{version}/tanzu-cli-linux-%{arch}.tar.gz
+
+%description
+VMware Tanzu is a modular, cloud native application platform that enables vital DevSecOps outcomes
+in a multi-cloud world.  The Tanzu CLI allows you to control VMware Tanzu from the command-line.
+
+# Go does not generate a build-id compatible with RPM, so we disable the need for a build-id
+# See https://github.com/rpm-software-management/rpm/issues/367
+%global _missing_build_ids_terminate_build 0
+
+# This is required to avoid some missing debug file errors
+%define debug_package %nil
+
+%prep
+%setup -q -n v%{cli_version}
+
+%build
+# Nothing to build
+
+%install
+rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT/%{_bindir}
+mv tanzu-core-linux_%{arch} $RPM_BUILD_ROOT/%{_bindir}/tanzu
+
+%files
+%{_bindir}/tanzu


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds a script to build anRPM package to install the Tanzu CLI using YUM and DNF.

### Which issue(s) this PR fixes

Part of #3.
Other package managers have to be included before we can completely resolve this issue.

### Describe testing done for PR

```
$ cd tanzu-framework
$ cd cli/core
$ VERSION=v0.26.0 make rpm-package
```
Then I uploaded the `_output/rpm` repository to our `tanzu-cli-os-packages` bucket on GCloud.
Then:
```
$ docker run -it --rm fedora

$ tanzu
bash: tanzu: command not found

# Notice tanzu is not installed

$ cat << EOF | sudo tee /etc/yum.repos.d/tanzu-cli.repo
[tanzu-cli]
name=Tanzu CLI
baseurl=https://storage.googleapis.com/tanzu-cli-os-packages/rpm
enabled=1
gpgcheck=0
EOF

$ yum install -y tanzu-cli
[...]

$ tanzu
tanzu
Tanzu CLI

Usage:
  tanzu [command]
[...]

# Notice tanzu is now installed
```
### Additional information

This PR allows to build the Debian packages and repository.  Publishing the repo to GCloud is done manually for now.
In future PRs we need to:
1- Sign the repo
2- Figure out if and how to deal with different versions of RHEL/Fedora
3- when available, use an ARM64 build of the CLI for the ARM64 package
4- setup shell completion (if possible)
