### PR TITLE
Fix the KUBEVIP_LOADBALANCER_CIDRS typo

### DIFF
--- a/providers/config_default.yaml
+++ b/providers/config_default.yaml
@@ -702,7 +702,7 @@ ANTREA_TRAFFIC_CONTROL: false
 
 KUBEVIP_LOADBALANCER_ENABLE: false
 KUBEVIP_LOADBALANCER_IP_RANGES: ""
-KUBEVIP_LOADBALANCER_CIDRs: ""
+KUBEVIP_LOADBALANCER_CIDRS: ""
 
 #! ---------------------------------------------------------------------
 #! Internal configuration, not meant to be overridden


### PR DESCRIPTION
### What this PR does / why we need it
In this PR https://github.com/vmware-tanzu/tanzu-framework/pull/4022
I changed all the place from KUBEVIP_LOADBALANCER_CIDRs to KUBEVIP_LOADBALANCER_CIDRS by one place left
It will cause issue when creating cluster 
```
04:29:24  Fetching File="cluster-template-definition-devcc.yaml" Provider="vsphere" Type="InfrastructureProvider" Version="v1.5.0"
04:29:24  Deleting kind cluster: tkg-kind-ce49q1hi8e8dmcb0t5kg
04:29:29  Error: unable to set up management cluster: unable to build management cluster configuration: unable to get template: 
04:29:29  - key "KUBEVIP_LOADBALANCER_CIDRS" not in struct
04:29:29      in get_cluster_variables
04:29:29        324 |             if data.values[configVariable] != None:
04:29:29      in get_vsphere_vars
04:29:29        779 |     vars = get_cluster_variables()
04:29:29      in <toplevel>
04:29:29        overlay.yaml:138 |     #@ vars = get_vsphere_vars()
04:29:29  INFO:root:====== 196  Errored: 1 Encountered a bad command exit code!
```
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
