### PR TITLE
Enable feature-flag for `context-target` by default

### DIFF
--- a/cli/core/docs/cli/cli-architecture.md
+++ b/cli/core/docs/cli/cli-architecture.md
@@ -130,8 +130,6 @@ Earlier, this was distributed between the `tanzu login` command and `tanzu confi
 
 More details regarding Target is available in next section.
 
-Note: This is currently behind a feature flag. To enable the flag please run `tanzu config set features.global.context-target true`
-
 Create a new context:
 
 ```sh

--- a/cli/core/pkg/config/featureflags.go
+++ b/cli/core/pkg/config/featureflags.go
@@ -21,7 +21,7 @@ const (
 	// and the feature will be always enabled
 	FeatureContextAwareCLIForPlugins = "features.global.context-aware-cli-for-plugins"
 	// FeatureContextCommand determines whether to surface the context command. This is disabled by default.
-	FeatureContextCommand = "features.global.context-target"
+	FeatureContextCommand = "features.global.context-target-v2"
 )
 
 // DefaultCliFeatureFlags is used to populate an initially empty config file with default values for feature flags.
@@ -38,7 +38,7 @@ const (
 var (
 	DefaultCliFeatureFlags = map[string]bool{
 		FeatureContextAwareCLIForPlugins: contextAwareDiscoveryEnabled(),
-		FeatureContextCommand:            false,
+		FeatureContextCommand:            true,
 	}
 )
 

--- a/cli/core/pkg/pluginmanager/manager_helper_test.go
+++ b/cli/core/pkg/pluginmanager/manager_helper_test.go
@@ -79,7 +79,7 @@ func setupLocalDistoForTesting() func() {
 		log.Fatal(err, "Error while coping tanzu config next gen file for testing")
 	}
 
-	err = configlib.SetFeature("global", "context-target", "true")
+	err = configlib.SetFeature("global", "context-target-v2", "true")
 	if err != nil {
 		log.Fatal(err, "Error while coping tanzu config file for testing")
 	}

--- a/cli/core/pkg/pluginmanager/manager_test.go
+++ b/cli/core/pkg/pluginmanager/manager_test.go
@@ -87,7 +87,7 @@ func Test_DiscoverPlugins(t *testing.T) {
 		assertions.Equal(expectedDiscoveredPlugins[i].Target, p.Target)
 	}
 
-	err := configlib.SetFeature("global", "context-target", "false")
+	err := configlib.SetFeature("global", "context-target-v2", "false")
 	assertions.Nil(err)
 
 	serverPlugins, standalonePlugins = DiscoverPlugins()


### PR DESCRIPTION
### What this PR does / why we need it

- This PR enables the Context/Target feature-flag by default.

- This change requires rename of the feature-flag to `context-target-v2` to make sure default value gets update in the user's `config.yaml` if `context-target` feature-flag already exists. 
    - This is required because if the feature-flag already exists in `config.yaml` than current logic does not change the value.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #3653

### Describe testing done for PR
- Verified that all the Context/Target related commands/features are enabled and user can use it without configuring any additional feature-flag manually

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Enable Context/Target feature by default
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
