### PR TITLE
Get akoo package input from addon secret during cluster upgrade

### DIFF
--- a/packages/tkg/bundle/config/packageinstalls/ako-operator-pi.yaml
+++ b/packages/tkg/bundle/config/packageinstalls/ako-operator-pi.yaml
@@ -5,7 +5,7 @@
 apiVersion: packaging.carvel.dev/v1alpha1
 kind: PackageInstall
 metadata:
-  name: ako-operator-v2
+  name: ako-operator
   namespace: tkg-system
   labels:
     tkg.tanzu.vmware.com/package-type: "management"

--- a/tkg/client/management_components.go
+++ b/tkg/client/management_components.go
@@ -250,10 +250,6 @@ func (c *TkgClient) getUserConfigVariableValueMap() (map[string]interface{}, err
 func (c *TkgClient) getUserConfigVariableValueMapFromSecret(clusterClient clusterclient.Client) (map[string]interface{}, error) {
 	pollOptions := &clusterclient.PollOptions{Interval: clusterclient.CheckResourceInterval, Timeout: 3 * clusterclient.CheckResourceInterval}
 	configValues := make(map[string]interface{})
-	clusterName, _, err := c.getRegionalClusterNameAndNamespace(clusterClient)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get management cluster name and namespace")
-	}
 	// In ClusterClass based cluster, the user config variables can be retrieved from the tkg-pkg package data values secret directly
 	bytes, err := clusterClient.GetSecretValue(fmt.Sprintf(packagedatamodel.SecretName, constants.TKGManagementPackageInstallName, constants.TkgNamespace), constants.TKGPackageValuesFile, constants.TkgNamespace, pollOptions)
 	if err == nil {
@@ -269,6 +265,10 @@ func (c *TkgClient) getUserConfigVariableValueMapFromSecret(clusterClient cluste
 		// Handle the upgrade from legacy (non-package-based-lcm) management cluster as
 		// legacy (non-package-based-lcm) management cluster will not have the secret tkg-pkg-tkg-system-values
 		// defined on the cluster. Github issue: https://github.com/vmware-tanzu/tanzu-framework/issues/2147
+		clusterName, _, err := c.getRegionalClusterNameAndNamespace(clusterClient)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get management cluster name and namespace")
+		}
 		// So we retrieve the user config variables from the <cluster-name>-config-values secret
 		// which was managed in legacy ytt template providers/ytt/09_miscellaneous
 		bytes, err := clusterClient.GetSecretValue(fmt.Sprintf("%s-config-values", clusterName), "value", constants.TkgNamespace, pollOptions)

--- a/tkg/client/management_components_test.go
+++ b/tkg/client/management_components_test.go
@@ -5,19 +5,23 @@ package client_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	. "github.com/vmware-tanzu/tanzu-framework/tkg/client"
+	"github.com/vmware-tanzu/tanzu-framework/tkg/clusterclient"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/constants"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/fakes"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/log"
@@ -346,4 +350,123 @@ var _ = Describe("Unit tests for processAKOPackageInstallFile", func() {
 		})
 	})
 
