### PR TITLE
DNC: Test CAPD regression

### DIFF
--- a/.github/workflows/tkg_integration_tests.yaml
+++ b/.github/workflows/tkg_integration_tests.yaml
@@ -101,6 +101,7 @@ jobs:
         if [[ ! -z "${{ steps.extract_bom.outputs.bompath }}" ]]; then
           export TKG_DEFAULT_COMPATIBILITY_IMAGE_PATH=${{ steps.extract_bom.outputs.bompath }}
         fi
+        echo "Verifying CAPD regression...."
         make configure-bom
         make generate-embedproviders
         pushd tkg


### PR DESCRIPTION
### What this PR does / why we need it

Testing if non capd non-cc integ tests have regressed since late last week.


