### PR TITLE
Decouple the feature gate of control management-cluster and workload-cluster mode

### DIFF
--- a/.github/workflows/tkg_integration_tests.yaml
+++ b/.github/workflows/tkg_integration_tests.yaml
@@ -96,6 +96,10 @@ jobs:
     - name: Cleanup
       run: rm -rf ~/.tanzu ~/.tkg ~/.config; docker kill $(docker ps -q) | true; docker system prune -a --volumes -f
 
+    - name: Build CLI
+      run: |
+        make install-cli
+
     - name: Run TKG integration tests
       run: |
         if [[ ! -z "${{ steps.extract_bom.outputs.bompath }}" ]]; then
@@ -184,6 +188,10 @@ jobs:
 
     - name: Cleanup
       run: rm -rf ~/.tanzu ~/.tkg ~/.config; docker kill $(docker ps -q) | true; docker system prune -a --volumes -f
+
+    - name: Build CLI
+      run: |
+        make install-cli
 
     - name: Generate cluster prefix
       if: ${{ env.azure_client_id != '' }}

--- a/addons/controllers/addon_controller.go
+++ b/addons/controllers/addon_controller.go
@@ -280,11 +280,11 @@ func (r *AddonReconciler) reconcileNormal(
 		errors []error
 		result ctrl.Result
 	)
-	// Skip reconcile core package repository in the management cluster if the package based lcm is enabled.
-	// Because in the package based lcm cluster, the core packages are managed by the tkr
+	// Skip reconcile core package repository in the management cluster if the package based cc is enabled.
+	// Because in the package based cc cluster, the core packages are managed by the tkr
 	_, isMgmtCluster := cluster.ObjectMeta.Labels[constants.ManagementClusterRoleLabel]
 	if isMgmtCluster && r.Config.FeatureGateClusterBootstrap {
-		log.Info("skip reconciling the core package repository on the management cluster when the package based lcm is enabled")
+		log.Info("skip reconciling the core package repository on the management cluster when the package based cc is enabled")
 	} else {
 		// Reconcile core package repository in the cluster
 		pkgReconciler := &PackageReconciler{ctx: ctx, log: log, clusterClient: remoteClient, Config: r.Config}

--- a/cli/core/pkg/config/featureflags.go
+++ b/cli/core/pkg/config/featureflags.go
@@ -24,6 +24,16 @@ const (
 	FeatureContextCommand = "features.global.context-target-v2"
 )
 
+// This block is used to set the default value for management-cluster and workload-cluster
+const (
+	// PackageBasedCC feature flag determines whether to use package based lifecycle management of management component
+	// or legacy way of managing management components. This is also used for clusterclass based management cluster provisioning
+	FeatureFlagPackageBasedCC = "features.management-cluster.package-based-cc"
+	// FeatureFlagAllowLegacyCluster is used to decide the workload cluster is clusterclass based or legayc based.
+	// By default, it's false. If it's true, then workload cluster is legacy based.
+	FeatureFlagAllowLegacyCluster = "features.cluster.allow-legacy-cluster"
+)
+
 // DefaultCliFeatureFlags is used to populate an initially empty config file with default values for feature flags.
 // The keys MUST be in the format "features.global.<feature>" or initialization will fail
 //
@@ -39,6 +49,8 @@ var (
 	DefaultCliFeatureFlags = map[string]bool{
 		FeatureContextAwareCLIForPlugins: contextAwareDiscoveryEnabled(),
 		FeatureContextCommand:            true,
+		FeatureFlagPackageBasedCC:        true,
+		FeatureFlagAllowLegacyCluster:    false,
 	}
 )
 

--- a/cmd/cli/plugin/cluster/available_upgrade.go
+++ b/cmd/cli/plugin/cluster/available_upgrade.go
@@ -73,8 +73,8 @@ func availableUpgrades(cmd *cobra.Command, args []string) error { //nolint:gocyc
 		return err
 	}
 
-	// TODO: update this condition after CLI fully support the package based LCM.
-	// Since CLI should support the pre package-based-lcm where the updatesAvailable condition was part of
+	// TODO: update this condition after CLI fully support the package based cc.
+	// Since CLI should support the pre package-based-cc where the updatesAvailable condition was part of
 	// TKRs, code checking the TKRs for available upgrade should remain.
 	cluster, err := getClusterResource(clusterClient, clusterName, au.namespace)
 	if err == nil && capiconditions.Has(cluster, runv1.ConditionUpdatesAvailable) {

--- a/cmd/cli/plugin/cluster/featureflags.go
+++ b/cmd/cli/plugin/cluster/featureflags.go
@@ -13,5 +13,7 @@ var (
 		constants.FeatureFlagClusterDualStackIPv4Primary: false,
 		constants.FeatureFlagClusterDualStackIPv6Primary: false,
 		constants.FeatureFlagClusterCustomNameservers:    false,
+		constants.FeatureFlagAllowLegacyCluster:          false,
+		constants.FeatureFlagPackageBasedCC:              true,
 	}
 )

--- a/cmd/cli/plugin/cluster/upgrade.go
+++ b/cmd/cli/plugin/cluster/upgrade.go
@@ -164,8 +164,8 @@ func getValidTkrVersionFromTkrForUpgrade(tkgctlClient tkgctl.TKGClient, clusterC
 		return "", err
 	}
 
-	// TODO: update this condition after CLI fully support the package based LCM.
-	// Since CLI should support the pre package-based-lcm where the updatesAvailable condition was part of
+	// TODO: update this condition after CLI fully support the package based cc.
+	// Since CLI should support the pre package-based-cc where the updatesAvailable condition was part of
 	// TKRs, code checking the TKRs for available upgrade should remain.
 	cluster, err := getClusterResource(clusterClient, clusterName, uc.namespace)
 	if err == nil && capiconditions.Has(cluster, runv1.ConditionUpdatesAvailable) {

--- a/providers/config_default.yaml
+++ b/providers/config_default.yaml
@@ -730,8 +730,8 @@ VSPHERE_VERSION:
 #! CORE_DNS_IP is the IP of core DNS service, supports both IPv4 and IPv6
 #! It is the 10th index of SERVICE_CIDR subnet
 CORE_DNS_IP:
-#! This defines feature flag package-based-lcm is enabled or not
-FEATURE_FLAG_PACKAGE_BASED_LCM:
+#! This defines feature flag package-based-cc is enabled or not
+FEATURE_FLAG_PACKAGE_BASED_CC:
 #! Used for testing clusterclasses only
 TKR_DATA:
 VSPHERE_CLUSTER_CLASS_VERSION: v1.0.0

--- a/tkg/client/cluster.go
+++ b/tkg/client/cluster.go
@@ -159,7 +159,7 @@ func (c *TkgClient) CreateCluster(options *CreateClusterOptions, waitForCluster 
 			return false, errors.Wrap(err, "unable to get cluster configuration")
 		}
 
-		if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+		if !config.IsFeatureActivated(constants.FeatureFlagAllowLegacyCluster) {
 			clusterConfigDir, err := c.tkgConfigPathsClient.GetClusterConfigurationDirectory()
 			if err != nil {
 				return false, err
@@ -178,16 +178,6 @@ func (c *TkgClient) CreateCluster(options *CreateClusterOptions, waitForCluster 
 				log.Warningf("\nTo create a cluster with it, use")
 				log.Warningf("    tanzu cluster create --file %v", configFilePath)
 				return false, nil
-			}
-
-			// if both FeatureFlagPackageBasedLCM and FeatureFlagAutoApplyGeneratedClusterClassBasedConfiguration enabled
-			// customization ytt overlay will cause create legacy cluster
-			iscustomoverlaypresent, err := c.isCustomOverlayPresent()
-			if err != nil {
-				return false, errors.Wrap(err, "fail to get iscustomoverlaypresent")
-			}
-			if iscustomoverlaypresent && !isManagementCluster {
-				log.Warning(constants.YTTBasedClusterWarning)
 			}
 
 			log.Warningf("\nUsing this new Cluster configuration '%v' to create the cluster.\n", configFilePath)

--- a/tkg/client/config.go
+++ b/tkg/client/config.go
@@ -105,8 +105,8 @@ func (c *TkgClient) getClusterConfiguration(options *ClusterConfigOptions, isMan
 	// Set CLUSTER_PLAN to viper configuration
 	c.SetPlan(options.ProviderRepositorySource.Flavor)
 
-	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
-		c.TKGConfigReaderWriter().Set(constants.ConfigVariableFeatureFlagPackageBasedLCM, "true")
+	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
+		c.TKGConfigReaderWriter().Set(constants.ConfigVariableFeatureFlagPackageBasedCC, "true")
 	}
 
 	infraProviderName, _, err := ParseProviderName(infraProvider)

--- a/tkg/client/init.go
+++ b/tkg/client/init.go
@@ -213,7 +213,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 	}
 
 	// If clusterclass feature flag is enabled then deploy kapp-controller
-	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		log.Info("Installing kapp-controller on bootstrap cluster...")
 		if err = c.InstallOrUpgradeKappController(bootStrapClusterClient, constants.OperationTypeInstall); err != nil {
 			return errors.Wrap(err, "unable to install kapp-controller to bootstrap cluster")
@@ -228,7 +228,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 	}
 
 	// If clusterclass feature flag is enabled then deploy management components
-	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		if err = c.InstallOrUpgradeManagementComponents(bootStrapClusterClient, bootstrapPkgClient, "", false); err != nil {
 			return errors.Wrap(err, "unable to install management components to bootstrap cluster")
 		}
@@ -331,7 +331,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 	}
 
 	// If clusterclass feature flag is enabled then deploy kapp-controller
-	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		log.Info("Installing kapp-controller on management cluster...")
 		if err = c.InstallOrUpgradeKappController(regionalClusterClient, constants.OperationTypeInstall); err != nil {
 			return errors.Wrap(err, "unable to install kapp-controller to management cluster")
@@ -362,7 +362,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 	}
 
 	// If clusterclass feature flag is enabled then deploy management components to the cluster
-	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		if err = c.InstallOrUpgradeManagementComponents(regionalClusterClient, regionalPkgClient, kubeContext, false); err != nil {
 			return errors.Wrap(err, "unable to install management components to management cluster")
 		}
@@ -392,7 +392,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 	}
 
 	// Applying ClusterBootstrap and its associated resources on the management cluster
-	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		log.Infof("Applying ClusterBootstrap and its associated resources on management cluster")
 		if err := c.ApplyClusterBootstrapObjects(bootStrapClusterClient, regionalClusterClient); err != nil {
 			return errors.Wrap(err, "Unable to apply ClusterBootstarp and its associated resources on management cluster")
@@ -441,7 +441,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 		}
 	}
 