+})
+
+var _ = Describe("Unit tests for RetrieveAKOOVariablesFromAddonSecret", func() {
+	var (
+		err                  error
+		clusterClient        *fakes.ClusterClient
+		configValues         map[string]interface{}
+		clusterName          string
+		secretContent        string
+		invalidSecretContent string
+	)
+
+	BeforeEach(func() {
+		clusterClient = &fakes.ClusterClient{}
+		configValues = map[string]interface{}{}
+		clusterName = "fake-cluster"
+		secretContent = `
+#@data/values
+#@overlay/match-child-defaults missing_ok=True
+---
+akoOperator:
+  avi_enable: true
+  cluster_name: tkg-mgmt-vc
+  config:
+    avi_controller: 10.180.111.173
+    avi_username: fakeUserName
+    avi_password: fakePW
+    avi_ca_data_b64: fakeCA
+    avi_cloud_name: Default-Cloud
+    avi_service_engine_group: Default-Group
+    avi_management_cluster_service_engine_group: Default-Group
+    avi_data_network: VM Network
+    avi_data_network_cidr: 10.180.96.0/20
+    avi_control_plane_network: VM Network
+    avi_control_plane_network_cidr: 10.180.96.0/20
+    avi_management_cluster_vip_network_name: VM Network
+    avi_management_cluster_vip_network_cidr: 10.180.96.0/20
+    avi_management_cluster_control_plane_vip_network_name: VM Network
+    avi_management_cluster_control_plane_vip_network_cidr: 10.180.96.0/20
+    avi_control_plane_ha_provider: false
+`
+		invalidSecretContent = "invalid"
+	})
+
+	JustBeforeEach(func() {
+		err = RetrieveAKOOVariablesFromAddonSecret(clusterClient, clusterName, configValues)
+	})
+
+	Describe("When the ako-operator addon secret is not found", func() {
+		BeforeEach(func() {
+			clusterClient.GetSecretValueReturns(nil, apierrors.NewNotFound(
+				schema.GroupResource{Group: "fakeGroup", Resource: "fakeGroupResource"},
+				"fakeGroupResource"))
+		})
+		It("should find the secret with default name and namespace", func() {
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Describe("When failed to get the ako-operator addon secret", func() {
+		BeforeEach(func() {
+			clusterClient.GetSecretValueReturns(nil, errors.New("cannot get the secret"))
+		})
+		It("should find the secret with default name and namespace", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("cannot get the secret"))
+		})
+	})
+
+	Describe("When failed to yaml unmashall the ako-operator addon contents", func() {
+		BeforeEach(func() {
+			clusterClient.GetSecretValueCalls(func(secretName string, secretField string, secretNamespace string, pollOptions *clusterclient.PollOptions) ([]byte, error) {
+				if secretName == fmt.Sprintf("%s-%s-addon", clusterName, constants.AkoOperatorName) &&
+					secretNamespace == constants.TkgNamespace &&
+					secretField == "values.yaml" {
+					return []byte(invalidSecretContent), nil
+				}
+				return nil, errors.New("Not expected input")
+			})
+		})
+		It("should update the config based on the addon secret", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("cannot unmarshal"))
+		})
+	})
+
+	Describe("When the ako-operator addon secret exists", func() {
+		BeforeEach(func() {
+			clusterClient.GetSecretValueCalls(func(secretName string, secretField string, secretNamespace string, pollOptions *clusterclient.PollOptions) ([]byte, error) {
+				if secretName == fmt.Sprintf("%s-%s-addon", clusterName, constants.AkoOperatorName) &&
+					secretNamespace == constants.TkgNamespace &&
+					secretField == "values.yaml" {
+					return []byte(secretContent), nil
+				}
+				return nil, errors.New("Not expected input")
+			})
+		})
+		It("should update the config based on the addon secret", func() {
+			Expect(err).ToNot(HaveOccurred())
+			Expect(configValues[constants.ConfigVariableAviEnable].(bool)).To(Equal(true))
+			Expect(configValues[constants.ConfigVariableAviControllerAddress].(string)).To(Equal("10.180.111.173"))
+			Expect(configValues[constants.ConfigVariableAviControllerUsername].(string)).To(Equal("fakeUserName"))
+			Expect(configValues[constants.ConfigVariableAviControllerPassword].(string)).To(Equal("fakePW"))
+			Expect(configValues[constants.ConfigVariableAviControllerCA].(string)).To(Equal("fakeCA"))
+			Expect(configValues[constants.ConfigVariableAviCloudName].(string)).To(Equal("Default-Cloud"))
+			Expect(configValues[constants.ConfigVariableAviServiceEngineGroup].(string)).To(Equal("Default-Group"))
+			Expect(configValues[constants.ConfigVariableAviManagementClusterServiceEngineGroup].(string)).To(Equal("Default-Group"))
+			Expect(configValues[constants.ConfigVariableAviDataPlaneNetworkName].(string)).To(Equal("VM Network"))
+			Expect(configValues[constants.ConfigVariableAviDataPlaneNetworkCIDR].(string)).To(Equal("10.180.96.0/20"))
+			Expect(configValues[constants.ConfigVariableAviControlPlaneNetworkName].(string)).To(Equal("VM Network"))
+			Expect(configValues[constants.ConfigVariableAviControlPlaneNetworkCIDR].(string)).To(Equal("10.180.96.0/20"))
+			Expect(configValues[constants.ConfigVariableAviManagementClusterDataPlaneNetworkName].(string)).To(Equal("VM Network"))
+			Expect(configValues[constants.ConfigVariableAviManagementClusterDataPlaneNetworkCIDR].(string)).To(Equal("10.180.96.0/20"))
+			Expect(configValues[constants.ConfigVariableAviManagementClusterControlPlaneVipNetworkName].(string)).To(Equal("VM Network"))
+			Expect(configValues[constants.ConfigVariableAviManagementClusterControlPlaneVipNetworkCIDR].(string)).To(Equal("10.180.96.0/20"))
+			Expect(configValues[constants.ConfigVariableVsphereHaProvider].(bool)).To(Equal(false))
+			Expect(configValues[constants.ConfigVariableClusterName].(string)).To(Equal(clusterName))
+		})
+	})
 })

