### PR TITLE
Fix missing variable count on overlay for Windows

### DIFF
--- a/providers/infrastructure-vsphere/v1.4.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.4.1/yttcc/overlay.yaml
@@ -95,36 +95,42 @@ spec:
       #@overlay/replace
       - class: tkg-worker-windows
         name: md-0
+        #@overlay/match missing_ok=True
+        #@ if data.values.CLUSTER_PLAN == "prodcc":
+        replicas: #@ data.values.WORKER_MACHINE_COUNT_0
+        #@ else:
         replicas: #@ data.values.WORKER_MACHINE_COUNT
+        #@ end
         #@overlay/match missing_ok=True
         metadata:
           annotations:
-            #! VVV TODO(tenczar) os-name handling
             run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=windows
+        #@ if data.values.VSPHERE_AZ_0:
+        #@overlay/match missing_ok=True
+        failureDomain: #@ data.values.VSPHERE_AZ_0
+        #@ end
       #@ if data.values.CLUSTER_PLAN == "prodcc":
       #@overlay/append
       - class: tkg-worker-windows
         name: md-1
         replicas: #@ data.values.WORKER_MACHINE_COUNT_1
-        #@ if data.values.VSPHERE_AZ_1:
-        failureDomain: #@ data.values.VSPHERE_AZ_1
-        #@ end
         #@overlay/match missing_ok=True
         metadata:
           annotations:
-            #! VVV TODO(tenczar) os-name handling
             run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=windows
+        #@ if data.values.VSPHERE_AZ_1:
+        failureDomain: #@ data.values.VSPHERE_AZ_1
+        #@ end
       #@overlay/append
       - class: tkg-worker-windows
         name: md-2
         replicas: #@ data.values.WORKER_MACHINE_COUNT_2
+        metadata:
+          annotations:
+            run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=windows
         #@ if data.values.VSPHERE_AZ_2:
         failureDomain: #@ data.values.VSPHERE_AZ_2
         #@ end
-        metadata:
-          annotations:
-            #! VVV TODO(tenczar) os-name handling
-            run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=windows
       #@ end
       #@ end
     #@overlay/match missing_ok=True


### PR DESCRIPTION
### What this PR does / why we need it

- Fix Overlay Md replicas count for Prod, right now prodcc has 3 replicas on region one in the MD, and 1 in the others when using this plan.

```
~$ k get node -o wide
NAME                                        STATUS   ROLES                  AGE   VERSION            INTERNAL-IP      EXTERNAL-IP      OS-IMAGE                       KERNEL-VERSION    CONTAINER-RUNTIME
tkg-vc-antrea-lvnsn-lvqvv                   Ready    control-plane,master   82m   v1.23.8+vmware.2   VMware Photon OS/Linux         4.19.247-7.ph3    containerd://1.6.6
tkg-vc-antrea-lvnsn-mz9cs                   Ready    control-plane,master   89m   v1.23.8+vmware.2  VMware Photon OS/Linux         4.19.247-7.ph3    containerd://1.6.6
tkg-vc-antrea-lvnsn-nwjtr                   Ready    control-plane,master   84m   v1.23.8+vmware.2   Photon OS/Linux         4.19.247-7.ph3    containerd://1.6.6
tkg-vc-antrea-md-0-j9jdn-68756575c7-ff9t2   Ready    <none>                 83m   v1.23.8+vmware.2 Windows Server 2019 Standard   10.0.17763.2114   containerd://1.6.6
tkg-vc-antrea-md-0-j9jdn-68756575c7-mcwcl   Ready    <none>                 82m   v1.23.8+vmware.2 Windows Server 2019 Standard   10.0.17763.2114   containerd://1.6.6
tkg-vc-antrea-md-0-j9jdn-68756575c7-x2zpl   Ready    <none>                 82m   v1.23.8+vmware.2 Windows Server 2019 Standard   10.0.17763.2114   containerd://1.6.6
tkg-vc-antrea-md-1-2nmm8-5b956668c5-mhrkc   Ready    <none>                 82m   v1.23.8+vmware.2 Windows Server 2019 Standard   10.0.17763.2114   containerd://1.6.6
tkg-vc-antrea-md-2-7wkqp-66f9679dbb-kctmw   Ready    <none>                 82m   v1.23.8+vmware.2 Windows Server 2019 Standard   10.0.17763.2114   containerd://1.6.6
```

- Fixing other nits like reading the OS_NAME for the tkr resolution, and giving parity with Linux spec

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Prodcc machineDeployment replicas=1 for Windows clusters
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
