### PR TITLE
Adds logic to handle ingress port for addons-manager on upgrade

### DIFF
--- a/tkg/client/upgrade_cluster.go
+++ b/tkg/client/upgrade_cluster.go
@@ -1188,7 +1188,7 @@ func addAWSIngressrule(regionalClusterClient clusterclient.Client, upgradeCluste
 		return nil
 	}
 	if err := regionalClusterClient.UpdateAWSCNIIngressRules(upgradeClusterConfig.ClusterName, upgradeClusterConfig.ClusterNamespace, newRule); err != nil {
-		log.Infof("unable to update AWS CNI ingress rules for %s/%s kapp-controller: %s", upgradeClusterConfig.ClusterNamespace, upgradeClusterConfig.ClusterName, err.Error())
+		log.Warningf("unable to update AWS CNI ingress rules for %s/%s kapp-controller: %s", upgradeClusterConfig.ClusterNamespace, upgradeClusterConfig.ClusterName, err.Error())
 	}
 	return nil
 }

--- a/tkg/client/upgrade_cluster_test.go
+++ b/tkg/client/upgrade_cluster_test.go
@@ -4,6 +4,7 @@
 package client_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -14,7 +15,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
@@ -973,6 +976,111 @@ var _ = Describe("Unit tests for clusterclass-based upgrade", func() {
 		It("should not return an error", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
+	})
+})
+
+var _ = Describe("Unit test for prepareAddonsManagerUpgrade", func() {
+	var (
+		regionalClusterClient fakes.ClusterClient
+		upgradeClusterConfig  ClusterUpgradeInfo
+		tkgClient             TkgClient
+	)
+	BeforeEach(func() {
+		regionalClusterClient = fakes.ClusterClient{}
+	})
+	When("capa-system namespace is not found", func() {
+		It("Should return no error", func() {
+			regionalClusterClient.GetResourceReturns(apierrors.NewNotFound(schema.GroupResource{Resource: "fake-namespace"}, "fake-cluster"))
+			err := tkgClient.PrepareAddonsManagerUpgrade(&regionalClusterClient, &upgradeClusterConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(regionalClusterClient.UpdateAWSCNIIngressRulesCallCount()).To(Equal(0))
+		})
+	})
+	When("cannot fetch capa-system namespace", func() {
+		It("should return error", func() {
+			regionalClusterClient.GetResourceReturns(fmt.Errorf("some-error"))
+			err := tkgClient.PrepareAddonsManagerUpgrade(&regionalClusterClient, &upgradeClusterConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(regionalClusterClient.UpdateAWSCNIIngressRulesCallCount()).To(Equal(0))
+		})
+	})
+	When("capa-system is present", func() {
+		It("should return no error", func() {})
+		regionalClusterClient.GetResourceReturns(nil)
+		err := tkgClient.PrepareAddonsManagerUpgrade(&regionalClusterClient, &upgradeClusterConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(regionalClusterClient.UpdateAWSCNIIngressRulesCallCount()).To(Equal(1))
+	})
+	When("capa-system is present but can't add ingress rules", func() {
+		It("should return no error", func() {
+			regionalClusterClient.GetResourceReturns(nil)
+			regionalClusterClient.UpdateAWSCNIIngressRulesReturns(fmt.Errorf("some-error"))
+			err := tkgClient.PrepareAddonsManagerUpgrade(&regionalClusterClient, &upgradeClusterConfig)
+			Expect(err).To(HaveOccurred())
+			callcount := regionalClusterClient.UpdateAWSCNIIngressRulesCallCount()
+			Expect(callcount).To(Equal(1))
+		})
+	})
+})
+
+var _ = Describe("Unit test for handleKappControllerUpgrade", func() {
+	var (
+		regionalClusterClient fakes.ClusterClient
+		currentClusterClient  fakes.ClusterClient
+		upgradeClusterConfig  ClusterUpgradeInfo
+		tkgClient             TkgClient
+	)
+	BeforeEach(func() {
+		regionalClusterClient = fakes.ClusterClient{}
+	})
+
+	When("existing kapp-controller cannot be deleted", func() {
+		It("should return error", func() {
+			regionalClusterClient := fakes.ClusterClient{}
+			regionalClusterClient.GetResourceReturns(nil)
+			currentClusterClient.DeleteExistingKappControllerReturns(fmt.Errorf("some-error"))
+			regionalClusterClient.UpdateAWSCNIIngressRulesReturns(fmt.Errorf("some-error"))
+			err := tkgClient.HandleKappControllerUpgrade(&regionalClusterClient, &currentClusterClient, &upgradeClusterConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(regionalClusterClient.UpdateAWSCNIIngressRulesCallCount()).To(Equal(0))
+		})
+	})
+	When("capa-system namespace is not found", func() {
+		It("Should return no error", func() {
+			regionalClusterClient := fakes.ClusterClient{}
+			regionalClusterClient.GetResourceReturns(apierrors.NewNotFound(schema.GroupResource{Resource: "fake-namespace"}, "fake-cluster"))
+			currentClusterClient.DeleteExistingKappControllerReturns(nil)
+			err := tkgClient.HandleKappControllerUpgrade(&regionalClusterClient, &currentClusterClient, &upgradeClusterConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(regionalClusterClient.UpdateAWSCNIIngressRulesCallCount()).To(Equal(0))
+		})
+	})
+	When("cannot fetch capa-system namespace", func() {
+		It("should return error", func() {
+			regionalClusterClient.GetResourceReturns(fmt.Errorf("some-error"))
+			currentClusterClient.DeleteExistingKappControllerReturns(nil)
+			err := tkgClient.HandleKappControllerUpgrade(&regionalClusterClient, &currentClusterClient, &upgradeClusterConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(regionalClusterClient.UpdateAWSCNIIngressRulesCallCount()).To(Equal(0))
+		})
+	})
+	When("capa-system is present", func() {
+		It("should return no error", func() {
+			regionalClusterClient.GetResourceReturns(nil)
+			currentClusterClient.DeleteExistingKappControllerReturns(nil)
+			err := tkgClient.HandleKappControllerUpgrade(&regionalClusterClient, &currentClusterClient, &upgradeClusterConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(regionalClusterClient.UpdateAWSCNIIngressRulesCallCount()).To(Equal(1))
+		})
+	})
+	When("capa-system is present but can't add ingress rules", func() {
+		It("should return no error", func() {})
+		regionalClusterClient.GetResourceReturns(nil)
+		currentClusterClient.DeleteExistingKappControllerReturns(nil)
+		regionalClusterClient.UpdateAWSCNIIngressRulesReturns(fmt.Errorf("some-error"))
+		err := tkgClient.HandleKappControllerUpgrade(&regionalClusterClient, &currentClusterClient, &upgradeClusterConfig)
+		Expect(err).To(HaveOccurred())
+		Expect(regionalClusterClient.UpdateAWSCNIIngressRulesCallCount()).To(Equal(1))
 	})
 })
 

--- a/tkg/client/upgrade_region.go
+++ b/tkg/client/upgrade_region.go
@@ -127,6 +127,17 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 	}
 
 	log.Info("Upgrading management cluster providers...")
+
+	log.Info("Retrieving configuration for upgrade cluster...")
+	upgradeClusterConfig, err := c.getUpgradeClusterConfig(options)
+	if err != nil {
+		return errors.Wrap(err, "unable to retrieve component upgrade info")
+	}
+	err = c.prepareAddonsManagerUpgrade(regionalClusterClient, upgradeClusterConfig)
+	if err != nil {
+		return errors.Wrap(err, "unable to prepare addons manage for upgrade")
+	}
+
 	providersUpgradeClient := providersupgradeclient.New(c.clusterctlClient)
 	if err = c.DoProvidersUpgrade(regionalClusterClient, currentRegion.ContextName, providersUpgradeClient, options); err != nil {
 		return errors.Wrap(err, "failed to upgrade management cluster providers")

--- a/tkg/fakes/clusterclient.go
+++ b/tkg/fakes/clusterclient.go
@@ -9,6 +9,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	v1beta1a "sigs.k8s.io/cluster-api/api/v1beta1"
 	v1alpha3a "sigs.k8s.io/cluster-api/cmd/clusterctl/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
@@ -1058,11 +1059,12 @@ type ClusterClient struct {
 	scalePacificClusterWorkerNodesReturnsOnCall map[int]struct {
 		result1 error
 	}
-	UpdateAWSCNIIngressRulesStub        func(string, string) error
+	UpdateAWSCNIIngressRulesStub        func(string, string, v1beta2.CNIIngressRule) error
 	updateAWSCNIIngressRulesMutex       sync.RWMutex
 	updateAWSCNIIngressRulesArgsForCall []struct {
 		arg1 string
 		arg2 string
+		arg3 v1beta2.CNIIngressRule
 	}
 	updateAWSCNIIngressRulesReturns struct {
 		result1 error
@@ -6344,19 +6346,20 @@ func (fake *ClusterClient) ScalePacificClusterWorkerNodesReturnsOnCall(i int, re
 	}{result1}
 }
 
-func (fake *ClusterClient) UpdateAWSCNIIngressRules(arg1 string, arg2 string) error {
+func (fake *ClusterClient) UpdateAWSCNIIngressRules(arg1 string, arg2 string, arg3 v1beta2.CNIIngressRule) error {
 	fake.updateAWSCNIIngressRulesMutex.Lock()
 	ret, specificReturn := fake.updateAWSCNIIngressRulesReturnsOnCall[len(fake.updateAWSCNIIngressRulesArgsForCall)]
 	fake.updateAWSCNIIngressRulesArgsForCall = append(fake.updateAWSCNIIngressRulesArgsForCall, struct {
 		arg1 string
 		arg2 string
-	}{arg1, arg2})
+		arg3 v1beta2.CNIIngressRule
+	}{arg1, arg2, arg3})
 	stub := fake.UpdateAWSCNIIngressRulesStub
 	fakeReturns := fake.updateAWSCNIIngressRulesReturns
-	fake.recordInvocation("UpdateAWSCNIIngressRules", []interface{}{arg1, arg2})
+	fake.recordInvocation("UpdateAWSCNIIngressRules", []interface{}{arg1, arg2, arg3})
 	fake.updateAWSCNIIngressRulesMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1
@@ -6370,17 +6373,17 @@ func (fake *ClusterClient) UpdateAWSCNIIngressRulesCallCount() int {
 	return len(fake.updateAWSCNIIngressRulesArgsForCall)
 }
 
-func (fake *ClusterClient) UpdateAWSCNIIngressRulesCalls(stub func(string, string) error) {
+func (fake *ClusterClient) UpdateAWSCNIIngressRulesCalls(stub func(string, string, v1beta2.CNIIngressRule) error) {
 	fake.updateAWSCNIIngressRulesMutex.Lock()
 	defer fake.updateAWSCNIIngressRulesMutex.Unlock()
 	fake.UpdateAWSCNIIngressRulesStub = stub
 }
 
-func (fake *ClusterClient) UpdateAWSCNIIngressRulesArgsForCall(i int) (string, string) {
+func (fake *ClusterClient) UpdateAWSCNIIngressRulesArgsForCall(i int) (string, string, v1beta2.CNIIngressRule) {
 	fake.updateAWSCNIIngressRulesMutex.RLock()
 	defer fake.updateAWSCNIIngressRulesMutex.RUnlock()
 	argsForCall := fake.updateAWSCNIIngressRulesArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *ClusterClient) UpdateAWSCNIIngressRulesReturns(result1 error) {


### PR DESCRIPTION
makes adding aws cni ingress rules generic

adds rules for kapp-controller and addons-manager on upgrade

### What this PR does / why we need it
there are scenarios where the necessary aws ingress rules for kapp-controller and addons-manager might not be
present after upgrade. 
This PR ensures the necessary  aws ingress rules are present after cluster upgrade.
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #4083

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
pipeline testing only
### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
adds logic to ensure addons-manager and kapp-controller aws ingress rules are present after upgrade
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
