### PR TITLE
Fix the rendering of proxy cert in CC variables

### DIFF
--- a/providers/yttcc/lib/config_variable_association.star
+++ b/providers/yttcc/lib/config_variable_association.star
@@ -351,20 +351,23 @@ def get_cluster_variables():
         }
     end
 
-    trust = []
+
+    additionalTrustedCAs = []
     if data.values["TKG_PROXY_CA_CERT"] != "":
-        trust.append({
+        additionalTrustedCAs.append({
             "name": "proxy",
             "data": data.values["TKG_PROXY_CA_CERT"]
         })
     end
     if data.values["TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE"] != "":
-        trust.append({
+        additionalTrustedCAs.append({
             "name": "imageRepository",
             "data": data.values["TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE"]
         })
     end
-    if len(trust) > 0:
+    if len(additionalTrustedCAs) > 0:
+        trust = {}
+        trust["additionalTrustedCAs"] = additionalTrustedCAs
         vars["trust"] = trust
     end
 
@@ -394,7 +397,7 @@ def get_aws_vars():
 
 
     vars["bastion"] = {
-        "enabled": data.values["BASTION_HOST_ENABLED"] 
+        "enabled": data.values["BASTION_HOST_ENABLED"]
     }
 
     if vars.get("network") == None:


### PR DESCRIPTION
### What this PR does / why we need it
The current expected proxy struct in CC variables is 
```
      - name: trust
        value:
          additionalTrustedCAs:
            - name: CompanyInternalCA-1
              data: aGVsbG8=
            - name: CompanyInternalCA-2
              data: bHWtcH9=
```
The `config_variable_association.star` file is not rendering it correctly
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #https://github.com/vmware-tanzu/tanzu-framework/issues/3869

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
