### PR TITLE
add DRY-RUN-MODE for new addon upgrade to cc cable

### DIFF
--- a/tkg/client/init.go
+++ b/tkg/client/init.go
@@ -811,7 +811,14 @@ func (c *TkgClient) BuildRegionalClusterConfiguration(options *InitRegionOptions
 	if options.IsInputFileClusterClassBased {
 		bytes, err = getContentFromInputFile(options.ClusterConfigFile)
 	} else {
-		bytes, err = c.getClusterConfigurationBytes(&clusterConfigOptions, clusterConfigOptions.ProviderRepositorySource.InfrastructureProvider, true, false)
+		// if dryRunMode is legacy && filterByAddonType is not null, dry run result will be legacy
+		dryRunMode, _ := c.readerwriterConfigClient.TKGConfigReaderWriter().Get(constants.ConfigVariableDryRunMode)
+		filter, _ := c.readerwriterConfigClient.TKGConfigReaderWriter().Get(constants.ConfigVariableFilterByAddonType)
+		if options.GenerateOnly && dryRunMode == "legacy" && filter != "" {
+			bytes, err = c.getClusterConfiguration(&clusterConfigOptions, true, clusterConfigOptions.ProviderRepositorySource.InfrastructureProvider, false)
+		} else {
+			bytes, err = c.getClusterConfigurationBytes(&clusterConfigOptions, clusterConfigOptions.ProviderRepositorySource.InfrastructureProvider, true, false)
+		}
 		if err != nil {
 			return bytes, options.ClusterName, "", err
 		}

--- a/tkg/constants/config_variables.go
+++ b/tkg/constants/config_variables.go
@@ -170,6 +170,7 @@ const (
 	ConfigVariableEnableAutoscaler           = "ENABLE_AUTOSCALER"
 	ConfigVariableDisableTMCCloudPermissions = "DISABLE_TMC_CLOUD_PERMISSIONS"
 	AutoscalerDeploymentNameSuffix           = "-cluster-autoscaler"
+	ConfigVariableDryRunMode                 = "DRY_RUN_MODE"
 
 	ConfigVariableControlPlaneMachineCount = "CONTROL_PLANE_MACHINE_COUNT"
 	ConfigVariableControlPlaneMachineType  = "CONTROL_PLANE_MACHINE_TYPE"


### PR DESCRIPTION
### What this PR does / why we need it

#### What this PR does

add a DRY-RUN-MODE env. If FILTER_BY_ADDON_TYPE is enabled and DRY_RUN_MODE is ledacy, the result of dry-run will be legacy addon secret

#### why we need it
When the management cluster is upgraded from legacy to cc capable, according to this [doc](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid/1.6/vmware-tanzu-kubernetes-grid-16/GUID-upgrade-tkg-index.html), the new addon needs to be installed by dry-run generated the secret of the legacy addon. 
The cli of ccbase does not have ability to generate legacy addon secret.
So this pr add a ability to generate addon legacy secrets under ccbase.
