### PR TITLE
Use Cobra's bash completion V2

### DIFF
--- a/cli/core/pkg/command/completion.go
+++ b/cli/core/pkg/command/completion.go
@@ -97,7 +97,7 @@ func runCompletion(out io.Writer, cmd *cobra.Command, args []string) error {
 
 	switch strings.ToLower(args[0]) {
 	case "bash":
-		return cmd.Root().GenBashCompletion(out)
+		return cmd.Root().GenBashCompletionV2(out, true)
 	case "zsh":
 		return cmd.Root().GenZshCompletion(out)
 	case "fish":

--- a/cli/core/pkg/command/completion_test.go
+++ b/cli/core/pkg/command/completion_test.go
@@ -74,7 +74,7 @@ func Test_runCompletion_Bash(t *testing.T) {
 
 	// Check for a snippet of the bash completion output
 	// TODO make this test less brittle
-	if !strings.Contains(out.String(), "if [[ -z \"${BASH_VERSION:-}\" || \"${BASH_VERSINFO[0]:-}\" -gt 3 ]]; then") {
+	if !strings.Contains(out.String(), "# bash completion V2 for completion") {
 		t.Errorf("Unexpected output for the bash shell script: %s", out.String())
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it

This commit makes the tanzu CLI use Cobra's [bash completion V2](https://github.com/spf13/cobra/blob/main/shell_completions.md#bash-completion-v2).

Besides fixing #3963, this new version comes with extra features compared to the original bash completion logic, such as:
- Supports completion descriptions (like the other shells)
- Small bash completion script (325 lines versus 1342 lines for tanzu)
- Streamlined user experience thanks to a completion behavior aligned with the other shells (for example, it does not suggest the = form for flag completion)

It is also the version that is actively maintained by Cobra.

While at it, the commit also enables completion descriptions for bash which is available with Cobra's bash completion v2.
Tanzu CLI offers shell completions descriptions for `zsh`, `fish` and `powershell`, we were just missing `bash`.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fix #3963

### Describe testing done for PR

Testing for bug fix:
Before PR:
```
bash
bash-5.1$ source <(tanzu completion bash)
bash-5.1$ tanzu te[tab][tab]
telemetry  test
tanzu plugin delete test
Deleting Plugin 'test'. Are you sure? [y/N]: y
✔  successfully deleted plugin 'test'

# Notice that `test` is still being suggested
bash-5.1$ tanzu te[tab][tab]
telemetry  test
bash-5.1$ tanzu test
✖  unknown command "test" for "tanzu"
```
After PR:
```
bash
bash-5.1$ source <(./tanzu completion bash)
bash-5.1$ tanzu plugin install test
ℹ  Installing plugin 'test:v0.28.0-dev'
✔  successfully installed 'test' plugin
bash-5.1$ tanzu te[tab][tab]
telemetry  (configure cluster-wide settings for vmware tanzu telemetry)
test       (Test the CLI)
bash-5.1$ tanzu plugin delete test
Deleting Plugin 'test'. Are you sure? [y/N]: y
✔  successfully deleted plugin 'test'

# Notice `test` is no longer suggested
bash-5.1$ tanzu t[tab][tab]
bash-5.1$ tanzu telemetry
```

Testing for new features:

Before PR:
```
bash
bash-5.1$ source <(tanzu completion bash)
bash-5.1$ tanzu c[tab][tab]
cluster     codegen     completion  config
bash-5.1$ tanzu plugin install --[tab][tab]
--local     --local=    --version   --version=
```
With PR:
```
bash
bash-5.1$ source <(./tanzu completion bash)

# Notice descriptions
bash-5.1$ ./tanzu c[tab][tab]
cluster     (Kubernetes cluster operations)  completion  (Output shell completion code)
codegen     (Tanzu code generation tool)     config      (Configuration for the CLI)

# Notice that the = form is no longer suggested for flags
bash-5.1$ ./tanzu plugin install --[tab][tab]
--local    (path to local discovery/distribution source)  --version  (version of the plugin)
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Shell completions for the bash shell now include descriptions.
```



### Additional information

Helm has been using this version of bash completion since August 2nd 2021 (https://github.com/helm/helm/pull/9990)
Kubectl has been using this version of bash completion since January 12, 2022 (https://github.com/kubernetes/kubernetes/pull/107439)