-	if !config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if !config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		log.Info("Waiting for additional components to be up and running...")
 		if err := c.WaitForAddonsDeployments(regionalClusterClient); err != nil {
 			return err
@@ -451,14 +451,14 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 	// Wait for packages if the feature-flag is disabled
 	// We do not need to wait for packages as we have already installed and waited for all
 	// packages to be deployed during tkg package installation
-	if !config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if !config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		log.Info("Waiting for packages to be up and running...")
 		if err := c.WaitForPackages(regionalClusterClient, regionalClusterClient, options.ClusterName, targetClusterNamespace, true); err != nil {
 			log.Warningf("Warning: Management cluster is created successfully, but some packages are failing. %v", err)
 		}
 	}
 
-	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		log.Info("Creating tkg-bom versioned ConfigMaps...")
 		if err := c.CreateOrUpdateVerisionedTKGBom(regionalClusterClient); err != nil {
 			log.Warningf("Warning: Management cluster is created successfully, but the tkg-bom versioned ConfigMaps creation is failing. %v", err)
@@ -496,7 +496,7 @@ func (c *TkgClient) PatchClusterInitOperations(regionalClusterClient clusterclie
 		return errors.Wrap(err, "unable to patch optional metadata under labels")
 	}
 
-	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		// Patch and remove kapp-controller labels from clusterclass resources
 		err = c.removeKappControllerLabelsFromClusterClassResources(regionalClusterClient)
 		if err != nil {

--- a/tkg/client/management_components.go
+++ b/tkg/client/management_components.go
@@ -267,8 +267,8 @@ func (c *TkgClient) getUserConfigVariableValueMapFromSecret(clusterClient cluste
 		configValues = tkgPackageConfig.ConfigValues
 
 	} else if err != nil && apierrors.IsNotFound(err) {
-		// Handle the upgrade from legacy (non-package-based-lcm) management cluster as
-		// legacy (non-package-based-lcm) management cluster will not have the secret tkg-pkg-tkg-system-values
+		// Handle the upgrade from legacy (non-package-based-cc) management cluster as
+		// legacy (non-package-based-cc) management cluster will not have the secret tkg-pkg-tkg-system-values
 		// defined on the cluster. Github issue: https://github.com/vmware-tanzu/tanzu-framework/issues/2147
 		clusterName, _, err := c.getRegionalClusterNameAndNamespace(clusterClient)
 		if err != nil {

--- a/tkg/client/upgrade_cluster.go
+++ b/tkg/client/upgrade_cluster.go
@@ -197,9 +197,9 @@ func (c *TkgClient) DoLegacyClusterUpgrade(regionalClusterClient, currentCluster
 	// The addons should upgrade prior to cluster upgrade to account for forward compatibility
 	// i.e. some old addons may not run on the nodes with new k8s version
 	// We will ensure backward compatibility when shipping packages going forward
-	// With package-package-lcm approach addons will be upgraded as part of management package upgrade
+	// With cluster class approach addons will be upgraded as part of management package upgrade
 	// and we do not need to upgrade addons with below function
-	if !options.SkipAddonUpgrade && !config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if !options.SkipAddonUpgrade && !config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		err = c.upgradeAddonPreNodeUpgrade(regionalClusterClient, currentClusterClient, options.ClusterName, options.Namespace, options.IsRegionalCluster, options.Edition)
 		if err != nil {
 			return err
@@ -212,7 +212,7 @@ func (c *TkgClient) DoLegacyClusterUpgrade(regionalClusterClient, currentCluster
 	}
 
 	// Upgrade addon metadata configmaps after the nodes are upgraded
-	if !options.SkipAddonUpgrade && !config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if !options.SkipAddonUpgrade && !config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		err = c.upgradeAddonPostNodeUpgrade(regionalClusterClient, currentClusterClient, options.ClusterName, options.Namespace, options.IsRegionalCluster, options.Edition)
 		if err != nil {
 			return err
@@ -228,7 +228,7 @@ func (c *TkgClient) DoLegacyClusterUpgrade(regionalClusterClient, currentCluster
 	}
 
 	if options.IsRegionalCluster {
-		if !config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+		if !config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 			log.Info("Waiting for additional components to be up and running...")
 			if err := c.WaitForAddonsDeployments(regionalClusterClient); err != nil {
 				return err

--- a/tkg/client/upgrade_region.go
+++ b/tkg/client/upgrade_region.go
@@ -144,7 +144,7 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 	log.Info("Management cluster providers upgraded successfully...")
 
 	// If clusterclass feature flag is enabled then deploy management components
-	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		log.Info("Upgrading kapp-controller...")
 		if err = c.InstallOrUpgradeKappController(regionalClusterClient, constants.OperationTypeUpgrade); err != nil {
 			return errors.Wrap(err, "unable to upgrade kapp-controller")
@@ -181,7 +181,7 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 		return err
 	}
 
-	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		log.Info("Creating tkg-bom versioned ConfigMaps...")
 		if err := c.CreateOrUpdateVerisionedTKGBom(regionalClusterClient); err != nil {
 			log.Warningf("Warning: Management cluster is created successfully, but the tkg-bom versioned ConfigMaps creation is failing. %v", err)
@@ -446,7 +446,7 @@ func (c *TkgClient) WaitForPackages(regionalClusterClient, currentClusterClient 
 	var packagesInstalled []kapppkgv1alpha1.Package
 
 	// Add tanzu-core-management-plugins packages to the list of packages to wait for management-cluster
-	if isRegionalCluster && !config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if isRegionalCluster && !config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		packagesInstalled = append(packagesInstalled, kapppkgv1alpha1.Package{ObjectMeta: metav1.ObjectMeta{Name: constants.CoreManagementPluginsPackageName, Namespace: constants.TkgNamespace}})
 	}
 

--- a/tkg/client/utils.go
+++ b/tkg/client/utils.go
@@ -433,7 +433,7 @@ func IsProdPlan(plan string) bool {
 // Sets the appropriate CAPI ClusterTopology configuration unless it has been explicitly overridden
 func (c *TkgClient) ensureClusterTopologyConfiguration() {
 	clusterTopologyValueToSet := trueStr
-	if !c.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if !c.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		value, err := c.TKGConfigReaderWriter().Get(constants.ConfigVariableClusterTopology)
 		if err != nil {
 			clusterTopologyValueToSet = falseStr

--- a/tkg/client/utils_test.go
+++ b/tkg/client/utils_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Utils", func() {
 
 		Context("when feature flag is set to enable CC use", func() {
 			BeforeEach(func() {
-				featureFlagClient.FeatureValues[constants.FeatureFlagPackageBasedLCM] = true
+				featureFlagClient.FeatureValues[constants.FeatureFlagPackageBasedCC] = true
 			})
 
 			It("The cluster topology configuration is always set to true", func() {
@@ -223,7 +223,7 @@ var _ = Describe("Utils", func() {
 
 		Context("when feature flag is set to not enable CC use", func() {
 			BeforeEach(func() {
-				featureFlagClient.FeatureValues[constants.FeatureFlagPackageBasedLCM] = false
+				featureFlagClient.FeatureValues[constants.FeatureFlagPackageBasedCC] = false
 			})
 
 			Context("when CLUSTER_TOPOLOGY is explicitly overridden", func() {

--- a/tkg/client/validate.go
+++ b/tkg/client/validate.go
@@ -116,8 +116,8 @@ func (c *TkgClient) DownloadBomFile(tkrName string) error {
 	}
 
 	namespace := constants.TkrNamespace
-	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
-		//TODO: After CLI fully support package based LCM, "constants.TkrNamespace" should be updated to "tkg-system"
+	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
+		//TODO: After CLI fully support cluster class, "constants.TkrNamespace" should be updated to "tkg-system"
 		namespace = "tkg-system"
 	}
 

--- a/tkg/constants/cluster_internal.go
+++ b/tkg/constants/cluster_internal.go
@@ -18,7 +18,7 @@ const (
 	ErrorMsgClusterExistsAlready    = "cluster with name %s already exists, please specify another name"
 	ErrorMsgClusterListError        = "unable to get list of workload clusters managed by current management cluster"
 
-	ErrorMsgCClassInputFeatureFlagDisabled = "input file is cluster class based but CLI feature flag '%v' is disabled, make sure its enabled to create cluster class based cluster"
+	ErrorMsgCClassInputFeatureFlagEnabled = "input file is cluster class based but CLI feature flag '%v' is enabled, make sure its disabled to create cluster class based cluster"
 
 	PacificGCMControllerDeployment = "vmware-system-tkg-controller-manager"
 	PacificGCMControllerNamespace  = "vmware-system-tkg"

--- a/tkg/constants/config_variables.go
+++ b/tkg/constants/config_variables.go
@@ -253,7 +253,8 @@ const (
 	ConfigVariableInternalNMIImageTag                       = "NMI_IMAGE_TAG"
 
 	// Other variables related to provider installation
-	ConfigVariableClusterTopology = "CLUSTER_TOPOLOGY"
+	ConfigVariableClusterTopology    = "CLUSTER_TOPOLOGY"
+	ConfigVariableAllowLegacyCluster = "ALLOW_LEGACY_CLUSTER"
 
 	ConfigVariablePackageInstallTimeout = "PACKAGE_INSTALL_TIMEOUT"
 
@@ -283,9 +284,8 @@ const (
 	ConfigVariableAviManagementClusterControlPlaneVipNetworkName = "AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_NAME"
 	ConfigVariableAviManagementClusterControlPlaneVipNetworkCIDR = "AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_CIDR"
 
-	ConfigVariableFeatureFlagPackageBasedLCM = "FEATURE_FLAG_PACKAGE_BASED_LCM"
-
 	ConfigVariableKubevipLoadbalancerEnable   = "KUBEVIP_LOADBALANCER_ENABLE"
 	ConfigVariableKubevipLoadbalancerCIDRs    = "KUBEVIP_LOADBALANCER_CIDRS"
 	ConfigVariableKubevipLoadbalancerIPRanges = "KUBEVIP_LOADBALANCER_IP_RANGES"
+	ConfigVariableFeatureFlagPackageBasedCC   = "FEATURE_FLAG_PACKAGE_BASED_CC"
 )

--- a/tkg/constants/featureflags.go
+++ b/tkg/constants/featureflags.go
@@ -23,10 +23,9 @@ const (
 	// support of ARM should be included when discovering available AWS instance types. Setting feature flag to true
 	// filters out ARM supporting instance types; false allows ARM instance types to be included in results.
 	FeatureFlagAwsInstanceTypesExcludeArm = "features.management-cluster.aws-instance-types-exclude-arm"
-	// PackageBasedLCM feature flag determines whether to use package based lifecycle management of management component
-	// or legacy way of managing management components. This is also used for clusterclass based management and workload
-	// cluster provisioning
-	FeatureFlagPackageBasedLCM = "features.global.package-based-lcm-beta"
+	// PackageBasedCC feature flag determines whether to use package based lifecycle management of management component
+	// or legacy way of managing management components. This is also used for clusterclass based management cluster provisioning
+	FeatureFlagPackageBasedCC = "features.management-cluster.package-based-cc"
 	// FeatureFlagAutoApplyGeneratedClusterClassBasedConfiguration feature flag determines whether to auto-apply the generated ClusterClass
 	// based configuration after converting legacy configration to ClusterClass based config or not
 	// Note: This is a hidden feature-flag that doesn't get persisted to config.yaml by default
@@ -42,4 +41,7 @@ const (
 	// determines whether to apply the In-Cluster IPAM provider to the
 	// management cluster.
 	FeatureFlagManagementClusterDeployInClusterIPAMProvider = "features.management-cluster.deploy-in-cluster-ipam-provider-beta"
+	// FeatureFlagAllowLegacyCluster is used to decide the workload cluster is clusterclass based or legayc based.
+	// By default, it's false. If it's true, then workload cluster is legacy based.
+	FeatureFlagAllowLegacyCluster = "features.cluster.allow-legacy-cluster"
 )

--- a/tkg/test/cc_setup.md
+++ b/tkg/test/cc_setup.md
@@ -10,11 +10,13 @@ export _MANAGEMENT_PACKAGE_REPO_IMAGE=gcr.io/eminent-nation-87317/tanzu_framewor
 export _MANAGEMENT_PACKAGE_VERSION=0.21.0
 ```
 
-- Make sure to enable the feature-flag for `package-based-lcm`
+- Make sure to enable the feature-flag for `package-based-cc`
 
 ```bash
-tanzu config set features.global.package-based-lcm-beta true
+tanzu config set features.management-cluster.package-based-cc true
 ```
+
+By default, it's true. You can check it use `tanzu config get`
 
 - Create aws management-cluster using existing VPC.
 

--- a/tkg/test/scripts/cc_hack.sh
+++ b/tkg/test/scripts/cc_hack.sh
@@ -4,5 +4,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 tanzu config set features.cluster.auto-apply-generated-clusterclass-based-configuration true
-tanzu config set features.global.package-based-lcm-beta true
 tanzu config get

--- a/tkg/test/scripts/legacy_hack.sh
+++ b/tkg/test/scripts/legacy_hack.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+tanzu config set features.management-cluster.package-based-cc false
+tanzu config set features.cluster.allow-legacy-cluster true
+tanzu config get

--- a/tkg/test/tkgctl/aws/aws_suite_test.go
+++ b/tkg/test/tkgctl/aws/aws_suite_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/tkg/tkgctl"
 
 	"github.com/vmware-tanzu/tanzu-framework/tkg/test/framework"
+	"github.com/vmware-tanzu/tanzu-framework/tkg/test/framework/exec"
 )
 
 const clusterName = "tkg-cli-wc"
@@ -82,6 +83,17 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			e2eConfig.ManagementClusterOptions.Endpoint = mcEndPointIP
 		}
 	}
+
+	hackCmd := exec.NewCommand(
+		exec.WithCommand("../../scripts/legacy_hack.sh"),
+		exec.WithStdout(GinkgoWriter),
+	)
+
+	fmt.Println("Executing the legacy hack script")
+	out, cmdErr, err := hackCmd.Run(context.Background())
+	fmt.Println(string(out))
+	fmt.Println(string(cmdErr))
+	Expect(err).To(BeNil())
 
 	cli, err := tkgctl.New(tkgctl.Options{
 		ConfigDir: e2eConfig.TkgConfigDir,

--- a/tkg/test/tkgctl/azure/azure_suite_test.go
+++ b/tkg/test/tkgctl/azure/azure_suite_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-framework/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/test/framework"
+	"github.com/vmware-tanzu/tanzu-framework/tkg/test/framework/exec"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/tkgctl"
 )
 
@@ -75,6 +76,17 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(err).To(BeNil())
 
 	timeout, err := time.ParseDuration(e2eConfig.DefaultTimeout)
+	Expect(err).To(BeNil())
+
+	hackCmd := exec.NewCommand(
+		exec.WithCommand("../../scripts/legacy_hack.sh"),
+		exec.WithStdout(GinkgoWriter),
+	)
+
+	fmt.Println("Executing the legacy hack script")
+	out, cmdErr, err := hackCmd.Run(context.Background())
+	fmt.Println(string(out))
+	fmt.Println(string(cmdErr))
 	Expect(err).To(BeNil())
 
 	cli, err := tkgctl.New(tkgctl.Options{

--- a/tkg/test/tkgctl/docker/docker_suite_test.go
+++ b/tkg/test/tkgctl/docker/docker_suite_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-framework/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/test/framework"
+	"github.com/vmware-tanzu/tanzu-framework/tkg/test/framework/exec"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/tkgctl"
 )
 
@@ -67,6 +68,17 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	By(fmt.Sprintf("Loading the e2e test configuration from %q", e2eConfigPath))
 	e2eConfig = framework.LoadE2EConfig(context.TODO(), framework.E2EConfigInput{ConfigPath: e2eConfigPath})
 	Expect(e2eConfigPath).ToNot(BeNil(), "Failed to load e2e config from %s", e2eConfigPath)
+
+	hackCmd := exec.NewCommand(
+		exec.WithCommand("../../scripts/legacy_hack.sh"),
+		exec.WithStdout(GinkgoWriter),
+	)
+
+	fmt.Println("Executing the legacy hack script")
+	out, cmdErr, err := hackCmd.Run(context.Background())
+	fmt.Println(string(out))
+	fmt.Println(string(cmdErr))
+	Expect(err).To(BeNil())
 
 	logLocation := filepath.Join(artifactsFolder, "logs")
 	cli, err := tkgctl.New(tkgctl.Options{

--- a/tkg/test/tkgctl/oracle_cc/oracle_cc_suite_test.go
+++ b/tkg/test/tkgctl/oracle_cc/oracle_cc_suite_test.go
@@ -77,7 +77,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	timeout, err := time.ParseDuration(e2eConfig.DefaultTimeout)
 	Expect(err).To(BeNil())
 
-	// turn on the `auto-apply-generated-clusterclass-based-configuration` and `package-based-lcm-beta` feature gate
+	// turn on the `auto-apply-generated-clusterclass-based-configuration` and `package-based-cc` feature gate
 	hackCmd := exec.NewCommand(
 		exec.WithCommand("../../scripts/cc_hack.sh"),
 		exec.WithStdout(GinkgoWriter),

--- a/tkg/test/tkgctl/tkgs/tkgs_suite_test.go
+++ b/tkg/test/tkgctl/tkgs/tkgs_suite_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/tkg/tkgctl"
 )
 
-const CLI_CLUSTERCLASS_FLAG = "features.global.package-based-lcm-beta"
-
 var (
 	// path to the e2e config file
 	e2eConfigPath string

--- a/tkg/test/tkgctl/tkgs_cc/tkgs_cc_suite_test.go
+++ b/tkg/test/tkgctl/tkgs_cc/tkgs_cc_suite_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/tkg/tkgctl"
 )
 
-const CLI_CLUSTERCLASS_FLAG = "features.global.package-based-lcm-beta"
-
 var (
 	// path to the e2e config file
 	e2eConfigPath string

--- a/tkg/test/tkgctl/vsphere67/vsphere_suite_test.go
+++ b/tkg/test/tkgctl/vsphere67/vsphere_suite_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vmware-tanzu/tanzu-framework/tkg/tkgctl"
 
 	"github.com/vmware-tanzu/tanzu-framework/tkg/test/framework"
+	"github.com/vmware-tanzu/tanzu-framework/tkg/test/framework/exec"
 )
 
 const clusterName = "tkg-cli-wc"
@@ -83,6 +84,17 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 			e2eConfig.ManagementClusterOptions.Endpoint = mcEndPointIP
 		}
 	}
+
+	hackCmd := exec.NewCommand(
+		exec.WithCommand("../../scripts/legacy_hack.sh"),
+		exec.WithStdout(GinkgoWriter),
+	)
+
+	fmt.Println("Executing the legacy hack script")
+	out, cmdErr, err := hackCmd.Run(context.Background())
+	fmt.Println(string(out))
+	fmt.Println(string(cmdErr))
+	Expect(err).To(BeNil())
 
 	cli, err := tkgctl.New(tkgctl.Options{
 		ConfigDir: e2eConfig.TkgConfigDir,

--- a/tkg/tkgctl/create_cluster.go
+++ b/tkg/tkgctl/create_cluster.go
@@ -153,7 +153,7 @@ func (t *tkgctl) processManagementClusterInputFile(ir *InitRegionOptions) (bool,
 	var err error
 	isInputFileClusterClassBased := false
 
-	if t.tkgClient.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
+	if t.tkgClient.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		isInputFileClusterClassBased, clusterobj, err = CheckIfInputFileIsClusterClassBased(ir.ClusterConfigFile)
 		if err != nil {
 			return isInputFileClusterClassBased, err
@@ -175,8 +175,8 @@ func (t *tkgctl) processWorkloadClusterInputFile(cc *CreateClusterOptions, isTKG
 		return isInputFileClusterClassBased, err
 	}
 	if isInputFileClusterClassBased {
-		if !isTKGSCluster && !t.tkgClient.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
-			return isInputFileClusterClassBased, fmt.Errorf(constants.ErrorMsgCClassInputFeatureFlagDisabled, constants.FeatureFlagPackageBasedLCM)
+		if !isTKGSCluster && t.tkgClient.IsFeatureActivated(constants.FeatureFlagAllowLegacyCluster) {
+			return isInputFileClusterClassBased, fmt.Errorf(constants.ErrorMsgCClassInputFeatureFlagEnabled, constants.FeatureFlagAllowLegacyCluster)
 		}
 		if isTKGSCluster {
 			t.TKGConfigReaderWriter().Set(constants.ConfigVariableClusterName, clusterobj.GetName())

--- a/tkg/tkgctl/create_cluster_test.go
+++ b/tkg/tkgctl/create_cluster_test.go
@@ -237,7 +237,7 @@ var _ = Describe("Unit tests for (AWS)  cluster_aws.yaml as input file for 'tanz
 			tkgConfigUpdaterClient: tkgconfigupdater.New(testingDir, nil, tkgConfigReaderWriter),
 			tkgBomClient:           bomClient,
 		}
-		tkgClient.IsFeatureActivatedReturns(true)
+		tkgClient.IsFeatureActivatedReturns(false)
 	})
 	Context("When input Cluster object file is valid, plan is devcc:", func() {
 		BeforeEach(func() {
@@ -408,7 +408,7 @@ var _ = Describe("Unit tests for - (Vsphere) - cluster_vsphere.yaml as input fil
 			tkgConfigUpdaterClient: tkgconfigupdater.New(testingDir, nil, tkgConfigReaderWriter),
 			tkgBomClient:           bomClient,
 		}
-		tkgClient.IsFeatureActivatedReturns(true)
+		tkgClient.IsFeatureActivatedReturns(false)
 	})
 	Context("When input file is valid Cluster Class, plan devcc:", func() {
 		BeforeEach(func() {
@@ -516,7 +516,7 @@ var _ = Describe("Unit tests for - (Azure) - cluster_azure.yaml as input file fo
 			tkgConfigUpdaterClient: tkgconfigupdater.New(testingDir, nil, tkgConfigReaderWriter),
 			tkgBomClient:           bomClient,
 		}
-		tkgClient.IsFeatureActivatedReturns(true)
+		tkgClient.IsFeatureActivatedReturns(false)
 	})
 	Context("When input file is valid Cluster Class, plan devcc:", func() {
 		BeforeEach(func() {
@@ -589,7 +589,7 @@ var _ = Describe("TKGS Cluster - cluster_tkgs.yaml as input file for 'tanzu clus
 			tkgBomClient:           bomClient,
 			featureGateHelper:      fg,
 		}
-		tkgClient.IsFeatureActivatedReturns(true)
+		tkgClient.IsFeatureActivatedReturns(false)
 	})
 	Context("When input file is valid Cluster Class", func() {
 		BeforeEach(func() {
@@ -666,7 +666,7 @@ var _ = Describe("Clusterclass FeatureGate specific use cases", func() {
 				featureGateHelper:      fg,
 			}
 		})
-		It("When feature flag (FeatureFlagPackageBasedLCM) enabled, input Cluster file is processed:", func() {
+		It("When feature flag (FeatureFlagAllowLegacyCluster) disabled, input Cluster file is processed:", func() {
 			fg.FeatureActivatedInNamespaceReturns(true, nil)
 			tkgClient.IsPacificManagementClusterReturnsOnCall(0, true, nil)
 			tkgClient.GetCurrentRegionContextReturns(regionContext, nil)
@@ -686,7 +686,7 @@ var _ = Describe("Clusterclass FeatureGate specific use cases", func() {
 			ns, _ := tkgctlClient.tkgConfigReaderWriter.Get(constants.ConfigVariableNamespace)
 			Expect(ns).To(Equal("ns01"))
 		})
-		It("Expect error when feature flag (FeatureFlagPackageBasedLCM) not enabled and CC feature is disabled but CClass input file and TKGS Cluster ", func() {
+		It("Expect error when feature flag (FeatureFlagAllowLegacyCluster) enabled and CC feature is disabled but CClass input file and TKGS Cluster ", func() {
 			fg.FeatureActivatedInNamespaceReturns(false, nil)
 			tkgClient.IsPacificManagementClusterReturnsOnCall(0, true, nil)
 			tkgClient.GetCurrentRegionContextReturns(regionContext, nil)
@@ -702,7 +702,7 @@ var _ = Describe("Clusterclass FeatureGate specific use cases", func() {
 			pc := tkgClient.IsPacificManagementClusterCallCount()
 			Expect(1).To(Equal(pc))
 		})
-		It("Should be able to create cluster when feature flag (FeatureFlagPackageBasedLCM) disabled and CC feature is enabled on supervisor cluster but CClass input file and TKGS Cluster ", func() {
+		It("Should be able to create cluster when feature flag (FeatureFlagAllowLegacyCluster) enabled and CC feature is enabled on supervisor cluster but CClass input file and TKGS Cluster ", func() {
 			fg.FeatureActivatedInNamespaceReturns(true, nil)
 			tkgClient.IsPacificManagementClusterReturnsOnCall(0, true, nil)
 			tkgClient.GetCurrentRegionContextReturns(regionContext, nil)
@@ -719,7 +719,7 @@ var _ = Describe("Clusterclass FeatureGate specific use cases", func() {
 			tkgClient.IsFeatureActivatedReturns(true)
 			tkgClient.CreateClusterReturnsOnCall(0, false, nil)
 
-			// feature flag (FeatureFlagPackageBasedLCM) activated, its clusterclass input file, but "clusterclass" feature in FeatureGate is disabled, so throws error
+			// feature flag (FeatureFlagAllowLegacyCluster) is not activated, its clusterclass input file, but "clusterclass" feature in FeatureGate is disabled, so throws error
 			err := tkgctlClient.CreateCluster(options)
 			expectedErrMsg := fmt.Sprintf(constants.ErrorMsgFeatureGateNotActivated, constants.ClusterClassFeature, constants.TKGSClusterClassNamespace)
 			Expect(err.Error()).To(ContainSubstring(expectedErrMsg))
@@ -775,7 +775,7 @@ var _ = Describe("Clusterclass FeatureGate specific use cases", func() {
 				featureGateHelper:      fg,
 			}
 		})
-		It("When feature flag (FeatureFlagPackageBasedLCM) enabled, input TKC file is processed:", func() {
+		It("When feature flag (FeatureFlagAllowLegacyCluster) is disabled, input TKC file is processed:", func() {
 			fg.FeatureActivatedInNamespaceReturns(true, nil)
 			tkgClient.IsPacificManagementClusterReturnsOnCall(0, true, nil)
 			tkgClient.GetCurrentRegionContextReturns(regionContext, nil)
@@ -795,7 +795,7 @@ var _ = Describe("Clusterclass FeatureGate specific use cases", func() {
 			ns, _ := tkgctlClient.tkgConfigReaderWriter.Get(constants.ConfigVariableNamespace)
 			Expect(ns).To(Equal(namespace))
 		})
-		It("Expect to complete CreateCluster call even feature flag (FeatureFlagPackageBasedLCM) not enabled, TKC input file ", func() {
+		It("Expect to complete CreateCluster call even feature flag (FeatureFlagAllowLegacyCluster) enabled, TKC input file ", func() {
 			fg.FeatureActivatedInNamespaceReturns(true, nil)
 			tkgClient.IsPacificManagementClusterReturnsOnCall(0, true, nil)
 			tkgClient.GetCurrentRegionContextReturns(regionContext, nil)
@@ -823,7 +823,7 @@ var _ = Describe("Clusterclass FeatureGate specific use cases", func() {
 			tkgClient.IsFeatureActivatedReturns(true)
 			tkgClient.CreateClusterReturnsOnCall(0, false, nil)
 
-			// feature flag (FeatureFlagPackageBasedLCM) activated, its clusterclass input file, but "clusterclass" feature in FeatureGate is disabled, so throws error
+			// feature flag (FeatureFlagAllowLegacyCluster) is not activated, its clusterclass input file, but "clusterclass" feature in FeatureGate is disabled, so throws error
 			err := tkgctlClient.CreateCluster(options)
 			expectedErrMsg := fmt.Sprintf(constants.ErrorMsgFeatureGateNotActivated, constants.TKCAPIFeature, constants.TKGSTKCAPINamespace)
 			Expect(err.Error()).To(ContainSubstring(expectedErrMsg))


### PR DESCRIPTION
### What this PR does / why we need it
Currently, we are using `features.global.package-based-lcm-beta` feature gate to control management-cluster and workload-cluster mode at the same time. However, in the feature, cluster class is the default mode for management-cluster and the workload cluster can be legacy or clusterclass. So we need to decouple mc and wc mode.
- Rename `features.global.package-based-lcm-beta` to `features.management-cluster.package-based-cc`. It only can control MC mode. By default, it true;
- Add a new feature gate `features.cluster.allow-legacy-cluster` for workload cluster mode. By default, it's false;

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #https://github.com/vmware-tanzu/tanzu-framework/issues/3957

### Describe testing done for PR
1. cluster class based management-cluster
- create a cluster class management-cluster(`features.management-cluster.package-based-cc` is true by default)
```
clientOptions:
    features:
        global:
            context-target: "false"
            context-aware-cli-for-plugins: "true"
            tkr-version-v1alpha3-beta: "false"
        cluster:
            dual-stack-ipv6-primary: "false"
            allow-legacy-cluster: "true"
            custom-nameservers: "false"
            dual-stack-ipv4-primary: "false"
        management-cluster:
            package-based-cc: "true"
            export-from-confirm: "true"
            import: "false"
            standalone-cluster-mode: "false"
            aws-instance-types-exclude-arm: "true"
            custom-nameservers: "false"
            dual-stack-ipv4-primary: "false"
            dual-stack-ipv6-primary: "false"
        package:
            kctrl-package-command-tree: "true"
```
cluster class based mc is created successfully:
```
kubo@guvRofrQi1q2i:~$ kubectl get cluster tkg-mgmt-vc -n tkg-system -o json | jq -r '.spec.topology.class'
tkg-vsphere-default
```
- Create cluster class based workload cluster (`features.cluster.allow-legacy-cluster` is false by default)
```
kubo@guvRofrQi1q2i:~$ tanzu cluster list
  NAME    NAMESPACE  STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES   PLAN  TKR
  cc-dev  default    running  1/1           1/1      v1.24.6+vmware.1  <none>        v1.24.6---vmware.1-tkg.1-zshippable
kubo@guvRofrQi1q2i:~$ kubectl get cluster cc-dev -o json | jq -r '.spec.topology.class'
tkg-vsphere-default
```
Also succeed.
- Enable `features.cluster.allow-legacy-cluster` to create legacy workload cluster.
```
clientOptions:
    features:
        global:
            context-target: "false"
            context-aware-cli-for-plugins: "true"
            tkr-version-v1alpha3-beta: "false"
        cluster:
            dual-stack-ipv6-primary: "false"
            allow-legacy-cluster: "true"
            custom-nameservers: "false"
            dual-stack-ipv4-primary: "false"
        management-cluster:
            package-based-cc: "true"
            export-from-confirm: "true"
            import: "false"
            standalone-cluster-mode: "false"
            aws-instance-types-exclude-arm: "true"
            custom-nameservers: "false"
            dual-stack-ipv4-primary: "false"
            dual-stack-ipv6-primary: "false"
        package:
            kctrl-package-command-tree: "true"
```
Legacy workload cluster is created:
```
kubo@guvRofrQi1q2i:~$ kubectl get cluster legacy-dev -ojson | jq -r '.spec'
{
  "clusterNetwork": {
    "pods": {
      "cidrBlocks": [
        "100.96.0.0/11"
      ]
    },
    "services": {
      "cidrBlocks": [
        "100.64.0.0/13"
      ]
    }
  },
  "controlPlaneEndpoint": {
    "host": "10.170.100.70",
    "port": 6443
  },
  "controlPlaneRef": {
    "apiVersion": "controlplane.cluster.x-k8s.io/v1beta1",
    "kind": "KubeadmControlPlane",
    "name": "legacy-dev-control-plane",
    "namespace": "default"
  },
  "infrastructureRef": {
    "apiVersion": "infrastructure.cluster.x-k8s.io/v1beta1",
    "kind": "VSphereCluster",
    "name": "legacy-dev",
    "namespace": "default"
  }
}
```

2. Legacy based management-cluster
- Disable `features.management-cluster.package-based-cc`
```
kubo@guvRofrQi1q2i:~/tanzu-framework$ tanzu config set features.management-cluster.package-based-cc false
kubo@guvRofrQi1q2i:~/tanzu-framework$ tanzu config get
clientOptions:
    features:
        global:
            context-target: "false"
            context-aware-cli-for-plugins: "true"
            tkr-version-v1alpha3-beta: "false"
        management-cluster:
            package-based-cc: "false"
            aws-instance-types-exclude-arm: "true"
            custom-nameservers: "false"
            dual-stack-ipv4-primary: "false"
            dual-stack-ipv6-primary: "false"
            export-from-confirm: "true"
            import: "false"
            standalone-cluster-mode: "false"
        cluster:
            dual-stack-ipv4-primary: "false"
            dual-stack-ipv6-primary: "false"
            allow-legacy-cluster: "false"
            custom-nameservers: "false"
        package:
            kctrl-package-command-tree: "true"
```
Legacy management-cluster is created successfully:
```
kubo@guvRofrQi1q2i:~$ kubectl get cluster -A
NAMESPACE    NAME          PHASE         AGE     VERSION
tkg-system   tkg-mgmt-vc   Provisioned   4m14s
kubo@guvRofrQi1q2i:~$ kubectl get cluster tkg-mgmt-vc -n tkg-system -o yaml
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  annotations:
    TKGOperationInfo: '{"Operation":"Create","OperationStartTimestamp":"2022-11-20
      03:02:02.02616915 +0000 UTC","OperationTimeout":1800}'
    TKGOperationLastObservedTimestamp: 2022-11-20 03:02:02.02616915 +0000 UTC
    TKGVERSION: v1.7.0-zshippable
    edition: tkg
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"cluster.x-k8s.io/v1beta1","kind":"Cluster","metadata":{"annotations":{"osInfo":"ubuntu,20.04,amd64","tkg.tanzu.vmware.com/cluster-controlplane-endpoint":"10.170.100.100","tkg/plan":"dev"},"labels":{"cluster-role.tkg.tanzu.vmware.com/management":"","tanzuKubernetesRelease":"v1.24.6---vmware.1-tkg.1-zshippable","tkg.tanzu.vmware.com/cluster-name":"tkg-mgmt-vc"},"name":"tkg-mgmt-vc","namespace":"tkg-system"},"spec":{"clusterNetwork":{"pods":{"cidrBlocks":["100.96.0.0/11"]},"services":{"cidrBlocks":["100.64.0.0/13"]}},"controlPlaneRef":{"apiVersion":"controlplane.cluster.x-k8s.io/v1beta1","kind":"KubeadmControlPlane","name":"tkg-mgmt-vc-control-plane"},"infrastructureRef":{"apiVersion":"infrastructure.cluster.x-k8s.io/v1beta1","kind":"VSphereCluster","name":"tkg-mgmt-vc"}}}
    osInfo: ubuntu,20.04,amd64
    tkg.tanzu.vmware.com/cluster-controlplane-endpoint: 10.170.100.100
    tkg/plan: dev
  creationTimestamp: "2022-11-20T03:07:17Z"
  finalizers:
  - cluster.cluster.x-k8s.io
  generation: 2
  labels:
    cluster-role.tkg.tanzu.vmware.com/management: ""
    tanzuKubernetesRelease: v1.24.6---vmware.1-tkg.1-zshippable
    tkg.tanzu.vmware.com/cluster-name: tkg-mgmt-vc
  name: tkg-mgmt-vc
  namespace: tkg-system
  resourceVersion: "2948"
  uid: 47b7c359-2819-4ab6-8944-27629b95fa8f
spec:
  clusterNetwork:
    pods:
      cidrBlocks:
      - 100.96.0.0/11
    services:
      cidrBlocks:
      - 100.64.0.0/13
  controlPlaneEndpoint:
    host: 10.170.100.100
    port: 6443
  controlPlaneRef:
    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
    kind: KubeadmControlPlane
    name: tkg-mgmt-vc-control-plane
    namespace: tkg-system
  infrastructureRef:
    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
```
- Create cluster class workload cluster fails (Expected);
```
kubo@guvRofrQi1q2i:~$ tanzu cluster create --file /home/kubo/.config/tanzu/tkg/clusterconfigs/cc-dev.yaml
Validating configuration...
Warning: Pinniped configuration not found; Authentication via Pinniped will not be set up in this cluster. If you wish to set up Pinniped after the cluster is created, please refer to the documentation.
creating workload cluster 'cc-dev'...
Error: unable to create cluster: unable to apply cluster configuration: kubectl apply failed, output: vsphereclustertemplate.infrastructure.cluster.x-k8s.io/tkg-vsphere-infrastructure unchanged
vspheremachinetemplate.infrastructure.cluster.x-k8s.io/tkg-vsphere-control-plane unchanged
vspheremachinetemplate.infrastructure.cluster.x-k8s.io/tkg-vsphere-worker unchanged
kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/tkg-vsphere-md-0 unchanged
secret/cc-dev-vsphere-credential configured
secret/cc-dev-nsxt-credential configured
secret/cc-dev configured
[resource mapping not found for name: "cc-dev" namespace: "default" from "/tmp/kubeapply-2427932359": no matches for kind "AntreaConfig" in version "cni.tanzu.vmware.com/v1alpha1"
ensure CRDs are installed first, resource mapping not found for name: "cc-dev" namespace: "default" from "/tmp/kubeapply-2427932359": no matches for kind "VSphereCPIConfig" in version "cpi.tanzu.vmware.com/v1alpha1"
ensure CRDs are installed first, resource mapping not found for name: "cc-dev" namespace: "default" from "/tmp/kubeapply-2427932359": no matches for kind "ClusterBootstrap" in version "run.tanzu.vmware.com/v1alpha3"
ensure CRDs are installed first]
Error from server (spec: Forbidden: can be set only if the ClusterTopology feature flag is enabled): error when creating "/tmp/kubeapply-2427932359": admission webhook "validation.kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io" denied the request: spec: Forbidden: can be set only if the ClusterTopology feature flag is enabled
Error from server (spec: Forbidden: can be set only if the ClusterTopology feature flag is enabled): error when creating "/tmp/kubeapply-2427932359": admission webhook "validation.clusterclass.cluster.x-k8s.io" denied the request: spec: Forbidden: can be set only if the ClusterTopology feature flag is enabled
Error from server (InternalError): error when creating "/tmp/kubeapply-2427932359": admission webhook "default.cluster.cluster.x-k8s.io" denied the request: Internal error occurred: Cluster cc-dev can't be validated. ClusterClass tkg-vsphere-default can not be retrieved: ClusterClass.cluster.x-k8s.io "tkg-vsphere-default" not found
: exit status 1
```
- Create legacy workload cluster is successful:
```
kubo@guvRofrQi1q2i:~$ tanzu config set features.cluster.allow-legacy-cluster true
kubo@guvRofrQi1q2i:~$ tanzu cluster create -f tkg-vc-antrea.yaml --dry-run
Warning: Pinniped configuration not found; Authentication via Pinniped will not be set up in this cluster. If you wish to set up Pinniped after the cluster is created, please refer to the documentation.
Setting config variable "VSPHERE_DATACENTER" to value "/dc0"
Setting config variable "VSPHERE_NETWORK" to value "/dc0/network/VM Network"
Setting config variable "VSPHERE_RESOURCE_POOL" to value "/dc0/host/cluster0/Resources/rp0"
Setting config variable "VSPHERE_DATASTORE" to value "/dc0/datastore/sharedVmfs-0"
Setting config variable "VSPHERE_FOLDER" to value "/dc0/vm/folder0"
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  annotations:
    osInfo: ubuntu,20.04,amd64
    tkg.tanzu.vmware.com/cluster-controlplane-endpoint: 10.170.100.70
    tkg/plan: dev
  labels:
    tanzuKubernetesRelease: v1.24.6---vmware.1-tkg.1-zshippable
    tkg.tanzu.vmware.com/cluster-name: cc-dev
  name: cc-dev
  namespace: default
spec:
  clusterNetwork:
    pods:
      cidrBlocks:
      - 100.96.0.0/11
    services:
      cidrBlocks:
      - 100.64.0.0/13
  controlPlaneRef:
    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
    kind: KubeadmControlPlane
    name: cc-dev-control-plane
  infrastructureRef:
    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
    kind: VSphereCluster
    name: legacy-dev
---
kubo@guvRofrQi1q2i:~$ tanzu cluster list
  NAME    NAMESPACE  STATUS   CONTROLPLANE  WORKERS  KUBERNETES        ROLES   PLAN  TKR
  legacy-dev  default    running  1/1           1/1      v1.24.6+vmware.1  <none>  dev   v1.24.6---vmware.1-tkg.1-zshippable
```

### Release note
 - Rename `features.global.package-based-lcm-beta` to `features.management-cluster.package-based-cc`. It only can control MC mode. By default, it true;
- Add a new feature gate `features.cluster.allow-legacy-cluster` for workload cluster mode. By default, it's false;
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
