### PR TITLE
Fix package plugin tests for classy clusters

### DIFF
--- a/cmd/cli/plugin/package/test/package_plugin_integration_test.go
+++ b/cmd/cli/plugin/package/test/package_plugin_integration_test.go
@@ -183,6 +183,20 @@ var _ = Describe("Package plugin integration test", func() {
 
 		if !config.UseExistingCluster {
 			By(fmt.Sprintf("Creating management cluster %q", config.ClusterNameMC))
+
+			// CAPD cluster creation on classy clusters doesnt work. So need to create legacy cluster.
+			// Below hack enables legacy cluster creation.
+			hackCmd := exec.NewCommand(
+				exec.WithCommand("./scripts/legacy_hack.sh"),
+				exec.WithStdout(GinkgoWriter),
+			)
+
+			fmt.Println("Executing the legacy hack script")
+			_, _, err := hackCmd.Run(context.Background())
+			Expect(err).To(BeNil())
+
+			os.Setenv("_ALLOW_CALICO_ON_MANAGEMENT_CLUSTER", "true")
+
 			cli, err := tkgctl.New(tkgctl.Options{
 				ConfigDir: tkgCfgDir,
 				LogOptions: tkgctl.LoggingOptions{
@@ -202,6 +216,8 @@ var _ = Describe("Package plugin integration test", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
+			os.Unsetenv("_ALLOW_CALICO_ON_MANAGEMENT_CLUSTER")
+
 			By(fmt.Sprintf("Creating workload cluster %q", config.ClusterNameWLC))
 			tkgCtlClient, err := tkgctl.New(tkgctl.Options{
 				ConfigDir: tkgCfgDir,
@@ -215,6 +231,7 @@ var _ = Describe("Package plugin integration test", func() {
 				ClusterName: config.ClusterNameWLC,
 				Namespace:   packagedatamodel.DefaultNamespace,
 				Plan:        "dev",
+				CniType:     "calico",
 			}
 			clusterConfigFile, err = framework.GetTempClusterConfigFile("", &options)
 			Expect(err).To(BeNil())
@@ -610,12 +627,33 @@ func pauseKappControllerPackage(clusterName, clusterNamespace, mgmtClusterKubeco
 	By("pausing kapp controller app")
 	mgmtClusterKubeCtx := mgmtClusterName + "-admin@" + mgmtClusterName
 
+	var (
+		carvelKind          string
+		packageInstallFound bool
+	)
+
 	command := exec.NewCommand(
 		exec.WithCommand("kubectl"),
-		exec.WithArgs("patch", "app", fmt.Sprintf("%s-kapp-controller", clusterName), "-n", clusterNamespace, "--type", "merge", "-p", fmt.Sprintf("{\"spec\":{\"paused\":%t}}", pause), "--context", mgmtClusterKubeCtx, "--kubeconfig", mgmtClusterKubeconfigPath),
+		exec.WithArgs("get", "packageinstall", fmt.Sprintf("%s-kapp-controller", clusterName), "-n", clusterNamespace, "--context", mgmtClusterKubeCtx, "--kubeconfig", mgmtClusterKubeconfigPath),
 		exec.WithStdout(GinkgoWriter),
 	)
 	err := command.RunAndRedirectOutput(context.Background())
+	if err == nil {
+		packageInstallFound = true
+	}
+
+	if packageInstallFound {
+		carvelKind = "packageinstall"
+	} else {
+		carvelKind = "app"
+	}
+
+	command = exec.NewCommand(
+		exec.WithCommand("kubectl"),
+		exec.WithArgs("patch", carvelKind, fmt.Sprintf("%s-kapp-controller", clusterName), "-n", clusterNamespace, "--type", "merge", "-p", fmt.Sprintf("{\"spec\":{\"paused\":%t}}", pause), "--context", mgmtClusterKubeCtx, "--kubeconfig", mgmtClusterKubeconfigPath),
+		exec.WithStdout(GinkgoWriter),
+	)
+	err = command.RunAndRedirectOutput(context.Background())
 	Expect(err).ToNot(HaveOccurred())
 }
 

--- a/cmd/cli/plugin/package/test/scripts/legacy_hack.sh
+++ b/cmd/cli/plugin/package/test/scripts/legacy_hack.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Copyright 2021 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+tanzu config set features.management-cluster.package-based-cc false
+tanzu config set features.cluster.allow-legacy-cluster true
+tanzu config get


### PR DESCRIPTION
### What this PR does / why we need it
Fix package plugin tests for classy clusters. Classy clusters use packageInstall CR on management cluster for installing kapp-controller on workload cluster. Legacy clusters use App CR on management cluster for installing kapp-controller on workload cluster. In the test we were pausing App before patching kapp-controller configmap but in Classy clusters this was getting overridden since PackageInstall CR is not paused. This change makes sure to check if packageinstall is found then pause packageinstall else pause app. 

### Which issue(s) this PR fixes
Fixes #4209 

### Describe testing done for PR
Ran the test on a classy and legacy cluster and it passes

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix package plugin tests for classy clusters
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
