### PR TITLE
Set clusterkind explicitly from constant instead of retrieving from o…

### DIFF
--- a/addons/controllers/antrea/antreaconfig_util.go
+++ b/addons/controllers/antrea/antreaconfig_util.go
@@ -141,9 +141,10 @@ func (r *AntreaConfigReconciler) ClusterToAntreaConfig(o client.Object) []ctrl.R
 			// corresponding AntreaConfig should have following ownerRef
 			ownerReference := metav1.OwnerReference{
 				APIVersion: clusterv1beta1.GroupVersion.String(),
-				Kind:       cluster.Kind,
-				Name:       cluster.Name,
-				UID:        cluster.UID,
+				// explictly set the cluster kind from variable instead from casted object
+				Kind: constants.ClusterKind,
+				Name: cluster.Name,
+				UID:  cluster.UID,
 			}
 
 			if clusterapiutil.HasOwnerRef(config.OwnerReferences, ownerReference) {

--- a/addons/controllers/antrea/antreaconfig_util.go
+++ b/addons/controllers/antrea/antreaconfig_util.go
@@ -141,7 +141,7 @@ func (r *AntreaConfigReconciler) ClusterToAntreaConfig(o client.Object) []ctrl.R
 			// corresponding AntreaConfig should have following ownerRef
 			ownerReference := metav1.OwnerReference{
 				APIVersion: clusterv1beta1.GroupVersion.String(),
-				// explictly set the cluster kind from variable instead from casted object
+				// explicitly set the cluster kind from variable instead from casted object
 				Kind: constants.ClusterKind,
 				Name: cluster.Name,
 				UID:  cluster.UID,

--- a/addons/controllers/calico/calicoconfig_utils.go
+++ b/addons/controllers/calico/calicoconfig_utils.go
@@ -70,7 +70,7 @@ func (r *CalicoConfigReconciler) ClusterToCalicoConfig(o client.Object) []ctrl.R
 			// corresponding CalicoConfig should have following ownerRef
 			ownerReference := metav1.OwnerReference{
 				APIVersion: clusterv1beta1.GroupVersion.String(),
-				Kind:       cluster.Kind,
+				Kind:       constants.ClusterKind,
 				Name:       cluster.Name,
 				UID:        cluster.UID,
 			}

--- a/addons/controllers/cpi/cpiconfig_util.go
+++ b/addons/controllers/cpi/cpiconfig_util.go
@@ -39,7 +39,7 @@ func performActionForCPIConfigIfOwnedByCluster(cpiConfig client.Object, cluster 
 	// corresponding CPIConfig should have following ownerRef
 	ownerReference := metav1.OwnerReference{
 		APIVersion: clusterapiv1beta1.GroupVersion.String(),
-		Kind:       cluster.Kind,
+		Kind:       constants.ClusterKind,
 		Name:       cluster.Name,
 		UID:        cluster.UID,
 	}

--- a/addons/controllers/csi/vspherecsiconfig_utils.go
+++ b/addons/controllers/csi/vspherecsiconfig_utils.go
@@ -59,7 +59,7 @@ func (r *VSphereCSIConfigReconciler) ClusterToVSphereCSIConfig(o client.Object) 
 			// corresponding VSphereCSIConfig should have following ownerRef
 			ownerReference := metav1.OwnerReference{
 				APIVersion: clusterv1beta1.GroupVersion.String(),
-				Kind:       cluster.Kind,
+				Kind:       constants.ClusterKind,
 				Name:       cluster.Name,
 				UID:        cluster.UID,
 			}

--- a/addons/controllers/kapp-controller/kappcontrollerconfig_handlers.go
+++ b/addons/controllers/kapp-controller/kappcontrollerconfig_handlers.go
@@ -51,7 +51,7 @@ func (r *KappControllerConfigReconciler) ClusterToKappControllerConfig(o client.
 			// corresponding kappControllerConfig should have following ownerRef
 			ownerReference := metav1.OwnerReference{
 				APIVersion: clusterv1beta1.GroupVersion.String(),
-				Kind:       cluster.Kind,
+				Kind:       constants.ClusterKind,
 				Name:       cluster.Name,
 				UID:        cluster.UID,
 			}

--- a/addons/controllers/kubevipcpi/kubevipcpiconfig_utils.go
+++ b/addons/controllers/kubevipcpi/kubevipcpiconfig_utils.go
@@ -45,7 +45,7 @@ func (r *KubevipCPIConfigReconciler) ClusterToKubevipCPIConfig(o client.Object) 
 			// corresponding KubevipCPIConfig should have following ownerRef
 			ownerReference := metav1.OwnerReference{
 				APIVersion: clusterapiv1beta1.GroupVersion.String(),
-				Kind:       cluster.Kind,
+				Kind:       constants.ClusterKind,
 				Name:       cluster.Name,
 				UID:        cluster.UID,
 			}


### PR DESCRIPTION
…bject that's cast from an interface

Right now the enqueue doesn't take effect since the kind is missing from the casted object, thus if cluster has change, correponding addon config is still not enqueued, thus cluster creation still takes long time
### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
