### PR TITLE
fix #3817  use latest available k8s version if not specified when upgrading cluster

### DIFF
--- a/cmd/cli/plugin/cluster/upgrade_test.go
+++ b/cmd/cli/plugin/cluster/upgrade_test.go
@@ -393,6 +393,19 @@ var _ = Describe("getValidTKRVersionFromClusterForUpgrade", func() {
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("no available upgrades for cluster '%s', namespace '%s'", cluster.Name, cluster.Namespace)))
 		})
 	})
+
+	Context("when user provided TKR prefix name is empty", func() {
+
+		BeforeEach(func() {
+			availableUpdates := fmt.Sprintf("[%s %s %s]", "v1.18.18+vmware.1-tkg.2", "v1.18.8+vmware.1-tkg.1", "v1.18.14+vmware.1-tkg.1-rc.1")
+			cluster = getFakeCluster("fake-cluster", availableUpdates)
+			tkrNamePrefix = ""
+		})
+		It("should return the highest available version", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(latestTKRVersion).To(Equal("v1.18.18+vmware.1-tkg.2"))
+		})
+	})
 })
 
 var _ = Describe("getClusterResource", func() {


### PR DESCRIPTION
### What this PR does / why we need it

* restore to previous k8s version if upgrade failed for cc clusters

* restore to previous tkr version label if upgrade failed for legacy clusters

* use latest available k8s version if not specified when upgrading cluster
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3817 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

tests done on local testbed:
* restore tkr label for clusters when upgrade failing
```
Upgrading workload cluster 'my-legacy-wc' to kubernetes version 'v1.23.13+vmware.1'. Are you sure? [y/N]: y
Warning: Use of ytt based cluster templates will be deprecated in favor of ClusterClass templates in a future version of TKG. Please work to move your workloads to a ClusterClass enabled cluster.
Verifying kubernetes version...
Upgrading kubernetes cluster from `v1.22.11---vmware.2-tkg.2-zshippable` to `v1.23.13+vmware.1-tkg.1-zshippable` version
Restoring kubernetes cluster to tkr `v1.22.11---vmware.2-tkg.2-zshippable` version
```
* restore k8s version for cc cluster when upgrade failing
```
Upgrading workload cluster 'my-wc1' to kubernetes version 'v1.24.6+vmware.1'. Are you sure? [y/N]: y
Upgrading kubernetes cluster from `v1.22.11+vmware.2` to `v1.24.6+vmware.1` version
Restoring kubernetes cluster to `v1.22.11+vmware.2` version
```

* use latest available version when upgrade cluster without `--tkr` specified
```
kubo@0LZ8DZiMkuKTi:~/tanzu-framework$ tanzu cluster upgrade my-legacy-wc
Upgrading workload cluster 'my-legacy-wc' to kubernetes version 'v1.23.13+vmware.1'. Are you sure? [y/N]: y
Warning: Use of ytt based cluster templates will be deprecated in favor of ClusterClass templates in a future version of TKG. Please work to move your workloads to a ClusterClass enabled cluster.
Verifying kubernetes version...
Upgrading kubernetes cluster from `v1.22.11---vmware.2-tkg.2-zshippable` to `v1.23.13+vmware.1-tkg.1-zshippable` version
Retrieving configuration for upgrade cluster...
Create InfrastructureTemplate for upgrade...
Upgrading control plane nodes...
Patching KubeadmControlPlane with the kubernetes version v1.23.13+vmware.1...
Updating the KCP object with k8s version v1.23.13+vmware.1
Waiting for kubernetes version to be updated for control plane nodes
Upgrading worker nodes...
Patching MachineDeployment with the kubernetes version v1.23.13+vmware.1...
Waiting for kubernetes version to be updated for worker nodes...
Waiting for packages to be up and running...
Cluster 'my-legacy-wc' successfully upgraded to kubernetes version 'v1.23.13+vmware.1'
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
