### PR TITLE
Update Cluster Toplogy utils to populate empty arr

### DIFF
--- a/tkg/client/machine_deployment_cc_test.go
+++ b/tkg/client/machine_deployment_cc_test.go
@@ -507,7 +507,10 @@ var _ = Describe("SetMachineDeploymentCC", func() {
 				actual, ok := clusterInterface.(*capi.Cluster)
 				Expect(ok).To(BeTrue())
 				Expect(len(actual.Spec.Topology.Variables)).To(Equal(2))
+
+				emptyArr, _ := json.Marshal([]interface{}{})
 				Expect(actual.Spec.Topology.Variables[1].Name).To(Equal("nodePoolLabels"))
+				Expect(actual.Spec.Topology.Variables[1].Value.Raw).To(Equal(emptyArr))
 				Expect(len(actual.Spec.Topology.Workers.MachineDeployments)).To(Equal(3))
 				Expect(actual.Spec.Topology.Workers.MachineDeployments[2].Variables.Overrides[0].Value.Raw).To(Equal(expected))
 			})

--- a/util/topology/cluster_test.go
+++ b/util/topology/cluster_test.go
@@ -148,6 +148,48 @@ var _ = Describe("Cluster variable getters and setters", func() {
 				Expect(aData).To(Equal(aData1), "Cluster var should still be the same")
 			})
 		})
+		When("the Cluster variable of array type does not exist", func() {
+			It("should populate the Cluster variable with an empty array", func() {
+				var aData *AData
+
+				// The Cluster level variable named C should not exist
+				Expect(GetVariable(cluster, varC, &aData)).To(Succeed())
+				Expect(aData).To(BeNil())
+
+				testArr := []int{0, 1, 2}
+				// Set the MachinedDeployment variable override for the variable named C
+				Expect(SetMDVariable(cluster, 0, varC, testArr)).To(Succeed())
+
+				// The Cluster level variable named C should be populated with an empty array
+				var varArr []int
+				Expect(GetVariable(cluster, varC, &varArr)).To(Succeed())
+				Expect(varArr).To(BeEmpty())
+				Expect(varArr).ToNot(BeNil())
+			})
+		})
+		When("the Cluster variable of map type does not exist", func() {
+			FIt("should populate the Cluster variable with an empty map", func() {
+				var aData *AData
+
+				// The Cluster level variable named C should not exist
+				Expect(GetVariable(cluster, varC, &aData)).To(Succeed())
+				Expect(aData).To(BeNil())
+
+				testMap := map[string]int{
+					"first":  0,
+					"second": 1,
+					"third":  2,
+				}
+				// Set the MachinedDeployment variable override for the variable named C
+				Expect(SetMDVariable(cluster, 0, varC, testMap)).To(Succeed())
+
+				// The Cluster level variable named C should be populated with an empty map
+				var varMap map[string]int
+				Expect(GetVariable(cluster, varC, &varMap)).To(Succeed())
+				Expect(varMap).To(BeEmpty())
+				Expect(varMap).ToNot(BeNil())
+			})
+		})
 	})
 
 	Describe("IsSingleNodeCluster()", func() {


### PR DESCRIPTION
This change makes sure that our cluster topology utils sets array typed cluster variables to an empty array instead of nil. This does the same for map typed variables.

### What this PR does / why we need it

The SetMDVariable util function will set the override variable for a given machine deployment in a cluster topology. The cluster topology requires the corresponding cluster variable is defined for the cluster, so the SetMDVariable function would also set a null variable in the cluster level variable definition. null is an invalid value for variables of type array or type map. This change updates the topology util functions to set a proper empty array or empty map when setting a MachineDeployment override on a variable that does not currently have a top level definition. 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
