### PR TITLE
fix some docker classy cluster issues

### DIFF
--- a/providers/infrastructure-docker/v1.2.4/yttcc/base-template.yaml
+++ b/providers/infrastructure-docker/v1.2.4/yttcc/base-template.yaml
@@ -4,9 +4,6 @@ metadata:
   name: ${CLUSTER_NAME}
   labels:
     tkg.tanzu.vmware.com/cluster-name: '${ CLUSTER_NAME }'
-    run.tanzu.vmware.com/tkr: v1.23.8---vmware.2-tkg.2-zshippable
-  annotations:
-    run.tanzu.vmware.com/resolve-tkr: ""
 spec:
   clusterNetwork:
     pods:

--- a/providers/infrastructure-docker/v1.2.4/yttcc/overlay.yaml
+++ b/providers/infrastructure-docker/v1.2.4/yttcc/overlay.yaml
@@ -19,8 +19,14 @@ kind: Cluster
 metadata:
   name: #@ data.values.CLUSTER_NAME
   labels:
+    #@overlay/match missing_ok=True
+    #@yaml/text-templated-strings
+    #@ if data.values.TKG_CLUSTER_ROLE != "workload":
+    cluster-role.tkg.tanzu.vmware.com/(@= data.values.TKG_CLUSTER_ROLE @): ""
+    #@ end
     tkg.tanzu.vmware.com/cluster-name: #@ data.values.CLUSTER_NAME
-    run.tanzu.vmware.com/tkr: v1.23.8---vmware.2-tkg.2-zshippable
+    #@overlay/match missing_ok=True
+    tanzuKubernetesRelease: #@ data.values.KUBERNETES_RELEASE
 spec:
   topology:
     class: #@ data.values.CLUSTER_CLASS

--- a/tkg/client/cluster.go
+++ b/tkg/client/cluster.go
@@ -58,6 +58,7 @@ type waitForAddonsOptions struct {
 	namespace             string
 	waitForCNI            bool
 	isTKGSCluster         bool
+	infraProviderName     string
 }
 
 // TKGSupportedClusterOptions is the comma separated list of cluster options that could be enabled by user
@@ -100,12 +101,21 @@ func (c *TkgClient) CreateCluster(options *CreateClusterOptions, waitForCluster 
 		return false, errors.Wrap(err, "unable to get cluster client while creating cluster")
 	}
 
+	infraProvider, err := regionalClusterClient.GetRegionalClusterDefaultProviderName(clusterctlv1.InfrastructureProviderType)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get cluster provider information.")
+	}
+	infraProviderName, _, err := ParseProviderName(infraProvider)
+	if err != nil {
+		return false, err
+	}
+
 	isPacific, err := regionalClusterClient.IsPacificRegionalCluster()
 	if err != nil {
 		return false, errors.Wrap(err, "error determining Tanzu Kubernetes Cluster service for vSphere management cluster ")
 	}
 	if isPacific {
-		return true, c.createPacificCluster(options, waitForCluster)
+		return true, c.createPacificCluster(options, waitForCluster, infraProviderName)
 	}
 
 	// Validate management cluster version
