### PR TITLE
Skip the same cluster name validation if dry-run

### DIFF
--- a/tkg/client/client.go
+++ b/tkg/client/client.go
@@ -83,6 +83,7 @@ type InitRegionOptions struct {
 	CeipOptIn                    bool
 	UseExistingCluster           bool
 	IsInputFileClusterClassBased bool
+	GenerateOnly                 bool
 }
 
 // DeleteRegionOptions contains options supported by DeleteRegion

--- a/tkg/client/validate.go
+++ b/tkg/client/validate.go
@@ -525,10 +525,13 @@ func (c *TkgClient) ConfigureAndValidateManagementClusterConfiguration(options *
 		return NewValidationError(ValidationErrorCode, "unable to verify cluster name uniqueness")
 	}
 
-	for _, region := range regions {
-		if region.ClusterName == options.ClusterName {
-			errMsg := fmt.Sprintf("cluster name %s matches another management cluster", options.ClusterName)
-			return NewValidationError(ValidationErrorCode, errMsg)
+	// Skip the same cluster name validation if dry-run
+	if !options.GenerateOnly {
+		for _, region := range regions {
+			if region.ClusterName == options.ClusterName {
+				errMsg := fmt.Sprintf("cluster name %s matches another management cluster", options.ClusterName)
+				return NewValidationError(ValidationErrorCode, errMsg)
+			}
 		}
 	}
 

--- a/tkg/tkgctl/init.go
+++ b/tkg/tkgctl/init.go
@@ -358,6 +358,7 @@ func (t *tkgctl) populateClientInitRegionOptions(options *InitRegionOptions, nod
 		VsphereControlPlaneEndpoint: options.VsphereControlPlaneEndpoint,
 		Edition:                     options.Edition,
 		AdditionalTKGManifests:      options.AdditionalTKGManifests,
+		GenerateOnly:                options.GenerateOnly,
 	}
 }
 


### PR DESCRIPTION
### What this PR does / why we need it
It is unnecessary to validate if the cluster name is duplicated with the existing cluster when dry run.