### PR TITLE
fix: build plugin incorrectly combines stdout&stderr

### DIFF
--- a/cmd/cli/plugin-admin/builder/command/cli_compile.go
+++ b/cmd/cli/plugin-admin/builder/command/cli_compile.go
@@ -252,13 +252,14 @@ func buildPlugin(path string, arch cli.Arch, id string) (plugin, error) {
 	}
 
 	cmd.Args = append(cmd.Args, "info")
-	b, err := cmd.CombinedOutput()
+	b, err := cmd.Output()
 
 	if err != nil {
 		log.Errorf("%s - error: %v", id, err)
 		log.Errorf("%s - output: %v", id, string(b))
 		return plugin{}, err
 	}
+
 	var desc cliapi.PluginDescriptor
 	err = json.Unmarshal(b, &desc)
 	if err != nil {


### PR DESCRIPTION
### What this PR does / why we need it

### Which issue(s) this PR fixes

Fixes #3907 

### Describe testing done for PR

- check out local plugin project
- go clean -modcache
- make build-local
(builds successfully where as would previously fail)

### Release note

```release-note
Builder plugin no longer combines stdout & stderr when reading the plugin descriptor.
```



