### PR TITLE
Remove kapp labels with patch verb

### DIFF
--- a/tkg/client/init.go
+++ b/tkg/client/init.go
@@ -894,7 +894,7 @@ func (c *TkgClient) removeKappControllerLabelsFromClusterClassResources(regional
 		if exists, err := regionalClusterClient.VerifyExistenceOfCRD(resourceName, gvk.Group); err != nil || !exists {
 			continue
 		}
-		errList = append(errList, regionalClusterClient.RemoveMatchingLabelsFromResources(gvk, constants.TkgNamespace, labelsToBeDeleted))
+		errList = append(errList, regionalClusterClient.RemoveMatchingMetadataFromResources(gvk, constants.TkgNamespace, "labels", labelsToBeDeleted))
 	}
 
 	return kerrors.NewAggregate(errList)

--- a/tkg/clusterclient/clusterclient_test.go
+++ b/tkg/clusterclient/clusterclient_test.go
@@ -3549,7 +3549,7 @@ prod.repo.com: prod.custom.repo.com`
 		})
 	})
 
-	Describe("Unit tests for RemoveMatchingLabelsFromResources", func() {
+	Describe("Unit tests for RemoveMatchingMetadataFromResources", func() {
 		var (
 			fakeClientSet     crtclient.Client
 			resources         []runtime.Object
@@ -3615,7 +3615,7 @@ prod.repo.com: prod.custom.repo.com`
 			Expect(err).NotTo(HaveOccurred())
 
 			clusterClassGVK := schema.GroupVersionKind{Group: capi.GroupVersion.Group, Version: capi.GroupVersion.Version, Kind: "ClusterClass"}
