### PR TITLE
Fix the deletion of discovery sources by using DeleteCLIDiscoverySource API in tanzu plugin source delete command

### DIFF
--- a/cli/core/pkg/command/discovery_source.go
+++ b/cli/core/pkg/command/discovery_source.go
@@ -200,25 +200,7 @@ var deleteDiscoverySourceCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		discoveryName := args[0]
 
-		// Acquire tanzu config lock
-		configlib.AcquireTanzuConfigLock()
-		defer configlib.ReleaseTanzuConfigLock()
-
-		cfg, err := configlib.GetClientConfigNoLock()
-		if err != nil {
-			return err
-		}
-		if cfg.ClientOptions == nil || cfg.ClientOptions.CLI == nil {
-			return fmt.Errorf("discovery %q unknown", discoveryName)
-		}
-
-		newDiscoverySources, err := deleteDiscoverySource(cfg.ClientOptions.CLI.DiscoverySources, discoveryName)
-		if err != nil {
-			return err
-		}
-
-		cfg.ClientOptions.CLI.DiscoverySources = newDiscoverySources
-		err = configlib.StoreClientConfig(cfg)
+		err = configlib.DeleteCLIDiscoverySource(discoveryName)
 		if err != nil {
 			return err
 		}

--- a/cli/runtime/config/cli_discovery_sources.go
+++ b/cli/runtime/config/cli_discovery_sources.go
@@ -24,7 +24,7 @@ func GetCLIDiscoverySources() ([]configapi.PluginDiscovery, error) {
 	return getCLIDiscoverySources(node)
 }
 