--- a/tkg/constants/cluster_internal.go
+++ b/tkg/constants/cluster_internal.go
@@ -67,6 +67,7 @@ const (
 	AkoNamespace             = "avi-system"
 	AkoCleanUpAnnotationKey  = "AviObjectDeletionStatus"
 	AkoCleanUpFinishedStatus = "Done"
+	AkoOperatorName          = "ako-operator"
 
 	ServiceDNSSuffix             = ".svc"
 	ServiceDNSClusterLocalSuffix = ".svc.cluster.local"

--- a/tkg/managementcomponents/management_component_install.go
+++ b/tkg/managementcomponents/management_component_install.go
@@ -304,8 +304,13 @@ func InstallManagementComponents(clusterClient clusterclient.Client, pkgClient p
 		}
 	}
 
+	// // Todo: For the addon secret deletion of ako-operator, this is for legacy to clusterclass capable management cluster upgrade.
+	// // Because the upgraded management cluster will deploy ako-operator by the management package tkg-pkg instead of addon secret.
+	// // We currently only pause the legacy ako-operator addon secret to disable it but do not delete it, in order to keep this ako-operator
+	// // configuration information as a debug reference in case the upgrade is failed.
+	// // This secret could be removed in later releases where all the management cluster has already successfully upgraded to clusterclass capable.
 	// if previousAkoOperatorIsFromCoreRepo {
-	// 	err = DeleteAddonSecret(clusterClient, fmt.Sprintf("%s-%s-addon", clusterName, akoOperatorName), constants.TkgNamespace)
+	// 	err = DeleteAddonSecret(clusterClient, fmt.Sprintf("%s-%s-addon", clusterName, constants.AkoOperatorName), constants.TkgNamespace)
 	// 	if err != nil {
 	// 		return err
 	// 	}

