### PR TITLE
Trim the version suffix from the default ClusterClass name

### DIFF
--- a/tkg/yamlprocessor/ytt.go
+++ b/tkg/yamlprocessor/ytt.go
@@ -6,6 +6,7 @@ package yamlprocessor
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 
@@ -85,7 +86,13 @@ func (p *YTTProcessor) GetTemplateName(version, plan string) string {
 // GetClusterClassTemplateName returns the file name of the cluster class
 // template that needs to be retrieved from the source.
 func (p *YTTProcessor) GetClusterClassTemplateName(version, name string) string {
-	return fmt.Sprintf("clusterclass-%s.yaml", name)
+	templateName := name
+	// TemplateDefinition file name equals to the ClusterClass name without its version suffix
+	pattern := regexp.MustCompile(`^(tkg-[a-z]+-default)-(v\d+\.\d+\.\d+)$`)
+	if subStrings := pattern.FindStringSubmatch(name); subStrings != nil {
+		templateName = subStrings[1]
+	}
+	return fmt.Sprintf("clusterclass-%s.yaml", templateName)
 }
 
 func (p *YTTProcessor) getLoader(rawArtifact []byte) (*workspace.LibraryExecution, error) {

--- a/tkg/yamlprocessor/ytt_test.go
+++ b/tkg/yamlprocessor/ytt_test.go
@@ -40,6 +40,13 @@ var _ = Describe("YttProcessor", func() {
 
 			Expect(yp.GetClusterClassTemplateName("version", "foo")).To(Equal("clusterclass-foo.yaml"))
 		})
+		It("trim version suffix from the default clusterclass name", func() {
+			yp := yamlprocessor.NewYttProcessor()
+
+			Expect(yp.GetClusterClassTemplateName("version", "tkg-vsphere-default-v2.1.0")).To(Equal("clusterclass-tkg-vsphere-default.yaml"))
+			Expect(yp.GetClusterClassTemplateName("version", "tkg-aws-default-v2.1.0")).To(Equal("clusterclass-tkg-aws-default.yaml"))
+			Expect(yp.GetClusterClassTemplateName("version", "tkg-azure-default-v2.1.0")).To(Equal("clusterclass-tkg-azure-default.yaml"))
+		})
 	})
 
 	Context("GetVariables", func() {


### PR DESCRIPTION
When we dry run management Cluster creation, the bootstrap Cluster is not running yet but clusterctl will try to render the ClusterClass template which referenced by the Cluster at the same time.

We can get the template file name by trimming the version suffix from the default ClusterClass name.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