-// GetCLIDiscoverySource retrieves cli discovery source by name
+// GetCLIDiscoverySource retrieves cli discovery source by name assuming that there should only be one source with the name, returns the first match
 func GetCLIDiscoverySource(name string) (*configapi.PluginDiscovery, error) {
 	// Retrieve client config node
 	node, err := getClientConfigNode()

--- a/cli/runtime/config/cli_discovery_sources_test.go
+++ b/cli/runtime/config/cli_discovery_sources_test.go
@@ -254,15 +254,14 @@ func TestDeleteCLIDiscoverySource(t *testing.T) {
 	}(f.Name())
 
 	tests := []struct {
-		name    string
-		src     *configapi.ClientConfig
-		input   string
-		deleted bool
-		count   int
-		errStr  string
+		name   string
+		src    *configapi.ClientConfig
+		input  string
+		count  int
+		errStr string
 	}{
 		{
-			name: "should return true on deleting non existing item",
+			name: "should return err on deleting non existing source",
 			src: &configapi.ClientConfig{
 				ClientOptions: &configapi.ClientOptions{
 					CLI: &configapi.CLIOptions{
@@ -278,13 +277,12 @@ func TestDeleteCLIDiscoverySource(t *testing.T) {
 					},
 				},
 			},
-			input:   "test-notfound",
-			deleted: true,
-			count:   1,
-			errStr:  "cli discovery source not found",
+			input:  "test-notfound",
+			count:  1,
+			errStr: "cli discovery source not found",
 		},
 		{
-			name: "should return true on deleting existing item",
+			name: "should delete existing test source",
 			src: &configapi.ClientConfig{
 				ClientOptions: &configapi.ClientOptions{
 					CLI: &configapi.CLIOptions{
@@ -300,12 +298,11 @@ func TestDeleteCLIDiscoverySource(t *testing.T) {
 					},
 				},
 			},
-			input:   "test",
-			count:   0,
-			deleted: true,
+			input: "test",
+			count: 0,
 		},
 		{
-			name: "should return true on deleting existing test2",
+			name: "should delete test2 source",
 			src: &configapi.ClientConfig{
 				ClientOptions: &configapi.ClientOptions{
 					CLI: &configapi.CLIOptions{
@@ -328,21 +325,20 @@ func TestDeleteCLIDiscoverySource(t *testing.T) {
 					},
 				},
 			},
-			count:   1,
-			input:   "test",
-			deleted: true,
+			count: 1,
+			input: "test2",
 		},
 		{
-			name: "should delete local source",
+			name: "should delete local default source",
 			src: &configapi.ClientConfig{
 				ClientOptions: &configapi.ClientOptions{
 					CLI: &configapi.CLIOptions{
 						DiscoverySources: []configapi.PluginDiscovery{
 							{
 								GCP: &configapi.GCPDiscovery{
-									Name:         "test2",
-									Bucket:       "test-bucket2",
-									ManifestPath: "test-manifest-path2",
+									Name:         "test",
+									Bucket:       "test-bucket",
+									ManifestPath: "test-manifest-path",
 								},
 								ContextType: configapi.CtxTypeTMC,
 							},
@@ -364,9 +360,8 @@ func TestDeleteCLIDiscoverySource(t *testing.T) {
 					},
 				},
 			},
-			count:   2,
-			input:   "default",
-			deleted: true,
+			count: 2,
+			input: "default",
 		},
 	}
 	for _, spec := range tests {

--- a/cli/runtime/config/cli_discovery_sources_test.go
+++ b/cli/runtime/config/cli_discovery_sources_test.go
@@ -340,21 +340,18 @@ func TestDeleteCLIDiscoverySource(t *testing.T) {
 									Bucket:       "test-bucket",
 									ManifestPath: "test-manifest-path",
 								},
-								ContextType: configapi.CtxTypeTMC,
 							},
 							{
 								Local: &configapi.LocalDiscovery{
 									Name: "default",
 									Path: "standalone",
 								},
-								ContextType: configapi.CtxTypeK8s,
 							},
 							{
 								Local: &configapi.LocalDiscovery{
 									Name: "admin-local",
 									Path: "admin",
 								},
-								ContextType: configapi.CtxTypeK8s,
 							},
 						},
 					},

--- a/cli/runtime/config/legacy_clientconfig_factory.go
+++ b/cli/runtime/config/legacy_clientconfig_factory.go
@@ -42,7 +42,7 @@ func GetClientConfigNoLock() (cfg *configapi.ClientConfig, err error) {
 // StoreClientConfig stores the config in the local directory.
 // Make sure to Acquire and Release tanzu lock when reading/writing to the
 // tanzu client configuration
-// Deprecated: StoreClientConfig is deprecated. Use New Config API methods
+// Deprecated: StoreClientConfig is deprecated. Avoid using this method for Delete operations. Use New Config API methods.
 func StoreClientConfig(cfg *configapi.ClientConfig) error {
 	// new plugins would be setting only contexts, so populate servers for backwards compatibility
 	populateServers(cfg)


### PR DESCRIPTION
### What this PR does / why we need it

Fix the deletion of discovery sources.
Uses the Config API method `DeleteCLIDiscoverySource` instead of deprecated `StoreClientConfig`

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #4055 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Unit Testing and Validate the `tanzu plugin source delete` command

```
mpanchajanya@mpanchajany-a01 tanzu-framework % tanzu config get                  
clientOptions:
    features:
        global:
            context-target: "false"
            context-aware-cli-for-plugins: "true"
            tkr-version-v1alpha3-beta: "false"
        management-cluster:
            dual-stack-ipv6-primary: "false"
            export-from-confirm: "true"
            import: "false"
            standalone-cluster-mode: "false"
            aws-instance-types-exclude-arm: "true"
            custom-nameservers: "false"
            dual-stack-ipv4-primary: "false"
        package:
            kctrl-package-command-tree: "true"
        cluster:
            dual-stack-ipv6-primary: "false"
            custom-nameservers: "false"
            dual-stack-ipv4-primary: "false"
    cli:
        discoverySources:
            - local:
                name: admin-local
                path: admin
            - local:
                name: default
                path: standalone
              contextType: k8s
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
```

```
mpanchajanya@mpanchajany-a01 tanzu-framework % tanzu plugin source list
  NAME         TYPE   SCOPE       
  admin-local  local  Standalone  
  default      local  Standalone  
```

```
mpanchajanya@mpanchajany-a01 tanzu-framework % tanzu plugin source delete admin-local
✔  deleted discovery source admin-local
```

```
mpanchajanya@mpanchajany-a01 tanzu-framework % tanzu config get                      
clientOptions:
    features:
        global:
            context-target: "false"
            context-aware-cli-for-plugins: "true"
            tkr-version-v1alpha3-beta: "false"
        management-cluster:
            dual-stack-ipv6-primary: "false"
            export-from-confirm: "true"
            import: "false"
            standalone-cluster-mode: "false"
            aws-instance-types-exclude-arm: "true"
            custom-nameservers: "false"
            dual-stack-ipv4-primary: "false"
        package:
            kctrl-package-command-tree: "true"
        cluster:
            dual-stack-ipv6-primary: "false"
            custom-nameservers: "false"
            dual-stack-ipv4-primary: "false"
    cli:
        discoverySources:
            - local:
                name: default
                path: standalone
              contextType: k8s
        edition: tkg
        bomRepo: projects.registry.vmware.com/tkg
        compatibilityFilePath: tkg-compatibility
```