### PR TITLE
Allow using VSphereClusterIdentity based identityRef

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -457,6 +457,19 @@ spec:
       openAPIV3Schema:
         type: object
         properties: {}
+  - name: identityRef
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          name:
+            type: string
+          kind:
+            type: string
+        required:
+        - name
+        - kind
   patches:
   - name: vsphereClusterTemplate
     definitions:
@@ -480,12 +493,25 @@ spec:
         path: /spec/template/spec/server
         valueFrom:
           variable: vcenter.server
+  - name: vSphereClusterIdentityRef
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereClusterTemplate
+        matchResources:
+          infrastructureCluster: true
+      jsonPatches:
       - op: add
         path: /spec/template/spec/identityRef
         valueFrom:
           template: |
+            {{ if .identityRef -}}
+            kind: {{ .identityRef.kind }}
+            name: {{ .identityRef.name }}
+            {{- else -}}
             kind: Secret
             name: '{{ .builtin.cluster.name }}'
+            {{- end }}
   - name: controlPlaneMachineTemplate
     definitions:
     - selector:

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/rbac.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/rbac.yaml
@@ -60,6 +60,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vsphereclusteridentities
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-service-account.yaml
+++ b/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-service-account.yaml
@@ -172,6 +172,15 @@ rules:
       - get
       - list
       - delete
+  # TODO: remove the followings when vm template resolver is separated to an individual package
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    resources:
+    - vsphereclusteridentities
+    verbs:
+    - get
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/cconly/base.yaml
@@ -457,6 +457,19 @@ spec:
       openAPIV3Schema:
         type: object
         properties: {}
+  - name: identityRef
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          name:
+            type: string
+          kind:
+            type: string
+        required:
+        - name
+        - kind
   patches:
   - name: vsphereClusterTemplate
     definitions:
@@ -480,12 +493,25 @@ spec:
         path: /spec/template/spec/server
         valueFrom:
           variable: vcenter.server
+  - name: vSphereClusterIdentityRef
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereClusterTemplate
+        matchResources:
+          infrastructureCluster: true
+      jsonPatches:
       - op: add
         path: /spec/template/spec/identityRef
         valueFrom:
           template: |
+            {{ if .identityRef -}}
+            kind: {{ .identityRef.kind }}
+            name: {{ .identityRef.name }}
+            {{- else -}}
             kind: Secret
             name: '{{ .builtin.cluster.name }}'
+            {{- end }}
   - name: controlPlaneMachineTemplate
     definitions:
     - selector:

--- a/providers/infrastructure-vsphere/v1.4.1/cconly/rbac.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/cconly/rbac.yaml
@@ -60,6 +60,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - vsphereclusteridentities
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/tkg/vsphere-template-resolver/main.go
+++ b/tkg/vsphere-template-resolver/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"flag"
 	"os"
+	capvv1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +34,7 @@ func init() {
 	utilruntime.Must(runv1.AddToScheme(scheme))
 	utilruntime.Must(corev1.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
+	utilruntime.Must(capvv1beta1.AddToScheme(scheme))
 }
 
 func main() {

--- a/tkg/vsphere-template-resolver/template/resolver.go
+++ b/tkg/vsphere-template-resolver/template/resolver.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	capvv1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,8 @@ const (
 	osImageRefVersion  = "version"
 	osImageRefTemplate = "template"
 	osImageRefMOID     = "moid"
+	varIdentityRef     = "identityRef"
+	namespaceCAPV      = "capv-system"
 )
 
 type Webhook struct {
@@ -307,11 +310,40 @@ func populateTKRDataFromResult(tkrDataValue *resolver_cluster.TKRDataValue, temp
 
 func (cw *Webhook) getVSphereContext(ctx context.Context, cluster *clusterv1.Cluster) (*templateresolver.VSphereContext, error) {
 	c := cw.Client
-	// Get Secret (cluster name in cluster namespace)
-	clusterName, clusterNamespace := cluster.Name, cluster.Namespace
+
+	// By default, a Secret with the same name and namespace will be used as the vSphere identity. However, API
+	// consumers like TMC are allowed to use alternative identity type, e.g. VSphereClusterIdentity through the
+	// Cluster variable identityRef. We need to retrieve the credential Secret according to different use cases.
+	secretName := cluster.Name
+	secretNamespace := cluster.Namespace
+	for _, variable := range cluster.Spec.Topology.Variables {
+		if variable.Name == varIdentityRef {
+			identityRef := &capvv1beta1.VSphereIdentityReference{}
+			if err := json.Unmarshal(variable.Value.Raw, identityRef); err != nil {
+				return nil, errors.Wrapf(err, fmt.Sprintf("could not parse variable identityRef: %v", variable))
+			}
+			switch identityRef.Kind {
+			case capvv1beta1.VSphereClusterIdentityKind:
+				vSphereClusterIdentity := &capvv1beta1.VSphereClusterIdentity{}
+				if err := c.Get(ctx, client.ObjectKey{Name: identityRef.Name}, vSphereClusterIdentity); err != nil {
+					return nil, errors.Wrapf(err, fmt.Sprintf("could not get VSphereClusterIdentity %s", identityRef.Name))
+				}
+				if vSphereClusterIdentity.Status.Ready {
+					secretName = vSphereClusterIdentity.Spec.SecretName
+					secretNamespace = namespaceCAPV
+				} else {
+					return nil, errors.New(fmt.Sprintf("VShereClusterIdentity %s is not ready yet", identityRef.Name))
+				}
+			case capvv1beta1.SecretKind:
+				secretName = identityRef.Name
+			default:
+				return nil, errors.New(fmt.Sprintf("not supported identityRef type %s", identityRef.Kind))
+			}
+		}
+	}
 
 	secret := &corev1.Secret{}
-	objKey := client.ObjectKey{Name: clusterName, Namespace: clusterNamespace}
+	objKey := client.ObjectKey{Name: secretName, Namespace: secretNamespace}
 	cw.Log.Info("Getting secret for VC Client", "key", objKey)
 	err := c.Get(ctx, objKey, secret)
 	if err != nil {


### PR DESCRIPTION
API consumers like TMC can not save any vCenter credentials, so it can not create a Secret based identityRef for each Cluster. It relies on TKG admin to create a VSphereClusterIdentity shared by multiple Clusters.

In this patch a Cluster variable is introduced to allow users to specify a different identityRef. Nevertheless, Tanzu cli still use Secret as the default identity type to keep backward UX compatible.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
