### PR TITLE
ignore dns servers from dhcp when providing nameservers

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -1087,8 +1087,20 @@ spec:
               - {{ . }}
                 {{- end }}
               {{- end }}
-              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}} dhcp4: true {{- end }}
-              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}} dhcp6: true {{- end }}
+              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}}
+              dhcp4: true
+              {{ if .controlPlane.network.nameservers -}}
+              dhcp4Overrides:
+                useDNS: false
+              {{- end }}
+              {{- end }}
+              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}}
+              dhcp6: true
+              {{ if .controlPlane.network.nameservers -}}
+              dhcp6Overrides:
+                useDNS: false
+              {{- end }}
+              {{- end }}
               {{ if .network.addressesFromPools  -}}
               addressesFromPools:
                 {{- range .network.addressesFromPools }}
@@ -1124,8 +1136,20 @@ spec:
               - {{ . }}
                 {{- end }}
               {{- end }}
-              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}} dhcp4: true {{- end }}
-              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}} dhcp6: true {{- end }}
+              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}}
+              dhcp4: true
+              {{ if .worker.network.nameservers -}}
+              dhcp4Overrides:
+                useDNS: false
+              {{- end }}
+              {{- end }}
+              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}}
+              dhcp6: true
+              {{ if .worker.network.nameservers -}}
+              dhcp6Overrides:
+                useDNS: false
+              {{- end }}
+              {{- end }}
               {{ if .network.addressesFromPools  -}}
               addressesFromPools:
                 {{- range .network.addressesFromPools }}

--- a/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
@@ -1087,8 +1087,20 @@ spec:
               - {{ . }}
                 {{- end }}
               {{- end }}
-              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}} dhcp4: true {{- end }}
-              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}} dhcp6: true {{- end }}
+              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}}
+              dhcp4: true
+              {{ if .controlPlane.network.nameservers -}}
+              dhcp4Overrides:
+                useDNS: false
+              {{- end }}
+              {{- end }}
+              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}}
+              dhcp6: true
+              {{ if .controlPlane.network.nameservers -}}
+              dhcp6Overrides:
+                useDNS: false
+              {{- end }}
+              {{- end }}
               {{ if .network.addressesFromPools  -}}
               addressesFromPools:
                 {{- range .network.addressesFromPools }}
@@ -1124,8 +1136,20 @@ spec:
               - {{ . }}
                 {{- end }}
               {{- end }}
-              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}} dhcp4: true {{- end }}
-              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}} dhcp6: true {{- end }}
+              {{ if list "IPv4" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}}
+              dhcp4: true
+              {{ if .worker.network.nameservers -}}
+              dhcp4Overrides:
+                useDNS: false
+              {{- end }}
+              {{- end }}
+              {{ if list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily | and (empty .network.addressesFromPools) -}}
+              dhcp6: true
+              {{ if .worker.network.nameservers -}}
+              dhcp6Overrides:
+                useDNS: false
+              {{- end }}
+              {{- end }}
               {{ if .network.addressesFromPools  -}}
               addressesFromPools:
                 {{- range .network.addressesFromPools }}


### PR DESCRIPTION
### What this PR does / why we need it

When users specify nameservers via CONTROL_PLANE_NODE_NAMESERVERS or WORKER_NODE_NAMESERVERS, CAPV is configured to ignore nameservers configured from DHCP. Without this change nameservers from DHCP will be added to the list of available nameservers.

CAPV v1.5+ was recently bumped, which contains the ability to configure DHCP overrides, so this change can be validated

### Which issue(s) this PR fixes

Fixes #1103

### Describe testing done for PR

Deployed clusters while using WORKER_NODE_NAMESERVERS and CONTROL_PLANE_NODE_NAMESERVERS and saw that CAPV was correctly configured with the VSphereMachineTemplate `.spec.template.spec.network.dhcpOverrides.useDNS` is set to false. SSH onto node vms and verfiy networkctl is configured correctly.


### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
When WORKER_NODE_NAMESERVERS or CONTROL_PLANE_NODE_NAMESERVERS variables are set, nameservers from DHCP are ignored.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
