### PR TITLE
Change port value to string in kube-vip jsonPatch

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -704,7 +704,7 @@ spec:
                     value: {{ .apiServerEndpoint }}
                   {{- if and (not .aviControlPlaneHAProvider) .apiServerPort }}
                   - name: port
-                    value: {{ .apiServerPort }}
+                    value: "{{ .apiServerPort }}"
                   {{- end }}
                   - name: vip_interface
                     value: {{ .vipNetworkInterface }}

--- a/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
@@ -704,7 +704,7 @@ spec:
                     value: {{ .apiServerEndpoint }}
                   {{- if and (not .aviControlPlaneHAProvider) .apiServerPort }}
                   - name: port
-                    value: {{ .apiServerPort }}
+                    value: "{{ .apiServerPort }}"
                   {{- end }}
                   - name: vip_interface
                     value: {{ .vipNetworkInterface }}


### PR DESCRIPTION
### What this PR does / why we need it

The port in kube-vip manifest env needs to be string if it is set, otherwise parsing manifest fails.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3803 

### Describe testing done for PR

Manually created cluster with customized CLUSTER_API_SERVER_PORT.
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support CLUSTER_API_SERVER_PORT in classy cluster on vSphere
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
