### PR TITLE
Adds aws cni ingress rules

### DIFF
--- a/tkg/clusterclient/clusterclient_test.go
+++ b/tkg/clusterclient/clusterclient_test.go
@@ -3000,14 +3000,8 @@ var _ = Describe("Cluster Client", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				ingressRules := awsCluster.Spec.NetworkSpec.CNI.CNIIngressRules
-				expectedIngressRules := capav1beta2.CNIIngressRules{
-					{
-						Description: "kapp-controller",
-						Protocol:    capav1beta2.SecurityGroupProtocolTCP,
-						FromPort:    DefaultKappControllerHostPort,
-						ToPort:      DefaultKappControllerHostPort,
-					},
-				}
+				expectedIngressRules := capav1beta2.CNIIngressRules{}
+				expectedIngressRules = append(expectedIngressRules, AWSIngressRules...)
 				Expect(ingressRules).To(Equal(expectedIngressRules))
 			})
 		})
@@ -3032,7 +3026,7 @@ var _ = Describe("Cluster Client", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("should have CNI Ingress rules for kapp-controller", func() {
+			It("should have AWSIngressRules and existing one", func() {
 				err = clstClient.UpdateAWSCNIIngressRules("fake-clusterName", "fake-namespace")
 				Expect(err).NotTo(HaveOccurred())
 
@@ -3041,6 +3035,7 @@ var _ = Describe("Cluster Client", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				ingressRules := awsCluster.Spec.NetworkSpec.CNI.CNIIngressRules
+
 				expectedIngressRules := capav1beta2.CNIIngressRules{
 					{
 						Description: "antrea-controller",
@@ -3048,18 +3043,13 @@ var _ = Describe("Cluster Client", func() {
 						FromPort:    10349,
 						ToPort:      10349,
 					},
-					{
-						Description: "kapp-controller",
-						Protocol:    capav1beta2.SecurityGroupProtocolTCP,
-						FromPort:    DefaultKappControllerHostPort,
-						ToPort:      DefaultKappControllerHostPort,
-					},
 				}
+				expectedIngressRules = append(expectedIngressRules, AWSIngressRules...)
 				Expect(ingressRules).To(Equal(expectedIngressRules))
 			})
 		})
 
-		Context("When kapp-controller CNI Ingress Rules already exist", func() {
+		Context("When one of the rules in AWSIngressRules already exists", func() {
 			JustBeforeEach(func() {
 				awsCluster := &capav1beta2.AWSCluster{}
 				err = clstClient.GetResource(awsCluster, "fake-clusterName", "fake-namespace", nil, nil)
@@ -3079,7 +3069,7 @@ var _ = Describe("Cluster Client", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("should have CNI Ingress rules for kapp-controller", func() {
+			It("should have all  CNI Ingress rules listed in AWSIngressRules", func() {
 				err = clstClient.UpdateAWSCNIIngressRules("fake-clusterName", "fake-namespace")
 				Expect(err).NotTo(HaveOccurred())
 
@@ -3088,15 +3078,7 @@ var _ = Describe("Cluster Client", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				ingressRules := awsCluster.Spec.NetworkSpec.CNI.CNIIngressRules
-				expectedIngressRules := capav1beta2.CNIIngressRules{
-					{
-						Description: "kapp-controller",
-						Protocol:    capav1beta2.SecurityGroupProtocolTCP,
-						FromPort:    DefaultKappControllerHostPort,
-						ToPort:      DefaultKappControllerHostPort,
-					},
-				}
-				Expect(ingressRules).To(Equal(expectedIngressRules))
+				Expect(ingressRules).To(Equal(AWSIngressRules))
 			})
 		})
 


### PR DESCRIPTION
### What this PR does / why we need it
It allows the addition of new aws ingress rules to an aws cluster
Ensures ingress rules for kapp-controller and addons-manager are configured after an aws cluster upgrade 
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #4083

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes # 4083

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
pipeline testing only 

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

ensures aws ingress rules for addons-manager are in place after cluster upgrade

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
