### PR TITLE
Support specifying extraArgs for kubelet/scheduler/apiserver/controllermanager

### DIFF
--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
@@ -53,6 +53,46 @@ spec:
         additionalProperties:
           type: string
         default: {}
+  - name: apiServerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: kubeSchedulerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: kubeControllerManagerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: controlPlaneKubeletExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: workerKubeletExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
   - name: tlsCipherSuites
     required: false
     schema:
@@ -329,6 +369,167 @@ spec:
             {{- end }}
             {{- if not $containCipherSuites }}
             cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+  - name: apiServerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .apiServerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: aws
+            {{- end }}
+  - name: kubeSchedulerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/scheduler/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{- range $key, $val := .kubeSchedulerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+  - name: kubeControllerManagerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .kubeControllerManagerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: aws
+            {{- end }}
+  - name: controlPlaneKubeletExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .controlPlaneKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: aws
+            {{- end }}
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .controlPlaneKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: aws
+            {{- end }}
+  - name: workerKubeletExtraArgs
+    definitions:
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - "tkg-worker"
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .workerKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: aws
             {{- end }}
   - name: AWSCT_main
     definitions:
@@ -1190,13 +1391,9 @@ spec:
           apiServer:
             timeoutForControlPlane: "8m0s"
             extraVolumes: []
-            extraArgs:
-              cloud-provider: aws
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+            extraArgs: {}
           controllerManager:
-            extraArgs:
-              cloud-provider: aws
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            extraArgs: {}
           dns:
             imageRepository: dummy.registry.vmware.com
             imageTag: 1.8.4_dummy.5
@@ -1208,22 +1405,17 @@ spec:
               extraArgs: {}
           imageRepository: dummy.registry.vmware.com
           scheduler:
-            extraArgs:
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            extraArgs: {}
         initConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
             name: '{{ ds.meta_data.local_hostname }}'
-            kubeletExtraArgs:
-              cloud-provider: aws
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            kubeletExtraArgs: {}
         joinConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
             name: '{{ ds.meta_data.local_hostname }}'
-            kubeletExtraArgs:
-              cloud-provider: aws
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            kubeletExtraArgs: {}
 ---
 kind: AWSMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
@@ -1270,9 +1462,7 @@ spec:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
           name: '{{ ds.meta_data.local_hostname }}'
-          kubeletExtraArgs:
-            cloud-provider: aws
-            tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+          kubeletExtraArgs: {}
       files:
       - path: /tmp/empty.txt
         owner: "root:root"

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -53,6 +53,46 @@ spec:
         additionalProperties:
           type: string
         default: {}
+  - name: apiServerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: kubeSchedulerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: kubeControllerManagerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: controlPlaneKubeletExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: workerKubeletExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
   - name: tlsCipherSuites
     required: false
     schema:
@@ -398,6 +438,237 @@ spec:
             {{- end }}
             {{- if not $containQuotaBackendBytes }}
             quota-backend-bytes: "8589934592"
+            {{- end }}
+  - name: kubeControllerManagerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containAllocateNodeCidrs := false }}
+            {{ $containCloudConfig := false }}
+            {{ $containCloudProvider := false }}
+            {{ $containClusterName := false }}
+            {{- range $key, $val := .kubeControllerManagerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "allocate-node-cidrs" }}
+              {{- $containAllocateNodeCidrs = true }}
+            {{- end }}
+            {{- if eq $key "cloud-config" }}
+              {{- $containCloudConfig = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{- if eq $key "cluster-name" }}
+              {{- $containClusterName = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containAllocateNodeCidrs }}
+            allocate-node-cidrs: "true"
+            {{- end }}
+            {{- if not $containCloudConfig }}
+            cloud-config: /etc/kubernetes/azure.json
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: azure
+            {{- end }}
+            {{- if not $containClusterName }}
+            cluster-name: ${CLUSTER_NAME}
+            {{- end }}
+  - name: apiServerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudConfig := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .apiServerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-config" }}
+              {{- $containCloudConfig = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudConfig }}
+            cloud-config: /etc/kubernetes/azure.json
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: azure
+            {{- end }}
+  - name: kubeSchedulerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/scheduler/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{- range $key, $val := .kubeSchedulerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+  - name: controlPlaneKubeletExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudConfig := false }}
+            {{ $containCloudProvider := false }}
+            {{ $containContainerRegistConf := false }}
+            {{- range $key, $val := .controlPlaneKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-config" }}
+              {{- $containCloudConfig = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{- if eq $key "azure-container-registry-config" }}
+              {{- $containContainerRegistConf = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudConfig }}
+            cloud-config: /etc/kubernetes/azure.json
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: azure
+            {{- end }}
+            {{- if not $containContainerRegistConf }}
+            azure-container-registry-config: /etc/kubernetes/azure.json
+            {{- end }}
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudConfig := false }}
+            {{ $containCloudProvider := false }}
+            {{ $containContainerRegistConf := false }}
+            {{- range $key, $val := .controlPlaneKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-config" }}
+              {{- $containCloudConfig = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{- if eq $key "azure-container-registry-config" }}
+              {{- $containContainerRegistConf = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudConfig }}
+            cloud-config: /etc/kubernetes/azure.json
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: azure
+            {{- end }}
+            {{- if not $containContainerRegistConf }}
+            azure-container-registry-config: /etc/kubernetes/azure.json
+            {{- end }}
+  - name: workerKubeletExtraArgs
+    definitions:
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudConfig := false }}
+            {{ $containCloudProvider := false }}
+            {{ $containContainerRegistConf := false }}
+            {{- range $key, $val := .workerKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-config" }}
+              {{- $containCloudConfig = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{- if eq $key "azure-container-registry-config" }}
+              {{- $containContainerRegistConf = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudConfig }}
+            cloud-config: /etc/kubernetes/azure.json
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: azure
+            {{- end }}
+            {{- if not $containContainerRegistConf }}
+            azure-container-registry-config: /etc/kubernetes/azure.json
             {{- end }}
   - name: AzureClusterCustomTags
     enabledIf: '{{ not (empty .customTags) }}'
@@ -1221,25 +1492,20 @@ spec:
           controlPlane: true
       jsonPatches:
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-path: /var/log/kubernetes/audit.log
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-path
+        value: /var/log/kubernetes/audit.log
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-policy-file: /etc/kubernetes/audit-policy.yaml
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-policy-file
+        value: /etc/kubernetes/audit-policy.yaml
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-maxage: "30"
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-maxage
+        value: "30"
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-maxbackup: "10"
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-maxbackup
+        value: "10"
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-maxsize: "100"
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-maxsize
+        value: "100"
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes/-
         value:
@@ -1453,17 +1719,13 @@ spec:
       kubeadmConfigSpec:
         clusterConfiguration:
           apiServer:
-            extraArgs:
-              cloud-config: /etc/kubernetes/azure.json
-              cloud-provider: azure
+            extraArgs: {}
             extraVolumes: []
             timeoutForControlPlane: 20m
+          scheduler:
+            extraArgs: {}
           controllerManager:
-            extraArgs:
-              allocate-node-cidrs: "true"
-              cloud-config: /etc/kubernetes/azure.json
-              cloud-provider: azure
-              cluster-name: ${CLUSTER_NAME}
+            extraArgs: {}
             extraVolumes:
             - hostPath: /etc/kubernetes/azure.json
               mountPath: /etc/kubernetes/azure.json
@@ -1505,18 +1767,12 @@ spec:
         initConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              azure-container-registry-config: /etc/kubernetes/azure.json
-              cloud-config: /etc/kubernetes/azure.json
-              cloud-provider: azure
+            kubeletExtraArgs: {}
             name: '{{ ds.meta_data["local_hostname"] }}'
         joinConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              azure-container-registry-config: /etc/kubernetes/azure.json
-              cloud-config: /etc/kubernetes/azure.json
-              cloud-provider: azure
+            kubeletExtraArgs: {}
             name: '{{ ds.meta_data["local_hostname"] }}'
         mounts:
         - - LABEL=etcd_disk
@@ -1582,10 +1838,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
-          kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
+          kubeletExtraArgs: {}
           name: '{{ ds.meta_data["local_hostname"] }}'
       useExperimentalRetryJoin: true
       preKubeadmCommands:

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -85,16 +85,11 @@ spec:
           apiServer:
             timeoutForControlPlane: "8m0s"
             extraVolumes: []
-            extraArgs:
-              cloud-provider: external
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            extraArgs: {}
           controllerManager:
-            extraArgs:
-              cloud-provider: external
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            extraArgs: {}
           scheduler:
-            extraArgs:
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            extraArgs: {}
         files:
         - path: /tmp/empty.txt
           owner: "root:root"
@@ -104,16 +99,12 @@ spec:
         initConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              cloud-provider: external
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            kubeletExtraArgs: {}
             name: '{{ ds.meta_data.hostname }}'
         joinConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              cloud-provider: external
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            kubeletExtraArgs: {}
             name: '{{ ds.meta_data.hostname }}'
         preKubeadmCommands:
         - hostname "{{ ds.meta_data.hostname }}"
@@ -139,9 +130,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
-          kubeletExtraArgs:
-            cloud-provider: external
-            tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+          kubeletExtraArgs: {}
           name: '{{ ds.meta_data.hostname }}'
       preKubeadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
@@ -524,6 +513,46 @@ spec:
         additionalProperties:
           type: string
         default: {}
+  - name: apiServerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: kubeSchedulerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: kubeControllerManagerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: controlPlaneKubeletExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: workerKubeletExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
   - name: tlsCipherSuites
     required: false
     schema:
@@ -582,6 +611,168 @@ spec:
             {{- end }}
             {{- if not $containCipherSuites }}
             cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+  - name: apiServerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .apiServerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: external
+            {{- end }}
+  - name: kubeSchedulerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/scheduler/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{- range $key, $val := .kubeSchedulerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+  - name: kubeControllerManagerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .kubeControllerManagerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: external
+            {{- end }}
+  - name: controlPlaneKubeletExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .controlPlaneKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: external
+            {{- end }}
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .controlPlaneKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: external
+            {{- end }}
+  - name: workerKubeletExtraArgs
+    definitions:
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+            - tkg-worker-windows
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .workerKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: external
             {{- end }}
   - name: vsphereClusterTemplate
     definitions:
@@ -1448,25 +1639,20 @@ spec:
           controlPlane: true
       jsonPatches:
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-path: /var/log/kubernetes/audit.log
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-path
+        value: /var/log/kubernetes/audit.log
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-policy-file: /etc/kubernetes/audit-policy.yaml
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-policy-file
+        value: /etc/kubernetes/audit-policy.yaml
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-maxage: "30"
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-maxage
+        value: "30"
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-maxbackup: "10"
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-maxbackup
+        value: "10"
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-maxsize: "100"
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-maxsize
+        value: "100"
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes/-
         value:

--- a/providers/config_default.yaml
+++ b/providers/config_default.yaml
@@ -71,6 +71,31 @@ BUILD_EDITION:
 #! E.g. "heartbeat-interval=300;election-timeout=2000"
 ETCD_EXTRA_ARGS:
 
+#! APISERVER_EXTRA_ARGS specified kube api server flags.
+#! It should be of the format "key1=value1;key2=value2".
+#! E.g. "tls-min-version=VersionTLS12;tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+APISERVER_EXTRA_ARGS:
+
+#! KUBE_SCHEDULER_EXTRA_ARGS specified kube scheduler flags.
+#! It should be of the format "key1=value1;key2=value2".
+#! E.g. "tls-min-version=VersionTLS12;profiling=false"
+KUBE_SCHEDULER_EXTRA_ARGS:
+
+#! KUBE_CONTROLLER_MANAGER_EXTRA_ARGS specified kube controller manager flags.
+#! It should be of the format "key1=value1;key2=value2".
+#! E.g. "tls-min-version=VersionTLS12;profiling=false"
+KUBE_CONTROLLER_MANAGER_EXTRA_ARGS:
+
+#! CONTROLPLANE_KUBELET_EXTRA_ARGS specified kubelet flags for control plane nodes.
+#! It should be of the format "key1=value1;key2=value2".
+#! E.g. "heartbeat-interval=300;election-timeout=2000"
+CONTROLPLANE_KUBELET_EXTRA_ARGS:
+
+#! WORKER_KUBELET_EXTRA_ARGS specified kubelet flags for worker nodes.
+#! It should be of the format "key1=value1;key2=value2".
+#! E.g. "read-only-port=0;event-qps=0"
+WORKER_KUBELET_EXTRA_ARGS:
+
 #! ---------------------------------------------------------------------
 #! Settings for vSphere infrastructure provider
 #! ---------------------------------------------------------------------

--- a/providers/config_default.yaml
+++ b/providers/config_default.yaml
@@ -88,7 +88,7 @@ KUBE_CONTROLLER_MANAGER_EXTRA_ARGS:
 
 #! CONTROLPLANE_KUBELET_EXTRA_ARGS specified kubelet flags for control plane nodes.
 #! It should be of the format "key1=value1;key2=value2".
-#! E.g. "heartbeat-interval=300;election-timeout=2000"
+#! E.g. "read-only-port=0;event-qps=0"
 CONTROLPLANE_KUBELET_EXTRA_ARGS:
 
 #! WORKER_KUBELET_EXTRA_ARGS specified kubelet flags for worker nodes.

--- a/providers/infrastructure-aws/v2.0.2/cconly/base.yaml
+++ b/providers/infrastructure-aws/v2.0.2/cconly/base.yaml
@@ -53,6 +53,46 @@ spec:
         additionalProperties:
           type: string
         default: {}
+  - name: apiServerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: kubeSchedulerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: kubeControllerManagerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: controlPlaneKubeletExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: workerKubeletExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
   - name: tlsCipherSuites
     required: false
     schema:
@@ -329,6 +369,167 @@ spec:
             {{- end }}
             {{- if not $containCipherSuites }}
             cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+  - name: apiServerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .apiServerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: aws
+            {{- end }}
+  - name: kubeSchedulerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/scheduler/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{- range $key, $val := .kubeSchedulerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+  - name: kubeControllerManagerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .kubeControllerManagerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: aws
+            {{- end }}
+  - name: controlPlaneKubeletExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .controlPlaneKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: aws
+            {{- end }}
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .controlPlaneKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: aws
+            {{- end }}
+  - name: workerKubeletExtraArgs
+    definitions:
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - "tkg-worker"
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .workerKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: aws
             {{- end }}
   - name: AWSCT_main
     definitions:
@@ -1190,13 +1391,9 @@ spec:
           apiServer:
             timeoutForControlPlane: "8m0s"
             extraVolumes: []
-            extraArgs:
-              cloud-provider: aws
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
+            extraArgs: {}
           controllerManager:
-            extraArgs:
-              cloud-provider: aws
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            extraArgs: {}
           dns:
             imageRepository: dummy.registry.vmware.com
             imageTag: 1.8.4_dummy.5
@@ -1208,22 +1405,17 @@ spec:
               extraArgs: {}
           imageRepository: dummy.registry.vmware.com
           scheduler:
-            extraArgs:
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            extraArgs: {}
         initConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
             name: '{{ ds.meta_data.local_hostname }}'
-            kubeletExtraArgs:
-              cloud-provider: aws
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            kubeletExtraArgs: {}
         joinConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
             name: '{{ ds.meta_data.local_hostname }}'
-            kubeletExtraArgs:
-              cloud-provider: aws
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            kubeletExtraArgs: {}
 ---
 kind: AWSMachineTemplate
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta2
@@ -1270,9 +1462,7 @@ spec:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
           name: '{{ ds.meta_data.local_hostname }}'
-          kubeletExtraArgs:
-            cloud-provider: aws
-            tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+          kubeletExtraArgs: {}
       files:
       - path: /tmp/empty.txt
         owner: "root:root"

--- a/providers/infrastructure-aws/v2.0.2/yttcc/overlay.yaml
+++ b/providers/infrastructure-aws/v2.0.2/yttcc/overlay.yaml
@@ -109,7 +109,7 @@ spec:
     variables:
     #@ vars = get_aws_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["etcdExtraArgs", "region", "sshKeyName", "bastion", "network", "controlPlane", "worker", "loadBalancerSchemeInternal", "identityRef", "imageRepository", "trust", "auditLogging", "cni", "TKR_DATA", "proxy", "controlPlaneCertificateRotation"]:
+    #@  if vars[configVariable] != None and configVariable in ["workerKubeletExtraArgs","controlPlaneKubeletExtraArgs","kubeControllerManagerExtraArgs","kubeSchedulerExtraArgs","apiServerExtraArgs","etcdExtraArgs", "region", "sshKeyName", "bastion", "network", "controlPlane", "worker", "loadBalancerSchemeInternal", "identityRef", "imageRepository", "trust", "auditLogging", "cni", "TKR_DATA", "proxy", "controlPlaneCertificateRotation"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
+++ b/providers/infrastructure-azure/v1.5.3/cconly/base.yaml
@@ -53,6 +53,46 @@ spec:
         additionalProperties:
           type: string
         default: {}
+  - name: apiServerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: kubeSchedulerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: kubeControllerManagerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: controlPlaneKubeletExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: workerKubeletExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
   - name: tlsCipherSuites
     required: false
     schema:
@@ -398,6 +438,237 @@ spec:
             {{- end }}
             {{- if not $containQuotaBackendBytes }}
             quota-backend-bytes: "8589934592"
+            {{- end }}
+  - name: kubeControllerManagerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containAllocateNodeCidrs := false }}
+            {{ $containCloudConfig := false }}
+            {{ $containCloudProvider := false }}
+            {{ $containClusterName := false }}
+            {{- range $key, $val := .kubeControllerManagerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "allocate-node-cidrs" }}
+              {{- $containAllocateNodeCidrs = true }}
+            {{- end }}
+            {{- if eq $key "cloud-config" }}
+              {{- $containCloudConfig = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{- if eq $key "cluster-name" }}
+              {{- $containClusterName = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containAllocateNodeCidrs }}
+            allocate-node-cidrs: "true"
+            {{- end }}
+            {{- if not $containCloudConfig }}
+            cloud-config: /etc/kubernetes/azure.json
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: azure
+            {{- end }}
+            {{- if not $containClusterName }}
+            cluster-name: ${CLUSTER_NAME}
+            {{- end }}
+  - name: apiServerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudConfig := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .apiServerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-config" }}
+              {{- $containCloudConfig = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudConfig }}
+            cloud-config: /etc/kubernetes/azure.json
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: azure
+            {{- end }}
+  - name: kubeSchedulerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/scheduler/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{- range $key, $val := .kubeSchedulerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+  - name: controlPlaneKubeletExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudConfig := false }}
+            {{ $containCloudProvider := false }}
+            {{ $containContainerRegistConf := false }}
+            {{- range $key, $val := .controlPlaneKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-config" }}
+              {{- $containCloudConfig = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{- if eq $key "azure-container-registry-config" }}
+              {{- $containContainerRegistConf = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudConfig }}
+            cloud-config: /etc/kubernetes/azure.json
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: azure
+            {{- end }}
+            {{- if not $containContainerRegistConf }}
+            azure-container-registry-config: /etc/kubernetes/azure.json
+            {{- end }}
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudConfig := false }}
+            {{ $containCloudProvider := false }}
+            {{ $containContainerRegistConf := false }}
+            {{- range $key, $val := .controlPlaneKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-config" }}
+              {{- $containCloudConfig = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{- if eq $key "azure-container-registry-config" }}
+              {{- $containContainerRegistConf = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudConfig }}
+            cloud-config: /etc/kubernetes/azure.json
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: azure
+            {{- end }}
+            {{- if not $containContainerRegistConf }}
+            azure-container-registry-config: /etc/kubernetes/azure.json
+            {{- end }}
+  - name: workerKubeletExtraArgs
+    definitions:
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudConfig := false }}
+            {{ $containCloudProvider := false }}
+            {{ $containContainerRegistConf := false }}
+            {{- range $key, $val := .workerKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-config" }}
+              {{- $containCloudConfig = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{- if eq $key "azure-container-registry-config" }}
+              {{- $containContainerRegistConf = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudConfig }}
+            cloud-config: /etc/kubernetes/azure.json
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: azure
+            {{- end }}
+            {{- if not $containContainerRegistConf }}
+            azure-container-registry-config: /etc/kubernetes/azure.json
             {{- end }}
   - name: AzureClusterCustomTags
     enabledIf: '{{ not (empty .customTags) }}'
@@ -1221,25 +1492,20 @@ spec:
           controlPlane: true
       jsonPatches:
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-path: /var/log/kubernetes/audit.log
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-path
+        value: /var/log/kubernetes/audit.log
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-policy-file: /etc/kubernetes/audit-policy.yaml
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-policy-file
+        value: /etc/kubernetes/audit-policy.yaml
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-maxage: "30"
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-maxage
+        value: "30"
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-maxbackup: "10"
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-maxbackup
+        value: "10"
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-maxsize: "100"
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-maxsize
+        value: "100"
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes/-
         value:
@@ -1453,17 +1719,13 @@ spec:
       kubeadmConfigSpec:
         clusterConfiguration:
           apiServer:
-            extraArgs:
-              cloud-config: /etc/kubernetes/azure.json
-              cloud-provider: azure
+            extraArgs: {}
             extraVolumes: []
             timeoutForControlPlane: 20m
+          scheduler:
+            extraArgs: {}
           controllerManager:
-            extraArgs:
-              allocate-node-cidrs: "true"
-              cloud-config: /etc/kubernetes/azure.json
-              cloud-provider: azure
-              cluster-name: ${CLUSTER_NAME}
+            extraArgs: {}
             extraVolumes:
             - hostPath: /etc/kubernetes/azure.json
               mountPath: /etc/kubernetes/azure.json
@@ -1505,18 +1767,12 @@ spec:
         initConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              azure-container-registry-config: /etc/kubernetes/azure.json
-              cloud-config: /etc/kubernetes/azure.json
-              cloud-provider: azure
+            kubeletExtraArgs: {}
             name: '{{ ds.meta_data["local_hostname"] }}'
         joinConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              azure-container-registry-config: /etc/kubernetes/azure.json
-              cloud-config: /etc/kubernetes/azure.json
-              cloud-provider: azure
+            kubeletExtraArgs: {}
             name: '{{ ds.meta_data["local_hostname"] }}'
         mounts:
         - - LABEL=etcd_disk
@@ -1582,10 +1838,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
-          kubeletExtraArgs:
-            azure-container-registry-config: /etc/kubernetes/azure.json
-            cloud-config: /etc/kubernetes/azure.json
-            cloud-provider: azure
+          kubeletExtraArgs: {}
           name: '{{ ds.meta_data["local_hostname"] }}'
       useExperimentalRetryJoin: true
       preKubeadmCommands:

--- a/providers/infrastructure-azure/v1.5.3/yttcc/overlay.yaml
+++ b/providers/infrastructure-azure/v1.5.3/yttcc/overlay.yaml
@@ -139,7 +139,7 @@ spec:
     variables:
     #@ vars = get_azure_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["etcdExtraArgs", "location", "network", "controlPlane", "worker", "resourceGroup", "subscriptionID", "identityRef", "clusterRole", "environment", "sshPublicKey", "acceleratedNetworking", "privateCluster", "frontendPrivateIP", "imageRepository", "auditLogging", "customTags", "apiServerPort", "trust", "TKR_DATA", "proxy", "controlPlaneCertificateRotation"]:
+    #@  if vars[configVariable] != None and configVariable in ["workerKubeletExtraArgs","controlPlaneKubeletExtraArgs","kubeControllerManagerExtraArgs","kubeSchedulerExtraArgs","apiServerExtraArgs","etcdExtraArgs", "location", "network", "controlPlane", "worker", "resourceGroup", "subscriptionID", "identityRef", "clusterRole", "environment", "sshPublicKey", "acceleratedNetworking", "privateCluster", "frontendPrivateIP", "imageRepository", "auditLogging", "customTags", "apiServerPort", "trust", "TKR_DATA", "proxy", "controlPlaneCertificateRotation"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
@@ -85,16 +85,11 @@ spec:
           apiServer:
             timeoutForControlPlane: "8m0s"
             extraVolumes: []
-            extraArgs:
-              cloud-provider: external
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            extraArgs: {}
           controllerManager:
-            extraArgs:
-              cloud-provider: external
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            extraArgs: {}
           scheduler:
-            extraArgs:
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            extraArgs: {}
         files:
         - path: /tmp/empty.txt
           owner: "root:root"
@@ -104,16 +99,12 @@ spec:
         initConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              cloud-provider: external
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            kubeletExtraArgs: {}
             name: '{{ ds.meta_data.hostname }}'
         joinConfiguration:
           nodeRegistration:
             criSocket: /var/run/containerd/containerd.sock
-            kubeletExtraArgs:
-              cloud-provider: external
-              tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+            kubeletExtraArgs: {}
             name: '{{ ds.meta_data.hostname }}'
         preKubeadmCommands:
         - hostname "{{ ds.meta_data.hostname }}"
@@ -139,9 +130,7 @@ spec:
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
-          kubeletExtraArgs:
-            cloud-provider: external
-            tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+          kubeletExtraArgs: {}
           name: '{{ ds.meta_data.hostname }}'
       preKubeadmCommands:
       - hostname "{{ ds.meta_data.hostname }}"
@@ -524,6 +513,46 @@ spec:
         additionalProperties:
           type: string
         default: {}
+  - name: apiServerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: kubeSchedulerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: kubeControllerManagerExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: controlPlaneKubeletExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
+  - name: workerKubeletExtraArgs
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        additionalProperties:
+          type: string
+        default: {}
   - name: tlsCipherSuites
     required: false
     schema:
@@ -582,6 +611,168 @@ spec:
             {{- end }}
             {{- if not $containCipherSuites }}
             cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+  - name: apiServerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .apiServerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: external
+            {{- end }}
+  - name: kubeSchedulerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/scheduler/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{- range $key, $val := .kubeSchedulerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+  - name: kubeControllerManagerExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/controllerManager/extraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .kubeControllerManagerExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: external
+            {{- end }}
+  - name: controlPlaneKubeletExtraArgs
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/initConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .controlPlaneKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: external
+            {{- end }}
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .controlPlaneKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: external
+            {{- end }}
+  - name: workerKubeletExtraArgs
+    definitions:
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+            - tkg-worker-windows
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs
+        valueFrom:
+          template: |
+            {{ $containCipherSuites := false }}
+            {{ $containCloudProvider := false }}
+            {{- range $key, $val := .workerKubeletExtraArgs }}
+            {{- if eq $key "tls-cipher-suites" }}
+              {{- $containCipherSuites = true }}
+            {{- end }}
+            {{- if eq $key "cloud-provider" }}
+              {{- $containCloudProvider = true }}
+            {{- end }}
+            {{ $key -}} : "{{ $val }}"
+            {{- end }}
+            {{- if not $containCipherSuites }}
+            tls-cipher-suites: "{{ .tlsCipherSuites }}"
+            {{- end }}
+            {{- if not $containCloudProvider }}
+            cloud-provider: external
             {{- end }}
   - name: vsphereClusterTemplate
     definitions:
@@ -1448,25 +1639,20 @@ spec:
           controlPlane: true
       jsonPatches:
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-path: /var/log/kubernetes/audit.log
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-path
+        value: /var/log/kubernetes/audit.log
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-policy-file: /etc/kubernetes/audit-policy.yaml
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-policy-file
+        value: /etc/kubernetes/audit-policy.yaml
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-maxage: "30"
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-maxage
+        value: "30"
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-maxbackup: "10"
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-maxbackup
+        value: "10"
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/-
-        value:
-          audit-log-maxsize: "100"
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/audit-log-maxsize
+        value: "100"
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraVolumes/-
         value:

--- a/providers/infrastructure-vsphere/v1.5.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/yttcc/overlay.yaml
@@ -137,7 +137,7 @@ spec:
     variables:
     #@ vars = get_vsphere_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["etcdExtraArgs", "apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider", "additionalFQDN", "controlPlaneCertificateRotation"]:
+    #@  if vars[configVariable] != None and configVariable in ["workerKubeletExtraArgs","controlPlaneKubeletExtraArgs","kubeControllerManagerExtraArgs","kubeSchedulerExtraArgs","apiServerExtraArgs","etcdExtraArgs", "apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider", "additionalFQDN", "controlPlaneCertificateRotation"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/providers/yttcc/lib/config_variable_association.star
+++ b/providers/yttcc/lib/config_variable_association.star
@@ -126,6 +126,11 @@ return {
 "NODE_POOL_0_TAINTS": ["tkg-service-vsphere"],
 "CONTROL_PLANE_NODE_LABELS": ["vsphere", "aws", "azure"],
 "ETCD_EXTRA_ARGS": ["vsphere", "aws", "azure"],
+"APISERVER_EXTRA_ARGS": ["vsphere", "aws", "azure"],
+"KUBE_SCHEDULER_EXTRA_ARGS": ["vsphere", "aws", "azure"],
+"KUBE_CONTROLLER_MANAGER_EXTRA_ARGS": ["vsphere", "aws", "azure"],
+"CONTROLPLANE_KUBELET_EXTRA_ARGS": ["vsphere", "aws", "azure"],
+"WORKER_KUBELET_EXTRA_ARGS": ["vsphere", "aws", "azure"],
 
 "AZURE_ENVIRONMENT": ["azure"],
 "AZURE_TENANT_ID": ["azure"],
@@ -596,6 +601,21 @@ def get_aws_vars():
     if data.values["ETCD_EXTRA_ARGS"] != None:
         vars["etcdExtraArgs"] = get_extra_args_map_from_string(data.values["ETCD_EXTRA_ARGS"])
     end
+    if data.values["APISERVER_EXTRA_ARGS"] != None:
+        vars["apiServerExtraArgs"] = get_extra_args_map_from_string(data.values["APISERVER_EXTRA_ARGS"])
+    end
+    if data.values["KUBE_SCHEDULER_EXTRA_ARGS"] != None:
+        vars["kubeSchedulerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_SCHEDULER_EXTRA_ARGS"])
+    end
+    if data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"] != None:
+        vars["kubeControllerManagerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"])
+    end
+    if data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"] != None:
+        vars["controlPlaneKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"])
+    end
+    if data.values["WORKER_KUBELET_EXTRA_ARGS"] != None:
+        vars["workerKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["WORKER_KUBELET_EXTRA_ARGS"])
+    end
 
     controlPlane = {}
     if data.values["CONTROL_PLANE_MACHINE_TYPE"] != None:
@@ -732,6 +752,21 @@ def get_azure_vars():
 
     if data.values["ETCD_EXTRA_ARGS"] != None:
         vars["etcdExtraArgs"] = get_extra_args_map_from_string(data.values["ETCD_EXTRA_ARGS"])
+    end
+    if data.values["APISERVER_EXTRA_ARGS"] != None:
+        vars["apiServerExtraArgs"] = get_extra_args_map_from_string(data.values["APISERVER_EXTRA_ARGS"])
+    end
+    if data.values["KUBE_SCHEDULER_EXTRA_ARGS"] != None:
+        vars["kubeSchedulerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_SCHEDULER_EXTRA_ARGS"])
+    end
+    if data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"] != None:
+        vars["kubeControllerManagerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"])
+    end
+    if data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"] != None:
+        vars["controlPlaneKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"])
+    end
+    if data.values["WORKER_KUBELET_EXTRA_ARGS"] != None:
+        vars["workerKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["WORKER_KUBELET_EXTRA_ARGS"])
     end
 
     worker = {}
@@ -872,6 +907,21 @@ def get_vsphere_vars():
 
     if data.values["ETCD_EXTRA_ARGS"] != None:
         vars["etcdExtraArgs"] = get_extra_args_map_from_string(data.values["ETCD_EXTRA_ARGS"])
+    end
+    if data.values["APISERVER_EXTRA_ARGS"] != None:
+        vars["apiServerExtraArgs"] = get_extra_args_map_from_string(data.values["APISERVER_EXTRA_ARGS"])
+    end
+    if data.values["KUBE_SCHEDULER_EXTRA_ARGS"] != None:
+        vars["kubeSchedulerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_SCHEDULER_EXTRA_ARGS"])
+    end
+    if data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"] != None:
+        vars["kubeControllerManagerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"])
+    end
+    if data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"] != None:
+        vars["controlPlaneKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"])
+    end
+    if data.values["WORKER_KUBELET_EXTRA_ARGS"] != None:
+        vars["workerKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["WORKER_KUBELET_EXTRA_ARGS"])
     end
 
     worker = {}


### PR DESCRIPTION
* support specifying schedulerExtraArgs by `;` delimited array `KUBE_SCHEDULER_EXTRA_ARGS` in cluster config file

* support specifying apiServerExtraArgs by `;` delimited array `APISERVER_EXTRA_ARGS` in cluster config file

* support specifying kubeControllerManagerExtraArgs by `;` delimited array `KUBE_CONTROLLER_MANAGER_EXTRA_ARGS` in cluster config file

* support specifying controlPlaneKubeletExtraArgs & workerKubeletExtraArgs by `;` delimited array `CONTROLPLANE_KUBELET_EXTRA_ARGS` or `WORKER_KUBELET_EXTRA_ARGS` in cluster config file

* fix audit log ytt bug when `ENABLE_AUDIT_LOGGING: 'true'`. extraArgs type is object instead of array

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

tested in vsphere env with cusomize fake val:
```
```

cluster obj and kcp obj could be created successfully with the fake envs
```
spec:
  kubeadmConfigSpec:
    clusterConfiguration:
      apiServer:
        extraArgs:
          admission-control-config-file: /etc/kubernetes/kube-apiserver-admission-pss.yaml
          cloud-provider: external
          t1_1: val1_1
          t1_2: val1_2
          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
        extraVolumes:
        - hostPath: /etc/kubernetes/kube-apiserver-admission-pss.yaml
          mountPath: /etc/kubernetes/kube-apiserver-admission-pss.yaml
          name: admission-pss
          pathType: File
          readOnly: true
        timeoutForControlPlane: 8m0s
      controllerManager:
        extraArgs:
          cloud-provider: external
          t3_1: val3_1
          t3_2: val3_2
          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
      dns:
        imageRepository: projects-stg.registry.vmware.com/tkg
        imageTag: v1.8.6_vmware.12
      etcd:
        local:
          dataDir: /var/lib/etcd
          extraArgs:
            cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
          imageRepository: projects-stg.registry.vmware.com/tkg
          imageTag: v3.5.4_vmware.10
      imageRepository: projects-stg.registry.vmware.com/tkg
      networking: {}
      scheduler:
        extraArgs:
          t2_1: val2_1
          t2_2: val2_2
          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384

...

    initConfiguration:
      localAPIEndpoint: {}
      nodeRegistration:
        criSocket: /var/run/containerd/containerd.sock
        kubeletExtraArgs:
          cloud-provider: external
          node-labels: image-type=ova,os-name=photon,os-type=linux,run.tanzu.vmware.com/tkr=v1.24.6---vmware.1-tkg.1-zshippable
          t4_1: val4_1
          t4_2: val4_2
          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
        name: '{{ ds.meta_data.hostname }}'
    joinConfiguration:
      discovery: {}
      nodeRegistration:
        criSocket: /var/run/containerd/containerd.sock
        kubeletExtraArgs:
          cloud-provider: external
          node-labels: image-type=ova,os-name=photon,os-type=linux,run.tanzu.vmware.com/tkr=v1.24.6---vmware.1-tkg.1-zshippable
          t4_1: val4_1
          t4_2: val4_2
          tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
```

mc created successfully with normal args

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
