### PR TITLE
Skip deletion of ako packageInstall when cluster is deleted since AKO…

### DIFF
--- a/addons/controllers/clusterbootstrap_controller_test.go
+++ b/addons/controllers/clusterbootstrap_controller_test.go
@@ -171,7 +171,7 @@ var _ = Describe("ClusterBootstrap Reconciler", func() {
 
 				By("packageinstall should have been created for each additional package in the clusterBoostrap")
 				Expect(hasPackageInstalls(ctx, k8sClient, cluster, constants.TKGSystemNS,
-					clusterBootstrap.Spec.AdditionalPackages, setupLog)).To(BeTrue())
+					clusterBootstrap.Spec.AdditionalPackages, clusterBootstrap.Annotations, setupLog)).To(BeTrue())
 
 				By("packageinstalls for core packages should not have owner references")
 				var corePackages []*runtanzuv1alpha3.ClusterBootstrapPackage
@@ -742,10 +742,10 @@ var _ = Describe("ClusterBootstrap Reconciler", func() {
 
 				By("instacllpackages for additional packages should have been removed.")
 				Expect(hasPackageInstalls(ctx, k8sClient, cluster, constants.TKGSystemNS,
-					clusterBootstrap.Spec.AdditionalPackages, setupLog)).To(BeTrue())
+					clusterBootstrap.Spec.AdditionalPackages, clusterBootstrap.Annotations, setupLog)).To(BeTrue())
 				Eventually(func() bool {
 					return hasPackageInstalls(ctx, k8sClient, cluster, constants.TKGSystemNS,
-						clusterBootstrap.Spec.AdditionalPackages, setupLog)
+						clusterBootstrap.Spec.AdditionalPackages, clusterBootstrap.Annotations, setupLog)
 				}, waitTimeout, pollingInterval).Should(BeFalse())
 
 				By("finalizer should be removed from clusterboostrap")
@@ -1244,6 +1244,131 @@ var _ = Describe("ClusterBootstrap Reconciler", func() {
 					Expect(strings.Contains(string(valueTexts), "loadbalancerIPRanges: 10.0.0.1-10.0.0.2")).Should(BeTrue())
 					return true
 				}, waitTimeout, pollingInterval).Should(BeTrue())
