### PR TITLE
[DoNotMerge]Fix aws cluster upgrade provider version mismatch

### DIFF
--- a/tkg/client/upgrade_region.go
+++ b/tkg/client/upgrade_region.go
@@ -337,8 +337,23 @@ func (c *TkgClient) getProvidersUpgradeInfo(regionalClusterClient clusterclient.
 				installedProviders.Items[i].ProviderName, latestVersion, installedProviders.Items[i].Version)
 			continue
 		}
+
+		providerVersion := fmt.Sprintf("v%v.%v.%v", latestSemVersion.Major(), latestSemVersion.Minor(), latestSemVersion.Patch())
+		// special handling for pre-release versions
+		if preReleaseVersion := latestSemVersion.PreRelease(); preReleaseVersion != "" {
+			preReleaseVersionArray := strings.Split(preReleaseVersion, "-")
+			if len(preReleaseVersionArray) == 1 || len(preReleaseVersionArray) > 2 {
+				// latestSemVersion like 2.0.0-beta.1 or 2.0.0-beta.1-13-ga74685ee9, set the version to v2.0.0-beta.1
+				installedProviders.Items[i].Version = fmt.Sprintf("%s-%s", providerVersion, preReleaseVersionArray[0])
+			} else {
+				// latestSemVersion like 2.0.0-13-ga74685ee9, set the version to v2.0.0
+				installedProviders.Items[i].Version = providerVersion
+			}
+		} else {
+			// latestSemVersion like 2.0.0, set the version to v2.0.0
+			installedProviders.Items[i].Version = providerVersion
+		}
 		// update the provider to the latest version to be upgraded
-		installedProviders.Items[i].Version = fmt.Sprintf("v%v.%v.%v", latestSemVersion.Major(), latestSemVersion.Minor(), latestSemVersion.Patch())
 		pUpgradeInfo.providers = append(pUpgradeInfo.providers, installedProviders.Items[i])
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it
Fix the upgrade failure of version mismatch when the version of infrastructure-aws should be v2.0.0-beta.1, yet when runing tanzu mc upgrade, it is looking for v2.0.0.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/3842

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

This could be unnecessary if we are doing 2nd bump for removing 2.0.0-beta.1 version

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