--- a/tkg/managementcomponents/management_component_install.go
+++ b/tkg/managementcomponents/management_component_install.go
@@ -33,7 +33,6 @@ import (
 const (
 	addonsManagerName = "addons-manager"
 	addonFinalizer    = "tkg.tanzu.vmware.com/addon"
-	akoOperatorName   = "ako-operator"
 )
 
 // ClusterOptions specifies cluster configuration
@@ -169,7 +168,7 @@ func NoopDeletePackageInstall(clusterClient clusterclient.Client, pkgiName, name
 
 // DeleteLegacyAkoOperatorPackageInstall removes legacy management cluster ako operator packageInstall
 func DeleteLegacyAkoOperatorPackageInstall(clusterClient clusterclient.Client, akoOperatorAddonName string) error {
-	akoOperatorPkgiName := akoOperatorName
+	akoOperatorPkgiName := constants.AkoOperatorName
 
 	if err := pauseAddonSecretReconciliation(clusterClient, akoOperatorAddonName, constants.TkgNamespace); err != nil {
 		return err
@@ -265,7 +264,7 @@ func InstallManagementComponents(clusterClient clusterclient.Client, pkgClient p
 		}
 	}
 
-	akoOperatorAddonName := fmt.Sprintf("%s-%s-addon", clusterName, akoOperatorName)
+	akoOperatorAddonName := fmt.Sprintf("%s-%s-addon", clusterName, constants.AkoOperatorName)
 	previousAkoOperatorIsFromCoreRepo, err := AddonSecretExists(clusterClient, akoOperatorAddonName, constants.TkgNamespace)
 	if err != nil {
 		return err
@@ -305,7 +304,7 @@ func InstallManagementComponents(clusterClient clusterclient.Client, pkgClient p
 	}
 
 	if previousAkoOperatorIsFromCoreRepo {
-		err = DeleteAddonSecret(clusterClient, fmt.Sprintf("%s-%s-addon", clusterName, akoOperatorName), constants.TkgNamespace)
+		err = DeleteAddonSecret(clusterClient, fmt.Sprintf("%s-%s-addon", clusterName, constants.AkoOperatorName), constants.TkgNamespace)
 		if err != nil {
 			return err
 		}

--- a/tkg/managementcomponents/management_component_install.go
+++ b/tkg/managementcomponents/management_component_install.go
@@ -269,9 +269,10 @@ func InstallManagementComponents(clusterClient clusterclient.Client, pkgClient p
 	if err != nil {
 		return err
 	}
-
-	if err := DeleteLegacyAkoOperatorPackageInstall(clusterClient, clusterName); err != nil {
-		return err
+	if previousAkoOperatorIsFromCoreRepo {
+		if err := DeleteLegacyAkoOperatorPackageInstall(clusterClient, akoOperatorAddonName); err != nil {
+			return err
+		}
 	}
 
 	if err = InstallManagementPackages(pkgClient, mcip.ManagementPackageRepositoryOptions); err != nil {
@@ -303,12 +304,12 @@ func InstallManagementComponents(clusterClient clusterclient.Client, pkgClient p
 		}
 	}
 
-	if previousAkoOperatorIsFromCoreRepo {
-		err = DeleteAddonSecret(clusterClient, fmt.Sprintf("%s-%s-addon", clusterName, constants.AkoOperatorName), constants.TkgNamespace)
-		if err != nil {
-			return err
-		}
-	}
+	// if previousAkoOperatorIsFromCoreRepo {
+	// 	err = DeleteAddonSecret(clusterClient, fmt.Sprintf("%s-%s-addon", clusterName, akoOperatorName), constants.TkgNamespace)
+	// 	if err != nil {
+	// 		return err
+	// 	}
+	// }
 
 	return nil
 }


### PR DESCRIPTION
### What this PR does / why we need it
Get akoo package input from addon secret during cluster upgrade. Since the akoo is deployed from tkg-pkg after cluster upgrade and the old akoo packageInstall will be removed, we are reusing the old akoo's addon secret for generating the akoo package input data values.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Added ut for fetching ako-operator addon secret and passed locally.

Created a tkg 1.6.0 env and manually built tanzu cli & management-package repo to test the upgrade. management-package upgrade succeeded and both the management cluster and workload cluster upgraded passed


```
~$ k get pkgi -A
NAMESPACE    NAME                                PACKAGE NAME                                         PACKAGE VERSION                            DESCRIPTION           AGE
tkg-system   ako-operator                        ako-operator-v2.tanzu.vmware.com                     0.77.0-dev                                 Reconcile succeeded   5m56s
tkg-system   antrea                              antrea.tanzu.vmware.com                              1.7.1+vmware.1-tkg.1-advanced-zshippable   Reconcile succeeded   59m
tkg-system   load-balancer-and-ingress-service   load-balancer-and-ingress-service.tanzu.vmware.com   1.8.1+vmware.1-tkg.1-zshippable            Reconcile succeeded   58m
tkg-system   metrics-server                      metrics-server.tanzu.vmware.com                      0.6.1+vmware.1-tkg.3-zshippable            Reconcile succeeded   59m
tkg-system   secretgen-controller                secretgen-controller.tanzu.vmware.com                0.11.0+vmware.2-tkg.1-zshippable           Reconcile succeeded   59m
tkg-system   tanzu-addons-manager                addons-manager.tanzu.vmware.com                      0.77.0-dev                                 Reconcile succeeded   5m33s
tkg-system   tanzu-auth                          tanzu-auth.tanzu.vmware.com                          0.77.0-dev                                 Reconcile succeeded   5m33s
tkg-system   tanzu-cliplugins                    cliplugins.tanzu.vmware.com                          0.77.0-dev                                 Reconcile succeeded   5m33s
tkg-system   tanzu-core-management-plugins       core-management-plugins.tanzu.vmware.com             0.77.0-dev                                 Reconcile succeeded   62m
tkg-system   tanzu-featuregates                  featuregates.tanzu.vmware.com                        0.77.0-dev                                 Reconcile succeeded   62m
tkg-system   tanzu-framework                     framework.tanzu.vmware.com                           0.77.0-dev                                 Reconcile succeeded   5m56s
tkg-system   tkg-clusterclass                    tkg-clusterclass.tanzu.vmware.com                    0.77.0-dev                                 Reconcile succeeded   5m56s
tkg-system   tkg-clusterclass-vsphere            tkg-clusterclass-vsphere.tanzu.vmware.com            0.77.0-dev                                 Reconcile succeeded   5m48s
tkg-system   tkg-pkg                             tkg.tanzu.vmware.com                                 0.77.0-dev                                 Reconcile succeeded   6m4s
tkg-system   tkr-service                         tkr-service.tanzu.vmware.com                         0.77.0-dev                                 Reconcile succeeded   5m33s
tkg-system   tkr-source-controller               tkr-source-controller.tanzu.vmware.com               0.77.0-dev                                 Reconcile succeeded   4m28s
tkg-system   tkr-vsphere-resolver                tkr-vsphere-resolver.tanzu.vmware.com                0.77.0-dev                                 Reconcile succeeded   4m28s
tkg-system   vsphere-cpi                         vsphere-cpi.tanzu.vmware.com                         1.24.0+vmware.1-tkg.1-zshippable           Reconcile succeeded   59m
tkg-system   vsphere-csi                         vsphere-csi.tanzu.vmware.com                         2.6.2+vmware.2-tkg.1-zshippable            Reconcile succeeded   59m
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