+			})
+		})
+	})
+
+	// This test case is for ensuring that controller will skip deleting additional packages that's inside annotation run.tanzu.vmware.com/skip-packageinstall-deletion
+	When("Cluster with ako", func() {
+		BeforeEach(func() {
+			clusterName = "test-cluster-8"
+			clusterNamespace = "cluster-namespace-8"
+			clusterResourceFilePath = "testdata/test-cluster-bootstrap-8.yaml"
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterNamespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		})
+
+		Context("from a ClusterBootstrap", func() {
+			It("should perform ClusterBootstrap reconciliation", func() {
+
+				By("verifying CAPI cluster is created properly")
+				cluster := &clusterapiv1beta1.Cluster{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: clusterNamespace, Name: clusterName}, cluster)).To(Succeed())
+				cluster.Status.Phase = string(clusterapiv1beta1.ClusterPhaseProvisioned)
+				Expect(k8sClient.Status().Update(ctx, cluster)).To(Succeed())
+
+				By("ClusterBootstrap CR is created with correct ownerReference added")
+				clusterBootstrap := &runtanzuv1alpha3.ClusterBootstrap{}
+				// Verify ownerReference for cluster in cloned object
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), clusterBootstrap)
+					if err != nil {
+						return false
+					}
+					for _, ownerRef := range clusterBootstrap.OwnerReferences {
+						if ownerRef.UID == cluster.UID {
+							return true
+						}
+					}
+					return false
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+				By("patching secret of ako with ownerRef as ClusterBootstrapController would do")
+				config := &corev1.Secret{}
+				key := client.ObjectKey{
+					Namespace: clusterNamespace,
+					Name:      util.GenerateDataValueSecretName(clusterName, "load-balancer-and-ingress-service"),
+				}
+				Eventually(func() bool {
+					if err := k8sClient.Get(ctx, key, config); err != nil {
+						return false
+					}
+
+					if len(config.OwnerReferences) > 0 {
+						return false
+					}
+
+					Expect(len(config.OwnerReferences)).Should(Equal(0))
+					return true
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+
+				patchedSecret := config.DeepCopy()
+				ownerRef := metav1.OwnerReference{
+					APIVersion: clusterapiv1beta1.GroupVersion.String(),
+					Kind:       "Cluster",
+					Name:       cluster.Name,
+					UID:        cluster.UID,
+				}
+
+				patchedSecret.OwnerReferences = clusterapiutil.EnsureOwnerRef(patchedSecret.OwnerReferences, ownerRef)
+				Expect(k8sClient.Patch(ctx, patchedSecret, client.MergeFrom(config))).ShouldNot(HaveOccurred())
+
+				By("ClusterBootstrap CR is created with correct ownerReference added")
+				// Verify ownerReference for cluster in cloned object
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), clusterBootstrap)
+					if err != nil {
+						return false
+					}
+					for _, ownerRef := range clusterBootstrap.OwnerReferences {
+						if ownerRef.UID == cluster.UID {
+							return true
+						}
+					}
+					return false
+				}, waitTimeout, pollingInterval).Should(BeTrue())
+
+				By("Should have remote packageinstall created for ako")
+				remoteClient, err := util.GetClusterClient(ctx, k8sClient, scheme, clusterapiutil.ObjectKey(cluster))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(remoteClient).NotTo(BeNil())
+
+				akoPackageInstallExist := func() bool {
+					pkgInstall := &kapppkgiv1alpha1.PackageInstall{}
+					if err := remoteClient.Get(ctx, client.ObjectKey{Name: util.GeneratePackageInstallName(clusterName, "load-balancer-and-ingress-service"), Namespace: "tkg-system"}, pkgInstall); err != nil {
+						return false
+					}
+					return true
+				}()
+
+				Eventually(akoPackageInstallExist, waitTimeout, pollingInterval).Should(BeTrue())
+
+				By("delete cluster with foreground propagation policy")
+				deletePropagation := metav1.DeletePropagationForeground
+				deleteOptions := client.DeleteOptions{PropagationPolicy: &deletePropagation}
+				Expect(k8sClient.Delete(ctx, cluster, &deleteOptions)).To(Succeed())
+
+				By("instacllpackages for additional packages should have been removed.")
+				Eventually(func() bool {
+					return hasPackageInstalls(ctx, k8sClient, cluster, constants.TKGSystemNS,
+						clusterBootstrap.Spec.AdditionalPackages, clusterBootstrap.Annotations, setupLog)
+				}, waitTimeout, pollingInterval).Should(BeFalse())
+
+				By("Should have left ako packageInstall")
+				Eventually(akoPackageInstallExist, waitTimeout, pollingInterval).Should(BeTrue())
+
+				By("finalizer should be removed from clusterboostrap")
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), clusterBootstrap)
+					if err != nil {
+						return false
+					}
+					return controllerutil.ContainsFinalizer(clusterBootstrap, addontypes.AddonFinalizer)
+				}, waitTimeout, pollingInterval).Should(BeFalse())
+
 			})
 		})
 	})

--- a/addons/controllers/machine_controller_test.go
+++ b/addons/controllers/machine_controller_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Machine Reconciler", func() {
 			err := k8sClient.List(ctx, pkgInstallsList)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hasPackageInstalls(ctx, k8sClient, cluster, addonNamespace,
-				clusterBootstrap.Spec.AdditionalPackages, setupLog)).To(BeTrue())
+				clusterBootstrap.Spec.AdditionalPackages, clusterBootstrap.Annotations, setupLog)).To(BeTrue())
 
 			By("Cluster deletion with foreground propagation policy")
 			deletePropagation := metav1.DeletePropagationForeground
