### PR TITLE
Add a seperate controller for cluster-metadata

### DIFF
--- a/addons/controllers/cluster_metadata_controller.go
+++ b/addons/controllers/cluster_metadata_controller.go
@@ -9,9 +9,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
-	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
-	"github.com/vmware-tanzu/tanzu-framework/addons/predicates"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -26,6 +23,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
+	"github.com/vmware-tanzu/tanzu-framework/addons/predicates"
 )
 
 // ClusterMetadataReconciler reconciles a ClusterBootstrap object

--- a/addons/controllers/cluster_metadata_controller.go
+++ b/addons/controllers/cluster_metadata_controller.go
@@ -1,0 +1,358 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
+	"github.com/vmware-tanzu/tanzu-framework/addons/predicates"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterapiutil "sigs.k8s.io/cluster-api/util"
+	clusterApiPredicates "sigs.k8s.io/cluster-api/util/predicates"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// ClusterMetadataReconciler reconciles a ClusterBootstrap object
+type ClusterMetadataReconciler struct {
+	client.Client
+	Log        logr.Logger
+	Scheme     *runtime.Scheme
+	context    context.Context
+	controller controller.Controller
+}
+
+// NewClusterMetadataReconciler returns a reconciler for ClusterMetadata
+func NewClusterMetadataReconciler(c client.Client, log logr.Logger, scheme *runtime.Scheme) *ClusterMetadataReconciler {
+	return &ClusterMetadataReconciler{
+		Client: c,
+		Log:    log,
+		Scheme: scheme,
+	}
+}
+
+// SetupWithManager performs the setup actions for a cluster metadata controller, using the passed in mgr.
+func (r *ClusterMetadataReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
+	metadataController, err := ctrl.NewControllerManagedBy(mgr).
+		For(&clusterapiv1beta1.Cluster{}).
+		WithOptions(options).WithEventFilter(clusterApiPredicates.ResourceNotPaused(r.Log)).
+		WithEventFilter(predicates.TKR(r.Log)).
+		Named("clusterMetadata-controller").
+		Build(r)
+	if err != nil {
+		r.Log.Error(err, "Error creating an cluster metadata controller")
+		return err
+	}
+	r.context = ctx
+	r.controller = metadataController
+	return nil
+}
+
+// Reconcile performs the reconciliation action for the controller.
+func (r *ClusterMetadataReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := r.Log.WithValues(constants.ClusterNamespaceLogKey, req.Namespace, constants.ClusterNameLogKey, req.Name)
+
+	cluster := &clusterapiv1beta1.Cluster{}
+	if err := r.Client.Get(ctx, req.NamespacedName, cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("Cluster not found")
+			return ctrl.Result{}, nil
+		}
+		log.Error(err, "unable to fetch cluster")
+		return ctrl.Result{}, err
+	}
+
+	if cluster.Status.Phase != string(clusterapiv1beta1.ClusterPhaseProvisioned) {
+		r.Log.Info(fmt.Sprintf("cluster %s/%s does not have status phase %s", cluster.Namespace, cluster.Name, clusterapiv1beta1.ClusterPhaseProvisioned))
+		return ctrl.Result{RequeueAfter: constants.RequeueAfterDuration}, nil
+	}
+
+	// make sure the TKR object exists
+	tkrName := util.GetClusterLabel(cluster.Labels, constants.TKRLabelClassyClusters)
+	if tkrName == "" {
+		tkrName = util.GetClusterLabel(cluster.Labels, constants.TKRLabel)
+		if tkrName == "" {
+			return ctrl.Result{}, nil
+		}
+	}
+
+	tkr, err := util.GetTKRByNameV1Alpha3(r.context, r.Client, tkrName)
+	if err != nil {
+		log.Error(err, "unable to fetch TKR object", "name", tkrName)
+		return ctrl.Result{}, err
+	}
+
+	// if tkr is not found, should not requeue for the reconciliation
+	if tkr == nil {
+		log.Info("TKR object not found", "name", tkrName)
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("Reconciling cluster")
+
+	// if deletion timestamp is set, handle cluster deletion
+	if !cluster.GetDeletionTimestamp().IsZero() {
+		log.Info("cluster is in a deletion process, skip")
+		return ctrl.Result{}, nil
+	}
+	return r.reconcileNormal(cluster, log, tkrName)
+}
+
+// reconcileNormal reconciles the cluster object
+func (r *ClusterMetadataReconciler) reconcileNormal(cluster *clusterapiv1beta1.Cluster, log logr.Logger, tkrName string) (reconcile.Result, error) {
+	remoteClient, err := util.GetClusterClient(r.context, r.Client, r.Scheme, clusterapiutil.ObjectKey(cluster))
+	if err != nil {
+		return ctrl.Result{RequeueAfter: constants.RequeueAfterDuration}, fmt.Errorf("failed to get remote cluster client: %w", err)
+	}
+
+	err = r.createOrUpdateClusterMetadata(remoteClient, cluster, tkrName)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: constants.RequeueAfterDuration}, err
+	}
+
+	return ctrl.Result{}, nil
+
+}
+
+func (r *ClusterMetadataReconciler) createOrUpdateClusterMetadata(remoteClient client.Client, cluster *clusterapiv1beta1.Cluster, tkrName string) error {
+	type ConfigmapRef struct {
+		Name string `yaml:"name"`
+	}
+
+	type Bom struct {
+		ConfigmapRef *ConfigmapRef `yaml:"configmapRef"`
+	}
+
+	type Infrastructure struct {
+		Provider string `yaml:"provider"`
+	}
+
+	type Cluster struct {
+		Name                string          `yaml:"name"`
+		Type                string          `yaml:"type"`
+		Plan                string          `yaml:"plan"`
+		KubernetesProvider  string          `yaml:"kubernetesProvider"`
+		TkgVersion          string          `yaml:"tkgVersion"`
+		Edition             string          `yaml:"edition"`
+		Infrastructure      *Infrastructure `yaml:"infrastructure"`
+		IsClusterClassBased bool            `yaml:"isClusterClassBased"`
+	}
+
+	type TkgMetadata struct {
+		Cluster *Cluster `yaml:"cluster"`
+		Bom     *Bom     `yaml:"bom"`
+	}
+
+	bom, err := util.GetTkgBomForCluster(r.context, r.Client, tkrName)
+	if err != nil {
+		return errors.Wrapf(err, "cannot get the bom configuration")
+	}
+
+	bomContent, err := bom.GetBomContent()
+	if err != nil {
+		return errors.Wrapf(err, "cannot get the bom content")
+	}
+	bomContentByte, err := yaml.Marshal(bomContent)
+	if err != nil {
+		return errors.Wrap(err, "unable to yaml marshal default bom configuration")
+	}
+
+	clusterType := "workload"
+	if _, ok := cluster.Labels[constants.ManagementClusterRoleLabel]; ok {
+		clusterType = "management"
+	}
+
+	// Could be useless information since the tce edition is deprecated
+	clusterEdition := "tkg"
+	if edition, ok := cluster.Annotations["edition"]; ok {
+		clusterEdition = edition
+	}
+
+	isClusterClassBased := IsClusterClassBased(cluster)
+
+	providerName, err := util.GetInfraProvider(cluster)
+	if err != nil {
+		return errors.Wrapf(err, "unable to get the infra provider for cluster %v", cluster.Name)
+	}
+
+	kubernetesProvider := "VMware Tanzu Kubernetes Grid"
+	if providerName == "tkg-service-vsphere" {
+		kubernetesProvider = "VMware Tanzu Kubernetes Grid Service for vSphere"
+	}
+
+	clusterPlan, found := cluster.Annotations["tkg/plan"]
+	if !found || clusterPlan == "" {
+		// following the legacy behavior to set dev plan as default when the plan information is missing
+		// but this should never happen
+		clusterPlan = "dev"
+	} else {
+		// convert cc plan to legacy plan because we do not want to expose cc plan to users
+		if clusterPlan == "devcc" {
+			clusterPlan = "dev"
+		} else if clusterPlan == "prodcc" {
+			clusterPlan = "prod"
+		}
+	}
+
+	tkgMetadata := &TkgMetadata{
+		Cluster: &Cluster{
+			Name:               cluster.Name,
+			Type:               clusterType,
+			Plan:               clusterPlan,
+			KubernetesProvider: kubernetesProvider,
+			TkgVersion:         bomContent.Release.Version,
+			Edition:            clusterEdition,
+			Infrastructure: &Infrastructure{
+				Provider: providerName,
+			},
+			IsClusterClassBased: isClusterClassBased,
+		},
+		Bom: &Bom{
+			ConfigmapRef: &ConfigmapRef{
+				Name: constants.TkgBomConfigMapName,
+			},
+		},
+	}
+
+	tkgMetadataByte, err := yaml.Marshal(tkgMetadata)
+	if err != nil {
+		return errors.Wrap(err, "unable to yaml marshal metadata")
+	}
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.ClusterMetadataNamespace,
+		},
+	}
+
+	// create namespace tkg-system-public
+	_, err = controllerutil.CreateOrPatch(r.context, remoteClient, namespace, nil)
+	if err != nil {
+		return errors.Wrapf(err, "unable to create the namespace %v", constants.ClusterMetadataNamespace)
+	}
+
+	// create role
+	namespaceRole := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.ClusterMetadataNamespaceRoleName,
+			Namespace: constants.ClusterMetadataNamespace,
+		},
+	}
+	_, err = controllerutil.CreateOrPatch(r.context, remoteClient, namespaceRole, func() error {
+		namespaceRole.Rules = []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{
+					"",
+				},
+				ResourceNames: []string{
+					"tkg-metadata",
+					"tkg-bom",
+				},
+				Resources: []string{
+					"configmaps",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "unable to create the namespace role %v", constants.ClusterMetadataNamespaceRoleName)
+	}
+
+	// create role binding
+	namespaceRoleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.ClusterMetadataNamespaceRoleName,
+			Namespace: constants.ClusterMetadataNamespace,
+		},
+	}
+	_, err = controllerutil.CreateOrPatch(r.context, remoteClient, namespaceRoleBinding, func() error {
+		namespaceRoleBinding.RoleRef = rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     constants.ClusterMetadataNamespaceRoleName,
+		}
+		namespaceRoleBinding.Subjects = []rbacv1.Subject{
+			{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Group",
+				Name:     constants.ClusterMetadataRolebindingSubjectName,
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "unable to create the namespace rolebinding %v", constants.ClusterMetadataNamespaceRoleName)
+	}
+
+	// create tkg-bom configmap
+	tkgBomConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.ClusterMetadataNamespace,
+			Name:      constants.TkgBomConfigMapName,
+		},
+	}
+	_, err = controllerutil.CreateOrPatch(r.context, remoteClient, tkgBomConfigMap, func() error {
+		tkgBomConfigMap.Data = make(map[string]string)
+		tkgBomConfigMap.Data["bom.yaml"] = string(bomContentByte)
+		return nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "unable to create the configmap %v", constants.TkgBomConfigMapName)
+	}
+
+	// create tkg-metadata configmap
+	tkgMetadataConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: constants.ClusterMetadataNamespace,
+			Name:      constants.TkgMetadataConfigMapName,
+		},
+	}
+
+	_, err = controllerutil.CreateOrPatch(r.context, remoteClient, tkgMetadataConfigMap, func() error {
+		tkgMetadataConfigMap.Data = make(map[string]string)
+		tkgMetadataConfigMap.Data["metadata.yaml"] = string(tkgMetadataByte)
+		return nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "unable to create the configmap %v", constants.TkgMetadataConfigMapName)
+	}
+
+	return nil
+}
+
+func IsClusterClassBased(clusterObj *clusterapiv1beta1.Cluster) bool {
+	if clusterObj.Spec.Topology == nil || clusterObj.Spec.Topology.Class == "" {
+		return false
+	}
+	// Make sure that Cluster resource doesn't have ownerRef indicating that other
+	// resource is managing this Cluster resource. When cluster is created through
+	// TKC API, the cluster resource will have ownerRef set
+	ownerRefs := clusterObj.GetOwnerReferences()
+	for i := range ownerRefs {
+		if ownerRefs[i].Kind == constants.KindTanzuKubernetesCluster {
+			return false
+		}
+	}
+	return true
+}