@@ -126,14 +136,6 @@ func (c *TkgClient) CreateCluster(options *CreateClusterOptions, waitForCluster 
 
 	if err := c.ConfigureAndValidateWorkloadClusterConfiguration(options, regionalClusterClient, false); err != nil {
 		return false, errors.Wrap(err, "workload cluster configuration validation failed")
-	}
-	infraProvider, err := regionalClusterClient.GetRegionalClusterDefaultProviderName(clusterctlv1.InfrastructureProviderType)
-	if err != nil {
-		return false, errors.Wrap(err, "failed to get cluster provider information.")
-	}
-	infraProviderName, _, err := ParseProviderName(infraProvider)
-	if err != nil {
-		return false, err
 	}
 
 	if options.IsInputFileClusterClassBased {
@@ -180,7 +182,7 @@ func (c *TkgClient) CreateCluster(options *CreateClusterOptions, waitForCluster 
 	if !waitForCluster {
 		return false, nil
 	}
-	return true, c.waitForClusterCreation(regionalClusterClient, options)
+	return true, c.waitForClusterCreation(regionalClusterClient, options, infraProviderName)
 }
 
 // getClusterConfigurationBytes returns cluster configuration by taking into consideration of legacy vs clusterclass based cluster creation
@@ -211,7 +213,7 @@ func getContentFromInputFile(fileName string) ([]byte, error) {
 	return content, nil
 }
 
-func (c *TkgClient) waitForClusterCreation(regionalClusterClient clusterclient.Client, options *CreateClusterOptions) error {
+func (c *TkgClient) waitForClusterCreation(regionalClusterClient clusterclient.Client, options *CreateClusterOptions, infraProviderName string) error {
 	log.Info("waiting for cluster to be initialized...")
 	kubeConfigBytes, err := c.WaitForClusterInitializedAndGetKubeConfig(regionalClusterClient, options.ClusterName, options.TargetNamespace)
 	if err != nil {
@@ -260,6 +262,7 @@ func (c *TkgClient) waitForClusterCreation(regionalClusterClient clusterclient.C
 			namespace:             options.TargetNamespace,
 			waitForCNI:            true,
 			isTKGSCluster:         isTKGSCluster,
+			infraProviderName:     infraProviderName,
 		}); err != nil {
 			return errors.Wrap(err, "error waiting for addons to get installed")
 		}
@@ -271,6 +274,7 @@ func (c *TkgClient) waitForClusterCreation(regionalClusterClient clusterclient.C
 			clusterName:           options.ClusterName,
 			namespace:             options.TargetNamespace,
 			waitForCNI:            true,
+			infraProviderName:     infraProviderName,
 		}); err != nil {
 			return errors.Wrap(err, "error waiting for addons to get installed")
 		}
@@ -452,14 +456,14 @@ func (c *TkgClient) WaitForAddonsCorePackagesInstallation(options waitForAddonsO
 	} else {
 		corePackagesNamespace = constants.CorePackagesNamespaceInTKGM
 	}
-	packages, err := GetCorePackagesFromClusterBootstrap(options.regionalClusterClient, options.workloadClusterClient, clusterBootstrap, corePackagesNamespace, options.clusterName)
+	packages, err := GetCorePackagesFromClusterBootstrap(options.regionalClusterClient, options.workloadClusterClient, clusterBootstrap, corePackagesNamespace, options.clusterName, options.infraProviderName)
 	if err != nil {
 		return err
 	}
 	return MonitorAddonsCorePackageInstallation(options.regionalClusterClient, options.workloadClusterClient, packages, c.getPackageInstallTimeoutFromConfig())
 }
 
-func (c *TkgClient) createPacificCluster(options *CreateClusterOptions, waitForCluster bool) (err error) {
+func (c *TkgClient) createPacificCluster(options *CreateClusterOptions, waitForCluster bool, infraProviderName string) (err error) {
 	// get the configuration
 	var configYaml []byte
 	var clusterName, namespace string
@@ -505,7 +509,7 @@ func (c *TkgClient) createPacificCluster(options *CreateClusterOptions, waitForC
 
 	log.V(3).Infof("Waiting for the Tanzu Kubernetes Cluster service for vSphere workload cluster\n")
 	if options.IsInputFileClusterClassBased {
-		err = c.waitForClusterCreation(clusterClient, options)
+		err = c.waitForClusterCreation(clusterClient, options, infraProviderName)
 	} else {
 		err = clusterClient.WaitForPacificCluster(clusterName, namespace)
 	}

--- a/tkg/client/init.go
+++ b/tkg/client/init.go
@@ -846,6 +846,8 @@ func (c *TkgClient) removeKappControllerLabelsFromClusterClassResources(regional
 		capzv1beta1.GroupVersion.WithKind(constants.KindAzureMachineTemplate):           constants.ResourceAzureMachineTemplate,
 		capvv1beta1.GroupVersion.WithKind(constants.KindVSphereClusterTemplate):         constants.ResourceVSphereClusterTemplate,
 		capvv1beta1.GroupVersion.WithKind(constants.KindVSphereMachineTemplate):         constants.ResourceVSphereMachineTemplate,
+		capvv1beta1.GroupVersion.WithKind(constants.KindDockerClusterTemplate):          constants.ResourceDockerClusterTemplate,
+		capvv1beta1.GroupVersion.WithKind(constants.KindDockerMachineTemplate):          constants.ResourceDockerMachineTemplate,
 	}
 
 	for gvk, resourceName := range gvkToResourcesMap {

--- a/tkg/constants/cluster_internal.go
+++ b/tkg/constants/cluster_internal.go
@@ -174,6 +174,7 @@ const (
 	KindAzureMachineTemplate        = "AzureMachineTemplate"
 	KindVSphereClusterTemplate      = "VSphereClusterTemplate"
 	KindVSphereMachineTemplate      = "VSphereMachineTemplate"
+	KindDockerClusterTemplate       = "DockerClusterTemplate"
 	KindDockerMachineTemplate       = "DockerMachineTemplate"
 )
 
@@ -188,6 +189,8 @@ const (
 	ResourceAzureMachineTemplate        = "azuremachinetemplates"
 	ResourceVSphereClusterTemplate      = "vsphereclustertemplates"
 	ResourceVSphereMachineTemplate      = "vspheremachinetemplates"
+	ResourceDockerClusterTemplate       = "dockerclustertemplates"
+	ResourceDockerMachineTemplate       = "dockermachinetemplates"
 )
 
 type OperationType int

--- a/tkg/constants/clusterclass_mapping.go
+++ b/tkg/constants/clusterclass_mapping.go
@@ -253,7 +253,7 @@ var ClusterAttributesWithArrayTypeValue = map[string]bool{
 // Cluster class variables constants
 const (
 	RegexpMachineDeploymentsOverrides = `spec.topology.workers.machineDeployments.[0-9].variables.overrides`
-	RegexpTopologyClassValue          = `tkg-(aws|azure|vsphere)-default`
+	RegexpTopologyClassValue          = `tkg-(aws|azure|vsphere|docker)-default`
 
 	TopologyVariablesNetworkSubnets   = "spec.topology.variables.network.subnets"
 	TopologyVariablesNodes            = "spec.topology.variables.nodes"


### PR DESCRIPTION
### Which issue(s) this PR fixes
1. Can only get one tkr in mgmt cluster on a docker cc env
```
kubo@0LZ8DZiMkuKTi:~$ kubectl  get tkr --kubeconfig ~/.kube-tkg/config
NAME                                   VERSION                              READY   COMPATIBLE   CREATED
v1.23.8---vmware.2-tkg.2-zshippable    v1.23.8+vmware.2-tkg.2-zshippable    True    True         32m
```
expect: 3 tkrs
2. docker cluster class package reconciled failed
```
I1101 09:04:46.949224    1230 request.go:601] Waited for 1.016601457s due to client-side throttling, not priority and fairness, request: GET:[https://100.64.0.1:443/apis/storage.k8s.io/v1](https://100.64.0.1/apis/storage.k8s.io/v1)
    kapp: Error: Ownership errors:
    - Resource 'dockermachinetemplate/quick-start-control-plane (infrastructure.cluster.x-k8s.io/v1beta1) namespace: tkg-system' is already associated with a different label 'kapp.k14s.io/app=1667288342486592479'
    - Resource 'dockerclustertemplate/quick-start-cluster (infrastructure.cluster.x-k8s.io/v1beta1) namespace: tkg-system' is already associated with a different label 'kapp.k14s.io/app=1667288342486592479'
    - Resource 'dockermachinetemplate/quick-start-default-worker-machinetemplate (infrastructure.cluster.x-k8s.io/v1beta1) namespace: tkg-system' is already associated with a different label 'kapp.k14s.io/app=1667288342486592479'
  version: 0.28.0-dev-94-g006af5a8+vmware.1
```
expect: reconciled successful
