### PR TITLE
Add missing `TKG_DEFAULT_IMAGE_REPOSITORY` in CLI Makefile

### DIFF
--- a/cli/core/Makefile
+++ b/cli/core/Makefile
@@ -52,6 +52,9 @@ LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/cli/core/pkg/buildinfo.D
 LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/cli/core/pkg/buildinfo.SHA=$(BUILD_SHA)'
 LD_FLAGS += -X 'github.com/vmware-tanzu/tanzu-framework/cli/core/pkg/buildinfo.Version=$(BUILD_VERSION)'
 
+ifndef TKG_DEFAULT_IMAGE_REPOSITORY
+TKG_DEFAULT_IMAGE_REPOSITORY = "projects-stg.registry.vmware.com/tkg"
+endif
 ifndef ENABLE_CONTEXT_AWARE_PLUGIN_DISCOVERY
 ENABLE_CONTEXT_AWARE_PLUGIN_DISCOVERY = "true"
 endif


### PR DESCRIPTION

### What this PR does / why we need it

Add the missing `TKG_DEFAULT_IMAGE_REPOSITORY` default value in the CLI makefile

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #4144


### Describe testing done for PR

Before PR:
```
$ cd tanzu-framework
$ # Build the CLI with OCI discovery
$ make install-cli-oci
$ tanzu config get | grep -A3 discoverySources

        discoverySources:
            - oci:
                name: default
                image: /packages/standalone-plugins:v0.28.0-dev

$ # Notice that the image is missing the domain name part (projects-stg.registry.vmware.com)
```
With PR:
```
$ cd tanzu-framework
$ # Build the CLI with OCI discovery
$ make install-cli-oci
$ tanzu config get | grep -A3 discoverySources

tanzu config get | grep -A3 discoverySources
        discoverySources:
            - oci:
                name: default
                image: projects-stg.registry.vmware.com/tkg/packages/standalone-plugins:v0.28.0-dev

$ # Notice that the image is now complete
```

#### Special notes for your reviewer

Note that this missing variable is not a problem for production builds because that environment variable is set explicitly outside the makefile.