### PR TITLE
[WIP] add retry for WaitForClusterInitialized when vcenter connection slow 

### DIFF
--- a/tkg/clusterclient/clusterclient.go
+++ b/tkg/clusterclient/clusterclient.go
@@ -587,12 +587,21 @@ func (c *client) WaitForClusterInitialized(clusterName, namespace string) error 
 		err = currentClusterInfo.RetrievalError
 
 		if err == nil {
-			// If cluster's ReadyCondition is False and severity is Error, it implies non-retriable error, so return error
+			// should retry in this condition
+			// For dimension env, sometimes it will take some time to connect to vcenter to create resources like cluster secret
 			if conditions.IsFalse(currentClusterInfo.ClusterObject, capi.ReadyCondition) &&
 				(*conditions.GetSeverity(currentClusterInfo.ClusterObject, capi.ReadyCondition) == capi.ConditionSeverityError) {
-				return true, errors.Errorf("cluster creation failed, reason:'%s', message:'%s'",
-					conditions.GetReason(currentClusterInfo.ClusterObject, capi.ReadyCondition),
-					conditions.GetMessage(currentClusterInfo.ClusterObject, capi.ReadyCondition))
+				reason := conditions.GetReason(currentClusterInfo.ClusterObject, capi.ReadyCondition)
+				message := conditions.GetMessage(currentClusterInfo.ClusterObject, capi.ReadyCondition)
+
+				maxTimeoutCounter++
+				// if exceeds maxTimeout, return error
+				if interval*time.Duration(maxTimeoutCounter) > maxTimeout {
+					return true, errors.Errorf("timed out waiting for cluster creation, reason:'%s', message:'%s'",
+						reason,
+						message)
+				}
+				return false, errors.Errorf("cluster not ready, reason:'%s', message:'%s'", reason, message)
 			}
 			// Could have checked cluster's ReadyCondition is True which is currently aggregation of ControlPlaneReadyCondition
 			// and InfrastructureReadyCondition, however in future if capi adds WorkersReadyCondition into aggregation, it would


### PR DESCRIPTION
cluster creation will failed due to `cluster secret not found` in dimension sddc on top of nimbus if the env is slow.

cluster secret will be created afterwards. Add retry for this condition

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
