### PR TITLE
Use -b for imgpkg command when copying package bundles

### DIFF
--- a/hack/gen-publish-images-totar.sh
+++ b/hack/gen-publish-images-totar.sh
@@ -110,7 +110,7 @@ for imageTag in ${list}; do
     get_comp_images="yq e '.components[\"${comp}\"][]  | select(has(\"images\"))|.images[] | .imagePath + \":\" + .tag' "\"tmp/\"$TKR_BOM_FILE""
 
     flags="-i"
-    if [ $comp = "tkg-core-packages" ]; then
+    if [ "$comp" = "tkg-core-packages" ] || [ "$comp" = "capabilities-package" ] || [ "$comp" = "tkg-storageclass-package" ]; then
       flags="-b"
     fi
     eval $get_comp_images | while read -r image; do


### PR DESCRIPTION
Signed-off-by: Daniel Guo <danniel1205@gmail.com>

### What this PR does / why we need it

This PR fixes a bug in`gen-publish-images-totar.sh`. The original script uses `-i` for `imgpkg copy` command for both `capabilities-package` and `tkg-storageclass-package`, it causes the following error:

```
imgpkg: Error: Expected bundle flag when copying a bundle (hint: Use -b instead of -i for bundles)
```

The fix checks `capabilities-package` and `tkg-storageclass-package`, uses `-b` instead.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3757 

### Describe testing done for PR

- Follow the official [doc](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.6/vmware-tanzu-kubernetes-grid-16/GUID-mgmt-clusters-image-copy-airgapped.html), and verified the flow works as expected. Especially looked into those failed two components (`capablities-package` and `tkg-storageclass-package`) and they all passed.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix the bug in gen-publish-images-totar.sh when generating the command to copy `capabilities-package` and `tkg-storageclass-package`
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
