### PR TITLE
Fixing correct default values for AntreaConfig template

### DIFF
--- a/addons/config/expected/cni.tanzu.vmware.com/v1alpha1/antreaconfig/default.yaml
+++ b/addons/config/expected/cni.tanzu.vmware.com/v1alpha1/antreaconfig/default.yaml
@@ -13,13 +13,20 @@ spec:
       tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
       disableUdpTunnelOffload: false
       featureGates:
-        AntreaProxy: true
-        EndpointSlice: true
+        AntreaIPAM: false
         AntreaPolicy: true
-        NodePortLocal: false
+        AntreaProxy: true
         AntreaTraceflow: true
-        Egress: false
+        Egress: true
+        EndpointSlice: true
         FlowExporter: false
+        Multicast: false
+        Multicluster: false
+        NetworkPolicyStats: false
+        NodePortLocal: true
+        SecondaryNetwork: false
+        ServiceExternalIP: false
+        TrafficControl: false
 ---
 apiVersion: cni.tanzu.vmware.com/v1alpha1
 kind: AntreaConfig
@@ -36,10 +43,17 @@ spec:
       tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
       disableUdpTunnelOffload: false
       featureGates:
-        AntreaProxy: true
-        EndpointSlice: true
+        AntreaIPAM: false
         AntreaPolicy: true
-        NodePortLocal: false
+        AntreaProxy: true
         AntreaTraceflow: true
-        Egress: false
+        Egress: true
+        EndpointSlice: true
         FlowExporter: false
+        Multicast: false
+        Multicluster: false
+        NetworkPolicyStats: false
+        NodePortLocal: true
+        SecondaryNetwork: false
+        ServiceExternalIP: false
+        TrafficControl: false

--- a/addons/config/templates/cni.tanzu.vmware.com/v1alpha1/antreaconfig.yaml
+++ b/addons/config/templates/cni.tanzu.vmware.com/v1alpha1/antreaconfig.yaml
@@ -15,13 +15,20 @@ spec:
       tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
       disableUdpTunnelOffload: false
       featureGates:
-        AntreaProxy: true
-        EndpointSlice: true
+        AntreaIPAM: false
         AntreaPolicy: true
-        NodePortLocal: false
+        AntreaProxy: true
         AntreaTraceflow: true
-        Egress: false
+        Egress: true
+        EndpointSlice: true
         FlowExporter: false
+        Multicast: false
+        Multicluster: false
+        NetworkPolicyStats: false
+        NodePortLocal: true
+        SecondaryNetwork: false
+        ServiceExternalIP: false
+        TrafficControl: false
 ---
 apiVersion: cni.tanzu.vmware.com/v1alpha1
 kind: AntreaConfig
@@ -38,10 +45,17 @@ spec:
       tlsCipherSuites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384
       disableUdpTunnelOffload: false
       featureGates:
-        AntreaProxy: true
-        EndpointSlice: true
+        AntreaIPAM: false
         AntreaPolicy: true
-        NodePortLocal: false
+        AntreaProxy: true
         AntreaTraceflow: true
-        Egress: false
+        Egress: true
+        EndpointSlice: true
         FlowExporter: false
+        Multicast: false
+        Multicluster: false
+        NetworkPolicyStats: false
+        NodePortLocal: true
+        SecondaryNetwork: false
+        ServiceExternalIP: false
+        TrafficControl: false

--- a/addons/controllers/antreaconfig_controller_test.go
+++ b/addons/controllers/antreaconfig_controller_test.go
@@ -136,6 +136,7 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.MultiCluster).Should(Equal(false))
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.SecondaryNetwork).Should(Equal(false))
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.TrafficControl).Should(Equal(false))
+				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.NodePortLocal).Should(Equal(true))
 
 				return true
 			}, waitTimeout, pollingInterval).Should(BeTrue())


### PR DESCRIPTION
### What this PR does / why we need it
The AntreaConfig generated on Cluster do not have the correct default values, this PR fix the template used to generate the default CR for the CBT

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
<!-- Example: Created vSphere workload cluster to verify change. -->
A testbed with the new template is created and the default AntreaConfig had the expected flags enabled.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
