### PR TITLE
Test CAPD cc and non-cc integ test fixes

### DIFF
--- a/providers/infrastructure-docker/v1.2.4/ytt/overlay.yaml
+++ b/providers/infrastructure-docker/v1.2.4/ytt/overlay.yaml
@@ -1,6 +1,6 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
-#@ load("lib/helpers.star", "get_bom_data_for_tkr_name",  "kubeadm_image_repo", "get_image_repo_for_component")
+#@ load("lib/helpers.star", "get_bom_data_for_tkr_name",  "kubeadm_image_repo", "get_image_repo_for_component", "disable_cgroupdriver_cgroupfs")
 #@ load("@ytt:yaml", "yaml")
 
 #@ bomDataForK8sVersion = get_bom_data_for_tkr_name()
@@ -76,6 +76,20 @@ spec:
       kind: DockerMachineTemplate
       name: #@ "{}-control-plane".format(data.values.CLUSTER_NAME)
   kubeadmConfigSpec:
+    initConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          #@ if disable_cgroupdriver_cgroupfs():
+          #@overlay/remove
+          cgroup-driver: cgroupfs
+          #@ end
+    joinConfiguration:
+      nodeRegistration:
+        kubeletExtraArgs:
+          #@ if disable_cgroupdriver_cgroupfs():
+          #@overlay/remove
+          cgroup-driver: cgroupfs
+          #@ end
     clusterConfiguration:
       imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.imageRepository)
       etcd:
@@ -125,10 +139,24 @@ apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
   name: #@ "{}-md-0".format(data.values.CLUSTER_NAME)
-#@ if data.values.CNI == "antrea":
 spec:
   template:
     spec:
+      initConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            #@ if disable_cgroupdriver_cgroupfs():
+            #@overlay/remove
+            cgroup-driver: cgroupfs
+            #@ end
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            #@ if disable_cgroupdriver_cgroupfs():
+            #@overlay/remove
+            cgroup-driver: cgroupfs
+            #@ end
+      #@ if data.values.CNI == "antrea":
       preKubeadmCommands:
       #! disable TX hardware checksum offload for the veth interface of each Kind Node
       #! https://github.com/vmware-tanzu/antrea/blob/master/docs/kind.md#why-is-the-yaml-manifest-different-when-using-kind
@@ -138,7 +166,7 @@ spec:
       - #@ construct_pre_kubeadm_command()
       #@overlay/append
       - sysctl -w net.ipv4.tcp_retries2=4
-#@ end
+      #@ end
 
 
 #@overlay/match by=overlay.subset({"kind":"MachineDeployment"})

--- a/providers/infrastructure-docker/v1.2.4/yttcc/overlay.yaml
+++ b/providers/infrastructure-docker/v1.2.4/yttcc/overlay.yaml
@@ -24,8 +24,7 @@ metadata:
 spec:
   topology:
     class: #@ data.values.CLUSTER_CLASS
-    #! VVV TODO(vui) compute
-    version: #@ "{}-tkg.2-zshippable".format(data.values.KUBERNETES_VERSION)
+    version: #@ data.values.KUBERNETES_VERSION
     #@overlay/match missing_ok=True
     controlPlane:
       replicas: #@ data.values.CONTROL_PLANE_MACHINE_COUNT

--- a/providers/ytt/lib/helpers.star
+++ b/providers/ytt/lib/helpers.star
@@ -367,6 +367,14 @@ def enable_csi_driver():
   return False
 end
 
+def disable_cgroupdriver_cgroupfs():
+  tkrVersion = get_tkr_version_from_tkr_name(data.values.KUBERNETES_RELEASE)
+  if compare_semver_versions(tkrVersion, "v1.24.0") >= 0:
+     return True
+  end
+  return False
+end
+
 def map(f, list):
     return [f(x) for x in list]
 end


### PR DESCRIPTION
### What this PR does / why we need it

(This combines relevant changes in 3921 and 3928)

Test  CAPD cc and non-cc integ test fixes
Fixes the CAPD integration tests which fail to create v1.24 clusters because the templates always set the cgroup driver to cgroupfs.
Kind images >= v1.24 only support the systemd cgroup driver.

Fix hardcode topology.version of docker CC overlay 


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes N/A

### Describe testing done for PR

monitoring CI

### Release Notes
```release-note
None
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
