### PR TITLE
Hide the default completion command of plugins

### DIFF
--- a/cli/runtime/plugin/root.go
+++ b/cli/runtime/plugin/root.go
@@ -14,6 +14,17 @@ func newRootCmd(descriptor *cliapi.PluginDescriptor) *cobra.Command {
 		Use:     descriptor.Name,
 		Short:   descriptor.Description,
 		Aliases: descriptor.Aliases,
+		// Hide the default completion command of the plugin.
+		// Shell completion is enabled using the Tanzu CLI's `completion` command so a plugin
+		// does not need its own `completion` command.  Having such a command is just
+		// confusing for users. However, we don't disable it completely for two reasons:
+		//   1. backwards-compatibility, as the command used to be available for some plugins
+		//   2. to allow shell completion when using the plugin as a native program (mostly for testing)
+		// Note that a plugin can completely disable this command itself using:
+		//  plugin.Cmd.CompletionOptions.DisableDefaultCmd = true
+		CompletionOptions: cobra.CompletionOptions{
+			HiddenDefaultCmd: true,
+		},
 	}
 	cobra.AddTemplateFuncs(TemplateFuncs)
 	cmd.SetUsageTemplate(CmdTemplate)


### PR DESCRIPTION
### What this PR does / why we need it

Plugins automatically get a default `completion` command from Cobra.  For example:
```
tanzu cluster completion
tanzu package completion
```
This commit hides this default command for any plugin through the plugin runtime library.

Notice that users enable shell completion using `tanzu completion`, and that this allows completion to work for plugins as well.  Therefore plugins do not need to also have their own `completion` command.  Having such a command for a plugin (e.g., `tanzu cluster completion`) is just confusing for users.

### Which issue(s) this PR fixes

Fixes #3160

### Describe testing done for PR

I built the CLI and the plugins and then ran
``` 
$ tanzu cluster -h
$ tanzu management-cluster -h
$ tanzu package -h
```
and confirmed there was no `completion` command listed.

I then ran
```
$ tanzu cluster completion
$ tanzu management-cluster completion
$ tanzu package completion
```
and confirmed the command still existed but is simply hidden.
The reasons for keeping it hidden instead of removing it is explained in the section below.

### Release note
```release-note
The completion command of any plugin is removed since it is not needed.
```

### Additional information

We don't completely disable a plugin's default completion command for two reasons:
 1. backwards-compatibility, as the command used to be available for some plugins
 2. to allow to use shell completion when using the plugin as a native program (mostly for testing)

Note that a plugin can completely disable this command itself using: 
```
plugin.Cmd.CompletionOptions.DisableDefaultCmd = true
```

#### Special notes for your reviewer

This change impacts **all** plugins that will be compiled with this new version of the runtime library.