### PR TITLE
Update dependabot.yaml to disable version checks correctly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,54 +1,69 @@
 # Dependabot config for go mod version upgrades
+#
+# TODO(vuil):
+# All version updates being disabled with
+# 'open-pull-requests-limit: 0'
+# restoring of version updates being tracked in
+# https://github.com/vmware-tanzu/tanzu-framework/issues/4148
 
-# (vuil) temporarily disable version upgrades until CI stabilizes
 version: 2
-updates: []
-# - package-ecosystem: "github-actions"
-#   directory: "/un"
-#   schedule:
-#     interval: "daily"
-#
-#  - package-ecosystem: "gomod"
-#    directory: "addons/"
-#    schedule:
-#      interval: "daily"
-#
-#  - package-ecosystem: "gomod"
-#    directory: "pinniped-components/post-deploy/"
-#    schedule:
-#      interval: "daily"
-#
-#  - package-ecosystem: "gomod"
-#    directory: "/"
-#    schedule:
-#      interval: "daily"
-#
-#  - package-ecosystem: "gomod"
-#    directory: "hack/packages/kbld-image-replace/"
-#    schedule:
-#      interval: "daily"
-#
-#  - package-ecosystem: "gomod"
-#    directory: "hack/tools/"
-#    schedule:
-#      interval: "daily"
-#
-#  - package-ecosystem: "gomod"
-#    directory: "pkg/v1/providers/tests/"
-#    schedule:
-#      interval: "daily"
-#
-#  - package-ecosystem: "npm"
-#    directory: "tkg/web/e2e/"
-#    schedule:
-#      interval: "daily"
-#
-#  - package-ecosystem: "npm"
-#    directory: "tkg/web/node-server/"
-#    schedule:
-#      interval: "daily"
-#
-#  - package-ecosystem: "npm"
-#    directory: "tkg/web/"
-#    schedule:
-#      interval: "daily"
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "gomod"
+    directory: "addons/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "gomod"
+    directory: "pinniped-components/post-deploy/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "gomod"
+    directory: "hack/packages/kbld-image-replace/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "gomod"
+    directory: "hack/tools/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "gomod"
+    directory: "pkg/v1/providers/tests/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "npm"
+    directory: "tkg/web/e2e/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "npm"
+    directory: "tkg/web/node-server/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "npm"
+    directory: "tkg/web/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
### What this PR does / why we need it

Looks like the current way of disabling version updates is no longer valid. Update the configuration to achieve the same effect.

Signed-off-by: Vui Lam <vui@vmware.com>

### Which issue(s) this PR fixes
Related-to: #4148

### Describe testing done for PR

Monitor CI before merge.
Will monitor dependabot PRs after to verify only security updates are posted.

### Release note
```release-note
None
```

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
