### PR TITLE
Remove package installing when deleting cc mgmt cluster

### DIFF
--- a/tkg/client/delete_region.go
+++ b/tkg/client/delete_region.go
@@ -20,8 +20,6 @@ import (
 	clusterctlv1 "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	crtclient "sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/vmware-tanzu/tanzu-framework/cli/runtime/config"
-	"github.com/vmware-tanzu/tanzu-framework/packageclients/pkg/packageclient"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/clusterclient"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/log"
@@ -137,38 +135,11 @@ func (c *TkgClient) DeleteRegion(options DeleteRegionOptions) error { //nolint:f
 		if err != nil {
 			return errors.Wrap(err, "cannot create cleanup cluster client")
 		}
-		cleanupPkgClient, err := packageclient.NewPackageClientForContext(cleanupClusterKubeconfigPath, "")
-		if err != nil {
-			return errors.Wrap(err, "unable to get a PackageClient")
-		}
-
-		// If clusterclass feature flag is enabled then deploy kapp-controller
-		if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
-			if err = c.InstallOrUpgradeKappController(cleanupClusterClient, constants.OperationTypeInstall); err != nil {
-				return errors.Wrap(err, "unable to install kapp-controller to bootstrap cluster")
-			}
-		}
 
 		log.Info("Installing providers to cleanup cluster...")
 		// Initialize cleanup cluster using same provider name and version from management cluster
 		if err = c.InitializeProviders(&initOptionsForCleanupCluster, cleanupClusterClient, cleanupClusterKubeconfigPath); err != nil {
 			return errors.Wrap(err, "unable to initialize providers")
-		}
-
-		// If clusterclass feature flag is enabled then deploy management components
-		if config.IsFeatureActivated(constants.FeatureFlagPackageBasedLCM) {
-			// Read config variable from management cluster and set it into cleanup cluster
-			configValues, err := c.getUserConfigVariableValueMapFromSecret(regionalClusterClient)
-			if err != nil {
-				return errors.Wrap(err, "unable to get config variables from management cluster")
-			}
-			for k, v := range configValues {
-				// Handle bool, int and string
-				c.TKGConfigReaderWriter().Set(k, fmt.Sprint(v))
-			}
-			if err = c.InstallOrUpgradeManagementComponents(cleanupClusterClient, cleanupPkgClient, "", false); err != nil {
-				return errors.Wrap(err, "unable to install management components to bootstrap cluster")
-			}
 		}
 
 		isStartedRegionalClusterDeletion = true


### PR DESCRIPTION
### What this PR does / why we need it
It is not necessary to install the kapp controller and meta-package when deleting classy mgmt cluster, so drop it.