### PR TITLE
Discard contexts and currentContext nodes from config.yaml

### DIFF
--- a/cli/runtime/config/cli_discovery_sources_it_test.go
+++ b/cli/runtime/config/cli_discovery_sources_it_test.go
@@ -138,36 +138,6 @@ servers:
             required: true
           contextType: tmc
 current: test-mc
-contexts:
-    - name: test-mc
-      target: kubernetes
-      group: one
-      clusterOpts:
-        isManagementCluster: true
-        annotation: one
-        required: true
-        annotationStruct:
-            one: one
-        endpoint: test-endpoint
-        path: test-path
-        context: test-context
-      discoverySources:
-        - gcp:
-            name: test
-            bucket: test-bucket
-            manifestPath: test-manifest-path
-            annotation: one
-            required: true
-          contextType: tmc
-        - gcp:
-            name: test-two
-            bucket: test-bucket
-            manifestPath: test-manifest-path
-            annotation: two
-            required: true
-          contextType: tmc
-currentContext:
-    kubernetes: test-mc
 `
 	//nolint:goconst
 	expectedCFG2 := `contexts:

--- a/cli/runtime/config/cli_repositories_it_test.go
+++ b/cli/runtime/config/cli_repositories_it_test.go
@@ -130,36 +130,6 @@ servers:
             required: true
           contextType: tmc
 current: test-mc
-contexts:
-    - name: test-mc
-      target: kubernetes
-      group: one
-      clusterOpts:
-        isManagementCluster: true
-        annotation: one
-        required: true
-        annotationStruct:
-            one: one
-        endpoint: updated-test-endpoint
-        path: updated-test-path
-        context: updated-test-context
-      discoverySources:
-        - gcp:
-            name: test
-            bucket: updated-test-bucket
-            manifestPath: updated-test-manifest-path
-            annotation: one
-            required: true
-          contextType: tmc
-        - gcp:
-            name: test-two
-            bucket: updated-test-bucket
-            manifestPath: updated-test-manifest-path
-            annotation: two
-            required: true
-          contextType: tmc
-currentContext:
-    kubernetes: test-mc
 `
 
 	cfg2 := `contexts:

--- a/cli/runtime/config/config_factory.go
+++ b/cli/runtime/config/config_factory.go
@@ -26,6 +26,11 @@ var LegacyConfigNodeKeys = []string{
 	KeyCurrentServer,
 }
 
+var DiscardedConfigNodeKeys = []string{
+	KeyContexts,
+	KeyCurrentContext,
+}
+
 // getMultiConfig retrieves combined config.yaml and config-ng.yaml
 func getMultiConfig() (*yaml.Node, error) {
 	cfgNode, err := getClientConfig()
@@ -135,6 +140,16 @@ func persistConfig(node *yaml.Node) error {
 					cfgNextGenNode.Content[0].Content = append(cfgNextGenNode.Content[0].Content, node.Content[0].Content[index:index+2]...)
 				}
 			}
+		}
+	}
+
+	// Discard nodes from config.yaml
+	for _, discardedCfgNodeKey := range DiscardedConfigNodeKeys {
+		// Discard node from config.yaml
+		legacyDiscardedContextsNodeIndex := nodeutils.GetNodeIndex(cfgNode.Content[0].Content, discardedCfgNodeKey)
+		if legacyDiscardedContextsNodeIndex != -1 {
+			// remove discarded node
+			cfgNode.Content[0].Content = append(cfgNode.Content[0].Content[:legacyDiscardedContextsNodeIndex-1], cfgNode.Content[0].Content[legacyDiscardedContextsNodeIndex+1:]...)
 		}
 	}
 

--- a/cli/runtime/config/config_factory_test.go
+++ b/cli/runtime/config/config_factory_test.go
@@ -98,7 +98,10 @@ contexts:
           required: true
         contextType: tmc
 currentContext:
-    kubernetes: test-mc
+  kubernetes: test-mc
+#extraneous fields/comments are preserved on file update
+extrafield:
+ extrasubfiled: 1
 `
 	expectedCfg := `apiVersion: config.tanzu.vmware.com/v1alpha1
 clientOptions:
@@ -154,36 +157,9 @@ servers:
             required: true
           contextType: tmc
 current: test-mc
-contexts:
-    - name: test-mc
-      target: kubernetes
-      group: one
-      clusterOpts:
-        isManagementCluster: true
-        annotation: one
-        required: true
-        annotationStruct:
-            one: one
-        endpoint: test-endpoint
-        path: test-path
-        context: test-context
-      discoverySources:
-        - gcp:
-            name: test
-            bucket: test-bucket
-            manifestPath: test-manifest-path
-            annotation: one
-            required: true
-          contextType: tmc
-        - gcp:
-            name: test-two
-            bucket: test-bucket
-            manifestPath: test-manifest-path
-            annotation: two
-            required: true
-          contextType: tmc
-currentContext:
-    kubernetes: test-mc
+#extraneous fields/comments are preserved on file update
+extrafield:
+    extrasubfiled: 1
 `
 
 	cfgNextGen := `

--- a/cli/runtime/config/patchstrategy_it_test.go
+++ b/cli/runtime/config/patchstrategy_it_test.go
@@ -87,21 +87,6 @@ servers:
         annotation: one
         required: true
 current: test-mc
-contexts:
-    - name: test-mc
-      target: kubernetes
-      group: one
-      clusterOpts:
-        isManagementCluster: true
-        annotation: one
-        required: true
-        annotationStruct:
-            one: one
-        endpoint: test-endpoint
-        path: test-path
-        context: test-context
-currentContext:
-    kubernetes: test-mc
 `
 
 	cfg2 := `contexts:


### PR DESCRIPTION
### What this PR does / why we need it

Discard or Delete the contexts from config.yaml since it could corrupt the config-ng.yaml because of interlink sync between servers and contexts.

### Solution

- Completely discard/ remove contexts from config.yaml

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #4072 

### Describe testing done for PR
Unit testing and Integration Tests

<!-- Example: Created vSphere workload cluster to verify change. -->
