### PR TITLE
Missing flag from isolated-cluster plugin

### DIFF
--- a/cmd/cli/plugin/isolated-cluster/imageop/publishimagesfromtar.go
+++ b/cmd/cli/plugin/isolated-cluster/imageop/publishimagesfromtar.go
@@ -36,11 +36,11 @@ var PublishImagesfromtarCmd = &cobra.Command{
 
 func init() {
 	PublishImagesfromtarCmd.Flags().StringVarP(&pushImage.TkgTarFilePath, "source-directory", "", "", "Path to the directory that contains the TAR file  (required)")
-	_ = PublishImagestotarCmd.MarkFlagRequired("source-directory")
+	_ = PublishImagesfromtarCmd.MarkFlagRequired("source-directory")
 	PublishImagesfromtarCmd.Flags().StringVarP(&pushImage.DestinationRepository, "destination-repo", "", "", "Private OCI repository where the images should be hosted in air-gapped (required)")
 	_ = PublishImagesfromtarCmd.MarkFlagRequired("destination-repo")
 	PublishImagesfromtarCmd.Flags().StringVarP(&pushImage.CustomImageRepoCertificate, "destination-ca-certificate", "", "", "The private repository’s CA certificate  (optional)")
-	PublishImagestotarCmd.Flags().BoolVarP(&pullImage.Insecure, "destination-insecure", "", false, "Trusts the server certificate without validating it (optional)")
+	PublishImagesfromtarCmd.Flags().BoolVarP(&pushImage.Insecure, "destination-insecure", "", false, "Trusts the private repository’s certificate without validating it (optional)")
 }
 
 func (p *PublishImagesFromTarOptions) PushImageToRepo() error {
@@ -80,7 +80,7 @@ func (p *PublishImagesFromTarOptions) PushImageToRepo() error {
 func publishImagesFromTar(cmd *cobra.Command, args []string) error {
 	pushImage.PkgClient = &imgpkgClient{}
 	if !pushImage.Insecure && pushImage.CustomImageRepoCertificate == "" {
-		return fmt.Errorf("CA certificate is empty and Insecure option is disable")
+		return fmt.Errorf("CA certificate is empty and Insecure option is disabled")
 	}
 
 	err := pushImage.PushImageToRepo()

--- a/cmd/cli/plugin/isolated-cluster/imageop/publishimagestotar.go
+++ b/cmd/cli/plugin/isolated-cluster/imageop/publishimagestotar.go
@@ -44,8 +44,7 @@ var PublishImagestotarCmd = &cobra.Command{
 }
 
 func init() {
-	PublishImagestotarCmd.Flags().StringVarP(&pullImage.TkgImageRepo, "source-repo", "", "projects.registry.vmware.com/tkg", "OCI repo where TKG bundles or images are hosted (required)")
-	_ = PublishImagestotarCmd.MarkFlagRequired("source-repo")
+	PublishImagestotarCmd.Flags().StringVarP(&pullImage.TkgImageRepo, "source-repo", "", "projects.registry.vmware.com/tkg", "OCI repo where TKG bundles or images are hosted")
 	PublishImagestotarCmd.Flags().StringVarP(&pullImage.TkgVersion, "tkg-version", "", "", "TKG version (required)")
 	_ = PublishImagestotarCmd.MarkFlagRequired("tkg-version")
 	PublishImagestotarCmd.Flags().BoolVarP(&pullImage.Insecure, "source-insecure", "", false, "Trusts the server certificate without validating it (optional)")
@@ -155,12 +154,12 @@ func (p *PublishImagesToTarOptions) DownloadTkrCompatibilityImage(tkrCompatibili
 		return nil, errors.Wrapf(err, "read directory tmp failed")
 	}
 	if len(files) != 1 || files[0].IsDir() {
-		return nil, fmt.Errorf("tkr-compatibility image should only has exact one file inside")
+		return nil, fmt.Errorf("tkr-compatibility image should only have exactly one file inside")
 	}
 	tkrCompatibilityFilePath := filepath.Join(outputDir, files[0].Name())
 	b, err := os.ReadFile(tkrCompatibilityFilePath)
 	if err != nil {
-		return nil, errors.Wrapf(err, "read tkr-compatibility file from %s faild", tkrCompatibilityFilePath)
+		return nil, errors.Wrapf(err, "read tkr-compatibility file from %s failed", tkrCompatibilityFilePath)
 	}
 	tkrCompatibility := &tkrv1.CompatibilityMetadata{}
 	if err := yaml.Unmarshal(b, tkrCompatibility); err != nil {
@@ -212,7 +211,7 @@ func (p *PublishImagesToTarOptions) DownloadTkrBomAndComponentImages(tkrVersion 
 	tkrBomFilePath := path.Join(outputDir, fmt.Sprintf("tkr-bom-%s.yaml", tkrVersion))
 	b, err := os.ReadFile(tkrBomFilePath)
 	if err != nil {
-		return errors.Wrapf(err, "read tkr-bom file from %s faild", tkrBomFilePath)
+		return errors.Wrapf(err, "read tkr-bom file from %s failed", tkrBomFilePath)
 	}
 	tkgBom, _ := tkrv1.NewBom(b)
 	// imgpkg copy each component's artifacts
@@ -305,7 +304,7 @@ func downloadImagesToTar(cmd *cobra.Command, args []string) error {
 	pullImage.PkgClient = &imgpkgClient{}
 
 	if !pullImage.Insecure && pullImage.CaCertificate == "" {
-		return fmt.Errorf("CA certificate is empty and Insecure option is disable")
+		return fmt.Errorf("CA certificate is empty and Insecure option is disabled")
 	}
 	if !strings.HasPrefix(pullImage.TkgVersion, "v") {
 		return fmt.Errorf("invalid TKG Tag %s", pullImage.TkgVersion)


### PR DESCRIPTION
### What this PR does / why we need it

For the new isolated-cluster plugin the flag `--destination-insecure` was being added to the `download-bundle` command instead of having it on the `upload-bundle` command.

Also, the `--source-directory` flag was meant to be required but was not due to a copy/paste error.

Also, the `--source-repo` flag should not be marked required since it has a documented default value.  This point needs to be confirmed, as we could instead remove the default value and possibly add it to the help text.  I will put a comment in-line to discuss this.

Finally, some spelling errors were present.

This commit fixes the above issues.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #4150 

### Describe testing done for PR

Apply the PR and check the help of both sub-commands of the `isolated-cluster` plugin and make sure
the `--destination-insecure` flag is on the `upload-bundle` command.

```
$ tanzu isolated-cluster upload-bundle -h
Upload images to private repository.

Usage:
  tanzu isolated-cluster upload-bundle [flags]

Flags:
      --destination-ca-certificate string   The private repository’s CA certificate  (optional)
      --destination-insecure                Trusts the private repository’s certificate without validating it (optional)
      --destination-repo string             Private OCI repository where the images should be hosted in air-gapped (required)
  -h, --help                                help for upload-bundle
      --source-directory string             Path to the directory that contains the TAR file  (required)

$ tanzu isolated-cluster download-bundle -h
Download images/bundle into local disk as TAR

Usage:
  tanzu isolated-cluster download-bundle [flags]

Flags:
  -h, --help                           help for download-bundle
      --source-ca-certificate string   The private repository’s CA certificate  (optional)
      --source-insecure                Trusts the server certificate without validating it (optional)
      --source-repo string             OCI repo where TKG bundles or images are hosted (default "projects.registry.vmware.com/tkg")
      --tkg-version string             TKG version (required)
```

Also test that `--source-directory` is required:
```
$ tanzu isolated-cluster upload-bundle
Error: required flag(s) "destination-repo", "source-directory" not set
```
Also test that `--source-repo` is no longer required:
```
$ tanzu isolated-cluster download-bundle
Error: required flag(s) "tkg-version" not set
```

cc @Vandy-P 