### PR TITLE
set tls min version only when utkg is enabled

### DIFF
--- a/addons/main.go
+++ b/addons/main.go
@@ -215,7 +215,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr.GetWebhookServer().TLSMinVersion = flags.tlsMinVersion
 	addonReconciler := &controllers.AddonReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("Addon"),
@@ -359,6 +358,7 @@ func enableClusterBootstrapAndConfigControllers(ctx context.Context, mgr ctrl.Ma
 }
 
 func enableWebhooks(ctx context.Context, mgr ctrl.Manager, flags *addonFlags) {
+	mgr.GetWebhookServer().TLSMinVersion = flags.tlsMinVersion
 	certPath := path.Join(constants.WebhookCertDir, "tls.crt")
 	keyPath := path.Join(constants.WebhookCertDir, "tls.key")
 	webhookTLS := webhooks.WebhookTLS{


### PR DESCRIPTION
### What this PR does / why we need it
This PR is needed to fix the issure that webhook only gets setup if utkg is enabled. 

### Which issue(s) this PR fixes
Fixes #3630


### Describe testing done for PR
tasking is done downstream using pysslscan to ensure only TLSv12 is accepted. 