@@ -155,11 +155,11 @@ var _ = Describe("Machine Reconciler", func() {
 
 			By("Results on additionalPackageInstalls being removed.")
 			Expect(hasPackageInstalls(ctx, k8sClient, cluster, addonNamespace,
-				clusterBootstrap.Spec.AdditionalPackages, setupLog)).To(BeTrue())
+				clusterBootstrap.Spec.AdditionalPackages, clusterBootstrap.Annotations, setupLog)).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(func() bool {
 				return hasPackageInstalls(ctx, k8sClient, cluster, addonNamespace,
-					clusterBootstrap.Spec.AdditionalPackages, setupLog)
+					clusterBootstrap.Spec.AdditionalPackages, clusterBootstrap.Annotations, setupLog)
 			}, waitTimeout, pollingInterval).Should(BeFalse())
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cluster), clusterBootstrap)

--- a/addons/controllers/testdata/test-cluster-bootstrap-8.yaml
+++ b/addons/controllers/testdata/test-cluster-bootstrap-8.yaml
@@ -2,17 +2,17 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
-  name: test-cluster-7
-  namespace: cluster-namespace-7
+  name: test-cluster-8
+  namespace: cluster-namespace-8
   labels:
-    tkg.tanzu.vmware.com/cluster-name: test-cluster-7
-    run.tanzu.vmware.com/tkr: v1.22.5
+    tkg.tanzu.vmware.com/cluster-name: test-cluster-8
+    run.tanzu.vmware.com/tkr: v1.22.22
 spec:
   infrastructureRef:
     kind: VSphereCluster
     apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    name: test-cluster-7
-    namespace: cluster-namespace-7
+    name: test-cluster-8
+    namespace: cluster-namespace-8
   clusterNetwork:
     pods:
       cidrBlocks: [ "192.168.0.0/16","fd00:100:96::/48" ]
@@ -22,25 +22,25 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereCluster
 metadata:
-  name: test-cluster-7
-  namespace: cluster-namespace-7
+  name: test-cluster-8
+  namespace: cluster-namespace-8
 spec:
   identityRef:
     kind: Secret
-    name: test-cluster-7
+    name: test-cluster-8
   thumbprint: test-thumbprint
   server: vsphere-server.local
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
 metadata:
-  name: test-cluster-7-control-plane
-  namespace: cluster-namespace-7
+  name: test-cluster-8-control-plane
+  namespace: cluster-namespace-8
 spec:
   template:
     spec:
       datacenter: dc0
-      template: /dc0/vm/photon-3-kube-v1.22.5+vmware.1-tkg.2
+      template: /dc0/vm/photon-3-kube-v1.22.22+vmware.1-tkg.2
       network:
         devices:
           - networkName: test-network
@@ -50,8 +50,8 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: test-cluster-7
-  namespace: cluster-namespace-7
+  name: test-cluster-8
+  namespace: cluster-namespace-8
 data:
   password: QWRtaW4hMjM= # Admin!23
   username: YWRtaW5pc3RyYXRvckB2c3BoZXJlLmxvY2Fs # administrator@vsphere.local
@@ -59,17 +59,17 @@ data:
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: cpi.tanzu.vmware.com.0.0.4
-  namespace: cluster-namespace-7
+  name: load-balancer-and-ingress-service.tanzu.vmware.com.0.0.4
+  namespace: cluster-namespace-8
 spec:
-  refName: cpi.tanzu.vmware.com
+  refName: load-balancer-and-ingress-service.tanzu.vmware.com
   version: 0.0.4+vmware.1-tkg.1
   releasedAt: "2021-05-13T18:00:00Z"
   releaseNotes: lb 0.0.4
   capacityRequirementsDescription: Varies significantly based on cluster size. This should be tuned based on observed usage.
   valuesSchema:
     openAPIv3:
-      title: cpi.tanzu.vmware.com.0.0.4+vmware.1-tkg.1 values schema
+      title: load-balancer-and-ingress-service.tanzu.vmware.com.0.0.4+vmware.1-tkg.1 values schema
       properties:
         namespace:
           type: string
@@ -81,7 +81,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/kube-vip-cloud-provider:v0.0.4_vmware.1-tkg.1
+            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/ako:v0.0.4_vmware.1-tkg.1
       template:
         - ytt:
             paths:
