### PR TITLE
Translate FQDN ytt template to ClusterClass json patch

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -496,7 +496,7 @@ spec:
         items:
           type: string
         default: []
-  - name: extraDNS
+  - name: additionalFQDN
     required: false
     schema:
       openAPIV3Schema:
@@ -1806,8 +1806,8 @@ spec:
               {{- range .ntpServers }}
             - {{ . }}
               {{- end }}
-  - name: extraDNS
-    enabledIf: '{{ not (empty .extraDNS) }}'
+  - name: additionalFQDN
+    enabledIf: '{{ not (empty .additionalFQDN) }}'
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -1816,10 +1816,9 @@ spec:
           controlPlane: true
       jsonPatches:
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/certSANs
         valueFrom:
           template: |
-            certSANs:
-              {{- range .extraDNS }}
+            {{- range .additionalFQDN }}
             - {{ . }}
-              {{- end }}
+            {{- end }}

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -496,6 +496,14 @@ spec:
         items:
           type: string
         default: []
+  - name: extraDNS
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: string
+        default: []
   - name: TKR_DATA
     required: false
     schema:
@@ -1796,5 +1804,22 @@ spec:
             enabled: true
             servers:
               {{- range .ntpServers }}
+            - {{ . }}
+              {{- end }}
+  - name: extraDNS
+    enabledIf: '{{ not (empty .extraDNS) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer
+        valueFrom:
+          template: |
+            certSANs:
+              {{- range .extraDNS }}
             - {{ . }}
               {{- end }}

--- a/providers/config_default.yaml
+++ b/providers/config_default.yaml
@@ -179,6 +179,7 @@ VSPHERE_INSECURE: false
 #! Virtual IP address or FQDN for the cluster's control plane nodes
 VSPHERE_CONTROL_PLANE_ENDPOINT:
 VSPHERE_CONTROL_PLANE_ENDPOINT_PORT: 6443
+VSPHERE_EXTRA_DNS:
 #! NSX-T specific configurations for enabling NSX-T routable pods
 #! set this to true to enable NSX-T routable pods
 NSXT_POD_ROUTING_ENABLED: false

--- a/providers/config_default.yaml
+++ b/providers/config_default.yaml
@@ -179,7 +179,7 @@ VSPHERE_INSECURE: false
 #! Virtual IP address or FQDN for the cluster's control plane nodes
 VSPHERE_CONTROL_PLANE_ENDPOINT:
 VSPHERE_CONTROL_PLANE_ENDPOINT_PORT: 6443
-VSPHERE_EXTRA_DNS:
+VSPHERE_ADDITIONAL_FQDN:
 #! NSX-T specific configurations for enabling NSX-T routable pods
 #! set this to true to enable NSX-T routable pods
 NSXT_POD_ROUTING_ENABLED: false

--- a/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
@@ -496,7 +496,7 @@ spec:
         items:
           type: string
         default: []
-  - name: extraDNS
+  - name: additionalFQDN
     required: false
     schema:
       openAPIV3Schema:
@@ -1806,8 +1806,8 @@ spec:
               {{- range .ntpServers }}
             - {{ . }}
               {{- end }}
-  - name: extraDNS
-    enabledIf: '{{ not (empty .extraDNS) }}'
+  - name: additionalFQDN
+    enabledIf: '{{ not (empty .additionalFQDN) }}'
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -1816,10 +1816,9 @@ spec:
           controlPlane: true
       jsonPatches:
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/certSANs
         valueFrom:
           template: |
-            certSANs:
-              {{- range .extraDNS }}
+            {{- range .additionalFQDN }}
             - {{ . }}
-              {{- end }}
+            {{- end }}

--- a/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
@@ -496,6 +496,14 @@ spec:
         items:
           type: string
         default: []
+  - name: extraDNS
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: string
+        default: []
   - name: TKR_DATA
     required: false
     schema:
@@ -1796,5 +1804,22 @@ spec:
             enabled: true
             servers:
               {{- range .ntpServers }}
+            - {{ . }}
+              {{- end }}
+  - name: extraDNS
+    enabledIf: '{{ not (empty .extraDNS) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer
+        valueFrom:
+          template: |
+            certSANs:
+              {{- range .extraDNS }}
             - {{ . }}
               {{- end }}

--- a/providers/infrastructure-vsphere/v1.5.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/yttcc/overlay.yaml
@@ -137,7 +137,7 @@ spec:
     variables:
     #@ vars = get_vsphere_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["etcdExtraArgs", "apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider", "extraDNS"]:
+    #@  if vars[configVariable] != None and configVariable in ["etcdExtraArgs", "apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider", "additionalFQDN"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/providers/infrastructure-vsphere/v1.5.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/yttcc/overlay.yaml
@@ -137,7 +137,7 @@ spec:
     variables:
     #@ vars = get_vsphere_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["etcdExtraArgs", "apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider"]:
+    #@  if vars[configVariable] != None and configVariable in ["etcdExtraArgs", "apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider", "extraDNS"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/providers/yttcc/lib/config_variable_association.star
+++ b/providers/yttcc/lib/config_variable_association.star
@@ -902,6 +902,10 @@ def get_vsphere_vars():
         vars["kubeVipLoadBalancerProvider"] = True
     end
 
+    if data.values["VSPHERE_EXTRA_DNS"] != None:
+        vars["extraDNS"] = data.values["VSPHERE_EXTRA_DNS"].replace(" ", "").split(",")
+    end
+
     return vars
 end
 

--- a/providers/yttcc/lib/config_variable_association.star
+++ b/providers/yttcc/lib/config_variable_association.star
@@ -902,8 +902,8 @@ def get_vsphere_vars():
         vars["kubeVipLoadBalancerProvider"] = True
     end
 
-    if data.values["VSPHERE_EXTRA_DNS"] != None:
-        vars["extraDNS"] = data.values["VSPHERE_EXTRA_DNS"].replace(" ", "").split(",")
+    if data.values["VSPHERE_ADDITIONAL_FQDN"] != None:
+        vars["additionalFQDN"] = data.values["VSPHERE_ADDITIONAL_FQDN"].replace(" ", "").split(",")
     end
 
     return vars


### PR DESCRIPTION
Signed-off-by: Chen Lin <linch@vmware.com>

### What this PR does / why we need it
Previously, we support this using ytt template. In order to support upgrade from non classy to classy cluster in the future, we need to support same functionality using json patch
https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.6/vmware-tanzu-kubernetes-grid-16/GUID-tanzu-k8s-clusters-config-plans.html#fqdn-control-plane-endpoint-with-nsx-alb-5
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
install-vc7 pipeline and manual validation following:
https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.6/vmware-tanzu-kubernetes-grid-16/GUID-tanzu-k8s-clusters-networking.html?hWord=N4IghgNiBcIMYCcCmYAuSAEATAdgZwzA2TgHsEsQBfIA

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
 Support FQDN Control Plane Endpoint with NSX ALB in Cluster Class
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
