### PR TITLE
Fix clusterboostrap webhook to include additional packages in CB but not present in CBT

### DIFF
--- a/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
+++ b/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
@@ -278,6 +278,26 @@ func addMissingFields(copyFrom, destination, keysToSkip map[string]interface{}) 
 						updatedSlice = append(updatedSlice, copiedVal)
 					}
 				}
+				// there might be packages thats there in CB but not in CBT. We need to add those.
+				// The below loop is to figure out those packages and add it as it is in CB
+				for _, sliceItemInTarget := range sliceInTarget {
+					foundMatch := false
+					itemMapInTarget := sliceItemInTarget.(map[string]interface{})
+					for _, sliceItemInFrom := range sliceInFrom {
+						itemMapInFrom := sliceItemInFrom.(map[string]interface{})
+						if itemMapInFrom["refName"].(string) == itemMapInTarget["refName"].(string) {
+							foundMatch = true
+							break
+						}
+					}
+					if !foundMatch {
+						copiedVal, _, copyErr := unstructured.NestedFieldCopy(itemMapInTarget)
+						if copyErr != nil {
+							return copyErr
+						}
+						updatedSlice = append(updatedSlice, copiedVal)
+					}
+				}
 				destination[keyInFrom] = updatedSlice
 			}
 		}

--- a/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone_test.go
+++ b/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone_test.go
@@ -514,6 +514,7 @@ var _ = Describe("ClusterbootstrapClone", func() {
 					},
 					AdditionalPackages: []*v1alpha3.ClusterBootstrapPackage{
 						{RefName: fakePinnipedCBPackageRefName, ValuesFrom: &v1alpha3.ValuesFrom{Inline: map[string]interface{}{"identity_management_type": "oidc"}}},
+						{RefName: "kube-vip", ValuesFrom: &v1alpha3.ValuesFrom{Inline: map[string]interface{}{"vip_address": "1.2.3.4"}}},
 					},
 				},
 			}
@@ -534,11 +535,14 @@ var _ = Describe("ClusterbootstrapClone", func() {
 			Expect(updatedClusterBootstrap.Spec.CPI.ValuesFrom.SecretRef).To(Equal(fakeCPIClusterBootstrapPackage.ValuesFrom.SecretRef))
 			// The ClusterBootstrapPackage not set in fakeClusterBootstrapTemplate. They should not be copied
 			Expect(updatedClusterBootstrap.Spec.Kapp).To(BeNil())
-			Expect(len(updatedClusterBootstrap.Spec.AdditionalPackages)).To(Equal(len(fakeClusterBootstrapTemplate.Spec.AdditionalPackages)))
-			for idx := range updatedClusterBootstrap.Spec.AdditionalPackages {
+			// Adding +1 since we expect kube-vip package to be there eventhough it is not in CBT
+			Expect(len(updatedClusterBootstrap.Spec.AdditionalPackages)).To(Equal(len(fakeClusterBootstrapTemplate.Spec.AdditionalPackages) + 1))
+			for idx := 0; idx < 2; idx++ {
 				Expect(updatedClusterBootstrap.Spec.AdditionalPackages[idx].RefName).To(Equal(fakeClusterBootstrapTemplate.Spec.AdditionalPackages[idx].RefName))
 				Expect(updatedClusterBootstrap.Spec.AdditionalPackages[idx].ValuesFrom).To(Equal(fakeClusterBootstrapTemplate.Spec.AdditionalPackages[idx].ValuesFrom))
 			}
+			Expect(updatedClusterBootstrap.Spec.AdditionalPackages[2].RefName).To(Equal("kube-vip"))
+			Expect(updatedClusterBootstrap.Spec.AdditionalPackages[2].ValuesFrom).To(Equal(&v1alpha3.ValuesFrom{Inline: map[string]interface{}{"vip_address": "1.2.3.4"}}))
 		})
 
 		It("should add valuesFrom back if not specified in ClusterBootstrap", func() {


### PR DESCRIPTION
### What this PR does / why we need it
Fix clusterboostrap webhook to include additional packages in CB but not present in CBT

### Which issue(s) this PR fixes
Fixes #TBA

### Describe testing done for PR
Unit test

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix clusterboostrap webhook to include additional packages in CB but not present in CBT
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
