### PR TITLE
Adjust aws-ebs-csi-driver default namespace to kube-system

### DIFF
--- a/addons/config/expected/csi.tanzu.vmware.com/v1alpha1/awsebscsiconfig/default.yaml
+++ b/addons/config/expected/csi.tanzu.vmware.com/v1alpha1/awsebscsiconfig/default.yaml
@@ -7,5 +7,5 @@ metadata:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:
   awsEBSCSIDriver:
-    namespace: tkg-system
-    deploymentReplicas: 1
+    namespace: kube-system
+    deploymentReplicas: 3

--- a/addons/config/templates/csi.tanzu.vmware.com/v1alpha1/awsebscsiconfig.yaml
+++ b/addons/config/templates/csi.tanzu.vmware.com/v1alpha1/awsebscsiconfig.yaml
@@ -9,5 +9,5 @@ metadata:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:
   awsEBSCSIDriver:
-    namespace: tkg-system
-    deploymentReplicas: 1
+    namespace: kube-system
+    deploymentReplicas: 3

--- a/addons/controllers/awsebscsi/awsescsiconfig_utils.go
+++ b/addons/controllers/awsebscsi/awsescsiconfig_utils.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultDataValueNameSpace          = "tkg-system"
+	defaultDataValueNameSpace          = "kube-system"
 	defaultDataValueDeploymentReplicas = 3
 )
 

--- a/tkg/test/tkgctl/shared/e2e_common_cc.go
+++ b/tkg/test/tkgctl/shared/e2e_common_cc.go
@@ -268,7 +268,7 @@ func E2ECommonCCSpec(ctx context.Context, inputGetter func() E2ECommonCCSpecInpu
 
 // getCustomCBResourceFile return a manifest containing custom ClusterBootstrap and AntreaConfig
 func getCustomCBResourceFile(clusterName, namespace string, tkrName string) []byte {
-	return []byte(fmt.Sprintf(customAntreaConfigAndCBResource, clusterName, namespace, namespace, clusterName, namespace, tkrName, clusterName, namespace, clusterName, clusterName))
+	return []byte(fmt.Sprintf(customAntreaConfigAndCBResource, clusterName, namespace, "kube-system", clusterName, namespace, tkrName, clusterName, namespace, clusterName, clusterName))
 }
 
 func getAvailableTKRs(ctx context.Context, mcProxy *framework.ClusterProxy, tkgConfigDir string) (sets.StringSet, *runv1alpha3.TanzuKubernetesRelease, *runv1alpha3.TanzuKubernetesRelease) {


### PR DESCRIPTION
Adjust aws-ebs-csi-driver default namespace to kube-system.

### What this PR does / why we need it
In some places, ebs csi driver is configured to tkg-system, other places are using kube-system, align the default installation namespace kube-system.

In prod plan, csi controller replica is still 1, update it to 3 no matter the plan (there is no way to set replica num according to plan in the addon config's default config after using CC)

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

- CAPA pipline passed
- Run ebs csi controller with 3 replicas well in dev and prod plan

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
