### PR TITLE
Support adding node labels for control plane nodes when cluster creation for vsphere/aws/azure

### DIFF
--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
@@ -602,7 +602,7 @@ spec:
                 {{- end }}
                 {{- .key -}} = {{- .value -}}
               {{ end }}
-            {{ end }}
+            {{- end }}
             {{- if .worker.nodeLabels -}}
               ,
               {{- $first := true }}

--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
@@ -591,6 +591,7 @@ spec:
             {{- end }}
             {{- $key -}} = {{- $val }}
             {{- end}}
+            {{- $nodePoolLabelNotExist := true }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}
@@ -601,9 +602,10 @@ spec:
                   ,
                 {{- end }}
                 {{- .key -}} = {{- .value -}}
-              {{ end }}
+                {{- $nodePoolLabelNotExist = false }}
+              {{- end }}
             {{- end }}
-            {{- if .worker.nodeLabels -}}
+            {{- if $nodePoolLabelNotExist | and .worker.nodeLabels -}}
               ,
               {{- $first := true }}
               {{- range .worker.nodeLabels }}

--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
@@ -211,16 +211,6 @@ spec:
                 #@ else:
                 default: 80
                 #@ end
-          nodeLabels:
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                value:
-                  type: string
-            default: []
   - name: imageRepository
     required: false
     schema:
@@ -591,24 +581,10 @@ spec:
             {{- end }}
             {{- $key -}} = {{- $val }}
             {{- end}}
-            {{- $nodePoolLabelNotExist := true }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}
               {{- range .nodePoolLabels }}
-                {{- if $first }}
-                  {{- $first = false }}
-                {{- else -}}
-                  ,
-                {{- end }}
-                {{- .key -}} = {{- .value -}}
-                {{- $nodePoolLabelNotExist = false }}
-              {{- end }}
-            {{- end }}
-            {{- if $nodePoolLabelNotExist | and .worker.nodeLabels -}}
-              ,
-              {{- $first := true }}
-              {{- range .worker.nodeLabels }}
                 {{- if $first }}
                   {{- $first = false }}
                 {{- else -}}

--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
@@ -182,6 +182,16 @@ spec:
                 #@ else:
                 default: 80
                 #@ end
+          nodeLabels:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+            default: []
   - name: worker
     required: true
     schema:
@@ -201,6 +211,16 @@ spec:
                 #@ else:
                 default: 80
                 #@ end
+          nodeLabels:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+            default: []
   - name: imageRepository
     required: false
     schema:
@@ -501,6 +521,31 @@ spec:
           controlPlane: true
       jsonPatches:
       - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs/node-labels
