### PR TITLE
Fix clusterbootstrap continuous reconciliation

### DIFF
--- a/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
+++ b/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
@@ -667,14 +667,14 @@ func (h *Helper) CreateOrPatchInlineSecret(
 
 	inlineSecret.Type = corev1.SecretTypeOpaque
 	opResult, createOrPatchErr := controllerutil.CreateOrPatch(h.Ctx, h.K8sClient, inlineSecret, func() error {
-		inlineSecret.OwnerReferences = []metav1.OwnerReference{
-			{
-				APIVersion: clusterapiv1beta1.GroupVersion.String(),
-				Kind:       cluster.Kind,
-				Name:       cluster.Name,
-				UID:        cluster.UID,
-			},
+		clusterOwnerRef := metav1.OwnerReference{
+			APIVersion: clusterapiv1beta1.GroupVersion.String(),
+			Kind:       cluster.Kind,
+			Name:       cluster.Name,
+			UID:        cluster.UID,
 		}
+		inlineSecret.OwnerReferences = clusterapiutil.EnsureOwnerRef(inlineSecret.OwnerReferences, clusterOwnerRef)
+
 		if inlineSecret.StringData == nil {
 			inlineSecret.StringData = make(map[string]string)
 		}


### PR DESCRIPTION
### What this PR does / why we need it
Fix clusterbootstrap continuous reconciliation.

Clusterbootstrap controller was continuously reconciling since the secret containing inline data values was continuously changing due to owner reference being overwritten.

This change ensures the owner reference is not overwritten.

### Which issue(s) this PR fixes
Fixes #<TBC>

### Describe testing done for PR
Tested cluster creation and ensured the continuous reconciliation is stopped

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
```release-note
Fix clusterbootstrap continuous reconciliation
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