--- a/addons/controllers/cluster_metadata_controller_test.go
+++ b/addons/controllers/cluster_metadata_controller_test.go
@@ -1,0 +1,146 @@
+package controllers
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	clusterapiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterapiutil "sigs.k8s.io/cluster-api/util"
+	"sigs.k8s.io/cluster-api/util/secret"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/constants"
+	"github.com/vmware-tanzu/tanzu-framework/addons/pkg/util"
+	"github.com/vmware-tanzu/tanzu-framework/addons/test/testutil"
+)
+
+var _ = Describe("ClusterMetadata Reconciler", func() {
+	var (
+		clusterName             string
+		clusterNamespace        string
+		clusterResourceFilePath string
+	)
+
+	JustBeforeEach(func() {
+		By("Creating kubeconfig for cluster")
+		Expect(testutil.CreateKubeconfigSecret(cfg, clusterName, clusterNamespace, k8sClient)).To(Succeed())
+		// create cluster resources
+		By("Creating a cluster, tkr, BOM config map and addon secret")
+		f, err := os.Open(clusterResourceFilePath)
+		Expect(err).ToNot(HaveOccurred())
+		defer f.Close()
+		Expect(testutil.CreateResources(f, cfg, dynamicClient)).To(Succeed())
+
+	})
+
+	AfterEach(func() {
+
+		By("Deleting kubeconfig for cluster")
+		key := client.ObjectKey{
+			Namespace: clusterNamespace,
+			Name:      secret.Name(clusterName, secret.Kubeconfig),
+		}
+		s := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, key, s)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, s)).To(Succeed())
+
+		// delete cluster
+		By("Deleting cluster")
+		f, err := os.Open(clusterResourceFilePath)
+		Expect(err).ToNot(HaveOccurred())
+		defer f.Close()
+		Expect(testutil.DeleteResources(f, cfg, dynamicClient, false)).To(Succeed())
+	})
+	When("reconcileAddonNormal for a tkr 1.23.2", func() {
+		BeforeEach(func() {
+			clusterName = "test-cluster-metadata"
+			clusterNamespace = "default"
+			clusterResourceFilePath = "testdata/test-cluster-metadata.yaml"
+		})
+		Context("from a tkg-bom configmap", func() {
+			It("Should create metadata namespace, namespaceRole, namespaceRoleBinding tkgBomConfigMap", func() {
+				By("verifying CAPI cluster is created properly")
+				cluster := &clusterapiv1beta1.Cluster{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: clusterNamespace, Name: clusterName}, cluster)).To(Succeed())
+				cluster.Status.Phase = string(clusterapiv1beta1.ClusterPhaseProvisioned)
+				Expect(k8sClient.Status().Update(ctx, cluster)).To(Succeed())
+
+				By("verifying the metadata resource are created properly")
+				remoteClient, err := util.GetClusterClient(ctx, k8sClient, scheme, clusterapiutil.ObjectKey(cluster))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(remoteClient).NotTo(BeNil())
+				Eventually(func() bool {
+					ns := &corev1.NamespaceList{}
+					err := remoteClient.List(ctx, ns)
+					if err != nil {
+						return false
+					}
+					for _, n := range ns.Items {
+						if n.Name == constants.ClusterMetadataNamespace {
+							return true
+						}
+					}
+					return false
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+
+				Eventually(func() bool {
+					roles := &rbacv1.RoleList{}
+					err := remoteClient.List(ctx, roles)
+					if err != nil {
+						return false
+					}
+					for _, r := range roles.Items {
+						if r.Name == constants.ClusterMetadataNamespaceRoleName {
+							rule := r.Rules[0]
+							if rule.APIGroups[0] == "" && rule.Verbs[0] == "get" && rule.Resources[0] == "configmaps" {
+								return true
+							}
+							return true
+						}
+					}
+					return false
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+
+				Eventually(func() bool {
+					roleBindings := &rbacv1.RoleBindingList{}
+					err := remoteClient.List(ctx, roleBindings)
+					if err != nil {
+						return false
+					}
+					for _, r := range roleBindings.Items {
+						if r.Name == constants.ClusterMetadataNamespaceRoleName &&
+							r.RoleRef.Name == constants.ClusterMetadataNamespaceRoleName {
+							if r.Subjects[0].Name == constants.ClusterMetadataRolebindingSubjectName {
+								return true
+							}
+
+						}
+					}
+					return false
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+
+				Eventually(func() bool {
+					configMaps := &corev1.ConfigMapList{}
+					err := remoteClient.List(ctx, configMaps)
+					if err != nil {
+						return false
+					}
+					var configmapHitCount int
+					for _, r := range configMaps.Items {
+						if r.Name == constants.TkgMetadataConfigMapName || r.Name == constants.TkgBomConfigMapName {
+							configmapHitCount++
+						}
+					}
+					if configmapHitCount == 2 {
+						return true
+					}
+					return false
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+
+			})
+		})
+	})
+})

--- a/addons/controllers/clusterbootstrap_controller_test.go
+++ b/addons/controllers/clusterbootstrap_controller_test.go
@@ -611,7 +611,7 @@ var _ = Describe("ClusterBootstrap Reconciler", func() {
 							return false
 						}
 						return !cluster.Spec.Paused
-					}, waitTimeout, pollingInterval).Should(BeTrue())
+					}, specialWaitTimeout, pollingInterval).Should(BeTrue())
 					if cluster.Annotations != nil {
 						_, ok := cluster.Annotations[constants.ClusterPauseLabel]
 						Expect(ok).ToNot(BeTrue())

--- a/addons/controllers/clusterbootstrap_controller_test.go
+++ b/addons/controllers/clusterbootstrap_controller_test.go
@@ -560,59 +560,63 @@ var _ = Describe("ClusterBootstrap Reconciler", func() {
 					Expect(k8sClient.Update(ctx, cluster)).To(Succeed())
 
 					// Wait for ClusterBootstrap upgrade reconciliation
+					upgradedClusterBootstrap := &runtanzuv1alpha3.ClusterBootstrap{}
 					Eventually(func() bool {
-						upgradedClusterBootstrap := &runtanzuv1alpha3.ClusterBootstrap{}
 						err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), upgradedClusterBootstrap)
 						if err != nil || upgradedClusterBootstrap.Status.ResolvedTKR != newTKRVersion {
 							return false
 						}
-						// Validate CNI
-						cni := upgradedClusterBootstrap.Spec.CNI
-						Expect(strings.HasPrefix(cni.RefName, "antrea")).To(BeTrue())
-						// Note: The value of CNI has been bumped to the one in TKR after cluster upgrade
-						Expect(cni.RefName).To(Equal("antrea.tanzu.vmware.com.1.5.2--vmware.3-tkg.1-advanced-zshippable"))
-						Expect(*cni.ValuesFrom.ProviderRef.APIGroup).To(Equal("cni.tanzu.vmware.com"))
-						Expect(cni.ValuesFrom.ProviderRef.Kind).To(Equal("AntreaConfig"))
-						Expect(cni.ValuesFrom.ProviderRef.Name).To(Equal(fmt.Sprintf("%s-antrea-package", clusterName)))
-
-						// Validate Kapp
-						kapp := upgradedClusterBootstrap.Spec.Kapp
-						Expect(kapp.RefName).To(Equal("kapp-controller.tanzu.vmware.com.0.30.2"))
-						Expect(*kapp.ValuesFrom.ProviderRef.APIGroup).To(Equal("run.tanzu.vmware.com"))
-						Expect(kapp.ValuesFrom.ProviderRef.Kind).To(Equal("KappControllerConfig"))
-						Expect(kapp.ValuesFrom.ProviderRef.Name).To(Equal(fmt.Sprintf("%s-kapp-controller-package", clusterName)))
-
-						// Validate additional packages
-						// foobar3 should be added, while foobar should be kept even it was removed from the template
-						Expect(len(upgradedClusterBootstrap.Spec.AdditionalPackages)).To(Equal(4))
-						for _, pkg := range upgradedClusterBootstrap.Spec.AdditionalPackages {
-							if pkg.RefName == "foobar1.example.com.1.18.2" {
-								Expect(pkg.ValuesFrom.SecretRef).To(Equal(fmt.Sprintf("%s-foobar1-package", clusterName)))
-							} else if pkg.RefName == "foobar3.example.com.1.17.2" {
-								Expect(*pkg.ValuesFrom.ProviderRef.APIGroup).To(Equal("run.tanzu.vmware.com"))
-								Expect(pkg.ValuesFrom.ProviderRef.Kind).To(Equal("FooBar"))
-								Expect(pkg.ValuesFrom.ProviderRef.Name).To(Equal(fmt.Sprintf("%s-foobar3-package", clusterName)))
-							} else if pkg.RefName == "foobar.example.com.1.17.2" {
-								Expect(*pkg.ValuesFrom.ProviderRef.APIGroup).To(Equal("run.tanzu.vmware.com"))
-								Expect(pkg.ValuesFrom.ProviderRef.Kind).To(Equal("FooBar"))
-								Expect(pkg.ValuesFrom.ProviderRef.Name).To(Equal(fmt.Sprintf("%s-foobar-package", clusterName)))
-							} else if pkg.RefName == "foobar2.example.com.1.18.2" {
-								Expect(pkg.ValuesFrom.Inline).NotTo(BeNil())
-							} else {
-								return false
-							}
-						}
-
-						// The cluster should be unpaused
-						Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: clusterNamespace, Name: clusterName}, cluster)).To(Succeed())
-						Expect(cluster.Spec.Paused).ToNot(BeTrue())
-						if cluster.Annotations != nil {
-							_, ok := cluster.Annotations[constants.ClusterPauseLabel]
-							Expect(ok).ToNot(BeTrue())
-						}
-
 						return true
 					}, waitTimeout, pollingInterval).Should(BeTrue())
