### PR TITLE
override imageRepo and cacert with tkgConfigReaderWriter

### DIFF
--- a/tkg/client/management_components.go
+++ b/tkg/client/management_components.go
@@ -208,7 +208,7 @@ func (c *TkgClient) getTKGPackageConfigValuesFile(mcClient clusterclient.Client,
 		return "", err
 	}
 
-	valuesFile, err := managementcomponents.GetTKGPackageConfigValuesFileFromUserConfig(managementPackageVersion, addonsManagerPackageVersion, userProviderConfigValues, tkgBomConfig)
+	valuesFile, err := managementcomponents.GetTKGPackageConfigValuesFileFromUserConfig(managementPackageVersion, addonsManagerPackageVersion, userProviderConfigValues, tkgBomConfig, c.TKGConfigReaderWriter())
 	if err != nil {
 		return "", err
 	}

--- a/tkg/managementcomponents/test/config.yaml
+++ b/tkg/managementcomponents/test/config.yaml
@@ -1,0 +1,2 @@
+# a fake config file for reader writer
+foo: bar

--- a/tkg/managementcomponents/test/output_vsphere_with_custom_repo_ca_rw.yaml
+++ b/tkg/managementcomponents/test/output_vsphere_with_custom_repo_ca_rw.yaml
@@ -1,0 +1,45 @@
+metadata:
+    infraProvider: vsphere
+configvalues:
+    PROVIDER_TYPE: vsphere
+    TKG_CUSTOM_IMAGE_REPOSITORY: fake-repo
+    TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE: fake-ca
+    TKG_HTTP_PROXY: http://192.168.116.1:3128
+    TKG_HTTPS_PROXY: http://192.168.116.1:3128
+    TKG_NO_PROXY: .svc,100.64.0.0/13,192.168.118.0/24,192.168.119.0/24,192.168.120.0/24
+frameworkPackage:
+    versionConstraints: v0.21.0
+    featureGatesPackageValues:
+        versionConstraints: v0.21.0
+    tkrServicePackageValues:
+        versionConstraints: v0.21.0
+    clipluginsPackageValues:
+        versionConstraints: v0.21.0
+    addonsManagerPackageValues:
+        versionConstraints: v0.21.0
+        tanzuAddonsManager:
+            featureGates:
+                clusterBootstrapController: true
+                packageInstallStatus: true
+    tanzuAuthPackageValues:
+        versionConstraints: v0.21.0
+clusterclassPackage:
+    versionConstraints: v0.21.0
+    clusterclassInfraPackageValues:
+        versionConstraints: v0.21.0
+tkrSourceControllerPackage:
+    versionConstraints: v0.21.0
+    tkrSourceControllerPackageValues:
+        versionConstraints: v0.21.0
+        bomImagePath: fake.custom.repo/tkr-bom
+        bomMetadataImagePath: fake.custom.repo/fake-path/tkr-compatibility
+        tkrRepoImagePath: fake.custom.repo/tkr-repository-vsphere-nonparavirt
+        defaultCompatibleTKR: v1.23.5+vmware.1-tkg.1-fake
+        caCerts: fake-ca-2
+        imageRepository: fake-repo-2
+        deployment:
+            httpProxy: http://192.168.116.1:3128
+            httpsProxy: http://192.168.116.1:3128
+            noProxy: .svc,100.64.0.0/13,192.168.118.0/24,192.168.119.0/24,192.168.120.0/24
+coreManagementPluginsPackage:
+    versionConstraints: v0.21.0


### PR DESCRIPTION
imageRepo and cacert value could be overriden by tkgConfigReaderWriter

such as in upgrade case, imageRepo in tkr-controller-config could be modified by export os env value

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information
per local test, values could be overridden in tkr-controller-config by ` export TKG_PROXY_CA_CERT="<test cert base64 encoded>"`