@@ -101,17 +101,17 @@ spec:
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: cpi.tanzu.vmware.com.0.0.4
+  name: load-balancer-and-ingress-service.tanzu.vmware.com.0.0.4
   namespace: tkg-system
 spec:
-  refName: cpi.tanzu.vmware.com
+  refName: load-balancer-and-ingress-service.tanzu.vmware.com
   version: 0.0.4+vmware.1-tkg.1
   releasedAt: "2021-05-13T18:00:00Z"
   releaseNotes: lb 0.0.4
   capacityRequirementsDescription: Varies significantly based on cluster size. This should be tuned based on observed usage.
   valuesSchema:
     openAPIv3:
-      title: cpi.tanzu.vmware.com.0.0.4+vmware.1-tkg.1 values schema
+      title: load-balancer-and-ingress-service.tanzu.vmware.com.0.0.4+vmware.1-tkg.1 values schema
       properties:
         namespace:
           type: string
@@ -123,7 +123,7 @@ spec:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/kube-vip-cloud-provider:v0.0.4_vmware.1-tkg.1
+            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/ako:v0.0.4_vmware.1-tkg.1
       template:
         - ytt:
             paths:
@@ -143,19 +143,19 @@ spec:
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: kapp-controller.tanzu.vmware.com.0.30.23
-  namespace: cluster-namespace-7
+  name: kapp-controller.tanzu.vmware.com.0.30.24
+  namespace: cluster-namespace-8
 spec:
   refName: kapp-controller.tanzu.vmware.com
-  version: 0.30.23
-  releaseNotes: kapp-controller 0.30.23 https://github.com/vmware-tanzu/carvel-kapp-controller
+  version: 0.30.24
+  releaseNotes: kapp-controller 0.30.24 https://github.com/vmware-tanzu/carvel-kapp-controller
   licenses:
     - 'VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)'
   template:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/kapp-controller:v0.30.23_vmware.1-tkg.1
+            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/kapp-controller:v0.30.24_vmware.1-tkg.1
       template:
         - ytt:
             paths:
@@ -174,13 +174,13 @@ spec:
   releasedAt: "2021-12-20T10:59:32Z"
   valuesSchema:
     openAPIv3:
-      title: kapp-controller.tanzu.vmware.com.0.30.23+vmware.1-tkg.1 values schema
+      title: kapp-controller.tanzu.vmware.com.0.30.24+vmware.1-tkg.1 values schema
 ---
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: calico.tanzu.vmware.com.3.19.1--vmware.1-tkg.1
-  namespace: cluster-namespace-7
+  namespace: cluster-namespace-8
 spec:
   refName: calico.tanzu.vmware.com
   version: 3.19.1+vmware.1-tkg.1
@@ -216,7 +216,7 @@ apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: antrea.tanzu.vmware.com.1.2.3--vmware.1-tkg.1
-  namespace: cluster-namespace-7
+  namespace: cluster-namespace-8
 spec:
   refName: antrea.tanzu.vmware.com
   version: 1.2.3+vmware.1-tkg.1
@@ -252,7 +252,7 @@ apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
   name: vsphere-cpi.tanzu.vmware.com.1.22.3--vmware.1-tkg.1
-  namespace: cluster-namespace-7
+  namespace: cluster-namespace-8
 spec:
   refName: vsphere-cpi.tanzu.vmware.com
   version: 1.22.3+vmware.1-tkg.1
@@ -287,31 +287,32 @@ spec:
 apiVersion: run.tanzu.vmware.com/v1alpha3
 kind: TanzuKubernetesRelease
 metadata:
-  name: v1.22.5
+  name: v1.22.22
 spec:
-  version: v1.22.5
+  version: v1.22.22
   kubernetes:
-    version: v1.22.5
+    version: v1.22.22
     imageRepository: foo
   osImages: []
-  bootstrapPackages: []
+  bootstrapPackages:
+  - name: "load-balancer-and-ingress-service.tanzu.vmware.com.0.0.4"
 ---
 apiVersion: data.packaging.carvel.dev/v1alpha1
 kind: Package
 metadata:
-  name: kapp-controller.tanzu.vmware.com.0.30.23
+  name: kapp-controller.tanzu.vmware.com.0.30.24
   namespace: tkg-system
 spec:
   refName: kapp-controller.tanzu.vmware.com
