### PR TITLE
ensure cluster's controlplane reference is set before accessing

### DIFF
--- a/addons/controllers/csi/vspherecsiconfig_utils.go
+++ b/addons/controllers/csi/vspherecsiconfig_utils.go
@@ -402,6 +402,10 @@ func (r *VSphereCSIConfigReconciler) computeRecommendedNumberOfDeploymentReplica
 func (r *VSphereCSIConfigReconciler) getNumberOfControlPlaneNodes(ctx context.Context,
 	cluster *clusterv1beta1.Cluster) (int32, error) {
 
+	if cluster.Spec.ControlPlaneRef == nil {
+		return -1, fmt.Errorf("cluster %s 's controlplane reference is not set yet", cluster.Name)
+	}
+
 	name := cluster.Spec.ControlPlaneRef.Name
 	namespace := cluster.Spec.ControlPlaneRef.Namespace
 


### PR DESCRIPTION
### What this PR does / why we need it
This PR ensures controlplane reference is set on the cluster before retrieving the control plane info. 

### Which issue(s) this PR fixes
Fixes #4119 