```
kubo@0LZ8DZiMkuKTi:~/kubeconfigs$ k get cm -n tkg-system tkr-controller-config -oyaml
apiVersion: v1
data:
  caCerts: |-
    -----BEGIN CERTIFICATE-----
    MIIDUDCCAjigAwIBAgIUDW6vTUYc90Bd7sO2GzOFvnAWCKEwDQYJKoZIhvcNAQEL
    BQAwHzELMAkGA1UEBhMCVVMxEDAOBgNVBAoMB1Bpdm90YWwwHhcNMjIwODIyMDgw
    NzQ3WhcNMjYwODIyMDgwNzQ2WjAfMQswCQYDVQQGEwJVUzEQMA4GA1UECgwHUGl2
    b3RhbDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAM54daZfpCFU6FNG
    zyP1N+wj8B+QGgYftQL2o3M1AISUrTKx1XCiAac8Uk88ePz2Oz4nCLD1gx0hfYNc
    TIy8d9bZdYzcVoda7m6BnGo9tk6QeGB3y153jg0kRZa2uBwjUlBTmRB6Btx4kO9C
    H0dYljTNI2sv8LQq8iMxYyzH753yFzZy1g6dwB5IPO69FAm5A7imJRxNSbO/+RKd
    w2kK0/jM3bRJa3jbHO9HEkQcz2RKVNxeAYApzDNHYrm6a/oLo9bpQQ5yUoqcHbVd
    o4mbqMbqM6SQx/LJeHF7HLDtmfQ9I40uN0+g/mi7j1cAfE5TtMhHp3GowgkXU5Zj
    RjXDN5cCAwEAAaOBgzCBgDAdBgNVHQ4EFgQUglPklVWCTL+BXFfpFyOWlp1jWZgw
    HwYDVR0jBBgwFoAUglPklVWCTL+BXFfpFyOWlp1jWZgwHQYDVR0lBBYwFAYIKwYB
    BQUHAwIGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEG
    MA0GCSqGSIb3DQEBCwUAA4IBAQDHN42k+hrX6iEr/RcZnJYQMzPJAGQ8a+MakzW1
    xhvFjMQ7aRVQPH1JC41sQcO7fzWqSnzEh0aJwZxb1ghvKOKrorZVfhSzTak7qHMG
    KihYZ1rHbv8fbfqeQ3S0sasoC+orcg/xwgn3ibGpjEipuy8vJEukGuqUyctn6c/X
    nM5jwMaj8h2ZssYJMtE1lwRC6rqwLV6ENvEnRfmPgrEbS3LN1tcR9VZRfwMwjHQA
    Kyp19Z1FmgMxs7ZRCP0Od59z/33pQ7Dh40VPCHZYAukaUt1qQjI+iIRs6I+0k0Hm
    rwzXFVtL9+YfO53nuETZ6Nc3YGGnVrqJfy+Kb8/CsrdA/OeR
    -----END CERTIFICATE-----
  imageRepository: projects-stg.registry.vmware.com/tkg
kind: ConfigMap
metadata:
  annotations:
    kapp.k14s.io/identity: v1;tkg-system//ConfigMap/tkr-controller-config;v1
    kapp.k14s.io/original: '{"apiVersion":"v1","data":{"caCerts":"-----BEGIN CERTIFICATE-----\nMIIDUDCCAjigAwIBAgIUDW6vTUYc90Bd7sO2GzOFvnAWCKEwDQYJKoZIhvcNAQEL\nBQAwHzELMAkGA1UEBhMCVVMxEDAOBgNVBAoMB1Bpdm90YWwwHhcNMjIwODIyMDgw\nNzQ3WhcNMjYwODIyMDgwNzQ2WjAfMQswCQYDVQQGEwJVUzEQMA4GA1UECgwHUGl2\nb3RhbDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAM54daZfpCFU6FNG\nzyP1N+wj8B+QGgYftQL2o3M1AISUrTKx1XCiAac8Uk88ePz2Oz4nCLD1gx0hfYNc\nTIy8d9bZdYzcVoda7m6BnGo9tk6QeGB3y153jg0kRZa2uBwjUlBTmRB6Btx4kO9C\nH0dYljTNI2sv8LQq8iMxYyzH753yFzZy1g6dwB5IPO69FAm5A7imJRxNSbO/+RKd\nw2kK0/jM3bRJa3jbHO9HEkQcz2RKVNxeAYApzDNHYrm6a/oLo9bpQQ5yUoqcHbVd\no4mbqMbqM6SQx/LJeHF7HLDtmfQ9I40uN0+g/mi7j1cAfE5TtMhHp3GowgkXU5Zj\nRjXDN5cCAwEAAaOBgzCBgDAdBgNVHQ4EFgQUglPklVWCTL+BXFfpFyOWlp1jWZgw\nHwYDVR0jBBgwFoAUglPklVWCTL+BXFfpFyOWlp1jWZgwHQYDVR0lBBYwFAYIKwYB\nBQUHAwIGCCsGAQUFBwMBMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEG\nMA0GCSqGSIb3DQEBCwUAA4IBAQDHN42k+hrX6iEr/RcZnJYQMzPJAGQ8a+MakzW1\nxhvFjMQ7aRVQPH1JC41sQcO7fzWqSnzEh0aJwZxb1ghvKOKrorZVfhSzTak7qHMG\nKihYZ1rHbv8fbfqeQ3S0sasoC+orcg/xwgn3ibGpjEipuy8vJEukGuqUyctn6c/X\nnM5jwMaj8h2ZssYJMtE1lwRC6rqwLV6ENvEnRfmPgrEbS3LN1tcR9VZRfwMwjHQA\nKyp19Z1FmgMxs7ZRCP0Od59z/33pQ7Dh40VPCHZYAukaUt1qQjI+iIRs6I+0k0Hm\nrwzXFVtL9+YfO53nuETZ6Nc3YGGnVrqJfy+Kb8/CsrdA/OeR\n-----END
      CERTIFICATE-----","imageRepository":"projects-stg.registry.vmware.com/tkg"},"kind":"ConfigMap","metadata":{"labels":{"kapp.k14s.io/app":"1669011177232425643","kapp.k14s.io/association":"v1.2f1c3338c3147091f1b8f28db7b3cd44"},"name":"tkr-controller-config","namespace":"tkg-system"}}'
    kapp.k14s.io/original-diff-md5: c6e94dc94aed3401b5d0f26ed6c0bff3
  creationTimestamp: "2022-11-21T06:12:59Z"
  labels:
    kapp.k14s.io/app: "1669011177232425643"
    kapp.k14s.io/association: v1.2f1c3338c3147091f1b8f28db7b3cd44
  name: tkr-controller-config
  namespace: tkg-system
  resourceVersion: "2573"
  uid: 36f56b92-4ccc-4959-8af0-0a318e4917bb
```

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
