### PR TITLE
Support configuring etcd flags

### DIFF
--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
@@ -45,6 +45,20 @@ spec:
       name: #@ "tkg-aws-default-{}-cluster".format(data.values.AWS_CLUSTER_CLASS_VERSION)
       namespace: #@ data.values.NAMESPACE
   variables:
+  - name: etcdExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: tlsCipherSuites
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: string
+        default: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
   - name: region
     required: true
     schema:
@@ -274,6 +288,28 @@ spec:
         type: object
         properties: {}
   patches:
+  - name: etcdExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd/local/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{- range $key, $val := .etcdExtraArgs }}
+            {{- if eq $key "cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
   - name: AWSCT_main
     definitions:
     - selector:
@@ -1135,8 +1171,7 @@ spec:
               dataDir: /var/lib/etcd
               imageRepository: dummy.registry.vmware.com
               imageTag: 1.8.4_dummy.5
-              extraArgs:
-                cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+              extraArgs: {}
           imageRepository: dummy.registry.vmware.com
           scheduler:
             extraArgs:

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -45,6 +45,20 @@ spec:
       name: #@ "tkg-azure-default-{}-cluster".format(data.values.AZURE_CLUSTER_CLASS_VERSION)
       namespace: #@ data.values.NAMESPACE
   variables:
+  - name: etcdExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: tlsCipherSuites
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: string
+        default: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
   - name: location
     required: true
     schema:
@@ -336,6 +350,35 @@ spec:
         type: object
         properties: {}
   patches:
+  - name: etcdExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd/local/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containQuotaBackendBytes := false }}
+            {{- range $key, $val := .etcdExtraArgs }}
+            {{- if eq $key "cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "quota-backend-bytes" }}
+              {{- $containQuotaBackendBytes = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containQuotaBackendBytes }}
+            quota-backend-bytes: "8589934592"
+            {{- end }}
   - name: AzureClusterCustomTags
     enabledIf: '{{ not (empty .customTags) }}'
     definitions:
@@ -1376,9 +1419,7 @@ spec:
           etcd:
             local:
               dataDir: /var/lib/etcddisk/etcd
-              extraArgs:
-                cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-                quota-backend-bytes: "8589934592"
+              extraArgs: {}
               imageRepository: #! e.g. registry.tkg.vmware.run
               imageTag: #! e.g v3.4.3_vmware.4
           imageRepository: #! e.g. registry.tkg.vmware.run

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -78,8 +78,7 @@ spec:
               dataDir: /var/lib/etcd
               imageRepository: dummy.registry.vmware.com
               imageTag: 1.8.4_dummy.5
-              extraArgs:
-                cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+              extraArgs: {}
           dns:
             imageRepository: dummy.registry.vmware.com
             imageTag: 1.8.4_dummy.5
@@ -506,6 +505,20 @@ spec:
       openAPIV3Schema:
         type: boolean
         default: true
+  - name: etcdExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: tlsCipherSuites
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: string
+        default: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
   - name: identityRef
     required: false
     schema:
@@ -520,6 +533,28 @@ spec:
         - name
         - kind
   patches:
+  - name: etcdExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd/local/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{- range $key, $val := .etcdExtraArgs }}
+            {{- if eq $key "cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
   - name: vsphereClusterTemplate
     definitions:
     - selector:

--- a/providers/config_default.yaml
+++ b/providers/config_default.yaml
@@ -62,6 +62,11 @@ ENABLE_TKGS_ON_VSPHERE7:
 #! Valid values for BUILD_EDITION are 'tce' and 'tkg'.
 BUILD_EDITION:
 
+#! ETCD_EXTRA_ARGS specified etcd flags.
+#! It should be of the format "key1=value1;key2=value2".
+#! E.g. "heartbeat-interval=300;election-timeout=2000"
+ETCD_EXTRA_ARGS:
+
 #! ---------------------------------------------------------------------
 #! Settings for vSphere infrastructure provider
 #! ---------------------------------------------------------------------

--- a/providers/infrastructure-aws/v2.0.1/cconly/base.yaml
+++ b/providers/infrastructure-aws/v2.0.1/cconly/base.yaml
@@ -45,6 +45,20 @@ spec:
       name: #@ "tkg-aws-default-{}-cluster".format(data.values.AWS_CLUSTER_CLASS_VERSION)
       namespace: #@ data.values.NAMESPACE
   variables:
+  - name: etcdExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: tlsCipherSuites
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: string
+        default: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
   - name: region
     required: true
     schema:
@@ -274,6 +288,28 @@ spec:
         type: object
         properties: {}
   patches:
+  - name: etcdExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd/local/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{- range $key, $val := .etcdExtraArgs }}
+            {{- if eq $key "cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
   - name: AWSCT_main
     definitions:
     - selector:
@@ -1135,8 +1171,7 @@ spec:
               dataDir: /var/lib/etcd
               imageRepository: dummy.registry.vmware.com
               imageTag: 1.8.4_dummy.5
-              extraArgs:
-                cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+              extraArgs: {}
           imageRepository: dummy.registry.vmware.com
           scheduler:
             extraArgs:

--- a/providers/infrastructure-aws/v2.0.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-aws/v2.0.1/yttcc/overlay.yaml
@@ -109,7 +109,7 @@ spec:
     variables:
     #@ vars = get_aws_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["region", "sshKeyName", "bastion", "network", "controlPlane", "worker", "loadBalancerSchemeInternal", "identityRef", "imageRepository", "trust", "auditLogging", "cni", "TKR_DATA", "proxy"]:
+    #@  if vars[configVariable] != None and configVariable in ["etcdExtraArgs", "region", "sshKeyName", "bastion", "network", "controlPlane", "worker", "loadBalancerSchemeInternal", "identityRef", "imageRepository", "trust", "auditLogging", "cni", "TKR_DATA", "proxy"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
+++ b/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
@@ -45,6 +45,20 @@ spec:
       name: #@ "tkg-azure-default-{}-cluster".format(data.values.AZURE_CLUSTER_CLASS_VERSION)
       namespace: #@ data.values.NAMESPACE
   variables:
+  - name: etcdExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: tlsCipherSuites
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: string
+        default: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
   - name: location
     required: true
     schema:
@@ -336,6 +350,35 @@ spec:
         type: object
         properties: {}
   patches:
+  - name: etcdExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd/local/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containQuotaBackendBytes := false }}
+            {{- range $key, $val := .etcdExtraArgs }}
+            {{- if eq $key "cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "quota-backend-bytes" }}
+              {{- $containQuotaBackendBytes = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containQuotaBackendBytes }}
+            quota-backend-bytes: "8589934592"
+            {{- end }}
   - name: AzureClusterCustomTags
     enabledIf: '{{ not (empty .customTags) }}'
     definitions:
@@ -1376,9 +1419,7 @@ spec:
           etcd:
             local:
               dataDir: /var/lib/etcddisk/etcd
-              extraArgs:
-                cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-                quota-backend-bytes: "8589934592"
+              extraArgs: {}
               imageRepository: #! e.g. registry.tkg.vmware.run
               imageTag: #! e.g v3.4.3_vmware.4
           imageRepository: #! e.g. registry.tkg.vmware.run

--- a/providers/infrastructure-azure/v1.5.3/yttcc/overlay.yaml
+++ b/providers/infrastructure-azure/v1.5.3/yttcc/overlay.yaml
@@ -139,7 +139,7 @@ spec:
     variables:
     #@ vars = get_azure_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["location", "network", "controlPlane", "worker", "resourceGroup", "subscriptionID", "identityRef", "clusterRole", "environment", "sshPublicKey", "acceleratedNetworking", "privateCluster", "frontendPrivateIP", "imageRepository", "auditLogging", "customTags", "apiServerPort", "trust", "TKR_DATA", "proxy"]:
+    #@  if vars[configVariable] != None and configVariable in ["etcdExtraArgs", "location", "network", "controlPlane", "worker", "resourceGroup", "subscriptionID", "identityRef", "clusterRole", "environment", "sshPublicKey", "acceleratedNetworking", "privateCluster", "frontendPrivateIP", "imageRepository", "auditLogging", "customTags", "apiServerPort", "trust", "TKR_DATA", "proxy"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/providers/infrastructure-vsphere/v1.5.0/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.0/cconly/base.yaml
@@ -78,8 +78,7 @@ spec:
               dataDir: /var/lib/etcd
               imageRepository: dummy.registry.vmware.com
               imageTag: 1.8.4_dummy.5
-              extraArgs:
-                cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+              extraArgs: {}
           dns:
             imageRepository: dummy.registry.vmware.com
             imageTag: 1.8.4_dummy.5
@@ -506,6 +505,20 @@ spec:
       openAPIV3Schema:
         type: boolean
         default: true
+  - name: etcdExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: tlsCipherSuites
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: string
+        default: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
   - name: identityRef
     required: false
     schema:
@@ -520,6 +533,28 @@ spec:
         - name
         - kind
   patches:
+  - name: etcdExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/etcd/local/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{- range $key, $val := .etcdExtraArgs }}
+            {{- if eq $key "cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
   - name: vsphereClusterTemplate
     definitions:
     - selector:

--- a/providers/infrastructure-vsphere/v1.5.0/yttcc/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.5.0/yttcc/overlay.yaml
@@ -137,7 +137,7 @@ spec:
     variables:
     #@ vars = get_vsphere_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider"]:
+    #@  if vars[configVariable] != None and configVariable in ["etcdExtraArgs", "apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/providers/yttcc/lib/config_variable_association.star
+++ b/providers/yttcc/lib/config_variable_association.star
@@ -3,6 +3,7 @@ load("@ytt:overlay", "overlay")
 load("@ytt:yaml", "yaml")
 load("/lib/helpers.star", "get_default_tkg_bom_data")
 load("/lib/helpers.star", "get_labels_array_from_string")
+load("/lib/helpers.star", "get_extra_args_map_from_string")
 
 #! This file contains function 'config_variable_association' which specifies all configuration variables
 #! mentioned in 'config_default.yaml' and describes association of each configuration variable with
@@ -122,6 +123,7 @@ return {
 "NODE_POOL_0_LABELS": ["tkg-service-vsphere"],
 "NODE_POOL_0_TAINTS": ["tkg-service-vsphere"],
 "CONTROL_PLANE_NODE_LABELS": ["vsphere", "aws", "azure"],
+"ETCD_EXTRA_ARGS": ["vsphere", "aws", "azure"],
 
 "AZURE_ENVIRONMENT": ["azure"],
 "AZURE_TENANT_ID": ["azure"],
@@ -578,6 +580,10 @@ def get_aws_vars():
 
     vars["worker"] = worker
 
+    if data.values["ETCD_EXTRA_ARGS"] != None:
+        vars["etcdExtraArgs"] = get_extra_args_map_from_string(data.values["ETCD_EXTRA_ARGS"])
+    end
+
     controlPlane = {}
     if data.values["CONTROL_PLANE_MACHINE_TYPE"] != None:
         controlPlane["instanceType"] = data.values["CONTROL_PLANE_MACHINE_TYPE"]
@@ -709,6 +715,10 @@ def get_azure_vars():
 
     if controlPlane != {}:
         vars["controlPlane"] = controlPlane
+    end
+
+    if data.values["ETCD_EXTRA_ARGS"] != None:
+        vars["etcdExtraArgs"] = get_extra_args_map_from_string(data.values["ETCD_EXTRA_ARGS"])
     end
 
     worker = {}
@@ -845,6 +855,10 @@ def get_vsphere_vars():
 
     if controlPlane != {}:
         vars["controlPlane"] = controlPlane
+    end
+
+    if data.values["ETCD_EXTRA_ARGS"] != None:
+        vars["etcdExtraArgs"] = get_extra_args_map_from_string(data.values["ETCD_EXTRA_ARGS"])
     end
 
     worker = {}

--- a/providers/yttcc/lib/helpers.star
+++ b/providers/yttcc/lib/helpers.star
@@ -323,15 +323,25 @@ end
 
 # get_labels_map_from_string constructs a map from given string of the format "key1=label1,key2=label2"
 def get_labels_map_from_string(labelString):
-   labelMap = {}
-   for val in labelString.split(','):
+   return get_map_from_string(labelString, ',')
+end
+
+# get_extra_args_map_from_string constructs a map from given string of the format "key1=label1,key2=label2"
+def get_extra_args_map_from_string(labelString):
+   return get_map_from_string(labelString, ';')
+end
+
+# get_map_from_string constructs a map from given string of the format "key1=label1<delimiter>key2=label2"
+def get_map_from_string(argsString, delimiter):
+   argsMap = {}
+   for val in argsString.split(delimiter):
     kv = val.split('=')
     if len(kv) != 2:
-      assert.fail("given labels string \""+labelString+"\" must be in the  \"key1=label1,key2=label2\" format ")
+      assert.fail("given args string \""+argsString+"\" must be in the  \"key1=label1"+delimiter+"key2=label2\" format ")
     end
-    labelMap.update({kv[0]: kv[1]})
+    argsMap.update({kv[0]: kv[1]})
    end
-   return labelMap
+   return argsMap
 end
 
 # get_labels_array_from_string constructs an array from given string of the format "key1=label1,key2=label2"


### PR DESCRIPTION
Add Cluster variable etcdExtraArgs to set arbitrary etcd flags. Add Cluster variable tlsCipherSuites to store the default cipher suites. When etcdExtraArgs does not contain cipher-suites, the default value is set.

Add variable ETCD_EXTRA_ARGS for UX backward compatibility.

### What this PR does / why we need it
We need to support configuring etcd flags since Nimbus testbeds have only low performance storages.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Use the variable ETCD_EXTRA_ARGS to configure etcd flags. See the following example:
ETCD_EXTRA_ARGS: "heartbeat-interval=300;election-timeout=2000"
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
