### PR TITLE
Fix featuregates package installation in Clusterclass based AWS clusters

### DIFF
--- a/packages/featuregates/bundle/config/values.yaml
+++ b/packages/featuregates/bundle/config/values.yaml
@@ -2,9 +2,8 @@
 ---
 namespace: tkg-system
 deployment:
-  hostNetwork: true
-  nodeSelector:
-    node-role.kubernetes.io/control-plane: ""
+  hostNetwork: false
+  nodeSelector: null
   tolerations: []
   webhookServerPort: 9443
   tlsCipherSuites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"

--- a/packages/framework/bundle/config/values.yaml
+++ b/packages/framework/bundle/config/values.yaml
@@ -6,9 +6,8 @@ featureGatesPackageValues:
   namespace:
   versionConstraints:
   deployment:
-    hostNetwork: true
-    nodeSelector:
-      node-role.kubernetes.io/control-plane: ""
+    hostNetwork: false
+    nodeSelector: null
     tolerations: []
     webhookServerPort: 9443
 tkrServicePackageValues:

--- a/packages/tkg/bundle/config/values.yaml
+++ b/packages/tkg/bundle/config/values.yaml
@@ -15,9 +15,8 @@ frameworkPackage:
     createNamespace: false
     versionConstraints:
     deployment:
-      hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/control-plane: ""
+      hostNetwork: false
+      nodeSelector: null
       tolerations: []
       webhookServerPort: 9443
   tkrServicePackageValues:


### PR DESCRIPTION
### What this PR does / why we need it

Currently, the hostNetwork is set to true and that is causing the featuregates package installation in cc based AWS clusters to fail as the ingress rule for featuregates is not created in AWS. This PR sets the hostNetwork to false for featuregates pod as there is no need for featuregates pod to use host network. 

This PR also reverts the workaround added by @12345lcr with this pr https://github.com/vmware-tanzu/tanzu-framework/pull/3983

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

Monitoring ClusterClass CAPA integration tests CI check

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
