### PR TITLE
Fix permissions duplicate entries in tanzu config file

### DIFF
--- a/cli/runtime/config/nodeutils/helpers.go
+++ b/cli/runtime/config/nodeutils/helpers.go
@@ -1,0 +1,20 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeutils
+
+import "gopkg.in/yaml.v3"
+
+func UniqNodes(nodes []*yaml.Node) []*yaml.Node {
+	uniq := make([]*yaml.Node, 0, len(nodes))
+	mapper := make(map[string]bool)
+
+	for _, node := range nodes {
+		if _, ok := mapper[node.Value]; !ok {
+			mapper[node.Value] = true
+			uniq = append(uniq, node)
+		}
+	}
+
+	return uniq
+}

--- a/cli/runtime/config/nodeutils/helpers_test.go
+++ b/cli/runtime/config/nodeutils/helpers_test.go
@@ -1,0 +1,62 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package nodeutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+func TestUniqNode(t *testing.T) {
+	tests := []struct {
+		name  string
+		nodes []*yaml.Node
+		count int
+	}{
+		{
+			name:  "success 2 uniq nodes",
+			count: 2,
+			nodes: []*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "test",
+					Style: 0,
+					Tag:   "!!str",
+				},
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "",
+					Style: 0,
+					Tag:   "!!str",
+				},
+			},
+		},
+		{
+			name:  "success 1 uniq nodes",
+			count: 1,
+			nodes: []*yaml.Node{
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "test",
+					Style: 0,
+					Tag:   "!!str",
+				},
+				{
+					Kind:  yaml.ScalarNode,
+					Value: "test",
+					Style: 0,
+					Tag:   "!!str",
+				},
+			},
+		},
+	}
+	for _, spec := range tests {
+		t.Run(spec.name, func(t *testing.T) {
+			nodes := UniqNodes(spec.nodes)
+			assert.Equal(t, spec.count, len(nodes))
+		})
+	}
+}

--- a/cli/runtime/config/nodeutils/merge_nodes.go
+++ b/cli/runtime/config/nodeutils/merge_nodes.go
@@ -64,6 +64,7 @@ func MergeNodes(src, dst *yaml.Node) error {
 func setSeqNode(src, dst *yaml.Node) {
 	if dst.Content[0].Kind == yaml.ScalarNode && src.Content[0].Kind == yaml.ScalarNode {
 		dst.Content = append(dst.Content, src.Content...)
+		dst.Content = UniqNodes(dst.Content)
 	}
 }
 


### PR DESCRIPTION
### What this PR does / why we need it

Fix Merging nodes of sequence type of scalar values to append unique values.

Example:-
Before: 
- globalOpts:
    auth:
      IDToken: ""
      accessToken: XXX
      expiration: "2022-09-10T01:46:34Z"
      issuer: issuer-api
      permissions:
                - service:member
                - csp:org_owner
                - service:admin
                - csp:org_member
                - service:member
                - service:member
                - csp:org_owner
                - service:admin
                - csp:org_member
                - service:member
                - service:member
                - csp:org_owner
                - service:admin
                - csp:org_member
                - service:member
                - service:member
                - csp:org_owner
      refresh_token: XXX
      type: api-token
      userName: tanzu-core
    endpoint: tanzu-endpoint


After the fix:- No duplicate values in list
- globalOpts:
    auth:
      IDToken: ""
      accessToken: XXX
      expiration: "2022-09-10T01:46:34Z"
      issuer: issuer-api
      permissions:
                - service:member
                - csp:org_owner
                - service:admin
                - csp:org_member
      refresh_token: XXX
      type: api-token
      userName: tanzu-core
    endpoint: tanzu-endpoint

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3978 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Unit testing and
Did run `make build-install-cli-local` to verify no duplicate entries being added to permissions list.


