### PR TITLE
Make manifest to azurecc, adjust default namespace, adjust format for the bootstraps yaml 

### DIFF
--- a/addons/config/expected/csi.tanzu.vmware.com/v1alpha1/azurefilecsiconfig/default.yaml
+++ b/addons/config/expected/csi.tanzu.vmware.com/v1alpha1/azurefilecsiconfig/default.yaml
@@ -7,5 +7,5 @@ metadata:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:
   azureFileCSIDriver:
-    namespace: tkg-system
-    deploymentReplicas: 1
+    namespace: kube-system
+    deploymentReplicas: 3

--- a/addons/config/templates/csi.tanzu.vmware.com/v1alpha1/azurefilecsiconfig.yaml
+++ b/addons/config/templates/csi.tanzu.vmware.com/v1alpha1/azurefilecsiconfig.yaml
@@ -9,5 +9,5 @@ metadata:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:
   azureFileCSIDriver:
-    namespace: tkg-system
-    deploymentReplicas: 1
+    namespace: kube-system
+    deploymentReplicas: 3

--- a/addons/controllers/azurefilecsi/azurefilecsiconfig_utils.go
+++ b/addons/controllers/azurefilecsi/azurefilecsiconfig_utils.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	defaultDataValueNameSpace          = "tkg-system"
+	defaultDataValueNameSpace          = "kube-system"
 	defaultDataValueDeploymentReplicas = 3
 )
 

--- a/apis/addonconfigs/config/crd/bases/csi.tanzu.vmware.com_azurefilecsiconfigs.yaml
+++ b/apis/addonconfigs/config/crd/bases/csi.tanzu.vmware.com_azurefilecsiconfigs.yaml
@@ -18,7 +18,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: AzureFileCSIConfig is the Schema for the azurefilecsiconfigs API
+        description: AzureFileCSIConfig is the Schema for the azurefilecsiconfigs
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -36,7 +36,7 @@ spec:
             description: AzureFileCSIConfigSpec defines the desired state of AzureFileCSIConfig
             properties:
               azureFileCSIDriver:
-                description: AzureFileCSI is the Schema for the azurefilecsiconfigs API
+                description: AzureFileCSI is the Schema for the AzureFileCSIConfig
                 properties:
                   deploymentReplicas:
                     format: int32

--- a/apis/addonconfigs/csi/v1alpha1/azurefilecsiconfig_types.go
+++ b/apis/addonconfigs/csi/v1alpha1/azurefilecsiconfig_types.go
@@ -12,24 +12,20 @@ import (
 
 // AzureFileCSIConfigSpec defines the desired state of AzureFileCSIConfig
 type AzureFileCSIConfigSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	// Foo is an example field of AzureFileCSIConfig. Edit azurefilecsiconfig_types.go to remove/update
 	AzureFileCSI AzureFileCSI `json:"azureFileCSIDriver"`
 }
 
 // AzureFileCSIConfigStatus defines the observed state of AzureFileCSIConfig
 type AzureFileCSIConfigStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	// Name of the secret created by csi controller
+	//+ kubebuilder:validation:Optional
 	SecretRef *string `json:"secretRef,omitempty"`
 }
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// AzureFileCSIConfig is the Schema for the azurefilecsiconfigs API
+// AzureFileCSIConfig is the Schema for the azurefilecsiconfigs
 type AzureFileCSIConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -47,10 +43,10 @@ type AzureFileCSIConfigList struct {
 	Items           []AzureFileCSIConfig `json:"items"`
 }
 
-// AzureFileCSI is the Schema for the AzureFileCSIConfig API
+// AzureFileCSI is the Schema for the AzureFileCSIConfig
 type AzureFileCSI struct {
 	// The namespace csi components are to be deployed in
-	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Required
 	Namespace string `json:"namespace"`
 
 	// +kubebuilder:validation:Optional

--- a/config/crd/bases/csi.tanzu.vmware.com_azurefilecsiconfigs.yaml
+++ b/config/crd/bases/csi.tanzu.vmware.com_azurefilecsiconfigs.yaml
@@ -19,7 +19,6 @@ spec:
     schema:
       openAPIV3Schema:
         description: AzureFileCSIConfig is the Schema for the azurefilecsiconfigs
-          API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -37,8 +36,7 @@ spec:
             description: AzureFileCSIConfigSpec defines the desired state of AzureFileCSIConfig
             properties:
               azureFileCSIDriver:
-                description: Foo is an example field of AzureFileCSIConfig. Edit azurefilecsiconfig_types.go
-                  to remove/update
+                description: AzureFileCSI is the Schema for the AzureFileCSIConfig
                 properties:
                   deploymentReplicas:
                     format: int32
@@ -52,6 +50,8 @@ spec:
                     type: string
                   noProxy:
                     type: string
+                required:
+                - namespace
                 type: object
             required:
             - azureFileCSIDriver
@@ -60,9 +60,7 @@ spec:
             description: AzureFileCSIConfigStatus defines the observed state of AzureFileCSIConfig
             properties:
               secretRef:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
+                description: Name of the secret created by csi controller
                 type: string
             type: object
         type: object

--- a/packages/addons-manager/bundle/config/upstream/addonconfigscrds/csi.tanzu.vmware.com_azurefilecsiconfigs.yaml
+++ b/packages/addons-manager/bundle/config/upstream/addonconfigscrds/csi.tanzu.vmware.com_azurefilecsiconfigs.yaml
@@ -18,7 +18,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: AzureFileCSIConfig is the Schema for the azurefilecsiconfigs API
+        description: AzureFileCSIConfig is the Schema for the azurefilecsiconfigs
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -36,7 +36,7 @@ spec:
             description: AzureFileCSIConfigSpec defines the desired state of AzureFileCSIConfig
             properties:
               azureFileCSIDriver:
-                description: AzureFileCSI is the Schema for the azurefilecsiconfigs API
+                description: AzureFileCSI is the Schema for the AzureFileCSIConfig
                 properties:
                   deploymentReplicas:
                     format: int32

--- a/providers/yttcb/clusterbootstrap.yaml
+++ b/providers/yttcb/clusterbootstrap.yaml
@@ -309,9 +309,8 @@ spec:
     httpProxy: #@ data.values.TKG_HTTP_PROXY
     httpsProxy: #@ data.values.TKG_HTTPS_PROXY
     noProxy: #@ data.values.TKG_NO_PROXY
----
 #@ end
-
+---
 #@ if awsebscsi_configs_exist():
 apiVersion: csi.tanzu.vmware.com/v1alpha1
 kind: AwsEbsCSIConfig


### PR DESCRIPTION
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.
1. Make manifest to azurecc,some auto-generated files for make manifests are not been taken care of, submit them to make manifests happy
2. Adjust default namespace for azurefile cc,change from tkg-system to kube-system,
3.Adjust format for the bootstraps yaml to avoid possible format error.
-->

