### PR TITLE
Adding timestamps to the make release target for performance optimiza…

### DIFF
--- a/cmd/cli/plugin-admin/builder/command/cli_compile.go
+++ b/cmd/cli/plugin-admin/builder/command/cli_compile.go
@@ -24,6 +24,11 @@ import (
 	cliapi "github.com/vmware-tanzu/tanzu-framework/cli/runtime/apis/cli/v1alpha1"
 )
 
+func init() {
+	// TODO, aunum is an old logging library, need to replace w/ klog, but we want timestamps immediately for build optimizations, so one time hack.
+	log.Timestamps = true
+}
+
 var (
 	version, artifactsDir, ldflags string
 	tags, goprivate                string

--- a/cmd/cli/plugin-admin/builder/command/cli_compile.go
+++ b/cmd/cli/plugin-admin/builder/command/cli_compile.go
@@ -16,8 +16,7 @@ import (
 	"sync"
 	"time"
 
-	log "k8s.io/klog/v2"
-
+	"github.com/aunum/log"
 	"github.com/gobwas/glob"
 	"gopkg.in/yaml.v2"
 
@@ -99,6 +98,7 @@ func getMaxParallelism() int {
 
 // compileCore builds the core plugin for the plugin at the given corePath and arch.
 func compileCore(corePath string, arch cli.Arch) cli.Plugin {
+	log.Break()
 	log.Info("building core binary")
 	err := buildTargets(corePath, filepath.Join(artifactsDir, cli.CoreName, version), cli.CoreName, arch, "", "")
 	if err != nil {
@@ -167,7 +167,6 @@ func Compile(compileArgs *PluginCompileArgs) error {
 	maxConcurrent := getMaxParallelism()
 	guard := make(chan struct{}, maxConcurrent)
 
-	log.Info("Compile: Mixing up IDs to avoid different sets and building plugins in parallel")
 	// Mix up IDs so we don't always get the same set.
 	randSkew := rand.Intn(len(identifiers)) // nolint:gosec
 	var wg sync.WaitGroup
@@ -180,7 +179,6 @@ func Compile(compileArgs *PluginCompileArgs) error {
 				wg.Add(1)
 				guard <- struct{}{}
 				go func(fullPath, id string) {
-					log.Infof("starting go func for build of %v %v %v", fullPath, arch, id)
 					defer wg.Done()
 					p, err := buildPlugin(fullPath, arch, id)
 					if err != nil {
@@ -202,7 +200,7 @@ func Compile(compileArgs *PluginCompileArgs) error {
 	close(plugins)
 	close(fatalErrors)
 
-	log.Info("Compile: Checking for errors...")
+	log.BreakHard()
 	hasFailed := false
 	for err := range fatalErrors {
 		hasFailed = true
@@ -228,7 +226,7 @@ func Compile(compileArgs *PluginCompileArgs) error {
 		return err
 	}
 
-	log.Info("successfully built local repository")
+	log.Success("successfully built local repository")
 	return nil
 }
 
@@ -298,7 +296,8 @@ func buildPlugin(path string, arch cli.Arch, id string) (plugin, error) {
 		p.testPath = testPath
 		p.modPath = ""
 	}
-	log.Infof("plugin %v", p)
+
+	log.Debugy("plugin", p)
 
 	err = p.compile()
 	if err != nil {
@@ -495,7 +494,6 @@ func buildTargets(targetPath, outPath, pluginName string, arch cli.Arch, id, mod
 }
 
 func runDownloadGoDep(targetPath, prefix string) error {
-	log.Info("run download of godep")
 	cmdgomoddownload := goCommand("mod", "download")
 	cmdgomoddownload.Dir = targetPath
 

--- a/cmd/cli/plugin-admin/builder/go.mod
+++ b/cmd/cli/plugin-admin/builder/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime v0.0.0-00010101000000-000000000000
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.24.2
-	k8s.io/klog/v2 v2.60.1
 )
 
 require (
@@ -139,6 +138,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/client-go v0.24.2 // indirect
 	k8s.io/component-base v0.24.2 // indirect
+	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	k8s.io/kubectl v0.24.0 // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect

--- a/cmd/cli/plugin-admin/builder/go.mod
+++ b/cmd/cli/plugin-admin/builder/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime v0.0.0-00010101000000-000000000000
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.24.2
+	k8s.io/klog/v2 v2.60.1
 )
 
 require (
@@ -138,7 +139,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.24.2 // indirect
 	k8s.io/client-go v0.24.2 // indirect
 	k8s.io/component-base v0.24.2 // indirect
-	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	k8s.io/kubectl v0.24.0 // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect


### PR DESCRIPTION
What this PR does / why we need it

See the parent issue: We want to optimize Tanzu framework builds , and make release is time-consuming w/ remote registries, so need logs that are easy to interpret in any environment.

Which issue(s) this PR fixes

Fixes #4036 

Describe testing done for PR

`make release` locally
Release note

NONE

fixes https://github.com/vmware-tanzu/tanzu-framework/issues/4036