### PR TITLE
Xport Update Cluster Toplogy utils to populate empty arr

### DIFF
--- a/pkg/v1/tkg/client/machine_deployment_cc_test.go
+++ b/pkg/v1/tkg/client/machine_deployment_cc_test.go
@@ -500,7 +500,10 @@ var _ = Describe("SetMachineDeploymentCC", func() {
 				actual, ok := clusterInterface.(*capi.Cluster)
 				Expect(ok).To(BeTrue())
 				Expect(len(actual.Spec.Topology.Variables)).To(Equal(2))
+
+				emptyArr, _ := json.Marshal([]interface{}{})
 				Expect(actual.Spec.Topology.Variables[1].Name).To(Equal("nodePoolLabels"))
+				Expect(actual.Spec.Topology.Variables[1].Value.Raw).To(Equal(emptyArr))
 				Expect(len(actual.Spec.Topology.Workers.MachineDeployments)).To(Equal(3))
 				Expect(actual.Spec.Topology.Workers.MachineDeployments[2].Variables.Overrides[0].Value.Raw).To(Equal(expected))
 			})

--- a/pkg/v2/tkr/util/topology/cluster.go
+++ b/pkg/v2/tkr/util/topology/cluster.go
@@ -46,21 +46,31 @@ func GetVariable(cluster *clusterv1.Cluster, name string, value interface{}) err
 // SetMDVariable sets the variable for the given machineDeployment, overriding it if necessary, to the given value.
 // Pre-reqs: cluster.Spec.Topology != nil && cluster.Spec.Topology.Workers != nil
 func SetMDVariable(cluster *clusterv1.Cluster, mdIndex int, name string, value interface{}) error {
-	jsonValue, err := jsonValue(value)
+	jsonVal, err := jsonValue(value)
 	if err != nil {
 		return err
 	}
 
+	var varDefault *apiextensionsv1.JSON
+	switch reflect.TypeOf(value).Kind() {
+	case reflect.Slice:
+		varDefault, _ = jsonValue([]interface{}{})
+	case reflect.Map:
+		varDefault, _ = jsonValue(map[string]interface{}{})
+	default:
+		varDefault = &apiextensionsv1.JSON{}
+	}
+
 	md := &cluster.Spec.Topology.Workers.MachineDeployments[mdIndex]
 
-	cVar := ensureClusterVariableForName(cluster, name)
-	if reflect.DeepEqual(*jsonValue, cVar.Value) { // if cluster variable with the same name already has the value being set
+	cVar := ensureClusterVariableForNameDefault(cluster, name, varDefault)
+	if reflect.DeepEqual(*jsonVal, cVar.Value) { // if cluster variable with the same name already has the value being set
 		removeMDVariableForName(md, name) // make sure the machineDeployment override is not set
 		return nil
 	}
 
 	mdVar := ensureMDVariableForName(md, name)
-	mdVar.Value = *jsonValue
+	mdVar.Value = *jsonVal
 	return nil
 }
 
@@ -107,13 +117,17 @@ func clusterVariableForName(cluster *clusterv1.Cluster, name string) *clusterv1.
 // ensureClusterVariableForName finds or creates in the cluster the *ClusterVariable for the given name.
 // Pre-reqs: cluster.Spec.Topology != nil
 func ensureClusterVariableForName(cluster *clusterv1.Cluster, name string) *clusterv1.ClusterVariable {
+	return ensureClusterVariableForNameDefault(cluster, name, &apiextensionsv1.JSON{})
+}
+
+func ensureClusterVariableForNameDefault(cluster *clusterv1.Cluster, name string, v *apiextensionsv1.JSON) *clusterv1.ClusterVariable {
 	for i := range cluster.Spec.Topology.Variables {
 		v := &cluster.Spec.Topology.Variables[i]
 		if v.Name == name {
 			return v
 		}
 	}
-	cluster.Spec.Topology.Variables = append(cluster.Spec.Topology.Variables, clusterv1.ClusterVariable{Name: name})
+	cluster.Spec.Topology.Variables = append(cluster.Spec.Topology.Variables, clusterv1.ClusterVariable{Name: name, Value: *v})
 	return &cluster.Spec.Topology.Variables[len(cluster.Spec.Topology.Variables)-1]
 }
 

--- a/pkg/v2/tkr/util/topology/cluster_test.go
+++ b/pkg/v2/tkr/util/topology/cluster_test.go
@@ -148,5 +148,47 @@ var _ = Describe("Cluster variable getters and setters", func() {
 				Expect(aData).To(Equal(aData1), "Cluster var should still be the same")
 			})
 		})
+		When("the Cluster variable of array type does not exist", func() {
+			It("should populate the Cluster variable with an empty array", func() {
+				var aData *AData
+
+				// The Cluster level variable named C should not exist
+				Expect(GetVariable(cluster, varC, &aData)).To(Succeed())
+				Expect(aData).To(BeNil())
+
+				testArr := []int{0, 1, 2}
+				// Set the MachinedDeployment variable override for the variable named C
+				Expect(SetMDVariable(cluster, 0, varC, testArr)).To(Succeed())
+
+				// The Cluster level variable named C should be populated with an empty array
+				var varArr []int
+				Expect(GetVariable(cluster, varC, &varArr)).To(Succeed())
+				Expect(varArr).To(BeEmpty())
+				Expect(varArr).ToNot(BeNil())
+			})
+		})
+		When("the Cluster variable of map type does not exist", func() {
+			FIt("should populate the Cluster variable with an empty map", func() {
+				var aData *AData
+
+				// The Cluster level variable named C should not exist
+				Expect(GetVariable(cluster, varC, &aData)).To(Succeed())
+				Expect(aData).To(BeNil())
+
+				testMap := map[string]int{
+					"first":  0,
+					"second": 1,
+					"third":  2,
+				}
+				// Set the MachinedDeployment variable override for the variable named C
+				Expect(SetMDVariable(cluster, 0, varC, testMap)).To(Succeed())
+
+				// The Cluster level variable named C should be populated with an empty map
+				var varMap map[string]int
+				Expect(GetVariable(cluster, varC, &varMap)).To(Succeed())
+				Expect(varMap).To(BeEmpty())
+				Expect(varMap).ToNot(BeNil())
+			})
+		})
 	})
 })


### PR DESCRIPTION
This change makes sure that our cluster topology utils sets array typed cluster variables to an empty array instead of nil. This does the same for map typed variables.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
