### PR TITLE
Correct the label selector of MachineDeployment in CLI to support backup/restore management cluster with Velero

### DIFF
--- a/providers/infrastructure-vsphere/v1.4.1/ytt/base-template.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/ytt/base-template.yaml
@@ -249,14 +249,12 @@ spec:
   clusterName: '${ CLUSTER_NAME }'
   replicas: ${ WORKER_MACHINE_COUNT }
   selector:
-    matchLabels:
-      cluster.x-k8s.io/cluster-name: '${ CLUSTER_NAME }'
+    matchLabels: {}
   strategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: '${ CLUSTER_NAME }'
         node-pool: "${CLUSTER_NAME}-worker-pool"
     spec:
       bootstrap:

--- a/providers/infrastructure-vsphere/v1.4.1/ytt/overlay-windows.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/ytt/overlay-windows.yaml
@@ -422,12 +422,10 @@ spec:
   clusterName: #@ data.values.CLUSTER_NAME
   replicas: #@ data.values.WORKER_MACHINE_COUNT
   selector:
-    matchLabels:
-      cluster.x-k8s.io/cluster-name: #@ data.values.CLUSTER_NAME
+    matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: #@ data.values.CLUSTER_NAME
         node-pool: #@ "{}-worker-pool".format(data.values.CLUSTER_NAME)
     spec:
       bootstrap:

--- a/providers/infrastructure-vsphere/v1.4.1/ytt/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/ytt/overlay.yaml
@@ -441,8 +441,7 @@ spec:
   clusterName: #@ data.values.CLUSTER_NAME
   replicas: #@ data.values.WORKER_MACHINE_COUNT
   selector:
-    matchLabels:
-      cluster.x-k8s.io/cluster-name: #@ data.values.CLUSTER_NAME
+    matchLabels: {}
   #@ if data.values.WORKER_ROLLOUT_STRATEGY:
   strategy:
     type: #@ verify_and_configure_machine_deployment_rollout_strategy(data.values.WORKER_ROLLOUT_STRATEGY)
@@ -450,7 +449,6 @@ spec:
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: #@ data.values.CLUSTER_NAME
         node-pool: #@ "{}-worker-pool".format(data.values.CLUSTER_NAME)
     spec:
       bootstrap:

--- a/providers/infrastructure-vsphere/ytt/vsphere-overlay.yaml
+++ b/providers/infrastructure-vsphere/ytt/vsphere-overlay.yaml
@@ -111,12 +111,10 @@ spec:
   clusterName: #@ data.values.CLUSTER_NAME
   replicas: #@ data.values.WORKER_MACHINE_COUNT_1
   selector:
-    matchLabels:
-      cluster.x-k8s.io/cluster-name: #@ data.values.CLUSTER_NAME
+    matchLabels: {}
   template:
     metadata:
       labels:
-        cluster.x-k8s.io/cluster-name: #@ data.values.CLUSTER_NAME
         node-pool: #@ "{}-worker-pool".format(data.values.CLUSTER_NAME)
     spec:
       bootstrap:
@@ -144,8 +142,7 @@ spec:
   clusterName: #@ data.values.CLUSTER_NAME
   replicas: #@ data.values.WORKER_MACHINE_COUNT_2
   selector:
-    matchLabels:
-      cluster.x-k8s.io/cluster-name: #@ data.values.CLUSTER_NAME
+    matchLabels: {}
   template:
     metadata:
       labels:


### PR DESCRIPTION
### What this PR does / why we need it
Currently, the CLI sets the label selector of MachineDeployment as follows, the selectors are not unique for each MachineDeployment:
```
apiVersion: cluster.x-k8s.io/v1alpha3
kind: MachineDeployment
metadata: 
  labels: 
    cluster.x-k8s.io/cluster-name: '${ CLUSTER_NAME }'
  name: '${ CLUSTER_NAME }-md-0'
  namespace: '${ NAMESPACE }'
spec: 
  clusterName: '${ CLUSTER_NAME }'
  replicas: ${ WORKER_MACHINE_COUNT }
  selector: 
    matchLabels: 
      cluster.x-k8s.io/cluster-name: '${ CLUSTER_NAME }'
```
As Velero removes the OwnerReferences when restoring, this triggers MachineDeployment to adopt MachineSets which not belong to it and causes the actual MachineSets count doesn't match the desired replicas and causes the restoration failure.