### PR TITLE
Allowing spread of Windows MD across zones

### DIFF
--- a/tkg/client/client_suite_test.go
+++ b/tkg/client/client_suite_test.go
@@ -1487,7 +1487,7 @@ var _ = Describe("DistributeMachineDeploymentWorkers", func() {
 	JustBeforeEach(func() {
 		tkgClient, err = CreateTKGClient(tkgConfigPath, testingDir, defaultTKGBoMFileForTesting, 2*time.Second)
 		Expect(err).NotTo(HaveOccurred())
-		workerCounts, err = tkgClient.DistributeMachineDeploymentWorkers(workerMachineCount, isProdConfig, isManagementCluster, infraProviderName, false)
+		workerCounts, err = tkgClient.DistributeMachineDeploymentWorkers(workerMachineCount, isProdConfig, isManagementCluster, infraProviderName)
 	})
 
 	Context("when not aws and azure", func() {
@@ -1666,6 +1666,22 @@ var _ = Describe("DistributeMachineDeploymentWorkers", func() {
 			Expect(workerCounts[0]).To(Equal(2))
 			Expect(workerCounts[1]).To(Equal(1))
 			Expect(workerCounts[2]).To(Equal(3))
+		})
+	})
+
+	Context("when docker prod plan and is mgmt cluster", func() {
+		BeforeEach(func() {
+			workerMachineCount = 5
+			isProdConfig = true
+			isManagementCluster = true
+			infraProviderName = constants.InfrastructureProviderDocker
+			tkgConfigPath = configFile7
+		})
+		It("should have first worker count as total machine count ", func() {
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(workerCounts[0]).To(Equal(5))
+			Expect(workerCounts[1]).To(Equal(0))
+			Expect(workerCounts[2]).To(Equal(0))
 		})
 	})
 

--- a/tkg/client/cluster.go
+++ b/tkg/client/cluster.go
@@ -156,7 +156,7 @@ func (c *TkgClient) CreateCluster(options *CreateClusterOptions, waitForCluster 
 			return false, err
 		}
 	} else {
-		bytes, err = c.getClusterConfigurationBytes(&options.ClusterConfigOptions, infraProviderName, isManagementCluster, options.IsWindowsWorkloadCluster)
+		bytes, err = c.getClusterConfigurationBytes(&options.ClusterConfigOptions, infraProviderName, isManagementCluster)
 		if err != nil {
 			return false, errors.Wrap(err, "unable to get cluster configuration")
 		}
@@ -199,7 +199,7 @@ func (c *TkgClient) CreateCluster(options *CreateClusterOptions, waitForCluster 
 }
 
 // getClusterConfigurationBytes returns cluster configuration by taking into consideration of legacy vs clusterclass based cluster creation
-func (c *TkgClient) getClusterConfigurationBytes(options *ClusterConfigOptions, infraProviderName string, isManagementCluster, isWindowsWorkloadCluster bool) ([]byte, error) {
+func (c *TkgClient) getClusterConfigurationBytes(options *ClusterConfigOptions, infraProviderName string, isManagementCluster bool) ([]byte, error) {
 	deployClusterClassBasedCluster, err := c.ShouldDeployClusterClassBasedCluster(isManagementCluster)
 	if err != nil {
 		return nil, err
@@ -215,7 +215,7 @@ func (c *TkgClient) getClusterConfigurationBytes(options *ClusterConfigOptions, 
 	}
 
 	// Get the cluster configuration yaml bytes
-	return c.getClusterConfiguration(options, isManagementCluster, infraProviderName, isWindowsWorkloadCluster)
+	return c.getClusterConfiguration(options, isManagementCluster, infraProviderName)
 }
 
 func getContentFromInputFile(fileName string) ([]byte, error) {
@@ -758,7 +758,7 @@ func (c *TkgClient) configureAndValidateProviderConfig(providerName string, opti
 		}
 	}
 
-	workerCounts, err := c.DistributeMachineDeploymentWorkers(*options.WorkerMachineCount, isProdPlan, false, providerName, false)
+	workerCounts, err := c.DistributeMachineDeploymentWorkers(*options.WorkerMachineCount, isProdPlan, false, providerName)
 	if err != nil {
 		return errors.Wrap(err, "failed to distribute machine deployments")
 	}

--- a/tkg/client/config.go
+++ b/tkg/client/config.go
@@ -43,7 +43,7 @@ func (c *TkgClient) GetClusterConfiguration(options *CreateClusterOptions) ([]by
 			if err := c.configureAndValidateConfiguration(options, nil, true); err != nil {
 				return nil, err
 			}
-			return c.getClusterConfiguration(&options.ClusterConfigOptions, false, provider, options.IsWindowsWorkloadCluster)
+			return c.getClusterConfiguration(&options.ClusterConfigOptions, false, provider)
 		}
 	}
 	currentRegion, err := c.GetCurrentRegionContext()
@@ -86,7 +86,7 @@ func (c *TkgClient) GetClusterConfiguration(options *CreateClusterOptions) ([]by
 		return nil, err
 	}
 
-	return c.getClusterConfigurationBytes(&options.ClusterConfigOptions, infraProviderName, false, options.IsWindowsWorkloadCluster)
+	return c.getClusterConfigurationBytes(&options.ClusterConfigOptions, infraProviderName, false)
 }
 
 func (c *TkgClient) configureAndValidateConfiguration(options *CreateClusterOptions, regionalClusterClient clusterclient.Client, skipValidation bool) error {
@@ -101,7 +101,7 @@ func (c *TkgClient) configureAndValidateConfiguration(options *CreateClusterOpti
 	return nil
 }
 
-func (c *TkgClient) getClusterConfiguration(options *ClusterConfigOptions, isManagementCluster bool, infraProvider string, isWindowsWorkloadCluster bool) ([]byte, error) {
+func (c *TkgClient) getClusterConfiguration(options *ClusterConfigOptions, isManagementCluster bool, infraProvider string) ([]byte, error) {
 	// Set CLUSTER_PLAN to viper configuration
 	c.SetPlan(options.ProviderRepositorySource.Flavor)
 
@@ -118,7 +118,7 @@ func (c *TkgClient) getClusterConfiguration(options *ClusterConfigOptions, isMan
 	SetClusterClass(c.TKGConfigReaderWriter())
 
 	// need to provide clusterctl the worker count for md0 and not the full worker-machine-count value.
-	workerCounts, err := c.DistributeMachineDeploymentWorkers(*options.WorkerMachineCount, options.ProviderRepositorySource.Flavor == constants.PlanProd, isManagementCluster, infraProviderName, isWindowsWorkloadCluster)
+	workerCounts, err := c.DistributeMachineDeploymentWorkers(*options.WorkerMachineCount, options.ProviderRepositorySource.Flavor == constants.PlanProd, isManagementCluster, infraProviderName)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to distribute machine deployments")
 	}

--- a/tkg/client/init.go
+++ b/tkg/client/init.go
@@ -815,9 +815,9 @@ func (c *TkgClient) BuildRegionalClusterConfiguration(options *InitRegionOptions
 		dryRunMode, _ := c.readerwriterConfigClient.TKGConfigReaderWriter().Get(constants.ConfigVariableDryRunMode)
 		filter, _ := c.readerwriterConfigClient.TKGConfigReaderWriter().Get(constants.ConfigVariableFilterByAddonType)
 		if options.GenerateOnly && dryRunMode == "legacy" && filter != "" {
-			bytes, err = c.getClusterConfiguration(&clusterConfigOptions, true, clusterConfigOptions.ProviderRepositorySource.InfrastructureProvider, false)
+			bytes, err = c.getClusterConfiguration(&clusterConfigOptions, true, clusterConfigOptions.ProviderRepositorySource.InfrastructureProvider)
 		} else {
-			bytes, err = c.getClusterConfigurationBytes(&clusterConfigOptions, clusterConfigOptions.ProviderRepositorySource.InfrastructureProvider, true, false)
+			bytes, err = c.getClusterConfigurationBytes(&clusterConfigOptions, clusterConfigOptions.ProviderRepositorySource.InfrastructureProvider, true)
 		}
 		if err != nil {
 			return bytes, options.ClusterName, "", err

--- a/tkg/client/validate.go
+++ b/tkg/client/validate.go
@@ -636,7 +636,7 @@ func (c *TkgClient) ConfigureAndValidateManagementClusterConfiguration(options *
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
-	workerCounts, err := c.DistributeMachineDeploymentWorkers(int64(workerMachineCount), isProdPlan, true, name, false)
+	workerCounts, err := c.DistributeMachineDeploymentWorkers(int64(workerMachineCount), isProdPlan, true, name)
 	if err != nil {
 		return NewValidationError(ValidationErrorCode, errors.Wrap(err, "failed to distribute machine deployments").Error())
 	}
@@ -1416,9 +1416,9 @@ func (c *TkgClient) ConfigureAndValidateCNIType(cniType string) error {
 }
 
 // DistributeMachineDeploymentWorkers distributes machine deployment for worker nodes
-func (c *TkgClient) DistributeMachineDeploymentWorkers(workerMachineCount int64, isProdConfig, isManagementCluster bool, infraProviderName string, isWindowsWorkloadCluster bool) ([]int, error) { // nolint:gocyclo
+func (c *TkgClient) DistributeMachineDeploymentWorkers(workerMachineCount int64, isProdConfig, isManagementCluster bool, infraProviderName string) ([]int, error) { // nolint:gocyclo
 	workerCounts := make([]int, 3)
-	if infraProviderName == DockerProviderName || isWindowsWorkloadCluster {
+	if infraProviderName == DockerProviderName {
 		workerCounts[0] = int(workerMachineCount)
 		return workerCounts, nil
 	}


### PR DESCRIPTION
### What this PR does / why we need it
Allow distribution of workers on different MDs for Windows clusters.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->
Fixes #4114

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

Tests were manually executed when creating the cluster

```
    workers:
      machineDeployments:
      - class: tkg-worker-windows
        metadata:
          annotations:
            run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=windows
        name: md-0
        replicas: 1
      - class: tkg-worker-windows
        metadata:
          annotations:
            run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=windows
        name: md-1
        replicas: 1
      - class: tkg-worker-windows
        metadata:
          annotations:
            run.tanzu.vmware.com/resolve-os-image: image-type=ova,os-name=windows
        name: md-2
        replicas: 1
```
#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
