### PR TITLE
Deploy IPAM Provider on bootstrap cluster

### DIFF
--- a/tkg/client/init.go
+++ b/tkg/client/init.go
@@ -220,6 +220,14 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 		}
 	}
 
+	if config.IsFeatureActivated(constants.FeatureFlagManagementClusterDeployInClusterIPAMProvider) && providerName == constants.InfrastructureProviderVSphere {
+		ipamProvider, err := c.tkgConfigUpdaterClient.CheckInfrastructureVersion("ipam-in-cluster")
+		if err != nil {
+			return err
+		}
+		options.IPAMProvider = ipamProvider
+	}
+
 	log.SendProgressUpdate(statusRunning, StepInstallProvidersOnBootstrapCluster, InitRegionSteps)
 	log.Info("Installing providers on bootstrapper...")
 	// Initialize bootstrap cluster with providers
@@ -338,7 +346,7 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 		}
 	}
 
-	if config.IsFeatureActivated(constants.FeatureFlagManagementClusterDeployInClusterIPAMProvider) {
+	if config.IsFeatureActivated(constants.FeatureFlagManagementClusterDeployInClusterIPAMProvider) && providerName == constants.InfrastructureProviderVSphere {
 		ipamProvider, err := c.tkgConfigUpdaterClient.CheckInfrastructureVersion("ipam-in-cluster")
 		if err != nil {
 			return err


### PR DESCRIPTION
### What this PR does / why we need it
Deploys the IPAM Provider on the teardown cluster when deleting a management cluster that has the IPAM provider deployed.

### Describe testing done for PR
Saw that the IPAM provider was installed on a teardown cluster when deleting a management cluster
Successfully deleted an IPAM-enabled management cluster