+
+					// Validate CNI
+					cni := upgradedClusterBootstrap.Spec.CNI
+					Expect(strings.HasPrefix(cni.RefName, "antrea")).To(BeTrue())
+					// Note: The value of CNI has been bumped to the one in TKR after cluster upgrade
+					Expect(cni.RefName).To(Equal("antrea.tanzu.vmware.com.1.5.2--vmware.3-tkg.1-advanced-zshippable"))
+					Expect(*cni.ValuesFrom.ProviderRef.APIGroup).To(Equal("cni.tanzu.vmware.com"))
+					Expect(cni.ValuesFrom.ProviderRef.Kind).To(Equal("AntreaConfig"))
+					Expect(cni.ValuesFrom.ProviderRef.Name).To(Equal(fmt.Sprintf("%s-antrea-package", clusterName)))
+
+					// Validate Kapp
+					kapp := upgradedClusterBootstrap.Spec.Kapp
+					Expect(kapp.RefName).To(Equal("kapp-controller.tanzu.vmware.com.0.30.2"))
+					Expect(*kapp.ValuesFrom.ProviderRef.APIGroup).To(Equal("run.tanzu.vmware.com"))
+					Expect(kapp.ValuesFrom.ProviderRef.Kind).To(Equal("KappControllerConfig"))
+					Expect(kapp.ValuesFrom.ProviderRef.Name).To(Equal(fmt.Sprintf("%s-kapp-controller-package", clusterName)))
+
+					// Validate additional packages
+					// foobar3 should be added, while foobar should be kept even it was removed from the template
+					Expect(len(upgradedClusterBootstrap.Spec.AdditionalPackages)).To(Equal(4))
+					for _, pkg := range upgradedClusterBootstrap.Spec.AdditionalPackages {
+						if pkg.RefName == "foobar1.example.com.1.18.2" {
+							Expect(pkg.ValuesFrom.SecretRef).To(Equal(fmt.Sprintf("%s-foobar1-package", clusterName)))
+						} else if pkg.RefName == "foobar3.example.com.1.17.2" {
+							Expect(*pkg.ValuesFrom.ProviderRef.APIGroup).To(Equal("run.tanzu.vmware.com"))
+							Expect(pkg.ValuesFrom.ProviderRef.Kind).To(Equal("FooBar"))
+							Expect(pkg.ValuesFrom.ProviderRef.Name).To(Equal(fmt.Sprintf("%s-foobar3-package", clusterName)))
+						} else if pkg.RefName == "foobar.example.com.1.17.2" {
+							Expect(*pkg.ValuesFrom.ProviderRef.APIGroup).To(Equal("run.tanzu.vmware.com"))
+							Expect(pkg.ValuesFrom.ProviderRef.Kind).To(Equal("FooBar"))
+							Expect(pkg.ValuesFrom.ProviderRef.Name).To(Equal(fmt.Sprintf("%s-foobar-package", clusterName)))
+						} else if pkg.RefName == "foobar2.example.com.1.18.2" {
+							Expect(pkg.ValuesFrom.Inline).NotTo(BeNil())
+						}
+					}
+
+					// The cluster should be unpaused
+					Eventually(func() bool {
+						err := k8sClient.Get(ctx, client.ObjectKey{Namespace: clusterNamespace, Name: clusterName}, cluster)
+						if err != nil {
+							return false
+						}
+						return !cluster.Spec.Paused
+					}, waitTimeout, pollingInterval).Should(BeTrue())
+					if cluster.Annotations != nil {
+						_, ok := cluster.Annotations[constants.ClusterPauseLabel]
+						Expect(ok).ToNot(BeTrue())
+					}
+
 				})
 
 				By("Test ClusterBootstrap webhook validateUpdate ", func() {

--- a/addons/controllers/suite_test.go
+++ b/addons/controllers/suite_test.go
@@ -71,6 +71,7 @@ import (
 
 const (
 	waitTimeout                         = time.Second * 90
+	specialWaitTimeout                  = 5 * time.Minute
 	pollingInterval                     = time.Second * 2
 	appSyncPeriod                       = 5 * time.Minute
 	appWaitTimeout                      = 30 * time.Second

--- a/addons/controllers/suite_test.go
+++ b/addons/controllers/suite_test.go
@@ -381,6 +381,13 @@ var _ = BeforeSuite(func(done Done) {
 			ConfigControllerConfig: addonconfig.ConfigControllerConfig{SystemNamespace: constants.TKGSystemNS}},
 	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
 
+	Expect((&ClusterMetadataReconciler{
+		Client:  mgr.GetClient(),
+		Log:     ctrl.Log.WithName("controllers").WithName("ClusterMetadata"),
+		Scheme:  mgr.GetScheme(),
+		context: ctx,
+	}).SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1})).To(Succeed())
+
 	// set up a ClusterCacheTracker to provide to PackageInstallStatus controller which requires a connection to remote clusters
 	l := ctrl.Log.WithName("remote").WithName("ClusterCacheTracker")
 	tracker, err := capiremote.NewClusterCacheTracker(mgr, capiremote.ClusterCacheTrackerOptions{Log: &l})

--- a/addons/controllers/testdata/test-cluster-metadata.yaml
+++ b/addons/controllers/testdata/test-cluster-metadata.yaml
@@ -1,0 +1,627 @@
+---
+apiVersion: run.tanzu.vmware.com/v1alpha1
+kind: TanzuKubernetesRelease
+metadata:
+  name: v1.23.8---vmware.2-tkg.2
+  namespace: tkr-system
+spec:
+  version: v1.23.8---vmware.2-tkg.2
+  kubernetesVersion: v1.23.8+vmware.2
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: test-cluster-metadata
+  namespace: default
+  labels:
+    tkg.tanzu.vmware.com/cluster-name: test-cluster-metadata
+    run.tanzu.vmware.com/tkr: v1.23.8---vmware.2-tkg.2
+  annotations:
+    tkg/plan: dev
+spec:
+  infrastructureRef:
+    kind: VSphereCluster
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    name: test-cluster-metadata
+    namespace: default
+  clusterNetwork:
+    pods:
+      cidrBlocks: [ "192.168.0.0/16","fd00:100:96::/48" ]
+    services:
+      cidrBlocks: [ "192.168.0.0/16","fd00:100:96::/48" ]
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: test-cluster-metadata-plane
+    namespace: default
+  topology:
+    class: test-clusterclass-tcbt
+    version: v1.22.3
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: tkg-system-public
+  name: tkg-system-public
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name:  tkg-bom-v1.7.0
+  namespace: tkg-system-public
+data:
+  bom.yaml: |
+    apiVersion: run.tanzu.vmware.com/v1alpha2
+    default:
+      k8sVersion: v1.23.8+vmware.2-tkg.2
+    release:
+      version: v1.7.0
+    components:
+      aad-pod-identity:
+      - version: v1.8.0+vmware.1
+        images:
+          micImage:
+            imagePath: cluster-api/mic
+            tag: v1.8.0_vmware.1
+          nmiImage:
+            imagePath: cluster-api/nmi
+            tag: v1.8.0_vmware.1
+      alertmanager:
+      - version: v0.24.0+vmware.1
+        images:
+          alertmanagerImage:
+            imagePath: prometheus/alertmanager
+            tag: v0.24.0_vmware.1
+      cloud-provider-azure:
+      - version: v0.7.4+vmware.1
+        images:
+          ccmAzureControllerImage:
+            imagePath: azure-cloud-controller-manager
+            tag: v0.7.4_vmware.1
+          ccmAzureNodeImage:
+            imagePath: azure-cloud-node-manager
+            tag: v0.7.4_vmware.1
+      cluster-api-provider-azure:
+      - version: v1.5.3+vmware.1
+        images:
+          capzControllerImage:
+            imagePath: cluster-api/cluster-api-azure-controller
+            tag: v1.5.3_vmware.1
+      cluster-api-provider-bringyourownhost:
+      - version: v0.2.0+vmware.4
+        images:
+          byohControllerImage:
+            imagePath: cluster-api/cluster-api-byoh-controller
+            tag: v0.2.0_vmware.4
+      cluster-api-provider-oci:
+      - version: v0.4.0+vmware.2
+        images:
+          capociControllerImage:
+            imagePath: cluster-api/cluster-api-oci-controller
+            tag: v0.4.0_vmware.2
+      cluster_api:
+      - version: v1.2.4+vmware.1
+        images:
+          cabpkControllerImage:
+            imagePath: cluster-api/kubeadm-bootstrap-controller
+            tag: v1.2.4_vmware.1
+          capdManagerImage:
+            imagePath: cluster-api/capd-manager
+            tag: v1.2.4_vmware.1
+          capiControllerImage:
+            imagePath: cluster-api/cluster-api-controller
+            tag: v1.2.4_vmware.1
+          kcpControllerImage:
+            imagePath: cluster-api/kubeadm-control-plane-controller
+            tag: v1.2.4_vmware.1
+      cluster_api_aws:
+      - version: v2.0.0-beta.1+vmware.1
+        images:
+          capaControllerImage:
+            imagePath: cluster-api/cluster-api-aws-controller
+            tag: v2.0.0-beta.1_vmware.1
+      cluster_api_vsphere:
+      - version: v1.4.1+vmware.1
+        images:
+          capvControllerImage:
+            imagePath: cluster-api/cluster-api-vsphere-controller
+            tag: v1.4.1_vmware.1
+      configmap-reload:
+      - version: v0.7.1+vmware.1
+        images:
+          configmapReloadImage:
+            imagePath: prometheus/configmap-reload
+            tag: v0.7.1_vmware.1
+      contour:
+      - version: v1.17.2+vmware.1
+        images:
+          contourImage:
+            imagePath: contour
+            tag: v1.17.2_vmware.1
+      - version: v1.18.2+vmware.1
+        images:
+          contourImage:
+            imagePath: contour
+            tag: v1.18.2_vmware.1
+      - version: v1.20.2+vmware.1
+        images:
+          contourImage:
+            imagePath: contour
+            tag: v1.20.2_vmware.1
+      - version: v1.22.0+vmware.1
+        images:
+          contourImage:
+            imagePath: contour
+            tag: v1.22.0_vmware.1
+      crash-diagnostics:
+      - version: v0.3.7+vmware.6
+      envoy:
+      - version: v1.18.4+vmware.1
+        images:
+          envoyImage:
+            imagePath: envoy
+            tag: v1.18.4_vmware.1
+      - version: v1.19.1+vmware.1
+        images:
+          envoyImage:
+            imagePath: envoy
+            tag: v1.19.1_vmware.1
+      - version: v1.21.3+vmware.1
+        images:
+          envoyImage:
+            imagePath: envoy
+            tag: v1.21.3_vmware.1
+      - version: v1.23.0+vmware.1
+        images:
+          envoyImage:
+            imagePath: envoy
+            tag: v1.23.0_vmware.1
+      external-dns:
+      - version: v0.12.2+vmware.1
+        images:
+          externalDNSImage:
+            imagePath: external-dns
+            tag: v0.12.2_vmware.1
+      fluent-bit:
+      - version: v1.8.15+vmware.1
+        images:
+          fluentBitImage:
+            imagePath: fluent-bit
+            tag: v1.8.15_vmware.1
+      grafana:
+      - version: v7.5.16+vmware.1
+        images:
+          grafanaImage:
+            imagePath: grafana/grafana
+            tag: v7.5.16_vmware.1
+      harbor:
+      - version: v2.6.1+vmware.1
+        images:
+          harborChartMuseumImage:
+            imagePath: harbor/chartmuseum-photon
+            tag: v2.6.1_vmware.1
+          harborCoreImage:
+            imagePath: harbor/harbor-core
+            tag: v2.6.1_vmware.1
+          harborDatabaseImage:
+            imagePath: harbor/harbor-db
+            tag: v2.6.1_vmware.1
+          harborExporterImage:
+            imagePath: harbor/harbor-exporter
+            tag: v2.6.1_vmware.1
+          harborJobServiceImage:
+            imagePath: harbor/harbor-jobservice
+            tag: v2.6.1_vmware.1
+          harborLogImage:
+            imagePath: harbor/harbor-log
+            tag: v2.6.1_vmware.1
+          harborNginxImage:
+            imagePath: harbor/nginx-photon
+            tag: v2.6.1_vmware.1
+          harborNotaryServerImage:
+            imagePath: harbor/notary-server-photon
+            tag: v2.6.1_vmware.1
+          harborNotarySignerImage:
+            imagePath: harbor/notary-signer-photon
+            tag: v2.6.1_vmware.1
+          harborPortalImage:
+            imagePath: harbor/harbor-portal
+            tag: v2.6.1_vmware.1
+          harborPrepareImage:
+            imagePath: harbor/prepare
+            tag: v2.6.1_vmware.1
+          harborRedisImage:
+            imagePath: harbor/redis-photon
+            tag: v2.6.1_vmware.1
+          harborRegistryCtlImage:
+            imagePath: harbor/harbor-registryctl
+            tag: v2.6.1_vmware.1
+          harborRegistryImage:
+            imagePath: harbor/registry-photon
+            tag: v2.6.1_vmware.1
+          harborTrivyAdapterImage:
+            imagePath: harbor/trivy-adapter-photon
+            tag: v2.6.1_vmware.1
+      image-builder:
+      - version: v0.1.12+vmware.2
+        images:
+          imagebuilder-tar:
+            imagePath: image-builder
+            tag: v0.1.12_vmware.2
+      imgpkg:
+      - version: v0.31.0+vmware.1
+      jetstack_cert-manager:
+      - version: v1.9.1+vmware.1
+        images:
+          certMgrControllerImage:
+            imagePath: cert-manager-controller
+            tag: v1.9.1_vmware.1
+          certMgrInjectorImage:
+            imagePath: cert-manager-cainjector
+            tag: v1.9.1_vmware.1
+          certMgrWebhookImage:
+            imagePath: cert-manager-webhook
+            tag: v1.9.1_vmware.1
+      k8s-sidecar:
+      - version: v1.12.1+vmware.3
+        images:
+          k8sSidecarImage:
+            imagePath: grafana/k8s-sidecar
+            tag: v1.12.1_vmware.3
+      - version: v1.15.6+vmware.2
+        images:
+          k8sSidecarImage:
+            imagePath: grafana/k8s-sidecar
+            tag: v1.15.6_vmware.2
+      k14s_kapp:
+      - version: v0.53.0+vmware.1
+      k14s_ytt:
+      - version: v0.43.0+vmware.1
+      kbld:
+      - version: v0.35.0+vmware.1
+      kube-state-metrics:
+      - version: v2.5.0+vmware.1
+        images:
+          kubeStateMetricsImage:
+            imagePath: prometheus/kube-state-metrics
+            tag: v2.5.0_vmware.1
+      kube-vip:
+      - version: v0.5.5+vmware.1
+        images:
+          kubeVipImage:
+            imagePath: kube-vip
+            tag: v0.5.5_vmware.1
+      kube-vip-cloud-provider:
+      - version: v0.0.4+vmware.1
+        images:
+          kubevipcloudproviderControllerImage:
+            imagePath: kube-vip/kube-vip-cloud-provider
+            tag: v0.0.4_vmware.1
+      kube_rbac_proxy:
+      - version: v0.11.0+vmware.2
+        images:
+          kubeRbacProxyControllerImage:
+            imagePath: kube-rbac-proxy
+            tag: v0.11.0_vmware.2
+          kubeRbacProxyControllerImageCapi:
+            imagePath: cluster-api/kube-rbac-proxy
+            tag: v0.11.0_vmware.2
+      kubernetes-sigs_kind:
+      - version: v1.23.8+vmware.2-tkg.1_v0.11.1
+        images:
+          kindNodeImage:
+            imagePath: kind/node
+            tag: v1.23.8_vmware.2-tkg.1_v0.11.1
+      kubernetes_autoscaler:
+      - version: v1.23.0+vmware.1
+        images:
+          kubernetesAutoscalerImage:
+            imagePath: cluster-autoscaler
+            tag: v1.23.0_vmware.1
+        metadata:
+          k8sversion: v1.23.3+vmware.1
+      - version: v1.22.0+vmware.1
+        images:
+          kubernetesAutoscalerImage:
+            imagePath: cluster-autoscaler
+            tag: v1.22.0_vmware.1
+        metadata:
+          k8sversion: v1.22.3+vmware.1
+      - version: v1.21.0+vmware.1
+        images:
+          kubernetesAutoscalerImage:
+            imagePath: cluster-autoscaler
+            tag: v1.21.0_vmware.1
+        metadata:
+          k8sversion: v1.21.1+vmware.1
+      multus-cni:
+      - version: v3.8.0+vmware.1
+        images:
+          multusCniImage:
+            imagePath: multus-cni
+            tag: v3.8.0_vmware.1
+      prometheus:
+      - version: v2.36.2+vmware.1
+        images:
+          prometheusImage:
+            imagePath: prometheus/prometheus
+            tag: v2.36.2_vmware.1
+      prometheus_node_exporter:
+      - version: v1.3.1+vmware.1
+        images:
+          prometheusNodeExporterImage:
+            imagePath: prometheus/prometheus_node_exporter
+            tag: v1.3.1_vmware.1
+      pushgateway:
+      - version: v1.4.3+vmware.1
+        images:
+          pushgatewayImage:
+            imagePath: prometheus/pushgateway
+            tag: v1.4.3_vmware.1
+      sonobuoy:
+      - version: v0.56.6+vmware.1
+        images:
+          sonobuoyImage:
+            imagePath: sonobuoy
+            tag: v0.56.6_vmware.1
+      standalone-plugins-package:
+      - version: v0.28.0-dev-104-g36b89720-standalone-plugins
+        images:
+          standalone-plugins.tanzu.vmware.com:
+            imagePath: packages/standalone-plugins
+            tag: v0.28.0-dev-104-g36b89720_vmware.1
+      tanzu-framework:
+      - version: v0.28.0-dev-104-g36b89720
+        images:
+          capabilitiesImage:
+            imagePath: tanzu_core/capabilities/capabilities-controller-manager-tf
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsClusterDarwinAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/cluster-darwin-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsClusterDarwinAmd64StaticImage:
+            imagePath: tanzu_core/tanzu-cli-plugins/cluster-darwin-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsClusterLinuxAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/cluster-linux-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsClusterLinuxAmd64StaticImage:
+            imagePath: tanzu_core/tanzu-cli-plugins/cluster-linux-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsClusterWindowsAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/cluster-windows-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsClusterWindowsAmd64StaticImage:
+            imagePath: tanzu_core/tanzu-cli-plugins/cluster-windows-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsFeatureDarwinAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/feature-darwin-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsFeatureDarwinAmd64StaticImage:
+            imagePath: tanzu_core/tanzu-cli-plugins/feature-darwin-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsFeatureLinuxAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/feature-linux-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsFeatureLinuxAmd64StaticImage:
+            imagePath: tanzu_core/tanzu-cli-plugins/feature-linux-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsFeatureWindowsAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/feature-windows-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsFeatureWindowsAmd64StaticImage:
+            imagePath: tanzu_core/tanzu-cli-plugins/feature-windows-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsKubernetesReleaseDarwinAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/kubernetes-release-darwin-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsKubernetesReleaseDarwinAmd64StaticImage:
+            imagePath: tanzu_core/tanzu-cli-plugins/kubernetes-release-darwin-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsKubernetesReleaseLinuxAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/kubernetes-release-linux-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsKubernetesReleaseLinuxAmd64StaticImage:
+            imagePath: tanzu_core/tanzu-cli-plugins/kubernetes-release-linux-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsKubernetesReleaseWindowsAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/kubernetes-release-windows-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsKubernetesReleaseWindowsAmd64StaticImage:
+            imagePath: tanzu_core/tanzu-cli-plugins/kubernetes-release-windows-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsLoginDarwinAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/login-darwin-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsLoginLinuxAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/login-linux-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsLoginWindowsAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/login-windows-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsManagementClusterDarwinAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/management-cluster-darwin-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsManagementClusterLinuxAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/management-cluster-linux-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsManagementClusterWindowsAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/management-cluster-windows-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsPackageDarwinAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/package-darwin-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsPackageLinuxAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/package-linux-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsPackageWindowsAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/package-windows-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsPinnipedAuthDarwinAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/pinniped-auth-darwin-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsPinnipedAuthLinuxAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/pinniped-auth-linux-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsPinnipedAuthWindowsAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/pinniped-auth-windows-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsSecretDarwinAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/secret-darwin-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsSecretLinuxAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/secret-linux-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsSecretWindowsAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/secret-windows-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsTelemetryDarwinAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/telemetry-darwin-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsTelemetryLinuxAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/telemetry-linux-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          clipluginsTelemetryWindowsAmd64Image:
+            imagePath: tanzu_core/tanzu-cli-plugins/telemetry-windows-amd64
+            tag: v0.28.0-dev-104-g36b89720
+          featuregatesImage:
+            imagePath: tanzu_core/featuregates/featuregates-controller-manager
+            tag: v0.28.0-dev-104-g36b89720
+          objectPropagationControllerImage:
+            imagePath: tanzu_core/objectpropogation/object-propagation-controller
+            tag: v0.28.0-dev-104-g36b89720
+          providerTemplateImage:
+            imagePath: tanzu_core/provider/provider-templates
+            tag: v0.28.0-dev-104-g36b89720
+          tkrConversionWebhookImage:
+            imagePath: tanzu_core/tkr/tkr-conversion-webhook
+            tag: v0.28.0-dev-104-g36b89720
+          tkrImage:
+            imagePath: tanzu_core/tkr/tkr-controller-manager
+            tag: v0.28.0-dev-104-g36b89720
+          tkrResolverImage:
+            imagePath: tanzu_core/tkr/tkr-resolver-cluster-webhook
+            tag: v0.28.0-dev-104-g36b89720
+          tkrSourceControllerImage:
+            imagePath: tanzu_core/tkr/tkr-source-controller
+            tag: v0.28.0-dev-104-g36b89720
+          tkrStatusControllerImage:
+            imagePath: tanzu_core/tkr/tkr-status-controller
+            tag: v0.28.0-dev-104-g36b89720
+          tkrVsphereResolverImage:
+            imagePath: tanzu_core/tkr/tkr-vsphere-cluster-webhook
+            tag: v0.28.0-dev-104-g36b89720
+      tanzu-framework-management-packages:
+      - version: v0.28.0-dev-104-g36b89720
+        images:
+          tanzuFrameworkManagementPackageRepositoryImage:
+            imagePath: packages/management/repo
+            tag: v0.28.0-dev-104-g36b89720
+          tanzuFrameworkManagementPackageRepositoryImageUTKG:
+            imagePath: packages/management/repo
+            tag: v0.28.0-dev-104-g36b89720-utkg
+      tkg-bom:
+      - version: v1.7.0
+        images:
+          tkgBomImage:
+            imagePath: tkg-bom
+            tag: v1.7.0
+      tkg-standard-packages:
+      - version: v1.7.0
+        images:
+          tanzuStandardPackageRepositoryImage:
+            imagePath: packages/standard/repo
+            tag: v1.7.0
+      tkg_telemetry:
+      - version: v1.6.0+vmware.1
+        images:
+          tkgTelemetryImage:
+            imagePath: tkg-telemetry
+            tag: v1.6.0_vmware.1
+      velero:
+      - version: v1.9.2+vmware.1
+        images:
+          veleroImage:
+            imagePath: velero/velero
+            tag: v1.9.2_vmware.1
+          veleroResticRestoreHelperImage:
+            imagePath: velero/velero-restic-restore-helper
+            tag: v1.9.2_vmware.1
+      velero-plugin-for-aws:
+      - version: v1.5.1+vmware.1
+        images:
+          veleroPluginForAwsImage:
+            imagePath: velero/velero-plugin-for-aws
+            tag: v1.5.1_vmware.1
+      velero-plugin-for-csi:
+      - version: v0.3.1+vmware.1
+        images:
+          veleroPluginForCsiImage:
+            imagePath: velero/velero-plugin-for-csi
+            tag: v0.3.1_vmware.1
+      velero-plugin-for-microsoft-azure:
+      - version: v1.5.1+vmware.1
+        images:
+          veleroPluginForMicrosoftAzureImage:
+            imagePath: velero/velero-plugin-for-microsoft-azure
+            tag: v1.5.1_vmware.1
+      velero-plugin-for-vsphere:
+      - version: v1.4.0+vmware.1
+        images:
+          veleroBackupDriverImage:
+            imagePath: velero/backup-driver
+            tag: v1.4.0_vmware.1
+          veleroDataManagerForPluginImage:
+            imagePath: velero/data-manager-for-plugin
+            tag: v1.4.0_vmware.1
+          veleroPluginForVsphereImage:
+            imagePath: velero/velero-plugin-for-vsphere
+            tag: v1.4.0_vmware.1
+      vendir:
+      - version: v0.30.0+vmware.1
+      whereabouts:
+      - version: v0.5.4+vmware.1
+        images:
+          whereaboutsImage:
+            imagePath: whereabouts
+            tag: v0.5.4_vmware.1
+    kindKubeadmConfigSpec:
+    - 'kind: Cluster'
+    - 'apiVersion: kind.x-k8s.io/v1alpha4'
+    - 'kubeadmConfigPatches:'
+    - '- |'
+    - '  apiVersion: kubeadm.k8s.io/v1beta2'
+    - '  kind: ClusterConfiguration'
+    - '  imageRepository: projects.registry.vmware.com/tkg'
+    - '  etcd:'
+    - '    local:'
+    - '      imageRepository: projects.registry.vmware.com/tkg'
+    - '      imageTag: v3.5.4_vmware.6'
+    - '  dns:'
+    - '    type: CoreDNS'
+    - '    imageRepository: projects.registry.vmware.com/tkg'
+    - '    imageTag: v1.8.6_vmware.7'
+    imageConfig:
+      imageRepository: projects-stg.registry.vmware.com/tkg
+    tkr-bom:
+      imagePath: tkr-bom
+    tkr-compatibility:
+      imagePath: v20-v1.7.0/tkr-compatibility
+    tkr-package-repo:
+      aws: tkr-repository-aws
+      azure: tkr-repository-azure
+      vsphere-nonparavirt: tkr-repository-vsphere-nonparavirt
+    tkr-package:
+      aws: tkr-aws
+      azure: tkr-azure
+      vsphere-nonparavirt: tkr-vsphere-nonparavirt
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bom-metadata
+  namespace: tkg-system
+binaryData:
+  compatibility: bWFuYWdlbWVudENsdXN0ZXJWZXJzaW9uczoKLSBzdXBwb3J0ZWRLdWJlcm5ldGVzVmVyc2lvbnM6CiAgLSB2MS4yMC40K3Ztd2FyZS4xLXRrZy4xCiAgLSB2MS4xOS44K3Ztd2FyZS4xLXRrZy4xCiAgLSB2MS4xOC4xNit2bXdhcmUuMS10a2cuMQogIC0gdjEuMTcuMTYrdm13YXJlLjItdGtnLjEKICB2ZXJzaW9uOiB2MS4zLjAKLSBzdXBwb3J0ZWRLdWJlcm5ldGVzVmVyc2lvbnM6CiAgLSB2MS4xOS44K3Ztd2FyZS4zLXRrZy4xCiAgLSB2MS4yMC41K3Ztd2FyZS4yLXRrZy4xCiAgLSB2MS4xOC4xNyt2bXdhcmUuMi10a2cuMQogIC0gdjEuMjAuNCt2bXdhcmUuMy10a2cuMQogIC0gdjEuMTkuOSt2bXdhcmUuMi10a2cuMQogIC0gdjEuMTguMTYrdm13YXJlLjMtdGtnLjEKICAtIHYxLjE3LjE2K3Ztd2FyZS4zLXRrZy4xCiAgdmVyc2lvbjogdjEuMy4xCi0gc3VwcG9ydGVkS3ViZXJuZXRlc1ZlcnNpb25zOgogIC0gdjEuMjAuNSt2bXdhcmUuMi1maXBzLjEtdGtnLjEKICB2ZXJzaW9uOiB2MS4zLjEtZmlwcy4xCi0gc3VwcG9ydGVkS3ViZXJuZXRlc1ZlcnNpb25zOgogIC0gdjEuMTkuOCt2bXdhcmUuMy10a2cuMQogIC0gdjEuMjAuNSt2bXdhcmUuMi10a2cuMQogIC0gdjEuMTguMTcrdm13YXJlLjItdGtnLjEKICAtIHYxLjIwLjQrdm13YXJlLjMtdGtnLjEKICAtIHYxLjE5Ljkrdm13YXJlLjItdGtnLjEKICAtIHYxLjE4LjE2K3Ztd2FyZS4zLXRrZy4xCiAgLSB2MS4xNy4xNit2bXdhcmUuMy10a2cuMQogIHZlcnNpb246IHYxLjMuMS1wYXRjaDEKLSBzdXBwb3J0ZWRLdWJlcm5ldGVzVmVyc2lvbnM6CiAgLSB2MS4xOS4xMit2bXdhcmUuMS10a2cuMQogIC0gdjEuMjEuMit2bXdhcmUuMS10a2cuMQogIC0gdjEuMjAuOCt2bXdhcmUuMS10a2cuMgogIHZlcnNpb246IHYxLjQuMAotIHN1cHBvcnRlZEt1YmVybmV0ZXNWZXJzaW9uczoKICAtIHYxLjIxLjIrdm13YXJlLjEtZmlwcy4xLXRrZy4xCiAgLSB2MS4yMC44K3Ztd2FyZS4xLWZpcHMuMS10a2cuMgogIHZlcnNpb246IHYxLjQuMC1maXBzLjEKLSBzdXBwb3J0ZWRLdWJlcm5ldGVzVmVyc2lvbnM6CiAgLSB2MS4yMS4yK3Ztd2FyZS4xLXRrZy4yCiAgLSB2MS4yMC44K3Ztd2FyZS4xLXRrZy4zCiAgLSB2MS4xOS4xMit2bXdhcmUuMS10a2cuMgogIHZlcnNpb246IHYxLjQuMQotIHN1cHBvcnRlZEt1YmVybmV0ZXNWZXJzaW9uczoKICAtIHYxLjIxLjgrdm13YXJlLjEtdGtnLjIKICAtIHYxLjE5LjE2K3Ztd2FyZS4xLXRrZy4xCiAgLSB2MS4yMC4xNCt2bXdhcmUuMS10a2cuMgogIHZlcnNpb246IHYxLjQuMgotIHN1cHBvcnRlZEt1YmVybmV0ZXNWZXJzaW9uczoKICAtIHYxLjIwLjE0K3Ztd2FyZS4xLXRrZy43CiAgLSB2MS4xOS4xNit2bXdhcmUuMS10a2cuMgogIC0gdjEuMjEuOCt2bXdhcmUuMS10a2cuNwogIHZlcnNpb246IHYxLjQuMwotIHN1cHBvcnRlZEt1YmVybmV0ZXNWZXJzaW9uczoKICAtIHYxLjIyLjUrdm13YXJlLjEtdGtnLjEKICAtIHYxLjIxLjgrdm13YXJlLjEtdGtnLjEKICAtIHYxLjIwLjE0K3Ztd2FyZS4xLXRrZy4xCiAgdmVyc2lvbjogdjEuNS4wCi0gc3VwcG9ydGVkS3ViZXJuZXRlc1ZlcnNpb25zOgogIC0gdjEuMjIuNSt2bXdhcmUuMS10a2cuMwogIC0gdjEuMjEuOCt2bXdhcmUuMS10a2cuNAogIC0gdjEuMjAuMTQrdm13YXJlLjEtdGtnLjQKICB2ZXJzaW9uOiB2MS41LjEKLSBzdXBwb3J0ZWRLdWJlcm5ldGVzVmVyc2lvbnM6CiAgLSB2MS4yMi41K3Ztd2FyZS4xLXRrZy40CiAgLSB2MS4yMC4xNCt2bXdhcmUuMS10a2cuNQogIC0gdjEuMjEuOCt2bXdhcmUuMS10a2cuNQogIHZlcnNpb246IHYxLjUuMgotIHN1cHBvcnRlZEt1YmVybmV0ZXNWZXJzaW9uczoKICAtIHYxLjIwLjE1K3Ztd2FyZS4xLXRrZy4xCiAgLSB2MS4yMi44K3Ztd2FyZS4xLXRrZy4xCiAgLSB2MS4yMS4xMSt2bXdhcmUuMS10a2cuMQogIHZlcnNpb246IHYxLjUuMwotIHN1cHBvcnRlZEt1YmVybmV0ZXNWZXJzaW9uczoKICAtIHYxLjIwLjE1K3Ztd2FyZS4xLWZpcHMuMS10a2cuMQogIC0gdjEuMjIuOCt2bXdhcmUuMS1maXBzLjEtdGtnLjEKICAtIHYxLjIxLjExK3Ztd2FyZS4xLWZpcHMuMS10a2cuMQogIHZlcnNpb246IHYxLjUuMy1maXBzLjEKLSBzdXBwb3J0ZWRLdWJlcm5ldGVzVmVyc2lvbnM6CiAgLSB2MS4yMC4xNSt2bXdhcmUuMS10a2cuMgogIC0gdjEuMjIuOSt2bXdhcmUuMS10a2cuMQogIC0gdjEuMjEuMTErdm13YXJlLjEtdGtnLjMKICB2ZXJzaW9uOiB2MS41LjQKLSBzdXBwb3J0ZWRLdWJlcm5ldGVzVmVyc2lvbnM6CiAgLSB2MS4yMC4xNSt2bXdhcmUuMi1maXBzLXRrZy4xCiAgLSB2MS4yMS4xMSt2bXdhcmUuMi1maXBzLXRrZy4xCiAgLSB2MS4yMi45K3Ztd2FyZS4xLWZpcHMtdGtnLjEKICB2ZXJzaW9uOiB2MS41LjQtZmlwcy4xCi0gc3VwcG9ydGVkS3ViZXJuZXRlc1ZlcnNpb25zOgogIC0gdjEuMjMuOCt2bXdhcmUuMi10a2cuMQogIC0gdjEuMjEuMTQrdm13YXJlLjItdGtnLjEKICAtIHYxLjIyLjExK3Ztd2FyZS4yLXRrZy4xCiAgdmVyc2lvbjogdjEuNi4wCi0gc3VwcG9ydGVkS3ViZXJuZXRlc1ZlcnNpb25zOgogIC0gdjEuMjMuOCt2bXdhcmUuMi1maXBzLjEtdGtnLjEKICAtIHYxLjIyLjExK3Ztd2FyZS4yLWZpcHMuMS10a2cuMQogIC0gdjEuMjEuMTQrdm13YXJlLjItZmlwcy4xLXRrZy4xCiAgdmVyc2lvbjogdjEuNi4wLWZpcHMuMQotIHN1cHBvcnRlZEt1YmVybmV0ZXNWZXJzaW9uczoKICAtIHYxLjI0LjYrdm13YXJlLjEtdGtnLjEKICAtIHYxLjIzLjgrdm13YXJlLjItdGtnLjIKICAtIHYxLjIyLjExK3Ztd2FyZS4yLXRrZy4yCiAgdmVyc2lvbjogdjEuNy4wCg==

--- a/addons/main.go
+++ b/addons/main.go
@@ -246,10 +246,24 @@ func main() {
 		enablePackageInstallStatusController(ctx, mgr, flags)
 	}
 
+	enableClusterMetadata(ctx, mgr)
 	setupChecks(mgr)
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}
+
+func enableClusterMetadata(ctx context.Context, mgr ctrl.Manager) {
+	clusterMetadataReconciler := controllers.NewClusterMetadataReconciler(
+		mgr.GetClient(),
+		ctrl.Log.WithName("ClusterMetadataReconciler"),
+		mgr.GetScheme(),
+	)
+
+	if err := clusterMetadataReconciler.SetupWithManager(ctx, mgr, controller.Options{MaxConcurrentReconciles: 1}); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "metadata")
 		os.Exit(1)
 	}
 }