-  version: 0.30.23
-  releaseNotes: kapp-controller 0.30.23 https://github.com/vmware-tanzu/carvel-kapp-controller
+  version: 0.30.24
+  releaseNotes: kapp-controller 0.30.24 https://github.com/vmware-tanzu/carvel-kapp-controller
   licenses:
     - 'VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)'
   template:
     spec:
       fetch:
         - imgpkgBundle:
-            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/kapp-controller:v0.30.23_vmware.1-tkg.1
+            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/packages/core/kapp-controller:v0.30.24_vmware.1-tkg.1
       template:
         - ytt:
             paths:
@@ -330,196 +331,141 @@ spec:
   releasedAt: "2021-12-20T10:59:32Z"
   valuesSchema:
     openAPIv3:
-      title: kapp-controller.tanzu.vmware.com.0.30.23+vmware.1-tkg.1 values schema
+      title: kapp-controller.tanzu.vmware.com.0.30.24+vmware.1-tkg.1 values schema
 
----
-apiVersion: cpi.tanzu.vmware.com/v1alpha1
-kind: KubevipCPIConfig
-metadata:
-  name: test-cluster-7
-  namespace: cluster-namespace-7
-spec:
-  loadbalancerIPRanges: 10.0.0.1-10.0.0.2
-  loadbalancerCIDRs: 10.0.0.1/24
-
----
-apiVersion: run.tanzu.vmware.com/v1alpha3
-kind: KappControllerConfig
-metadata:
-  name: test-cluster-7-kapp-controller-config
-  namespace: tkg-system
-spec:
-  namespace: test-ns
-  kappController:
-    createNamespace: true
-    globalNamespace: tanzu-package-repo-global
-    deployment:
-      concurrency: 4
-      hostNetwork: true
-      priorityClassName: system-cluster-critical
-      apiPort: 10100
-      metricsBindAddress: "0"
-      tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
----
-apiVersion: run.tanzu.vmware.com/v1alpha3
-kind: KappControllerConfig
-metadata:
-  name: test-cluster-7-kapp-controller-config
-  namespace: cluster-namespace-7
-spec:
-  namespace: test-ns
-  kappController:
-    createNamespace: true
-    globalNamespace: tanzu-package-repo-global
-    deployment:
-      concurrency: 4
-      hostNetwork: true
-      priorityClassName: system-cluster-critical
-      apiPort: 10100
-      metricsBindAddress: "0"
-      tolerations:
-        - key: CriticalAddonsOnly
-          operator: Exists
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/control-plane
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
----
-apiVersion: cni.tanzu.vmware.com/v1alpha1
-kind: AntreaConfig
-metadata:
-  name: test-cluster-7
-  namespace: tkg-system
-spec:
-  antrea:
-    config:
-      trafficEncapMode: encap
----
-apiVersion: cni.tanzu.vmware.com/v1alpha1
-kind: AntreaConfig
-metadata:
-  name: test-cluster-7
-  namespace: cluster-namespace-7
-spec:
-  antrea:
-    config:
-      trafficEncapMode: encap
 ---
 kind: Secret
 metadata:
-  name: foobar2secret
-  namespace: cluster-namespace-7
+  name: test-cluster-8-load-balancer-and-ingress-service-data-values
+  namespace: cluster-namespace-8
 stringData:
   values.yaml: |
     sample-key: sample-value
 ---
-apiVersion: data.packaging.carvel.dev/v1alpha1
-kind: Package
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: KappControllerConfig
 metadata:
-  name: foobar1.example.com.1.17.2
-  namespace: cluster-namespace-7
+  name: test-cluster-8-kapp-controller-config
+  namespace: tkg-system
 spec:
