### PR TITLE
Rename kctrl-command-tree feature flag

### DIFF
--- a/cli/runtime/config/config_factory_test.go
+++ b/cli/runtime/config/config_factory_test.go
@@ -47,7 +47,7 @@ clientOptions:
       import: 'false'
       standalone-cluster-mode: 'false'
     package:
-      kctrl-package-command-tree: 'true'
+      kctrl-command-tree: 'true'
 kind: ClientConfig
 metadata:
   creationTimestamp: null
@@ -135,7 +135,7 @@ clientOptions:
             import: 'false'
             standalone-cluster-mode: 'false'
         package:
-            kctrl-package-command-tree: 'true'
+            kctrl-command-tree: 'true'
 kind: ClientConfig
 metadata:
     creationTimestamp: null
@@ -538,7 +538,7 @@ clientOptions:
       import: 'false'
       standalone-cluster-mode: 'false'
     package:
-      kctrl-package-command-tree: 'true'
+      kctrl-command-tree: 'true'
 contexts:
   - name: test-mc
     target: kubernetes
@@ -608,7 +608,7 @@ clientOptions:
             import: 'false'
             standalone-cluster-mode: 'false'
         package:
-            kctrl-package-command-tree: 'true'
+            kctrl-command-tree: 'true'
 `,
 		},
 		{
@@ -645,7 +645,7 @@ clientOptions:
       import: 'false'
       standalone-cluster-mode: 'false'
     package:
-      kctrl-package-command-tree: 'true'
+      kctrl-command-tree: 'true'
 contexts:
   - name: test-mc
     target: kubernetes
@@ -745,7 +745,7 @@ clientOptions:
             import: 'false'
             standalone-cluster-mode: 'false'
         package:
-            kctrl-package-command-tree: 'true'
+            kctrl-command-tree: 'true'
 contexts:
     - name: test-mc
       target: kubernetes
@@ -812,7 +812,7 @@ clientOptions:
       import: 'false'
       standalone-cluster-mode: 'false'
     package:
-      kctrl-package-command-tree: 'true'
+      kctrl-command-tree: 'true'
 contexts:
   - name: test-mc
     target: kubernetes
@@ -912,7 +912,7 @@ clientOptions:
             import: 'false'
             standalone-cluster-mode: 'false'
         package:
-            kctrl-package-command-tree: 'true'
+            kctrl-command-tree: 'true'
 contexts:
     - name: test-mc
       target: kubernetes
@@ -979,7 +979,7 @@ clientOptions:
       import: 'false'
       standalone-cluster-mode: 'false'
     package:
-      kctrl-package-command-tree: 'true'
+      kctrl-command-tree: 'true'
 contexts:
   - name: test-mc
     target: kubernetes
@@ -1051,7 +1051,7 @@ clientOptions:
             import: 'false'
             standalone-cluster-mode: 'false'
         package:
-            kctrl-package-command-tree: 'true'
+            kctrl-command-tree: 'true'
 contexts: []
 currentContext: {}
 `,
@@ -1113,7 +1113,7 @@ clientOptions:
       import: 'false'
       standalone-cluster-mode: 'false'
     package:
-      kctrl-package-command-tree: 'true'
+      kctrl-command-tree: 'true'
 contexts:
   - name: test-mc
     target: kubernetes
@@ -1186,7 +1186,7 @@ clientOptions:
             import: 'false'
             standalone-cluster-mode: 'false'
         package:
-            kctrl-package-command-tree: 'true'
+            kctrl-command-tree: 'true'
 contexts: []
 currentContext: {}
 current:

--- a/cmd/cli/plugin/package/featureflags.go
+++ b/cmd/cli/plugin/package/featureflags.go
@@ -6,7 +6,7 @@ package main
 const (
 	// Package Plugin Kctrl Command Tree determines whether to use the command tree from kctrl. Setting feature flag to
 	// true will allow to use the package command tree from kctrl for package plugin
-	FeatureFlagPackagePluginKctrlCommandTree = "features.package.kctrl-package-command-tree"
+	FeatureFlagPackagePluginKctrlCommandTree = "features.package.kctrl-command-tree"
 )
 
 // DefaultFeatureFlagsForPackagePlugin is used to populate default feature-flags for the package plugin

--- a/cmd/cli/plugin/package/test/package_plugin_integration_test.go
+++ b/cmd/cli/plugin/package/test/package_plugin_integration_test.go
@@ -661,7 +661,7 @@ func disableKctrlCommandTree() {
 	By("disable kctrl command tree")
 	command := exec.NewCommand(
 		exec.WithCommand("tanzu"),
-		exec.WithArgs("config", "set", "features.package.kctrl-package-command-tree", "false"),
+		exec.WithArgs("config", "set", "features.package.kctrl-command-tree", "false"),
 		exec.WithStdout(GinkgoWriter),
 	)
 	err = command.RunAndRedirectOutput(context.Background())


### PR DESCRIPTION
### What this PR does / why we need it
Rename kctrl-command-tree feature flag.
Use `features.package.kctrl-command-tree` instead of `features.package.kctrl-package-command-tree`. This is done to ensure that the default value is toggled to true even while upgrading from an older version.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
`tanzu config set features.package.kctrl-command-tree false` can be used to turn off kctrl command tree.
```