+        valueFrom:
+          template: |
+            {{ $first := true }}
+            {{- range $key, $val := (index .TKR_DATA .builtin.controlPlane.version).labels }}
+            {{- if $first }}
+              {{- $first = false }}
+            {{- else -}}
+              ,
+            {{- end }}
+            {{- $key }}={{ $val }}
+            {{- end }}
+            {{- if .controlPlane.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .controlPlane.nodeLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
+      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs/node-labels
         valueFrom:
           template: |
@@ -513,6 +558,18 @@ spec:
             {{- end }}
             {{- $key }}={{ $val }}
             {{- end }}
+            {{- if .controlPlane.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .controlPlane.nodeLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
     - selector:
         apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
         kind: KubeadmConfigTemplate
@@ -538,6 +595,18 @@ spec:
               ,
               {{- $first := true }}
               {{- range .nodePoolLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
+            {{- if .worker.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .worker.nodeLabels }}
                 {{- if $first }}
                   {{- $first = false }}
                 {{- else -}}

--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
@@ -524,7 +524,9 @@ spec:
             {{- $key }}={{ $val }}
             {{- end }}
             {{- if .controlPlane.nodeLabels -}}
+              {{- if (index .TKR_DATA .builtin.controlPlane.version).labels -}}
               ,
+              {{- end -}}
               {{- $first := true }}
               {{- range .controlPlane.nodeLabels }}
                 {{- if $first }}
@@ -549,7 +551,9 @@ spec:
             {{- $key }}={{ $val }}
             {{- end }}
             {{- if .controlPlane.nodeLabels -}}
+              {{- if (index .TKR_DATA .builtin.controlPlane.version).labels -}}
               ,
+              {{- end -}}
               {{- $first := true }}
               {{- range .controlPlane.nodeLabels }}
                 {{- if $first }}

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -207,6 +207,16 @@ spec:
               frontendIPCount:
                 type: integer
                 default: 1
+          nodeLabels:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+            default: []
   - name: worker
     required: false
     schema:
@@ -257,6 +267,16 @@ spec:
               idleTimeoutInMinutes:
                 type: integer
                 default: 4
+          nodeLabels:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+            default: []
   - name: imageRepository
     required: false
     schema:
@@ -746,6 +766,31 @@ spec:
           controlPlane: true
       jsonPatches:
       - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs/node-labels
+        valueFrom:
+          template: |
+            {{ $first := true }}
+            {{- range $key, $val := (index .TKR_DATA .builtin.controlPlane.version).labels }}
+            {{- if $first }}
+              {{- $first = false }}
+            {{- else -}}
+              ,
+            {{- end }}
+            {{- $key -}} = {{- $val }}
+            {{- end }}
+            {{- if .controlPlane.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .controlPlane.nodeLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
+      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs/node-labels
         valueFrom:
           template: |
@@ -758,6 +803,18 @@ spec:
             {{- end }}
             {{- $key -}} = {{- $val }}
             {{- end }}
+            {{- if .controlPlane.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .controlPlane.nodeLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
     - selector:
         apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
         kind: KubeadmConfigTemplate
@@ -783,6 +840,18 @@ spec:
               ,
               {{- $first := true }}
               {{- range .nodePoolLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
+            {{- if .worker.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .worker.nodeLabels }}
                 {{- if $first }}
                   {{- $first = false }}
                 {{- else -}}

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -267,16 +267,6 @@ spec:
               idleTimeoutInMinutes:
                 type: integer
                 default: 4
-          nodeLabels:
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                value:
-                  type: string
-            default: []
   - name: imageRepository
     required: false
     schema:
@@ -836,24 +826,10 @@ spec:
             {{- end }}
             {{- $key -}} = {{- $val }}
             {{- end}}
-            {{- $nodePoolLabelNotExist := true }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}
               {{- range .nodePoolLabels }}
-                {{- if $first }}
-                  {{- $first = false }}
-                {{- else -}}
-                  ,
-                {{- end }}
-                {{- .key -}} = {{- .value -}}
-                {{- $nodePoolLabelNotExist = false }}
-              {{- end }}
-            {{- end }}
-            {{- if $nodePoolLabelNotExist | and .worker.nodeLabels -}}
-              ,
-              {{- $first := true }}
-              {{- range .worker.nodeLabels }}
                 {{- if $first }}
                   {{- $first = false }}
                 {{- else -}}

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -847,7 +847,7 @@ spec:
                 {{- end }}
                 {{- .key -}} = {{- .value -}}
               {{ end }}
-            {{ end }}
+            {{- end }}
             {{- if .worker.nodeLabels -}}
               ,
               {{- $first := true }}

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -836,6 +836,7 @@ spec:
             {{- end }}
             {{- $key -}} = {{- $val }}
             {{- end}}
+            {{- $nodePoolLabelNotExist := true }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}
@@ -846,9 +847,10 @@ spec:
                   ,
                 {{- end }}
                 {{- .key -}} = {{- .value -}}
-              {{ end }}
+                {{- $nodePoolLabelNotExist = false }}
+              {{- end }}
             {{- end }}
-            {{- if .worker.nodeLabels -}}
+            {{- if $nodePoolLabelNotExist | and .worker.nodeLabels -}}
               ,
               {{- $first := true }}
               {{- range .worker.nodeLabels }}

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -769,7 +769,9 @@ spec:
             {{- $key -}} = {{- $val }}
             {{- end }}
             {{- if .controlPlane.nodeLabels -}}
+              {{- if (index .TKR_DATA .builtin.controlPlane.version).labels -}}
               ,
+              {{- end -}}
               {{- $first := true }}
               {{- range .controlPlane.nodeLabels }}
                 {{- if $first }}
@@ -794,7 +796,9 @@ spec:
             {{- $key -}} = {{- $val }}
             {{- end }}
             {{- if .controlPlane.nodeLabels -}}
+              {{- if (index .TKR_DATA .builtin.controlPlane.version).labels -}}
               ,
+              {{- end -}}
               {{- $first := true }}
               {{- range .controlPlane.nodeLabels }}
                 {{- if $first }}

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -1044,6 +1044,7 @@ spec:
             {{- $key -}} = {{- $val }}
             {{- end }}
             {{- end }}
+            {{- $nodePoolLabelNotExist := true }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}
@@ -1054,9 +1055,10 @@ spec:
                   ,
                 {{- end }}
                 {{- .key -}} = {{- .value -}}
-              {{ end }}
+                {{- $nodePoolLabelNotExist = false }}
+              {{- end }}
             {{- end }}
-            {{- if .worker.nodeLabels -}}
+            {{- if $nodePoolLabelNotExist | and .worker.nodeLabels -}}
               ,
               {{- $first := true }}
               {{- range .worker.nodeLabels }}

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -450,16 +450,6 @@ spec:
                 items:
                   type: string
                 default: []
-          nodeLabels:
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                value:
-                  type: string
-            default: []
   - name: nodePoolLabels
     required: false
     schema:
@@ -1044,24 +1034,10 @@ spec:
             {{- $key -}} = {{- $val }}
             {{- end }}
             {{- end }}
-            {{- $nodePoolLabelNotExist := true }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}
               {{- range .nodePoolLabels }}
-                {{- if $first }}
-                  {{- $first = false }}
-                {{- else -}}
-                  ,
-                {{- end }}
-                {{- .key -}} = {{- .value -}}
-                {{- $nodePoolLabelNotExist = false }}
-              {{- end }}
-            {{- end }}
-            {{- if $nodePoolLabelNotExist | and .worker.nodeLabels -}}
-              ,
-              {{- $first := true }}
-              {{- range .worker.nodeLabels }}
                 {{- if $first }}
                   {{- $first = false }}
                 {{- else -}}

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -972,7 +972,9 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .controlPlane.nodeLabels -}}
+              {{- if (index .TKR_DATA .builtin.controlPlane.version).labels -}}
               ,
+              {{- end -}}
               {{- $first := true }}
               {{- range .controlPlane.nodeLabels }}
                 {{- if $first }}
@@ -999,7 +1001,9 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .controlPlane.nodeLabels -}}
+              {{- if (index .TKR_DATA .builtin.controlPlane.version).labels -}}
               ,
+              {{- end -}}
               {{- $first := true }}
               {{- range .controlPlane.nodeLabels }}
                 {{- if $first }}

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -409,6 +409,16 @@ spec:
                 items:
                   type: string
                 default: []
+          nodeLabels:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+            default: []
   - name: worker
     required: false
     schema:
@@ -440,6 +450,16 @@ spec:
                 items:
                   type: string
                 default: []
+          nodeLabels:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+            default: []
   - name: nodePoolLabels
     required: false
     schema:
@@ -947,6 +967,33 @@ spec:
           controlPlane: true
       jsonPatches:
       - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs/node-labels
+        valueFrom:
+          template: |
+            {{ $first := true }}
+            {{- range $key, $val := (index .TKR_DATA .builtin.controlPlane.version).labels }}
+            {{- if regexMatch "^(?:[a-zA-z])(?:[-\\w\\.]*[a-zA-z])$" $val }}
+            {{- if $first }}
+              {{- $first = false }}
+            {{- else -}}
+              ,
+            {{- end }}
+            {{- $key -}} = {{- $val }}
+            {{- end }}
+            {{- end }}
+            {{- if .controlPlane.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .controlPlane.nodeLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
+      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs/node-labels
         valueFrom:
           template: |
@@ -961,6 +1008,18 @@ spec:
             {{- $key -}} = {{- $val }}
             {{- end }}
             {{- end }}
+            {{- if .controlPlane.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .controlPlane.nodeLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
     - selector:
         apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
         kind: KubeadmConfigTemplate
@@ -989,6 +1048,18 @@ spec:
               ,
               {{- $first := true }}
               {{- range .nodePoolLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
+            {{- if .worker.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .worker.nodeLabels }}
                 {{- if $first }}
                   {{- $first = false }}
                 {{- else -}}

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -1055,7 +1055,7 @@ spec:
                 {{- end }}
                 {{- .key -}} = {{- .value -}}
               {{ end }}
-            {{ end }}
+            {{- end }}
             {{- if .worker.nodeLabels -}}
               ,
               {{- $first := true }}

--- a/providers/config_default.yaml
+++ b/providers/config_default.yaml
@@ -302,9 +302,6 @@ NODE_POOL_0_TAINTS:
 #! Specified node label for control plane
 #! It should be of the format "key1=value1,key2=value2"
 CONTROL_PLANE_NODE_LABELS:
-#! Specified node labels for worker node
-#! It should be of the format "key1=value1,key2=value2"
-WORKER_NODE_LABELS:
 
 
 

--- a/providers/config_default.yaml
+++ b/providers/config_default.yaml
@@ -299,6 +299,12 @@ NODE_POOL_0_LABELS:
 #! Specifies the taints string to be applied on first node pool. It should be of the
 #! format "key1=value1:effect1,key2=value2:effect2"
 NODE_POOL_0_TAINTS:
+#! Specified node label for control plane
+#! It should be of the format "key1=value1,key2=value2"
+CONTROL_PLANE_NODE_LABELS:
+#! Specified node labels for worker node
+#! It should be of the format "key1=value1,key2=value2"
+WORKER_NODE_LABELS:
 
 
 

--- a/providers/infrastructure-aws/v2.0.0-beta.1/cconly/base.yaml
+++ b/providers/infrastructure-aws/v2.0.0-beta.1/cconly/base.yaml
@@ -602,7 +602,7 @@ spec:
                 {{- end }}
                 {{- .key -}} = {{- .value -}}
               {{ end }}
-            {{ end }}
+            {{- end }}
             {{- if .worker.nodeLabels -}}
               ,
               {{- $first := true }}

--- a/providers/infrastructure-aws/v2.0.0-beta.1/cconly/base.yaml
+++ b/providers/infrastructure-aws/v2.0.0-beta.1/cconly/base.yaml
@@ -591,6 +591,7 @@ spec:
             {{- end }}
             {{- $key -}} = {{- $val }}
             {{- end}}
+            {{- $nodePoolLabelNotExist := true }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}
@@ -601,9 +602,10 @@ spec:
                   ,
                 {{- end }}
                 {{- .key -}} = {{- .value -}}
-              {{ end }}
+                {{- $nodePoolLabelNotExist = false }}
+              {{- end }}
             {{- end }}
-            {{- if .worker.nodeLabels -}}
+            {{- if $nodePoolLabelNotExist | and .worker.nodeLabels -}}
               ,
               {{- $first := true }}
               {{- range .worker.nodeLabels }}

--- a/providers/infrastructure-aws/v2.0.0-beta.1/cconly/base.yaml
+++ b/providers/infrastructure-aws/v2.0.0-beta.1/cconly/base.yaml
@@ -211,16 +211,6 @@ spec:
                 #@ else:
                 default: 80
                 #@ end
-          nodeLabels:
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                value:
-                  type: string
-            default: []
   - name: imageRepository
     required: false
     schema:
@@ -591,24 +581,10 @@ spec:
             {{- end }}
             {{- $key -}} = {{- $val }}
             {{- end}}
-            {{- $nodePoolLabelNotExist := true }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}
               {{- range .nodePoolLabels }}
-                {{- if $first }}
-                  {{- $first = false }}
-                {{- else -}}
-                  ,
-                {{- end }}
-                {{- .key -}} = {{- .value -}}
-                {{- $nodePoolLabelNotExist = false }}
-              {{- end }}
-            {{- end }}
-            {{- if $nodePoolLabelNotExist | and .worker.nodeLabels -}}
-              ,
-              {{- $first := true }}
-              {{- range .worker.nodeLabels }}
                 {{- if $first }}
                   {{- $first = false }}
                 {{- else -}}

--- a/providers/infrastructure-aws/v2.0.0-beta.1/cconly/base.yaml
+++ b/providers/infrastructure-aws/v2.0.0-beta.1/cconly/base.yaml
@@ -182,6 +182,16 @@ spec:
                 #@ else:
                 default: 80
                 #@ end
+          nodeLabels:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+            default: []
   - name: worker
     required: true
     schema:
@@ -201,6 +211,16 @@ spec:
                 #@ else:
                 default: 80
                 #@ end
+          nodeLabels:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+            default: []
   - name: imageRepository
     required: false
     schema:
@@ -501,6 +521,31 @@ spec:
           controlPlane: true
       jsonPatches:
       - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs/node-labels
+        valueFrom:
+          template: |
+            {{ $first := true }}
+            {{- range $key, $val := (index .TKR_DATA .builtin.controlPlane.version).labels }}
+            {{- if $first }}
+              {{- $first = false }}
+            {{- else -}}
+              ,
+            {{- end }}
+            {{- $key }}={{ $val }}
+            {{- end }}
+            {{- if .controlPlane.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .controlPlane.nodeLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
+      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs/node-labels
         valueFrom:
           template: |
@@ -513,6 +558,18 @@ spec:
             {{- end }}
             {{- $key }}={{ $val }}
             {{- end }}
+            {{- if .controlPlane.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .controlPlane.nodeLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
     - selector:
         apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
         kind: KubeadmConfigTemplate
@@ -538,6 +595,18 @@ spec:
               ,
               {{- $first := true }}
               {{- range .nodePoolLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
+            {{- if .worker.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .worker.nodeLabels }}
                 {{- if $first }}
                   {{- $first = false }}
                 {{- else -}}

--- a/providers/infrastructure-aws/v2.0.0-beta.1/cconly/base.yaml
+++ b/providers/infrastructure-aws/v2.0.0-beta.1/cconly/base.yaml
@@ -524,7 +524,9 @@ spec:
             {{- $key }}={{ $val }}
             {{- end }}
             {{- if .controlPlane.nodeLabels -}}
+              {{- if (index .TKR_DATA .builtin.controlPlane.version).labels -}}
               ,
+              {{- end -}}
               {{- $first := true }}
               {{- range .controlPlane.nodeLabels }}
                 {{- if $first }}
@@ -549,7 +551,9 @@ spec:
             {{- $key }}={{ $val }}
             {{- end }}
             {{- if .controlPlane.nodeLabels -}}
+              {{- if (index .TKR_DATA .builtin.controlPlane.version).labels -}}
               ,
+              {{- end -}}
               {{- $first := true }}
               {{- range .controlPlane.nodeLabels }}
                 {{- if $first }}

--- a/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
+++ b/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
@@ -207,6 +207,16 @@ spec:
               frontendIPCount:
                 type: integer
                 default: 1
+          nodeLabels:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+            default: []
   - name: worker
     required: false
     schema:
@@ -257,6 +267,16 @@ spec:
               idleTimeoutInMinutes:
                 type: integer
                 default: 4
+          nodeLabels:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+            default: []
   - name: imageRepository
     required: false
     schema:
@@ -746,6 +766,31 @@ spec:
           controlPlane: true
       jsonPatches:
       - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs/node-labels
+        valueFrom:
+          template: |
+            {{ $first := true }}
+            {{- range $key, $val := (index .TKR_DATA .builtin.controlPlane.version).labels }}
+            {{- if $first }}
+              {{- $first = false }}
+            {{- else -}}
+              ,
+            {{- end }}
+            {{- $key -}} = {{- $val }}
+            {{- end }}
+            {{- if .controlPlane.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .controlPlane.nodeLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
+      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs/node-labels
         valueFrom:
           template: |
@@ -758,6 +803,18 @@ spec:
             {{- end }}
             {{- $key -}} = {{- $val }}
             {{- end }}
+            {{- if .controlPlane.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .controlPlane.nodeLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
     - selector:
         apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
         kind: KubeadmConfigTemplate
@@ -783,6 +840,18 @@ spec:
               ,
               {{- $first := true }}
               {{- range .nodePoolLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
+            {{- if .worker.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .worker.nodeLabels }}
                 {{- if $first }}
                   {{- $first = false }}
                 {{- else -}}

--- a/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
+++ b/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
@@ -267,16 +267,6 @@ spec:
               idleTimeoutInMinutes:
                 type: integer
                 default: 4
-          nodeLabels:
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                value:
-                  type: string
-            default: []
   - name: imageRepository
     required: false
     schema:
@@ -836,24 +826,10 @@ spec:
             {{- end }}
             {{- $key -}} = {{- $val }}
             {{- end}}
-            {{- $nodePoolLabelNotExist := true }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}
               {{- range .nodePoolLabels }}
-                {{- if $first }}
-                  {{- $first = false }}
-                {{- else -}}
-                  ,
-                {{- end }}
-                {{- .key -}} = {{- .value -}}
-                {{- $nodePoolLabelNotExist = false }}
-              {{- end }}
-            {{- end }}
-            {{- if $nodePoolLabelNotExist | and .worker.nodeLabels -}}
-              ,
-              {{- $first := true }}
-              {{- range .worker.nodeLabels }}
                 {{- if $first }}
                   {{- $first = false }}
                 {{- else -}}

--- a/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
+++ b/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
@@ -847,7 +847,7 @@ spec:
                 {{- end }}
                 {{- .key -}} = {{- .value -}}
               {{ end }}
-            {{ end }}
+            {{- end }}
             {{- if .worker.nodeLabels -}}
               ,
               {{- $first := true }}

--- a/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
+++ b/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
@@ -836,6 +836,7 @@ spec:
             {{- end }}
             {{- $key -}} = {{- $val }}
             {{- end}}
+            {{- $nodePoolLabelNotExist := true }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}
@@ -846,9 +847,10 @@ spec:
                   ,
                 {{- end }}
                 {{- .key -}} = {{- .value -}}
-              {{ end }}
+                {{- $nodePoolLabelNotExist = false }}
+              {{- end }}
             {{- end }}
-            {{- if .worker.nodeLabels -}}
+            {{- if $nodePoolLabelNotExist | and .worker.nodeLabels -}}
               ,
               {{- $first := true }}
               {{- range .worker.nodeLabels }}

--- a/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
+++ b/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
@@ -769,7 +769,9 @@ spec:
             {{- $key -}} = {{- $val }}
             {{- end }}
             {{- if .controlPlane.nodeLabels -}}
+              {{- if (index .TKR_DATA .builtin.controlPlane.version).labels -}}
               ,
+              {{- end -}}
               {{- $first := true }}
               {{- range .controlPlane.nodeLabels }}
                 {{- if $first }}
@@ -794,7 +796,9 @@ spec:
             {{- $key -}} = {{- $val }}
             {{- end }}
             {{- if .controlPlane.nodeLabels -}}
+              {{- if (index .TKR_DATA .builtin.controlPlane.version).labels -}}
               ,
+              {{- end -}}
               {{- $first := true }}
               {{- range .controlPlane.nodeLabels }}
                 {{- if $first }}

--- a/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
@@ -1044,6 +1044,7 @@ spec:
             {{- $key -}} = {{- $val }}
             {{- end }}
             {{- end }}
+            {{- $nodePoolLabelNotExist := true }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}
@@ -1054,9 +1055,10 @@ spec:
                   ,
                 {{- end }}
                 {{- .key -}} = {{- .value -}}
-              {{ end }}
+                {{- $nodePoolLabelNotExist = false }}
+              {{- end }}
             {{- end }}
-            {{- if .worker.nodeLabels -}}
+            {{- if $nodePoolLabelNotExist | and .worker.nodeLabels -}}
               ,
               {{- $first := true }}
               {{- range .worker.nodeLabels }}

--- a/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
@@ -450,16 +450,6 @@ spec:
                 items:
                   type: string
                 default: []
-          nodeLabels:
-            type: array
-            items:
-              type: object
-              properties:
-                key:
-                  type: string
-                value:
-                  type: string
-            default: []
   - name: nodePoolLabels
     required: false
     schema:
@@ -1044,24 +1034,10 @@ spec:
             {{- $key -}} = {{- $val }}
             {{- end }}
             {{- end }}
-            {{- $nodePoolLabelNotExist := true }}
             {{- if .nodePoolLabels -}}
               ,
               {{- $first := true }}
               {{- range .nodePoolLabels }}
-                {{- if $first }}
-                  {{- $first = false }}
-                {{- else -}}
-                  ,
-                {{- end }}
-                {{- .key -}} = {{- .value -}}
-                {{- $nodePoolLabelNotExist = false }}
-              {{- end }}
-            {{- end }}
-            {{- if $nodePoolLabelNotExist | and .worker.nodeLabels -}}
-              ,
-              {{- $first := true }}
-              {{- range .worker.nodeLabels }}
                 {{- if $first }}
                   {{- $first = false }}
                 {{- else -}}

--- a/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
@@ -972,7 +972,9 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .controlPlane.nodeLabels -}}
+              {{- if (index .TKR_DATA .builtin.controlPlane.version).labels -}}
               ,
+              {{- end -}}
               {{- $first := true }}
               {{- range .controlPlane.nodeLabels }}
                 {{- if $first }}
@@ -999,7 +1001,9 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .controlPlane.nodeLabels -}}
+              {{- if (index .TKR_DATA .builtin.controlPlane.version).labels -}}
               ,
+              {{- end -}}
               {{- $first := true }}
               {{- range .controlPlane.nodeLabels }}
                 {{- if $first }}

--- a/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
@@ -409,6 +409,16 @@ spec:
                 items:
                   type: string
                 default: []
+          nodeLabels:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+            default: []
   - name: worker
     required: false
     schema:
@@ -440,6 +450,16 @@ spec:
                 items:
                   type: string
                 default: []
+          nodeLabels:
+            type: array
+            items:
+              type: object
+              properties:
+                key:
+                  type: string
+                value:
+                  type: string
+            default: []
   - name: nodePoolLabels
     required: false
     schema:
@@ -947,6 +967,33 @@ spec:
           controlPlane: true
       jsonPatches:
       - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs/node-labels
+        valueFrom:
+          template: |
+            {{ $first := true }}
+            {{- range $key, $val := (index .TKR_DATA .builtin.controlPlane.version).labels }}
+            {{- if regexMatch "^(?:[a-zA-z])(?:[-\\w\\.]*[a-zA-z])$" $val }}
+            {{- if $first }}
+              {{- $first = false }}
+            {{- else -}}
+              ,
+            {{- end }}
+            {{- $key -}} = {{- $val }}
+            {{- end }}
+            {{- end }}
+            {{- if .controlPlane.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .controlPlane.nodeLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
+      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs/node-labels
         valueFrom:
           template: |
@@ -961,6 +1008,18 @@ spec:
             {{- $key -}} = {{- $val }}
             {{- end }}
             {{- end }}
+            {{- if .controlPlane.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .controlPlane.nodeLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
     - selector:
         apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
         kind: KubeadmConfigTemplate
@@ -989,6 +1048,18 @@ spec:
               ,
               {{- $first := true }}
               {{- range .nodePoolLabels }}
+                {{- if $first }}
+                  {{- $first = false }}
+                {{- else -}}
+                  ,
+                {{- end }}
+                {{- .key -}} = {{- .value -}}
+              {{ end }}
+            {{ end }}
+            {{- if .worker.nodeLabels -}}
+              ,
+              {{- $first := true }}
+              {{- range .worker.nodeLabels }}
                 {{- if $first }}
                   {{- $first = false }}
                 {{- else -}}

--- a/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
@@ -1055,7 +1055,7 @@ spec:
                 {{- end }}
                 {{- .key -}} = {{- .value -}}
               {{ end }}
-            {{ end }}
+            {{- end }}
             {{- if .worker.nodeLabels -}}
               ,
               {{- $first := true }}

--- a/providers/yttcc/lib/config_variable_association.star
+++ b/providers/yttcc/lib/config_variable_association.star
@@ -120,7 +120,6 @@ return {
 "NODE_POOL_0_LABELS": ["tkg-service-vsphere"],
 "NODE_POOL_0_TAINTS": ["tkg-service-vsphere"],
 "CONTROL_PLANE_NODE_LABELS": ["vsphere", "aws", "azure"],
-"WORKER_NODE_LABELS": ["vsphere", "aws", "azure"],
 
 "AZURE_ENVIRONMENT": ["azure"],
 "AZURE_TENANT_ID": ["azure"],
@@ -563,10 +562,6 @@ def get_aws_vars():
         worker["rootVolume"] = rootVolume
     end
 
-    if data.values["WORKER_NODE_LABELS"] != None:
-        worker["nodeLabels"] = get_labels_array_from_string(data.values["WORKER_NODE_LABELS"])
-    end
-
     vars["worker"] = worker
 
     controlPlane = {}
@@ -754,10 +749,6 @@ def get_azure_vars():
         worker["outboundLB"] = outboundLB
     end
 
-    if data.values["WORKER_NODE_LABELS"] != None:
-        worker["nodeLabels"] = get_labels_array_from_string(data.values["WORKER_NODE_LABELS"])
-    end
-
     if worker != {}:
         vars["worker"] = worker
     end
@@ -869,10 +860,6 @@ def get_vsphere_vars():
     end
     if network != {}:
         worker["network"] = network
-    end
-
-    if data.values["WORKER_NODE_LABELS"] != None:
-        worker["nodeLabels"] = get_labels_array_from_string(data.values["WORKER_NODE_LABELS"])
     end
 
     if worker != {}:

--- a/providers/yttcc/lib/config_variable_association.star
+++ b/providers/yttcc/lib/config_variable_association.star
@@ -2,6 +2,7 @@ load("@ytt:data", "data")
 load("@ytt:overlay", "overlay")
 load("@ytt:yaml", "yaml")
 load("/lib/helpers.star", "get_default_tkg_bom_data")
+load("/lib/helpers.star", "get_labels_array_from_string")
 
 #! This file contains function 'config_variable_association' which specifies all configuration variables
 #! mentioned in 'config_default.yaml' and describes association of each configuration variable with
@@ -118,6 +119,8 @@ return {
 "NODE_POOL_0_NAME": ["tkg-service-vsphere"],
 "NODE_POOL_0_LABELS": ["tkg-service-vsphere"],
 "NODE_POOL_0_TAINTS": ["tkg-service-vsphere"],
+"CONTROL_PLANE_NODE_LABELS": ["vsphere", "aws", "azure"],
+"WORKER_NODE_LABELS": ["vsphere", "aws", "azure"],
 
 "AZURE_ENVIRONMENT": ["azure"],
 "AZURE_TENANT_ID": ["azure"],
@@ -560,6 +563,10 @@ def get_aws_vars():
         worker["rootVolume"] = rootVolume
     end
 
+    if data.values["WORKER_NODE_LABELS"] != None:
+        worker["nodeLabels"] = get_labels_array_from_string(data.values["WORKER_NODE_LABELS"])
+    end
+
     vars["worker"] = worker
 
     controlPlane = {}
@@ -570,6 +577,10 @@ def get_aws_vars():
         rootVolume = {}
         rootVolume["sizeGiB"] = data.values["AWS_CONTROL_PLANE_OS_DISK_SIZE_GIB"]
         controlPlane["rootVolume"] = rootVolume
+    end
+
+    if data.values["CONTROL_PLANE_NODE_LABELS"] != None:
+        controlPlane["nodeLabels"] = get_labels_array_from_string(data.values["CONTROL_PLANE_NODE_LABELS"])
     end
 
     vars["controlPlane"] = controlPlane
@@ -683,6 +694,10 @@ def get_azure_vars():
         controlPlane["outboundLB"] = outboundLB
     end
 
+    if data.values["CONTROL_PLANE_NODE_LABELS"] != None:
+        controlPlane["nodeLabels"] = get_labels_array_from_string(data.values["CONTROL_PLANE_NODE_LABELS"])
+    end
+
     if controlPlane != {}:
         vars["controlPlane"] = controlPlane
     end
@@ -737,6 +752,10 @@ def get_azure_vars():
     end
     if outboundLB != {}:
         worker["outboundLB"] = outboundLB
+    end
+
+    if data.values["WORKER_NODE_LABELS"] != None:
+        worker["nodeLabels"] = get_labels_array_from_string(data.values["WORKER_NODE_LABELS"])
     end
 
     if worker != {}:
@@ -814,6 +833,11 @@ def get_vsphere_vars():
     if network != {}:
         controlPlane["network"] = network
     end
+
+    if data.values["CONTROL_PLANE_NODE_LABELS"] != None:
+        controlPlane["nodeLabels"] = get_labels_array_from_string(data.values["CONTROL_PLANE_NODE_LABELS"])
+    end
+
     if controlPlane != {}:
         vars["controlPlane"] = controlPlane
     end
@@ -846,6 +870,11 @@ def get_vsphere_vars():
     if network != {}:
         worker["network"] = network
     end
+
+    if data.values["WORKER_NODE_LABELS"] != None:
+        worker["nodeLabels"] = get_labels_array_from_string(data.values["WORKER_NODE_LABELS"])
+    end
+
     if worker != {}:
         vars["worker"] = worker
     end

--- a/providers/yttcc/lib/helpers.star
+++ b/providers/yttcc/lib/helpers.star
@@ -333,3 +333,19 @@ def get_labels_map_from_string(labelString):
    end
    return labelMap
 end
+
+# get_labels_array_from_string constructs an array from given string of the format "key1=label1,key2=label2"
+def get_labels_array_from_string(labelString):
+   labelArray = []
+   for val in labelString.split(','):
+    kv = val.split('=')
+    if len(kv) != 2:
+      assert.fail("given labels string \""+labelString+"\" must be in the  \"key1=label1,key2=label2\" format ")
+    end
+    labelMap = {}
+    labelMap["key"] = kv[0]
+    labelMap["value"] = kv[1]
+    labelArray.append(labelMap)
+   end
+   return labelArray
+end


### PR DESCRIPTION
### What this PR does / why we need it

Add `CONTROL_PLANE_NODE_LABELS` param to support adding labels for control plane nodes upon cluster creation.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes  #3616 

### Describe testing done for PR

Manually created cluster with below variables set:
```
CONTROL_PLANE_NODE_LABELS: 'key1=value1,key2=value2'
```
The result on vSphere:
```
root@jammy:~# kubectl get no
NAME                               STATUS   ROLES                  AGE   VERSION
mgmt-97zkp-ns97s                   Ready    control-plane,master   47m   v1.23.8+vmware.2
mgmt-md-0-bvwq2-6b8fcb8848-sgjwx   Ready    <none>                 45m   v1.23.8+vmware.2
root@jammy:~# kubectl get no mgmt-97zkp-ns97s -o jsonpath='{.metadata.labels}'
{"beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"vsphere-vm.cpu-2.mem-8gb.os-photon","beta.kubernetes.io/os":"linux","image-type":"ova","key1":"value1","key2":"value2","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"mgmt-97zkp-ns97s","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":"","node-role.kubernetes.io/master":"","node.cluster.x-k8s.io/esxi-host":"10.206.189.22","node.kubernetes.io/exclude-from-external-load-balancers":"","node.kubernetes.io/instance-type":"vsphere-vm.cpu-2.mem-8gb.os-photon","os-name":"photon","os-type":"linux","run.tanzu.vmware.com/tkr":"v1.23.8---vmware.2-tkg.2-zshippable"}
```
The result on AWS:
```
~/ ❯ kubectl get no
NAME                                       STATUS   ROLES                  AGE   VERSION
ip-10-0-5-127.us-east-2.compute.internal   Ready    <none>                 11m   v1.23.8+vmware.2
ip-10-0-5-143.us-east-2.compute.internal   Ready    control-plane,master   12m   v1.23.8+vmware.2
~/ ❯ kubectl get no ip-10-0-5-143.us-east-2.compute.internal -o jsonpath='{.metadata.labels}'
{"ami-id":"ami-010edf5fc7bb6f7a3","ami-region":"us-east-2","beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"c5.xlarge","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"us-east-2","failure-domain.beta.kubernetes.io/zone":"us-east-2b","image-type":"ami","key1":"value1","key2":"value2","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"ip-10-0-5-143.us-east-2.compute.internal","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":"","node-role.kubernetes.io/master":"","node.kubernetes.io/exclude-from-external-load-balancers":"","node.kubernetes.io/instance-type":"c5.xlarge","os-arch":"amd64","os-name":"ubuntu","os-type":"linux","os-version":"2004","run.tanzu.vmware.com/os-image":"v1.23.8---vmware.2-ami-010edf5fc7bb6f7a3","run.tanzu.vmware.com/tkr":"v1.23.8---vmware.2-tkg.2-zshippable","topology.kubernetes.io/region":"us-east-2","topology.kubernetes.io/zone":"us-east-2b"}%
```
The result on Azure:
```
~/ ❯ kubectl get no
NAME                            STATUS   ROLES                  AGE   VERSION
dp2-control-plane-dqttd-qfcgd   Ready    control-plane,master   20m   v1.23.8+vmware.2
dp2-md-0-infra-bkb7d-lncf7      Ready    <none>                 18m   v1.23.8+vmware.2
~/ ❯ kubectl get no dp2-control-plane-dqttd-qfcgd -o jsonpath='{.metadata.labels}'
{"azure-offer":"tkg-capi-2022-06-24","azure-publisher":"vmware-inc","azure-sku":"k8s-1dot23dot8-ubuntu-2004","azure-thirdPartyImage":"true","azure-version":"2022.07.20","beta.kubernetes.io/arch":"amd64","beta.kubernetes.io/instance-type":"Standard_D2s_v3","beta.kubernetes.io/os":"linux","failure-domain.beta.kubernetes.io/region":"westus2","failure-domain.beta.kubernetes.io/zone":"westus2-1","image-type":"azure","key1":"value1","key2":"value2","kubernetes.io/arch":"amd64","kubernetes.io/hostname":"dp2-control-plane-dqttd-qfcgd","kubernetes.io/os":"linux","node-role.kubernetes.io/control-plane":"","node-role.kubernetes.io/master":"","node.kubernetes.io/exclude-from-external-load-balancers":"","node.kubernetes.io/instance-type":"Standard_D2s_v3","os-arch":"amd64","os-name":"ubuntu","os-type":"linux","os-version":"2004","run.tanzu.vmware.com/os-image":"v1.23.8---vmware.2-tkg.1-4fe60a764820f694f40a06fb273edc96","run.tanzu.vmware.com/tkr":"v1.23.8---vmware.2-tkg.2-zshippable","topology.kubernetes.io/region":"westus2","topology.kubernetes.io/zone":"westus2-1"}%
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add `CONTROL_PLANE_NODE_LABELS` param to support adding labels for control plane nodes upon cluster creation.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
