### PR TITLE
Fix kapp-controller upgrade missing CORE_DNS_IP and tkg-clusterclass-aws upgrade missing AWS_AMI_ID

### DIFF
--- a/tkg/client/init.go
+++ b/tkg/client/init.go
@@ -215,7 +215,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 	// If clusterclass feature flag is enabled then deploy kapp-controller
 	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		log.Info("Installing kapp-controller on bootstrap cluster...")
-		if err = c.InstallOrUpgradeKappController(bootStrapClusterClient, constants.OperationTypeInstall); err != nil {
+		if err = c.InstallOrUpgradeKappController(bootStrapClusterClient, constants.OperationTypeInstall, false); err != nil {
 			return errors.Wrap(err, "unable to install kapp-controller to bootstrap cluster")
 		}
 	}
@@ -333,7 +333,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 	// If clusterclass feature flag is enabled then deploy kapp-controller
 	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		log.Info("Installing kapp-controller on management cluster...")
-		if err = c.InstallOrUpgradeKappController(regionalClusterClient, constants.OperationTypeInstall); err != nil {
+		if err = c.InstallOrUpgradeKappController(regionalClusterClient, constants.OperationTypeInstall, false); err != nil {
 			return errors.Wrap(err, "unable to install kapp-controller to management cluster")
 		}
 	}
@@ -525,7 +525,7 @@ func (c *TkgClient) ApplyClusterBootstrapObjects(fromClusterClient, toClusterCli
 	clusterBootstrapTemplatesDirPath := filepath.Join(path, "yttcb")
 	configDefaultPath := filepath.Join(path, "config_default.yaml")
 
-	userConfigValuesFile, err := c.getUserConfigVariableValueMapFile()
+	userConfigValuesFile, err := c.getUserConfigVariableValueMapFile(toClusterClient, false)
 	if err != nil {
 		return err
 	}

--- a/tkg/client/upgrade_addon.go
+++ b/tkg/client/upgrade_addon.go
@@ -292,10 +292,6 @@ func (c *TkgClient) RetrieveRegionalClusterConfiguration(regionalClusterClient c
 		return errors.Wrap(err, "error while initializing networking configuration")
 	}
 
-	// config CORE_DNS_IP for kapp-controller update
-	if err := c.configureAndValidateCoreDNSIP(); err != nil {
-		return errors.Wrap(err, "error while initializing networking configuration")
-	}
 	return nil
 }
 

--- a/tkg/client/upgrade_addon.go
+++ b/tkg/client/upgrade_addon.go
@@ -291,6 +291,11 @@ func (c *TkgClient) RetrieveRegionalClusterConfiguration(regionalClusterClient c
 	if err := c.setNetworkingConfiguration(regionalClusterClient, clusterName, regionalClusterNamespace); err != nil {
 		return errors.Wrap(err, "error while initializing networking configuration")
 	}
+
+	// config CORE_DNS_IP for kapp-controller update
+	if err := c.configureAndValidateCoreDNSIP(); err != nil {
+		return errors.Wrap(err, "error while initializing networking configuration")
+	}
 	return nil
 }
 

--- a/tkg/client/upgrade_region.go
+++ b/tkg/client/upgrade_region.go
@@ -146,7 +146,7 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 	// If clusterclass feature flag is enabled then deploy management components
 	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		log.Info("Upgrading kapp-controller...")
-		if err = c.InstallOrUpgradeKappController(regionalClusterClient, constants.OperationTypeUpgrade); err != nil {
+		if err = c.InstallOrUpgradeKappController(regionalClusterClient, constants.OperationTypeUpgrade, true); err != nil {
 			return errors.Wrap(err, "unable to upgrade kapp-controller")
 		}
 		log.Info("Removing old management components...")


### PR DESCRIPTION
### What this PR does / why we need it
1. kapp-controller
During mgmt cluster upgrade, the func `InstallOrUpgradeKappController` is reused to upgrade the kapp-controller. But this func seems designed for cluster creation, which means all the default and user’s configurations have already generated and stored in TKGConfigReaderWriter . But in upgrade case the configurations are not stored locally but should be retrieved from the existing cluster before cluster upgrade in [configureVariablesForProvidersInstallation](https://github.com/vmware-tanzu/tanzu-framework/blob/99a8d0fafe246e6c395994d093774da5926c3fe7/tkg/client/upgrade_region.go#L235-L283) first to store the required fields in local TKGConfigReaderWriter .
Currently some of the kapp-controller input values like CORE_DNS_IP are not retrieved during mgmt cluster upgrade, which leads to the kapp-controller mis-configured. All kapp-controller required fields:
https://github.com/vmware-tanzu/tanzu-framework/blob/8df9dd7953c38988793651434f40530507407944/providers/kapp-controller-values/values.yaml

2. tkg-clusterclass-aws
The `AWS_AMI_ID` configuration for aws-clusterclass-package is missing during cluster upgrade.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
1. Add ut and passed locally

2. Created a tkg 1.6.0 env and manually build tanzu cli to upgrade.
- The mgmt and wl cluster upgrade are passed. 
- CORE_DNS_IP and AWS_AMI_ID are exist in the tkg-pkg-tkg-system-values secret. 
- The kapp-controller received the CORE_DNS_IP during upgrade.


<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
