### PR TITLE
add ordering to fix featuregates package installation

### DIFF
--- a/packages/featuregates/bundle/config/upstream/default-featuregate-cr.yaml
+++ b/packages/featuregates/bundle/config/upstream/default-featuregate-cr.yaml
@@ -9,6 +9,8 @@ metadata:
     kapp.k14s.io/change-rule.1: "delete before deleting featuregates.config.tanzu.vmware.com/crd"
     kapp.k14s.io/change-rule.2: "upsert after upserting features.config.tanzu.vmware.com/crd"
     kapp.k14s.io/change-rule.3: "delete before deleting features.config.tanzu.vmware.com/crd"
+    kapp.k14s.io/change-rule.4: "upsert after upserting tanzu-featuregates-controller-manager/deployment"
+    kapp.k14s.io/change-rule.5: "delete before deleting tanzu-featuregates-controller-manager/deployment"
     kapp.k14s.io/update-strategy: skip
 spec:
   namespaceSelector: {}

--- a/packages/featuregates/bundle/config/upstream/tanzu-featuregates-manager.yaml
+++ b/packages/featuregates/bundle/config/upstream/tanzu-featuregates-manager.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: #@ data.values.namespace
   annotations:
     kapp.k14s.io/update-strategy: "fallback-on-replace"
+    kapp.k14s.io/change-group: "tanzu-featuregates-controller-manager/deployment"
     kapp.k14s.io/change-rule.0: "upsert after upserting featuregates.config.tanzu.vmware.com/certificate"
     kapp.k14s.io/change-rule.1: "delete before deleting featuregates.config.tanzu.vmware.com/certificate"
 spec:


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds kapp ordering to featuregates package to create the featuregates deployment first and then the default `tkg-system` FeatureGate CR to fix the case where sometimes(noticed this in aws clusterclass based clusters) featuregates package installation is failing because the default `tkg-system` resource is being created before the featuregates deployment.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/3974

### Describe testing done for PR

Built the featuregates package and installed it in the cluster to verify package installation

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
