### PR TITLE
WIP:provider: [PSA] Remove the overlay to initialize apiserver/extraVolumes empty array for CAPZ

### DIFF
--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/overlay.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/overlay.yaml
@@ -35,4 +35,17 @@ spec:
           status: "False"
           timeout: #@ data.values.MHC_FALSE_STATUS_TIMEOUT
         #@ end
-
+  patches:
+    #@overlay/match by=overlay.index(0)
+    #@overlay/insert before=True
+    - definitions:
+      - jsonPatches:
+          - op: add
+            path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes
+            value: []
+        selector:
+          apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+          kind: KubeadmControlPlaneTemplate
+          matchResources:
+            controlPlane: true
+      name: CAPA_KCP_INIT_EMPTY_VOLUMES_ARRAY

--- a/packages/tkg-clusterclass-docker/bundle/config/upstream/overlay.yaml
+++ b/packages/tkg-clusterclass-docker/bundle/config/upstream/overlay.yaml
@@ -34,3 +34,14 @@ spec:
         matchResources:
           controlPlane: true
     name: CAPD_KCP_INIT_EMPTY_FILES_ARRAY
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes
+        value: []
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    name: CAPD_KCP_INIT_EMPTY_VOLUMES_ARRAYS

--- a/packages/tkg-clusterclass-oci/bundle/config/upstream/overlay.yaml
+++ b/packages/tkg-clusterclass-oci/bundle/config/upstream/overlay.yaml
@@ -49,3 +49,14 @@ spec:
             matchResources:
               controlPlane: true
       name: CAPOCI_KCP_INIT_EMPTY_FILES_ARRAY
+    - definitions:
+      - jsonPatches:
+        - op: add
+          path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes
+          value: []
+        selector:
+          apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+          kind: KubeadmControlPlaneTemplate
+          matchResources:
+            controlPlane: true
+      name: CAPOCI_KCP_INIT_EMPTY_VOLUMES_ARRAY

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/overlay.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/overlay.yaml
@@ -52,3 +52,17 @@ spec:
           status: "False"
           timeout: #@ data.values.MHC_FALSE_STATUS_TIMEOUT
       #@ end
+  patches:
+    #@overlay/match by=overlay.index(0)
+    #@overlay/insert before=True
+    - definitions:
+      - jsonPatches:
+        - op: add
+          path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes
+          value: []
+        selector:
+          apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+          kind: KubeadmControlPlaneTemplate
+          matchResources:
+            controlPlane: true
+      name: CAPV_KCP_INIT_EMPTY_VOLUMES_ARRAY

--- a/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-pi.yaml
+++ b/packages/tkg-clusterclass/bundle/config/packageinstalls/tkg-infra-clusterclass-pi.yaml
@@ -91,33 +91,6 @@ metadata:
     kapp.k14s.io/change-rule.1: "delete before deleting tkg-infra-clusterclass-packageinstall/serviceaccount"
 type: Opaque
 stringData:
-  kcp-empty-array-overlay.yaml: |
-    #! This overlay is adds a patch as first element in the patches to create empty
-    #! arrays inside the KCP object. With this other patches are able to append to the
-    #! now empty array.
-    #! Otherwise the arrays would not exist and the patches would fail.
-    #! Empty arrays get dropped due to omitEmpty set at the CRD level.
-    #@ load("@ytt:overlay", "overlay")
-    #@ load("@ytt:data", "data")
-
-    #@overlay/match by=overlay.subset({"kind":"ClusterClass"})
-    ---
-    spec:
-      patches:
-      #@overlay/match by=overlay.index(0)
-      #@overlay/insert before=True
-      - definitions:
-        - jsonPatches:
-          - op: add
-            path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes
-            value: []
-          selector:
-            apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-            kind: KubeadmControlPlaneTemplate
-            matchResources:
-              controlPlane: true
-        name: KCP_INIT_EMPTY_ARRAYS
-
   pod-security-overlay.yaml: |
     #@ load("@ytt:overlay", "overlay")
     #@ load("@ytt:data", "data")

--- a/providers/infrastructure-aws/v2.0.1/cconly/overlay.yaml
+++ b/providers/infrastructure-aws/v2.0.1/cconly/overlay.yaml
@@ -35,4 +35,17 @@ spec:
           status: "False"
           timeout: #@ data.values.MHC_FALSE_STATUS_TIMEOUT
         #@ end
-
+  patches:
+    #@overlay/match by=overlay.index(0)
+    #@overlay/insert before=True
+    - definitions:
+      - jsonPatches:
+          - op: add
+            path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes
+            value: []
+        selector:
+          apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+          kind: KubeadmControlPlaneTemplate
+          matchResources:
+            controlPlane: true
+      name: CAPA_KCP_INIT_EMPTY_VOLUMES_ARRAY

--- a/providers/infrastructure-docker/v1.2.6/cconly/overlay.yaml
+++ b/providers/infrastructure-docker/v1.2.6/cconly/overlay.yaml
@@ -34,3 +34,14 @@ spec:
         matchResources:
           controlPlane: true
     name: CAPD_KCP_INIT_EMPTY_FILES_ARRAY
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes
+        value: []
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    name: CAPD_KCP_INIT_EMPTY_VOLUMES_ARRAYS

--- a/providers/infrastructure-oci/v0.4.0/cconly/overlay.yaml
+++ b/providers/infrastructure-oci/v0.4.0/cconly/overlay.yaml
@@ -49,3 +49,14 @@ spec:
             matchResources:
               controlPlane: true
       name: CAPOCI_KCP_INIT_EMPTY_FILES_ARRAY
+    - definitions:
+      - jsonPatches:
+        - op: add
+          path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes
+          value: []
+        selector:
+          apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+          kind: KubeadmControlPlaneTemplate
+          matchResources:
+            controlPlane: true
+      name: CAPOCI_KCP_INIT_EMPTY_VOLUMES_ARRAY

--- a/providers/infrastructure-vsphere/v1.5.0/cconly/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.5.0/cconly/overlay.yaml
@@ -52,3 +52,17 @@ spec:
           status: "False"
           timeout: #@ data.values.MHC_FALSE_STATUS_TIMEOUT
       #@ end
+  patches:
+    #@overlay/match by=overlay.index(0)
+    #@overlay/insert before=True
+    - definitions:
+      - jsonPatches:
+        - op: add
+          path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes
+          value: []
+        selector:
+          apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+          kind: KubeadmControlPlaneTemplate
+          matchResources:
+            controlPlane: true
+      name: CAPV_KCP_INIT_EMPTY_VOLUMES_ARRAY


### PR DESCRIPTION
### What this PR does / why we need it
The PR https://github.com/vmware-tanzu/tanzu-framework/pull/3862 , adds overlay to initialize the apiServer/extraVolumes array for all providers. This is replacing the extraVolumes defined in base.yaml ( https://github.com/vmware-tanzu/tanzu-framework/blob/main/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml ) causing management cluster create to fail. This PR is to fix the same, remove initializing extraVolumes array for infrastructure-azure.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