-  refName: foobar1.example.com
-  version: 1.17.2
-  releasedAt: "2021-05-13T18:00:00Z"
-  releaseNotes: foobar1 1.17.2
-  capacityRequirementsDescription: Varies significantly based on cluster size. This should be tuned based on observed usage.
-  valuesSchema:
-    openAPIv3:
-      title: foobar1.example.com.1.17.2+vmware.1-tkg.1 values schema
-      properties:
-        namespace:
-          type: string
-          description: The namespace in which to deploy fluent-bit.
-          default: tanzu-system-logging
-  licenses:
-    - 'VMware''s End User License Agreement (Underlying OSS license: Apache License 2.0)'
-  template:
-    spec:
-      fetch:
-        - imgpkgBundle:
-            image: projects-stg.registry.vmware.com/tkg/tkgextensions-dev/fluent-bit:v1.7.5_vmware.1-tkg.1
-      template:
-        - ytt:
-            paths:
-              - config/
-            ignoreUnknownComments: true
-        - kbld:
-            paths:
-              - '-'
-              - .imgpkg/images.yml
-      deploy:
-        - kapp:
-            rawOptions:
-              - --wait-timeout=5m
-              - --kube-api-qps=20
-              - --kube-api-burst=30
+  namespace: test-ns
+  kappController:
+    createNamespace: true
+    globalNamespace: tanzu-package-repo-global
+    deployment:
+      concurrency: 4
+      hostNetwork: true
+      priorityClassName: system-cluster-critical
+      apiPort: 10100
+      metricsBindAddress: "0"
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+---
+apiVersion: run.tanzu.vmware.com/v1alpha3
+kind: KappControllerConfig
+metadata:
+  name: test-cluster-8-kapp-controller-config
+  namespace: cluster-namespace-8
+spec:
+  namespace: test-ns
+  kappController:
+    createNamespace: true
+    globalNamespace: tanzu-package-repo-global
+    deployment:
+      concurrency: 4
+      hostNetwork: true
+      priorityClassName: system-cluster-critical
+      apiPort: 10100
+      metricsBindAddress: "0"
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          value: "true"
+---
+apiVersion: cni.tanzu.vmware.com/v1alpha1
+kind: AntreaConfig
+metadata:
+  name: test-cluster-8
+  namespace: tkg-system
+spec:
+  antrea:
+    config:
+      trafficEncapMode: encap
+---
+apiVersion: cni.tanzu.vmware.com/v1alpha1
+kind: AntreaConfig
+metadata:
+  name: test-cluster-8
+  namespace: cluster-namespace-8
+spec:
+  antrea:
+    config:
+      trafficEncapMode: encap
 ---
 apiVersion: run.tanzu.vmware.com/v1alpha3
 kind: ClusterBootstrapTemplate
 metadata:
-  name: v1.22.5
+  name: v1.22.22
   namespace: tkg-system
 spec:
   kapp:
-    refName: kapp-controller.tanzu.vmware.com.0.30.23
+    refName: kapp-controller.tanzu.vmware.com.0.30.24
     valuesFrom:
       providerRef:
         apiGroup: run.tanzu.vmware.com
         kind: KappControllerConfig
-        name: test-cluster-7-kapp-controller-config
+        name: test-cluster-8-kapp-controller-config
   cni:
     refName: antrea.tanzu.vmware.com.1.2.3--vmware.1-tkg.1
     valuesFrom:
       providerRef:
         apiGroup: cni.tanzu.vmware.com
         kind: AntreaConfig
-        name: test-cluster-7
+        name: test-cluster-8
 
 ---
 apiVersion: run.tanzu.vmware.com/v1alpha3
 kind: ClusterBootstrap
 metadata:
-  name: test-cluster-7
-  namespace: cluster-namespace-7
+  name: test-cluster-8
+  namespace: cluster-namespace-8
+  annotations:
+    "tkg.tanzu.vmware.com/add-missing-fields-from-tkr": "v1.22.22"
+    "run.tanzu.vmware.com/skip-packageinstall-deletion": "load-balancer-and-ingress-service"
 spec:
   kapp:
-    refName: kapp-controller.tanzu.vmware.com.0.30.23
+    refName: kapp-controller.tanzu.vmware.com.0.30.24
     valuesFrom:
       providerRef:
         apiGroup: run.tanzu.vmware.com
         kind: KappControllerConfig
