### PR TITLE
Fix vCenter connection validation error on classy cluster manifest

### DIFF
--- a/tkg/fakes/config/cluster_vsphere.yaml
+++ b/tkg/fakes/config/cluster_vsphere.yaml
@@ -125,3 +125,12 @@ spec:
           failureDomain: us-east-1c # VSPHERE_AZ_2
           name: md-2
           replicas: 3 # WORKER_MACHINE_COUNT_2
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-workload-cluster1
+  namespace: namespace-test1
+stringData:
+  password: Admin!23
+  username: administrator@vsphere.local

--- a/tkg/tkgctl/create_cluster.go
+++ b/tkg/tkgctl/create_cluster.go
@@ -160,7 +160,7 @@ func (t *tkgctl) processManagementClusterInputFile(ir *InitRegionOptions) (bool,
 			return isInputFileClusterClassBased, err
 		}
 		if isInputFileClusterClassBased {
-			err = t.processClusterObjectForConfigurationVariables(clusterobj)
+			err = t.processClusterObjectForConfigurationVariables(clusterobj, ir.ClusterConfigFile)
 			if err != nil {
 				return isInputFileClusterClassBased, err
 			}
@@ -183,7 +183,7 @@ func (t *tkgctl) processWorkloadClusterInputFile(cc *CreateClusterOptions, isTKG
 			t.TKGConfigReaderWriter().Set(constants.ConfigVariableClusterName, clusterobj.GetName())
 			t.TKGConfigReaderWriter().Set(constants.ConfigVariableNamespace, clusterobj.GetNamespace())
 		} else {
-			err = t.processClusterObjectForConfigurationVariables(clusterobj)
+			err = t.processClusterObjectForConfigurationVariables(clusterobj, cc.ClusterConfigFile)
 			if err != nil {
 				return isInputFileClusterClassBased, err
 			}

--- a/tkg/tkgctl/helpers.go
+++ b/tkg/tkgctl/helpers.go
@@ -201,9 +201,52 @@ func CheckIfInputFileIsClusterClassBased(clusterConfigFile string) (bool, unstru
 	return isInputFileClusterClassBased, clusterObj, nil
 }
 
+func getFieldfromUnstructuredObject(obj unstructured.Unstructured, fields ...string) (string, error) {
+	path := strings.Join(fields, ".")
+	value, exists, err := unstructured.NestedString(obj.UnstructuredContent(), fields...)
+	if err != nil {
+		return "", errors.Wrap(err, fmt.Sprintf("Failed to parse %s in %s %s/%s", path, obj.GetKind(), obj.GetNamespace(), obj.GetName()))
+	}
+	if !exists {
+		return "", errors.New(fmt.Sprintf("%s not found in %s %s/%s", path, obj.GetKind(), obj.GetNamespace(), obj.GetName()))
+	}
+	return value, nil
+}
+
+func setVSphereCredentialFromInputfile(legacyVarMap *map[string]string, clusterConfigFile, clusterName, namespace string) error {
+	content, err := os.ReadFile(clusterConfigFile)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Unable to read input file: %s", clusterConfigFile))
+	}
+	yamlObjects, err := utilyaml.ToUnstructured(content)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("Input file content is not yaml formatted, file path: %s", clusterConfigFile))
+	}
+	found := false
+	for _, obj := range yamlObjects {
+		if obj.GetKind() == "Secret" && obj.GetName() == clusterName && obj.GetNamespace() == namespace {
+			if username, err := getFieldfromUnstructuredObject(obj, "stringData", "username"); err != nil {
+				return err
+			} else {
+				(*legacyVarMap)[constants.ConfigVariableVsphereUsername] = username
+			}
+			if password, err := getFieldfromUnstructuredObject(obj, "stringData", "password"); err != nil {
+				return err
+			} else {
+				(*legacyVarMap)[constants.ConfigVariableVspherePassword] = password
+			}
+			found = true
+		}
+	}
+	if !found {
+		return errors.New(fmt.Sprintf("Secret %s/%s not found in %s", namespace, clusterName, clusterConfigFile))
+	}
+	return nil
+}
+
 // processClusterObjectForConfigurationVariables takes cluster object, process it to capture all configuration variables and add them in environment.
 // TODO (chandrareddyp): validate the cluster class inputs without mapping to legacy variables and deprecate legacy validation (https://github.com/vmware-tanzu/tanzu-framework/issues/2432)
-func (t *tkgctl) processClusterObjectForConfigurationVariables(clusterObj unstructured.Unstructured) error {
+func (t *tkgctl) processClusterObjectForConfigurationVariables(clusterObj unstructured.Unstructured, clusterConfigFile string) error {
 	inputVariablesMap := make(map[string]interface{})
 	inputVariablesMap["metadata.name"] = clusterObj.GetName()
 	inputVariablesMap["metadata.namespace"] = clusterObj.GetNamespace()
@@ -231,6 +274,13 @@ func (t *tkgctl) processClusterObjectForConfigurationVariables(clusterObj unstru
 		}
 	}
 	legacyVarMap[constants.ConfigVariableInfraProvider] = providerName
+
+	// VSPHERE_USERNAME and VSPHERE_PASSWORD do not have mapping to any Cluster variables and should be retrieved from VSphereCluster's identityRef
+	if providerName == constants.InfrastructureProviderVSphere {
+		if err := setVSphereCredentialFromInputfile(&legacyVarMap, clusterConfigFile, clusterObj.GetName(), clusterObj.GetNamespace()); err != nil {
+			return err
+		}
+	}
 
 	// Some properties (NODE_MACHINE_TYPE_1, NODE_MACHINE_TYPE_2, etc)
 	// can have two values from Cluster object attributes, key and value of constants.ClusterAttributesHigherPrecedenceToLowerMap are two attribute paths points to same legacy variable.


### PR DESCRIPTION
Tanzu cli fails to validate vcenter connection when the config file is a classy cluster manifest. See the following error: Error: workload cluster configuration validation failed: vSphere config validation failed: failed to get VC client: failed to get VSPHERE_USERNAME

There is no cluster variable which can be mapped to them so we need to retrieve them from VSphereCluster's identityRef.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
