### PR TITLE
Oracle Support - Fix Oracle OSImage populate command.

### DIFF
--- a/cmd/cli/plugin/cluster/go.mod
+++ b/cmd/cli/plugin/cluster/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/tkg v0.0.0-00010101000000-000000000000
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.24.4
 	k8s.io/apimachinery v0.24.4
@@ -214,7 +215,6 @@ require (
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.0.0-20220909164309-bea034e7d591 // indirect
 	golang.org/x/oauth2 v0.0.0-20220909003341-f21342109be1 // indirect
-	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/sys v0.0.0-20220818161305-2296e01440c6 // indirect
 	golang.org/x/term v0.0.0-20220722155259-a9ba230a4035 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/cmd/cli/plugin/cluster/osimage.go
+++ b/cmd/cli/plugin/cluster/osimage.go
@@ -19,30 +19,12 @@ var (
 	// the input tkr package image path
 	// with tag, for example projects-stg.registry.vmware.com/tkg/tkr-oci:v1.23.5
 	tkrRegistryPath string
-	// the input public image endpoint URI
-	imageEndpoint string
 	// the output tkr path
 	outputDirectory string
-	// display name for the imported image and the created OSImage resource
-	name string
-
-	// Image Operating System Information
-	osType    string
-	osName    string
-	osVersion string
-	osArch    string
 )
 
 func init() {
 	osImageCmd.PersistentFlags().StringVar(&tkrRegistryPath, "tkr-path", "", "The input tkr package image path")
-	osImageCmd.PersistentFlags().StringVar(&imageEndpoint, "image", "", "The input public image endpoint URI")
 	osImageCmd.PersistentFlags().StringVarP(&outputDirectory, "output-directory", "d", "", "The output TKR path")
-
-	osImageCmd.PersistentFlags().StringVar(&name, "name", "", "Display name for the imported image and the created OSImage resource")
-	osImageCmd.PersistentFlags().StringVar(&osType, "os-type", "linux", "OS type")
-	osImageCmd.PersistentFlags().StringVar(&osName, "os-name", "ubuntu", "OS name")
-	osImageCmd.PersistentFlags().StringVar(&osVersion, "os-version", "2004", "OS version")
-	osImageCmd.PersistentFlags().StringVar(&osArch, "os-arch", "amd64", "OS amd64")
-
 	osImageCmd.AddCommand(oracleCmd)
 }


### PR DESCRIPTION
### What this PR does / why we need it

This is a follow-up PR for https://github.com/vmware-tanzu/tanzu-framework/pull/3376, cherry-picked from https://github.com/vmware-tanzu/tanzu-framework/pull/3557

It enables concurrent import for multiple public images using waitgroup. Behavioral-wise, it infers image information such as `imageURL` from the OSImage CR, instead of user passing-in using the flag. After the import finishes, it will put the private image OCID, compartment and region as the fields of `osimage.spec.image.ref`. 


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

manual build and verification.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
 Oracle Support - Fix Oracle OSImage populate command.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