-			err = clstClient.RemoveMatchingLabelsFromResources(clusterClassGVK, "fake-namespace", labelsToBeDeleted)
+			err = clstClient.RemoveMatchingMetadataFromResources(clusterClassGVK, "fake-namespace", "labels", labelsToBeDeleted)
 		})
 
 		Context("When matching objects not found", func() {

--- a/tkg/fakes/clusterclient.go
+++ b/tkg/fakes/clusterclient.go
@@ -1018,17 +1018,18 @@ type ClusterClient struct {
 	removeCEIPTelemetryJobReturnsOnCall map[int]struct {
 		result1 error
 	}
-	RemoveMatchingLabelsFromResourcesStub        func(schema.GroupVersionKind, string, []string) error
-	removeMatchingLabelsFromResourcesMutex       sync.RWMutex
-	removeMatchingLabelsFromResourcesArgsForCall []struct {
+	RemoveMatchingMetadataFromResourcesStub        func(schema.GroupVersionKind, string, string, []string) error
+	removeMatchingMetadataFromResourcesMutex       sync.RWMutex
+	removeMatchingMetadataFromResourcesArgsForCall []struct {
 		arg1 schema.GroupVersionKind
 		arg2 string
-		arg3 []string
+		arg3 string
+		arg4 []string
 	}
-	removeMatchingLabelsFromResourcesReturns struct {
+	removeMatchingMetadataFromResourcesReturns struct {
 		result1 error
 	}
-	removeMatchingLabelsFromResourcesReturnsOnCall map[int]struct {
+	removeMatchingMetadataFromResourcesReturnsOnCall map[int]struct {
 		result1 error
 	}
 	ScalePacificClusterControlPlaneStub        func(string, string, int32) error
@@ -6148,25 +6149,26 @@ func (fake *ClusterClient) RemoveCEIPTelemetryJobReturnsOnCall(i int, result1 er
 	}{result1}
 }
 
-func (fake *ClusterClient) RemoveMatchingLabelsFromResources(arg1 schema.GroupVersionKind, arg2 string, arg3 []string) error {
-	var arg3Copy []string
-	if arg3 != nil {
-		arg3Copy = make([]string, len(arg3))
-		copy(arg3Copy, arg3)
+func (fake *ClusterClient) RemoveMatchingMetadataFromResources(arg1 schema.GroupVersionKind, arg2 string, arg3 string, arg4 []string) error {
+	var arg4Copy []string
+	if arg4 != nil {
+		arg4Copy = make([]string, len(arg4))
+		copy(arg4Copy, arg4)
 	}
-	fake.removeMatchingLabelsFromResourcesMutex.Lock()
-	ret, specificReturn := fake.removeMatchingLabelsFromResourcesReturnsOnCall[len(fake.removeMatchingLabelsFromResourcesArgsForCall)]
-	fake.removeMatchingLabelsFromResourcesArgsForCall = append(fake.removeMatchingLabelsFromResourcesArgsForCall, struct {
+	fake.removeMatchingMetadataFromResourcesMutex.Lock()
+	ret, specificReturn := fake.removeMatchingMetadataFromResourcesReturnsOnCall[len(fake.removeMatchingMetadataFromResourcesArgsForCall)]
+	fake.removeMatchingMetadataFromResourcesArgsForCall = append(fake.removeMatchingMetadataFromResourcesArgsForCall, struct {
 		arg1 schema.GroupVersionKind
 		arg2 string
-		arg3 []string
-	}{arg1, arg2, arg3Copy})
-	stub := fake.RemoveMatchingLabelsFromResourcesStub
-	fakeReturns := fake.removeMatchingLabelsFromResourcesReturns
-	fake.recordInvocation("RemoveMatchingLabelsFromResources", []interface{}{arg1, arg2, arg3Copy})
-	fake.removeMatchingLabelsFromResourcesMutex.Unlock()
+		arg3 string
+		arg4 []string
+	}{arg1, arg2, arg3, arg4Copy})
+	stub := fake.RemoveMatchingMetadataFromResourcesStub
+	fakeReturns := fake.removeMatchingMetadataFromResourcesReturns
+	fake.recordInvocation("RemoveMatchingMetadataFromResources", []interface{}{arg1, arg2, arg3, arg4Copy})
+	fake.removeMatchingMetadataFromResourcesMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
@@ -6174,44 +6176,44 @@ func (fake *ClusterClient) RemoveMatchingLabelsFromResources(arg1 schema.GroupVe
 	return fakeReturns.result1
 }
 
-func (fake *ClusterClient) RemoveMatchingLabelsFromResourcesCallCount() int {
-	fake.removeMatchingLabelsFromResourcesMutex.RLock()
-	defer fake.removeMatchingLabelsFromResourcesMutex.RUnlock()
-	return len(fake.removeMatchingLabelsFromResourcesArgsForCall)
+func (fake *ClusterClient) RemoveMatchingMetadataFromResourcesCallCount() int {
+	fake.removeMatchingMetadataFromResourcesMutex.RLock()
+	defer fake.removeMatchingMetadataFromResourcesMutex.RUnlock()
+	return len(fake.removeMatchingMetadataFromResourcesArgsForCall)
 }
 
-func (fake *ClusterClient) RemoveMatchingLabelsFromResourcesCalls(stub func(schema.GroupVersionKind, string, []string) error) {
-	fake.removeMatchingLabelsFromResourcesMutex.Lock()
-	defer fake.removeMatchingLabelsFromResourcesMutex.Unlock()
-	fake.RemoveMatchingLabelsFromResourcesStub = stub
+func (fake *ClusterClient) RemoveMatchingMetadataFromResourcesCalls(stub func(schema.GroupVersionKind, string, string, []string) error) {
+	fake.removeMatchingMetadataFromResourcesMutex.Lock()
+	defer fake.removeMatchingMetadataFromResourcesMutex.Unlock()
+	fake.RemoveMatchingMetadataFromResourcesStub = stub
 }
 
-func (fake *ClusterClient) RemoveMatchingLabelsFromResourcesArgsForCall(i int) (schema.GroupVersionKind, string, []string) {
-	fake.removeMatchingLabelsFromResourcesMutex.RLock()
-	defer fake.removeMatchingLabelsFromResourcesMutex.RUnlock()
-	argsForCall := fake.removeMatchingLabelsFromResourcesArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+func (fake *ClusterClient) RemoveMatchingMetadataFromResourcesArgsForCall(i int) (schema.GroupVersionKind, string, string, []string) {
+	fake.removeMatchingMetadataFromResourcesMutex.RLock()
+	defer fake.removeMatchingMetadataFromResourcesMutex.RUnlock()
+	argsForCall := fake.removeMatchingMetadataFromResourcesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
-func (fake *ClusterClient) RemoveMatchingLabelsFromResourcesReturns(result1 error) {
-	fake.removeMatchingLabelsFromResourcesMutex.Lock()
-	defer fake.removeMatchingLabelsFromResourcesMutex.Unlock()
-	fake.RemoveMatchingLabelsFromResourcesStub = nil
-	fake.removeMatchingLabelsFromResourcesReturns = struct {
+func (fake *ClusterClient) RemoveMatchingMetadataFromResourcesReturns(result1 error) {
+	fake.removeMatchingMetadataFromResourcesMutex.Lock()
+	defer fake.removeMatchingMetadataFromResourcesMutex.Unlock()
+	fake.RemoveMatchingMetadataFromResourcesStub = nil
+	fake.removeMatchingMetadataFromResourcesReturns = struct {
 		result1 error
 	}{result1}
 }
 
-func (fake *ClusterClient) RemoveMatchingLabelsFromResourcesReturnsOnCall(i int, result1 error) {
-	fake.removeMatchingLabelsFromResourcesMutex.Lock()
-	defer fake.removeMatchingLabelsFromResourcesMutex.Unlock()
-	fake.RemoveMatchingLabelsFromResourcesStub = nil
-	if fake.removeMatchingLabelsFromResourcesReturnsOnCall == nil {
-		fake.removeMatchingLabelsFromResourcesReturnsOnCall = make(map[int]struct {
+func (fake *ClusterClient) RemoveMatchingMetadataFromResourcesReturnsOnCall(i int, result1 error) {
+	fake.removeMatchingMetadataFromResourcesMutex.Lock()
+	defer fake.removeMatchingMetadataFromResourcesMutex.Unlock()
+	fake.RemoveMatchingMetadataFromResourcesStub = nil
+	if fake.removeMatchingMetadataFromResourcesReturnsOnCall == nil {
+		fake.removeMatchingMetadataFromResourcesReturnsOnCall = make(map[int]struct {
 			result1 error
 		})
 	}
-	fake.removeMatchingLabelsFromResourcesReturnsOnCall[i] = struct {
+	fake.removeMatchingMetadataFromResourcesReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -8192,8 +8194,8 @@ func (fake *ClusterClient) Invocations() map[string][][]interface{} {
 	defer fake.patchResourceMutex.RUnlock()
 	fake.removeCEIPTelemetryJobMutex.RLock()
 	defer fake.removeCEIPTelemetryJobMutex.RUnlock()
-	fake.removeMatchingLabelsFromResourcesMutex.RLock()
-	defer fake.removeMatchingLabelsFromResourcesMutex.RUnlock()
+	fake.removeMatchingMetadataFromResourcesMutex.RLock()
+	defer fake.removeMatchingMetadataFromResourcesMutex.RUnlock()
 	fake.scalePacificClusterControlPlaneMutex.RLock()
 	defer fake.scalePacificClusterControlPlaneMutex.RUnlock()
 	fake.scalePacificClusterWorkerNodesMutex.RLock()


### PR DESCRIPTION
When ClusterClass and its templates are moved from the bootstrap cluster to the management cluster, kapp's labels must be removed for adoption. There may be update race condition between kapp controller and tanzu cli, see the following error:

"Operation cannot be fulfilled on
vspheremachinetemplates.infrastructure.cluster.x-k8s.io "tkg-mgmt-vc-md-2-infra-2zmvv": the object has been modified; please apply your changes to the latest version and try again"

Call patch verb to remove kapp labels to avoid this issue because it does not perform resourceVersion check.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
