### PR TITLE
Fix `current` field getting set to tmc context in client config

### DIFF
--- a/cli/runtime/config/contexts.go
+++ b/cli/runtime/config/contexts.go
@@ -80,7 +80,7 @@ func SetContext(c *configapi.Context, setCurrent bool) error {
 	}
 
 	// Set current server
-	if setCurrent {
+	if setCurrent && s.Type == configapi.ManagementClusterServerType {
 		persist, err = setCurrentServer(node, s.Name)
 		if err != nil {
 			return err


### PR DESCRIPTION
### What this PR does / why we need it
- Do not set `current` field to point to TMC context in client config

**Details:**
- `current` field in the config.yaml is meant to be used to just include managment-cluster/k8s context and it should not include tmc context
- For configuring tmc context CLI should use `currentContext.mission-control` field.
- Also, TMC plugins should be using `currentContext.mission-control` to determine the active tmc context.

- This is required for backward compatibility of kubernetes targeted plugins with new context/target functionality


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #4091

### Describe testing done for PR

Tested below commands:
- `tanzu login`
- `tanzu context create` 
- `tanzu context use` 

Above commands should not set the `current` to point to TMC context when creating or setting TMC context and just set it in the `currentContext.mission-control` field.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix `current` field getting set to tmc context in client config (config.yaml)
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
