### PR TITLE
Fix cluster upgrade from legacy to package based lcm

### DIFF
--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -61,6 +61,10 @@ const (
 	// TKGBomNamespace is the TKG add on BOM namespace.
 	TKGBomNamespace = "tkr-system"
 
+	// TKGBomNamespaceClassyClusters is the TKG add on BOM namespace for ClusterClass or
+	// ClusterClass capable management clusters.
+	TKGBomNamespaceClassyClusters = "tkg-system"
+
 	// TKRLabel is the TKR label.
 	TKRLabel = "tanzuKubernetesRelease"
 

--- a/packages/core-management-plugins/package.yaml
+++ b/packages/core-management-plugins/package.yaml
@@ -1,7 +1,7 @@
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: core-management-plugins.tanzu.vmware.com
+  name: tanzu-core-management-plugins.tanzu.vmware.com
   namespace: tkg-system
 spec:
   refName: core-management-plugins.tanzu.vmware.com

--- a/packages/tkg/bundle/config/packageinstalls/core-management-plugins-pi.yaml
+++ b/packages/tkg/bundle/config/packageinstalls/core-management-plugins-pi.yaml
@@ -5,7 +5,7 @@
 apiVersion: packaging.carvel.dev/v1alpha1
 kind: PackageInstall
 metadata:
-  name: core-management-plugins
+  name: tanzu-core-management-plugins
   namespace: #@ data.values.coreManagementPluginsPackage.namespaceForPackageInstallation
   annotations:
     kapp.k14s.io/change-rule.0: "upsert after upserting framework-packageinstall/tanzu-framework"

--- a/tkg/client/upgrade_cluster.go
+++ b/tkg/client/upgrade_cluster.go
@@ -211,7 +211,7 @@ func (c *TkgClient) DoLegacyClusterUpgrade(regionalClusterClient, currentCluster
 	}
 
 	// Upgrade addon metadata configmaps after the nodes are upgraded
-	if !options.SkipAddonUpgrade {
+	if !options.SkipAddonUpgrade && !config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
 		err = c.upgradeAddonPostNodeUpgrade(regionalClusterClient, currentClusterClient, options.ClusterName, options.Namespace, options.IsRegionalCluster, options.Edition)
 		if err != nil {
 			return err

--- a/tkg/constants/files.go
+++ b/tkg/constants/files.go
@@ -38,5 +38,4 @@ const (
 	LogFolderName = "logs"
 
 	TKGPackageValuesFile = "tkgpackagevalues.yaml"
-	TKGPackageValues     = "tkg-package-values"
 )


### PR DESCRIPTION
### What this PR does / why we need it
Fix cluster upgrade from legacy to package based lcm
* Retrieve `tkr-controller-config` from tkg-system namespace first then the legacy tkr-system.
* When Retrieve the user config variables for updating the tkg-pkg metapackage input secret `tkg-pkg-tkg-system-values`
  * The package-based-lcm created mgmt cluster will have the previous `tkg-pkg-tkg-system-values` secret defined on the cluster who stored the user config.
  * The legacy (non-package-based-lcm) management cluster does not have the `tkg-pkg-tkg-system-values` secret defined on the cluster. So using the `<cluster-name>-config-values secret` on legacy cluster to retrieve the user config which was managed in legacy ytt template `providers/ytt/09_miscellaneous`. Part of: https://github.com/vmware-tanzu/tanzu-framework/issues/2147
* Overwrite the user config with the current exported config variables.
* Stop generating ytt template on post node upgrade if package-based-lcm is enabled
* Change core-management-plugins packageInstall to tanzu-core-management-plugins for upgrade adoptions.
* Stop watching core-management-plugins packageInstall status if package-based-lcm is enabled. Since after the upgrade it does not belong to core packages and belongs to the tkg-pkg meta package.
* Validating the user config secret before cluster upgrade


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->



### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Created the tkg 1.6 mgmt and wl clusters, and upgraded them to tkg 1.7(kube 1.24).
* In mgmt cluster, everything upgraded successfully except ako/akoo, which the fix is currently ongoing in other prs.
* In workload cluster, everything upgraded successfully.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