--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -64,6 +64,9 @@ const (
 	// TKRLabel is the TKR label.
 	TKRLabel = "tanzuKubernetesRelease"
 
+	// TKGVersionLabel is the TKG version label.
+	TKGVersionLabel = "tkg.tanzu.vmware.com/version"
+
 	// TKRLabelClassyClusters is the TKR label for the clusters created using cluster-class
 	TKRLabelClassyClusters = "run.tanzu.vmware.com/tkr"
 
@@ -73,8 +76,29 @@ const (
 	// TKGAnnotationTemplateConfig is the TKG annotation for addon config CRs used by ClusterBootstrapTemplate
 	TKGAnnotationTemplateConfig = "tkg.tanzu.vmware.com/template-config"
 
+	// TKRBomContent is the TKR BOM content.
+	TKRBomContent = "bomContent"
+
 	// TKGBomContent is the TKG BOM content.
-	TKGBomContent = "bomContent"
+	TKGBomContent = "bom.yaml"
+
+	// ClusterMetadataNamespace is the namespace for ClusterMetadata
+	ClusterMetadataNamespace = "tkg-system-public"
+
+	// TkgBomConfigMapName is the name of TkgBomConfigMap
+	TkgBomConfigMapName = "tkg-bom"
+
+	// TkgMetadataConfigMapName is the name of TkgMetadataConfigMap
+	TkgMetadataConfigMapName = "tkg-metadata"
+
+	// ClusterMetadataNamespaceRoleName is the role name of ClusterMetadata
+	ClusterMetadataNamespaceRoleName = "tkg-metadata-reader"
+
+	// ClusterMetadataRolebindingSubjectName is the subjectName of ClusterMetadataRolebinding
+	ClusterMetadataRolebindingSubjectName = "system:authenticated"
+
+	// TKGCompatibility is the TKG compatibility content.
+	TKGCompatibility = "compatibility"
 
 	// TKRConfigmapName is the name of TKR config map
 	TKRConfigmapName = "tkr-controller-config"
@@ -179,6 +203,9 @@ const (
 
 	// TKGSystemNS is the TKG system namespace.
 	TKGSystemNS = "tkg-system"
+
+	// TKGbomMetadataConfigmapName is the confimap of bom-metadata
+	TKGbomMetadataConfigmapName = "bom-metadata"
 
 	// DiscoveryCacheInvalidateInterval is the interval for invalidating cache
 	DiscoveryCacheInvalidateInterval = time.Minute * 10
@@ -314,6 +341,9 @@ const (
 
 	// CAPVClusterSelectorKey is the selector key used by capv
 	CAPVClusterSelectorKey = "capv.vmware.com/cluster.name"
+
+	// KindTanzuKubernetesCluster is the owner name of cluster
+	KindTanzuKubernetesCluster = "TanzuKubernetesCluster"
 )
 
 var (

--- a/addons/pkg/util/bom_util.go
+++ b/addons/pkg/util/bom_util.go
@@ -28,9 +28,9 @@ func GetBOMByTKRName(ctx context.Context, c client.Client, tkrName string) (*tkr
 	}
 
 	bomConfigMap = &configMapList.Items[0]
-	bomData, ok := bomConfigMap.BinaryData[constants.TKGBomContent]
+	bomData, ok := bomConfigMap.BinaryData[constants.TKRBomContent]
 	if !ok {
-		bomDataString, ok := bomConfigMap.Data[constants.TKGBomContent]
+		bomDataString, ok := bomConfigMap.Data[constants.TKRBomContent]
 		if !ok {
 			return nil, nil
 		}
@@ -43,6 +43,28 @@ func GetBOMByTKRName(ctx context.Context, c client.Client, tkrName string) (*tkr
 	}
 
 	return &bom, nil
+}
+
+func GetTkgBomConfigMapByName(ctx context.Context, c client.Client, configmapName string) (*tkrv1.TkgBom, error) {
+	var bomConfigMap corev1.ConfigMap
+	objectKey := client.ObjectKey{Namespace: constants.ClusterMetadataNamespace, Name: configmapName}
+	if err := c.Get(ctx, objectKey, &bomConfigMap); err != nil {
+		return nil, err
+	}
+	bomData, ok := bomConfigMap.BinaryData[constants.TKGBomContent]
+	if !ok {
+		bomDataString, ok := bomConfigMap.Data[constants.TKGBomContent]
+		if !ok {
+			return nil, nil
+		}
+		bomData = []byte(bomDataString)
+	}
+
+	tkgBom, err := tkrv1.NewTkgBom(bomData)
+	if err != nil {
+		return nil, err
+	}
+	return &tkgBom, nil
 }
 
 // GetTKRNameFromBOMConfigMap returns tkr name given a bom configmap

--- a/apis/run/go.mod
+++ b/apis/run/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.1
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0
 	k8s.io/api v0.24.2
 	k8s.io/apimachinery v0.24.2
 	k8s.io/kubectl v0.24.0
@@ -63,7 +64,6 @@ require (
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
-	gopkg.in/yaml.v3 v3.0.0 // indirect
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/client-go v0.24.2 // indirect
 	k8s.io/component-base v0.24.2 // indirect

--- a/apis/run/pkg/tkr/v1/compatibility.go
+++ b/apis/run/pkg/tkr/v1/compatibility.go
@@ -1,0 +1,43 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+type Compatibility struct {
+	ManagementClusterVersions []ManagementClusterVersions `yaml:"managementClusterVersions"`
+}
+
+type ManagementClusterVersions struct {
+	SupportedKubernetesVersions []string `yaml:"supportedKubernetesVersions"`
+	Version                     string   `yaml:"version"`
+}
+
+func NewCompatibility(data []byte) (Compatibility, error) {
+	var compatibility Compatibility
+	if err := yaml.Unmarshal(data, &compatibility); err != nil {
+		return Compatibility{}, errors.Wrap(err, "unable to unmarshal compatibility file data to Compatibility struct")
+	}
+	return compatibility, nil
+}
+
+func FilterTkgVersionByTkr(compatibility Compatibility, tkrName string) (version string, err error) {
+	tkrVersion := strings.Replace(tkrName, "---", "+", 1)
+	for _, managementVersions := range compatibility.ManagementClusterVersions {
+		for _, supportVersion := range managementVersions.SupportedKubernetesVersions {
+			if supportVersion == "" {
+				return "", errors.New("invalid supportVersion")
+			}
+			if tkrVersion == supportVersion {
+				return managementVersions.Version, nil
+			}
+		}
+	}
+	return "", errors.New("there are no compatible tkg versions")
+}

--- a/apis/run/pkg/tkr/v1/tkgBom.go
+++ b/apis/run/pkg/tkr/v1/tkgBom.go
@@ -1,0 +1,115 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+type TkgBom struct {
+	bom        TkgBomContent
+	initialzed bool
+}
+
+type imageConfig struct {
+	ImageRepository string `yaml:"imageRepository"`
+}
+
+type kubeadmConfig struct {
+	APIVersion        string `yaml:"apiVersion"`
+	Kind              string `yaml:"kind"`
+	ImageRepository   string `yaml:"imageRepository"`
+	KubernetesVersion string `yaml:"kubernetesVersion"`
+	Etcd              etcd   `yaml:"etcd"`
+	DNS               dns    `yaml:"dns"`
+}
+
+type etcd struct {
+	Local *localEtcd `yaml:"local"`
+}
+
+type localEtcd struct {
+	DataDir         string            `yaml:"dataDir"`
+	ImageRepository string            `yaml:"imageRepository"`
+	ImageTag        string            `yaml:"imageTag"`
+	ExtraArgs       map[string]string `yaml:"extraArgs,omitempty"`
+}
+
+type dns struct {
+	Type            string `yaml:"type"`
+	ImageRepository string `yaml:"imageRepository"`
+	ImageTag        string `yaml:"imageTag"`
+}
+
+type extensionInfo struct {
+	ClusterTypes []string `yaml:"clusterTypes"`
+	ManagedBy    string   `yaml:"managedBy"`
+}
+
+// ReleaseInfo represents the release version information
+type ReleaseInfo struct {
+	Version string `yaml:"version"`
+}
+
+type defaultInfo struct {
+	TKRVersion string `yaml:"k8sVersion"`
+}
+
+type tkrBOMInfo struct {
+	ImagePath string `yaml:"imagePath"`
+}
+
+type tkrCompatibilityInfo struct {
+	ImagePath string `yaml:"imagePath"`
+}
+
+type tkrPackageRepo struct {
+	AWS                string `yaml:"aws"`
+	Azure              string `yaml:"azure"`
+	VSphereNonparavirt string `yaml:"vsphere-nonparavirt"`
+}
+
+type tkrPackage struct {
+	AWS                string `yaml:"aws"`
+	Azure              string `yaml:"azure"`
+	VSphereNonparavirt string `yaml:"vsphere-nonparavirt"`
+}
+
+// TkgBomContent defines the struct to represent BOM information
+type TkgBomContent struct {
+	Default               *defaultInfo                `yaml:"default"`
+	Release               *ReleaseInfo                `yaml:"release"`
+	Components            map[string][]*ComponentInfo `yaml:"components"`
+	KindKubeadmConfigSpec []string                    `yaml:"kindKubeadmConfigSpec"`
+	KubeadmConfigSpec     *kubeadmConfig              `yaml:"kubeadmConfigSpec"`
+	ImageConfig           *imageConfig                `yaml:"imageConfig"`
+	Extensions            map[string]*extensionInfo   `yaml:"extensions,omitempty"`
+	TKRBOM                *tkrBOMInfo                 `yaml:"tkr-bom"`
+	TKRCompatibility      *tkrCompatibilityInfo       `yaml:"tkr-compatibility"`
+	TKRPackageRepo        *tkrPackageRepo             `yaml:"tkr-package-repo"`
+	TKRPackage            *tkrPackage                 `yaml:"tkr-package"`
+}
+
+// DNSAddOnType defines string identifying DNS add-on types
+type DNSAddOnType string
+
+func NewTkgBom(data []byte) (TkgBom, error) {
+	var bomContent TkgBomContent
+	if err := yaml.Unmarshal(data, &bomContent); err != nil {
+		return TkgBom{}, errors.Wrap(err, "unable to unmarshal bom file data to BOMConfiguration struct")
+	}
+
+	return TkgBom{
+		bom:        bomContent,
+		initialzed: true,
+	}, nil
+}
+
+func (b *TkgBom) GetBomContent() (TkgBomContent, error) {
+	if !b.initialzed {
+		return TkgBomContent{}, errors.New("the tkg BOM is not initialized")
+	}
+	return b.bom, nil
+}

--- a/providers/yttcc/01_plans/dev.yaml
+++ b/providers/yttcc/01_plans/dev.yaml
@@ -1,7 +1,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
 
-#@ if data.values.CLUSTER_PLAN == "dev":
+#@ if data.values.CLUSTER_PLAN == "dev" or data.values.CLUSTER_PLAN == "devcc":
 #@overlay/match missing_ok=True,by=overlay.subset({"kind":"Cluster"})
 ---
 apiVersion: cluster.x-k8s.io/v1beta1

--- a/providers/yttcc/01_plans/prod.yaml
+++ b/providers/yttcc/01_plans/prod.yaml
@@ -1,7 +1,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
 
-#@ if data.values.CLUSTER_PLAN == "prod":
+#@ if data.values.CLUSTER_PLAN == "prod" or data.values.CLUSTER_PLAN == "prodcc":
 #@overlay/match missing_ok=True,by=overlay.subset({"kind":"Cluster"})
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -23,5 +23,4 @@ metadata:
     #@overlay/match missing_ok=True
     tkg/plan: prod
   #! possible other customizations specific to the prod plan....
-
 #@ end

--- a/tkg/client/client_suite_test.go
+++ b/tkg/client/client_suite_test.go
@@ -31,6 +31,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	capav1beta2 "sigs.k8s.io/cluster-api-provider-aws/api/v1beta2"
@@ -38,6 +39,7 @@ import (
 	capvv1beta1 "sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
+	clusterctlv1alpha3 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
 
 	tkgsv1alpha2 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
@@ -71,11 +73,13 @@ func init() {
 	_ = capiv1alpha3.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 	_ = appsv1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
 	_ = controlplanev1.AddToScheme(scheme)
 	_ = tkgsv1alpha2.AddToScheme(scheme)
 	_ = capav1beta2.AddToScheme(scheme)
 	_ = capzv1beta1.AddToScheme(scheme)
 	_ = capvv1beta1.AddToScheme(scheme)
+	_ = clusterctlv1alpha3.AddToScheme(scheme)
 }
 
 var _ = Describe("CheckInfrastructureVersion", func() {

--- a/tkg/client/init.go
+++ b/tkg/client/init.go
@@ -421,6 +421,13 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 		}
 	}
 
+	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+		log.Info("Creating tkg-bom versioned ConfigMaps...")
+		if err := c.CreateOrUpdateVerisionedTKGBom(regionalClusterClient); err != nil {
+			log.Warningf("Warning: Management cluster is created successfully, but the tkg-bom versioned ConfigMaps creation is failing. %v", err)
+		}
+	}
+
 	log.Infof("You can now access the management cluster %s by running 'kubectl config use-context %s'", options.ClusterName, kubeContext)
 	isSuccessful = true
 	return nil

--- a/tkg/client/update_cluster_versioned_bom.go
+++ b/tkg/client/update_cluster_versioned_bom.go
@@ -1,0 +1,134 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/vmware-tanzu/tanzu-framework/tkg/clusterclient"
+)
+
+const clusterMetadataNamespace = "tkg-system-public"
+const tkgBomConfigMapName = "tkg-bom"
+const clusterMetadataNamespaceRoleName = "tkg-metadata-reader"
+
+// CreateOrUpdateVerisionedTKGBom will create or update the tkg-bom-<tkg-version> ConfigMap. This is required for destributing tkg-bom information
+// to workload clusters.
+func (c *TkgClient) CreateOrUpdateVerisionedTKGBom(regionalClusterClient clusterclient.Client) error {
+	bomConfiguration, err := c.tkgBomClient.GetDefaultTkgBOMConfiguration()
+	if err != nil {
+		return errors.Wrapf(err, "cannot get the default bom configuration")
+	}
+
+	tkgBomConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: clusterMetadataNamespace,
+			Name:      tkgBomConfigMapName + "-" + bomConfiguration.Release.Version,
+		},
+		Data: make(map[string]string),
+	}
+
+	bomConfigurationByte, err := yaml.Marshal(bomConfiguration)
+	if err != nil {
+		return errors.Wrap(err, "unable to yaml marshal default bom configuration")
+	}
+	tkgBomConfigMap.Data["bom.yaml"] = string(bomConfigurationByte)
+
+	// in case the namespace and the corresponding rbac are not exists
+	err = createOrUpdateNamespaceRole(regionalClusterClient)
+	if err != nil {
+		return errors.Wrap(err, "failed to create or update namespace role")
+	}
+
+	// create or update tkg-bom ConfigMap
+	err = createOrUpdateResource(regionalClusterClient, tkgBomConfigMap, tkgBomConfigMapName, clusterMetadataNamespace)
+	if err != nil {
+		return errors.Wrap(err, "failed to create or update tkg-bom ConfigMap")
+	}
+
+	return nil
+}
+
+func createOrUpdateNamespaceRole(clusterClient clusterclient.Client) error {
+	err := clusterClient.CreateNamespace(clusterMetadataNamespace)
+	if err != nil {
+		return err
+	}
+
+	namespaceRole := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterMetadataNamespaceRoleName,
+			Namespace: clusterMetadataNamespace,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{
+					"",
+				},
+				ResourceNames: []string{
+					"tkg-metadata",
+					"tkg-bom",
+				},
+				Resources: []string{
+					"configmaps",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
+		},
+	}
+
+	namespaceRoleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterMetadataNamespaceRoleName,
+			Namespace: clusterMetadataNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     clusterMetadataNamespaceRoleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Group",
+				Name:     "system:authenticated",
+			},
+		},
+	}
+
+	// create or update tkg-metadata-reader Role
+	err = createOrUpdateResource(clusterClient, namespaceRole, clusterMetadataNamespaceRoleName, clusterMetadataNamespace)
+	if err != nil {
+		return errors.Wrap(err, "failed to create or update tkg-metadata-reader Role")
+	}
+
+	// create or update tkg-metadata-reader RoleBinding
+	err = createOrUpdateResource(clusterClient, namespaceRoleBinding, clusterMetadataNamespaceRoleName, clusterMetadataNamespace)
+	if err != nil {
+		return errors.Wrap(err, "failed to create or update tkg-metadata-reader RoleBinding")
+	}
+	return nil
+}
+
+func createOrUpdateResource(clusterClient clusterclient.Client, resoureReference interface{}, name string, namespace string) error {
+	err := clusterClient.UpdateResource(resoureReference, name, namespace)
+	if err != nil && apierrors.IsNotFound(err) {
+		err = clusterClient.CreateResource(resoureReference, name, namespace)
+		if err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+	return nil
+}

--- a/tkg/client/update_cluster_versioned_bom_test.go
+++ b/tkg/client/update_cluster_versioned_bom_test.go
@@ -1,0 +1,198 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	. "github.com/vmware-tanzu/tanzu-framework/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/tkg/fakes"
+	"github.com/vmware-tanzu/tanzu-framework/tkg/tkgconfigbom"
+)
+
+var _ = Describe("Unit tests for updating versioned tkg bom", func() {
+	var (
+		err                   error
+		regionalClusterClient *fakes.ClusterClient
+		tkgClient             *TkgClient
+	)
+
+	BeforeEach(func() {
+		regionalClusterClient = &fakes.ClusterClient{}
+		tkgClient, err = CreateTKGClient("../fakes/config/config.yaml", testingDir, "../fakes/config/bom/tkg-bom-v1.3.1.yaml", 2*time.Millisecond)
+		Expect(err).NotTo(HaveOccurred())
+		setupBomFile("../fakes/config/bom/tkg-bom-v1.3.1.yaml", testingDir)
+	})
+
+	Context("When updating versioned tkg bom", func() {
+		JustBeforeEach(func() {
+			err = tkgClient.CreateOrUpdateVerisionedTKGBom(regionalClusterClient)
+		})
+		Context("When failed to create or update namespace", func() {
+			BeforeEach(func() {
+				regionalClusterClient.CreateNamespaceReturns(errors.New("failed to create or update namespace"))
+			})
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to create or update namespace"))
+			})
+		})
+		Context("When failed to update role", func() {
+			BeforeEach(func() {
+				regionalClusterClient.UpdateResourceCalls(func(obj interface{}, objName string, namespace string, opts ...client.UpdateOption) error {
+					_, ok := obj.(*rbacv1.Role)
+					if !ok {
+						return nil
+					}
+					return errors.New("failed to update role")
+				})
+			})
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to update role"))
+			})
+		})
+		Context("When failed to create role", func() {
+			BeforeEach(func() {
+				regionalClusterClient.UpdateResourceCalls(func(obj interface{}, objName string, namespace string, opts ...client.UpdateOption) error {
+					_, ok := obj.(*rbacv1.Role)
+					if !ok {
+						return nil
+					}
+					return apierrors.NewNotFound(
+						schema.GroupResource{Group: "fakeGroup", Resource: "fakeGroupResource"},
+						"fakeGroupResource")
+				})
+				regionalClusterClient.CreateResourceCalls(func(obj interface{}, objName string, namespace string, opts ...client.CreateOption) error {
+					_, ok := obj.(*rbacv1.Role)
+					if !ok {
+						return nil
+					}
+					return errors.New("failed to create role")
+				})
+
+			})
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to create role"))
+			})
+		})
+		Context("When failed to update rolebinding", func() {
+			BeforeEach(func() {
+				regionalClusterClient.UpdateResourceCalls(func(obj interface{}, objName string, namespace string, opts ...client.UpdateOption) error {
+					_, ok := obj.(*rbacv1.RoleBinding)
+					if !ok {
+						return nil
+					}
+					return errors.New("failed to update rolebinding")
+				})
+			})
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to update rolebinding"))
+			})
+		})
+		Context("When failed to create rolebinding", func() {
+			BeforeEach(func() {
+				regionalClusterClient.UpdateResourceCalls(func(obj interface{}, objName string, namespace string, opts ...client.UpdateOption) error {
+					_, ok := obj.(*rbacv1.RoleBinding)
+					if !ok {
+						return nil
+					}
+					return apierrors.NewNotFound(
+						schema.GroupResource{Group: "fakeGroup", Resource: "fakeGroupResource"},
+						"fakeGroupResource")
+				})
+				regionalClusterClient.CreateResourceCalls(func(obj interface{}, objName string, namespace string, opts ...client.CreateOption) error {
+					_, ok := obj.(*rbacv1.RoleBinding)
+					if !ok {
+						return nil
+					}
+					return errors.New("failed to create rolebinding")
+				})
+
+			})
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to create rolebinding"))
+			})
+		})
+
+		Context("When failed to update versioned tkg bom configmap", func() {
+			BeforeEach(func() {
+				regionalClusterClient.UpdateResourceCalls(func(obj interface{}, objName string, namespace string, opts ...client.UpdateOption) error {
+					_, ok := obj.(*rbacv1.RoleBinding)
+					if !ok {
+						return nil
+					}
+					return errors.New("failed to update versioned tkg bom configmap")
+				})
+			})
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to update versioned tkg bom configmap"))
+			})
+		})
+		Context("When failed to create versioned tkg bom configmap", func() {
+			BeforeEach(func() {
+				regionalClusterClient.UpdateResourceCalls(func(obj interface{}, objName string, namespace string, opts ...client.UpdateOption) error {
+					_, ok := obj.(*corev1.ConfigMap)
+					if !ok {
+						return nil
+					}
+					return apierrors.NewNotFound(
+						schema.GroupResource{Group: "fakeGroup", Resource: "fakeGroupResource"},
+						"fakeGroupResource")
+				})
+				regionalClusterClient.CreateResourceCalls(func(obj interface{}, objName string, namespace string, opts ...client.CreateOption) error {
+					_, ok := obj.(*corev1.ConfigMap)
+					if !ok {
+						return nil
+					}
+					return errors.New("failed to create versioned tkg bom configmap")
+				})
+
+			})
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to create versioned tkg bom configmap"))
+			})
+		})
+
+		Context("When succeeded to update the versioned tkg bom configmap", func() {
+			BeforeEach(func() {
+				regionalClusterClient.UpdateResourceCalls(func(obj interface{}, objName string, namespace string, opts ...client.UpdateOption) error {
+					cm, ok := obj.(*corev1.ConfigMap)
+					if !ok {
+						return nil
+					}
+					Expect(cm.Name).To(Equal("tkg-bom-1.2.1-rc.1"))
+					Expect(cm.Namespace).To(Equal("tkg-system-public"))
+					bomYaml := cm.Data["bom.yaml"]
+					bom := &tkgconfigbom.BOMConfiguration{}
+					err := yaml.Unmarshal([]byte(bomYaml), bom)
+					Expect(err).ToNot(HaveOccurred())
+					return nil
+				})
+
+			})
+			It("should not return an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+	})
+
+})

--- a/tkg/client/upgrade_cluster.go
+++ b/tkg/client/upgrade_cluster.go
@@ -211,7 +211,7 @@ func (c *TkgClient) DoLegacyClusterUpgrade(regionalClusterClient, currentCluster
 	}
 
 	// Upgrade addon metadata configmaps after the nodes are upgraded
-	if !options.SkipAddonUpgrade {
+	if !options.SkipAddonUpgrade && !config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
 		err = c.upgradeAddonPostNodeUpgrade(regionalClusterClient, currentClusterClient, options.ClusterName, options.Namespace, options.IsRegionalCluster, options.Edition)
 		if err != nil {
 			return err

--- a/tkg/client/upgrade_region.go
+++ b/tkg/client/upgrade_region.go
@@ -171,6 +171,13 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 		return err
 	}
 
+	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+		log.Info("Creating tkg-bom versioned ConfigMaps...")
+		if err := c.CreateOrUpdateVerisionedTKGBom(regionalClusterClient); err != nil {
+			log.Warningf("Warning: Management cluster is created successfully, but the tkg-bom versioned ConfigMaps creation is failing. %v", err)
+		}
+	}
+
 	return nil
 }
 