-        name: test-cluster-7-kapp-controller-config
+        name: test-cluster-8-kapp-controller-config
   cni:
     refName: antrea.tanzu.vmware.com.1.2.3--vmware.1-tkg.1
     valuesFrom:
       providerRef:
         apiGroup: cni.tanzu.vmware.com
         kind: AntreaConfig
-        name: test-cluster-7
+        name: test-cluster-8
   additionalPackages:
-    - refName: foobar1.example.com.1.17.2
-      valuesFrom:
-        secretRef: foobar2secret
-    - refName: cpi.tanzu.vmware.com.0.0.4
-      valuesFrom:
-        providerRef:
-          apiGroup: cpi.tanzu.vmware.com
-          kind: KubevipCPIConfig
-          name: test-cluster-7
+  - refName: load-balancer-and-ingress-service.tanzu.vmware.com*
+    valuesFrom:
+      secretRef: test-cluster-8-load-balancer-and-ingress-service-data-values

--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -351,6 +351,11 @@ const (
 
 	// KindTanzuKubernetesCluster is the owner name of cluster
 	KindTanzuKubernetesCluster = "TanzuKubernetesCluster"
+
+	// SkipDeletePackageInstallAnnotation is the annotation that contains a list of comma separated packageInstalls to skip
+	// for example
+	// "run.tanzu.vmware.com/skip-packageinstall-deletion": "vsphere-cpi,antrea,load-balancer-and-ingress-service"
+	SkipDeletePackageInstallAnnotation = "run.tanzu.vmware.com/skip-packageinstall-deletion"
 )
 
 var (

--- a/addons/pkg/util/addon_util.go
+++ b/addons/pkg/util/addon_util.go
@@ -87,14 +87,6 @@ func GetPackageMetadata(ctx context.Context, c client.Client, carvelPkgName, car
 	return pkg.Spec.RefName, pkg.Spec.Version, nil
 }
 
-func GetPackageAnnotations(ctx context.Context, c client.Client, carvelPkgName, carvelPkgNamespace string) (map[string]string, error) {
-	pkg := &kapppkgv1alpha1.Package{}
-	if err := c.Get(ctx, client.ObjectKey{Name: carvelPkgName, Namespace: carvelPkgNamespace}, pkg); err != nil {
-		return nil, err
-	}
-	return pkg.Annotations, nil
-}
-
 // ParseStringForLabel parse the package ref name to make it valid for K8S object labels.
 // A package ref name could contain some characters that are not allowed as a label value.
 // Also the label should not end with any non-alphanumeric characters.

--- a/addons/pkg/util/addon_util.go
+++ b/addons/pkg/util/addon_util.go
@@ -87,6 +87,14 @@ func GetPackageMetadata(ctx context.Context, c client.Client, carvelPkgName, car
 	return pkg.Spec.RefName, pkg.Spec.Version, nil
 }
 
+func GetPackageAnnotations(ctx context.Context, c client.Client, carvelPkgName, carvelPkgNamespace string) (map[string]string, error) {
+	pkg := &kapppkgv1alpha1.Package{}
+	if err := c.Get(ctx, client.ObjectKey{Name: carvelPkgName, Namespace: carvelPkgNamespace}, pkg); err != nil {
+		return nil, err
+	}
+	return pkg.Annotations, nil
+}
+
 // ParseStringForLabel parse the package ref name to make it valid for K8S object labels.
 // A package ref name could contain some characters that are not allowed as a label value.
 // Also the label should not end with any non-alphanumeric characters.


### PR DESCRIPTION
… needs to clean up external resources.

AKO pod needs to clean up resource when cluster is getting deleted. But currently, its packageInstall just got deleted when cluster is deleted so it can't finish clean up. This will block cluster deletion since AKO has finalizer on the cluster

Added a new annotations on ClusterBootstrap
`run.tanzu.vmware.com/skip-packageinstall-deletion`
`SkipDeletePackageInstallAnnotation` is the annotation that contains a list of comma separated packageInstalls to skip when cluster is deleted
for example
```
"run.tanzu.vmware.com/skip-packageinstall-deletion": "cpi,cni,load-balancer-and-ingress-service"
```

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
