### PR TITLE
[provider][Azure] Add extraVolumes as jsonpatch

### DIFF
--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -533,7 +533,21 @@ spec:
         path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs/cluster-name
         valueFrom:
           template: '{{ .builtin.cluster.name }}'
-
+  - name: cloudConfigVolume
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes/-
+        value:
+          name: cloud-config
+          hostPath: /etc/kubernetes/azure.json
+          mountPath: /etc/kubernetes/azure.json
+          readOnly: true
   - name: apiServerBindPort
     enabledIf: '{{ not (empty .apiServerPort) }}'
     definitions:
@@ -1353,11 +1367,7 @@ spec:
             extraArgs:
               cloud-config: /etc/kubernetes/azure.json
               cloud-provider: azure
-            extraVolumes:
-            - hostPath: /etc/kubernetes/azure.json
-              mountPath: /etc/kubernetes/azure.json
-              name: cloud-config
-              readOnly: true
+            extraVolumes: []
             timeoutForControlPlane: 20m
           controllerManager:
             extraArgs:

--- a/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
+++ b/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
@@ -533,7 +533,21 @@ spec:
         path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs/cluster-name
         valueFrom:
           template: '{{ .builtin.cluster.name }}'
-
+  - name: cloudConfigVolume
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes/-
+        value:
+          name: cloud-config
+          hostPath: /etc/kubernetes/azure.json
+          mountPath: /etc/kubernetes/azure.json
+          readOnly: true
   - name: apiServerBindPort
     enabledIf: '{{ not (empty .apiServerPort) }}'
     definitions:
@@ -1353,11 +1367,7 @@ spec:
             extraArgs:
               cloud-config: /etc/kubernetes/azure.json
               cloud-provider: azure
-            extraVolumes:
-            - hostPath: /etc/kubernetes/azure.json
-              mountPath: /etc/kubernetes/azure.json
-              name: cloud-config
-              readOnly: true
+            extraVolumes: []
             timeoutForControlPlane: 20m
           controllerManager:
             extraArgs:


### PR DESCRIPTION
### What this PR does / why we need it
The PR https://github.com/vmware-tanzu/tanzu-framework/pull/3862 , adds overlay to initialize the apiServer/extraVolumes array for all providers. This is replacing the extraVolumes defined in base.yaml ( https://github.com/vmware-tanzu/tanzu-framework/blob/main/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml ) causing management cluster create to fail. This PR adds extraVolumes as jsonpatch instead to be inline with all other providers.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