--- a/tkg/cmd/upgrade_region.go
+++ b/tkg/cmd/upgrade_region.go
@@ -32,11 +32,11 @@ var upgradeRegionCmd = &cobra.Command{
 	tkg upgrade cluster mc-1 --os-name ubuntu --os-version 20.04 --os-arch amd64
 
 	[+] : Options available for: os-name, os-version, os-arch are as follows:
-	vSphere: 
+	vSphere:
 		--os-name ubuntu --os-version 20.04 --os-arch amd64
 		--os-name photon --os-version 3 --os-arch amd64
-		
-	aws: 
+
+	aws:
 		--os-name ubuntu --os-version 20.04 --os-arch amd64
 		--os-name amazon --os-version 2 --os-arch amd64
 

--- a/tkg/test/tkgctl/shared/e2e_common_cc.go
+++ b/tkg/test/tkgctl/shared/e2e_common_cc.go
@@ -260,6 +260,9 @@ func E2ECommonCCSpec(ctx context.Context, inputGetter func() E2ECommonCCSpecInpu
 			Expect(err).NotTo(HaveOccurred())
 		}
 
+		By(fmt.Sprintf("Validating the management cluster %q versioned tkg-bom", input.E2EConfig.ManagementClusterName))
+		verifyCCClusterVersionedTKGBOM(ctx, mngClient, getDefaultBomTKGVersion(input.E2EConfig.TkgConfigDir))
+
 		if input.CheckAdmissionWebhook {
 			checkAdmissionWebhooks(ctx, mngClient, admissionRegistrationClient)
 		}
@@ -289,6 +292,11 @@ func getAvailableTKRs(ctx context.Context, mcProxy *framework.ClusterProxy, tkgC
 	tkrVersions := getTKRVersions(tkrs)
 
 	return tkrVersions, oldTKR, defaultTKR
+}
+
+func getDefaultBomTKGVersion(tkgConfigDir string) string {
+	tkgBOMConfigClient := tkgconfigbom.New(tkgConfigDir, nil)
+	return tkgBOMConfigClient.GetCurrentTKGVersion()
 }
 
 func checkAdmissionWebhooks(ctx context.Context, mngClient client.Client, admissionRegistrationClient admissionregistrationv1.AdmissionregistrationV1Interface) {

--- a/tkg/test/tkgctl/shared/versioned_tkg_bom_cc.go
+++ b/tkg/test/tkgctl/shared/versioned_tkg_bom_cc.go
@@ -1,0 +1,31 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// nolint:typecheck,goconst,gocritic,stylecheck,nolintlint
+package shared
+
+import (
+	"context"
+
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware-tanzu/tanzu-framework/tkg/tkgconfigbom"
+)
+
+// verifyCCClusterVersionedTKGBOM verify the versioned tkg bom configmap
+func verifyCCClusterVersionedTKGBOM(ctx context.Context, c client.Client, tkgBomVersion string) {
+	// verifying tkg bom
+	bomConfigMap := &corev1.ConfigMap{}
+
+	Eventually(func() error {
+		return c.Get(ctx, client.ObjectKey{Namespace: "tkg-system-public", Name: "tkg-bom" + "-" + tkgBomVersion}, bomConfigMap)
+	}, getResourceTimeout, pollingInterval).Should(Succeed())
+	bomYaml := bomConfigMap.Data["bom.yaml"]
+	Expect(bomYaml).ToNot(Equal(""))
+	bom := &tkgconfigbom.BOMConfiguration{}
+	err := yaml.Unmarshal([]byte(bomYaml), bom)
+	Expect(err).ToNot(HaveOccurred())
+}


### PR DESCRIPTION
### What this PR does / why we need it
The cluster-metadata existed as a configmap in a legacy cluster, both mgmt and workload cluster.
It was used to install by ytt on the client side, but in utkg2.0 we will deprecate the way of installing resources by client side.
