### PR TITLE
check tkr creation in bootstrap cluster before creating cc-based mana…

### DIFF
--- a/tkg/client/init.go
+++ b/tkg/client/init.go
@@ -275,14 +275,14 @@ func (c *TkgClient) InitRegion(options *InitRegionOptions) error { //nolint:funl
 
 	if config.IsFeatureActivated(constants.FeatureFlagPackageBasedCC) {
 		// for cc based cluster, check if tkr/cbt is reconciled to avoid package not found error by addons-controller
-		tkrVersion, err := c.TKGConfigReaderWriter().Get(constants.ConfigVariableTkrName)
+		tkrName, err := c.TKGConfigReaderWriter().Get(constants.ConfigVariableTkrName)
 		if err != nil {
-			return errors.Wrap(err, "unable to get tkr version for cluster")
+			return errors.Wrap(err, "unable to get tkr name for cluster")
 		}
-		log.Infof("Checking Tkr %s in bootstrap cluster...", tkrVersion)
+		log.Infof("Checking Tkr %s in bootstrap cluster...", tkrName)
 
 		pollOptions := &clusterclient.PollOptions{Interval: clusterclient.CheckResourceInterval, Timeout: clusterclient.PackageInstallTimeout}
-		if err := bootStrapClusterClient.GetResource(&v1alpha3.TanzuKubernetesRelease{}, tkrVersion, "", nil, pollOptions); err != nil {
+		if err := bootStrapClusterClient.GetResource(&v1alpha3.TanzuKubernetesRelease{}, tkrName, "", nil, pollOptions); err != nil {
 			return errors.Wrap(err, "unable to check tkr in bootstrap cluster")
 		}
 	}


### PR DESCRIPTION
…gement cluster

### What this PR does / why we need it

check tkr before applying cluster manifest. 

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

tested locally, manually delete and recreate tkr before creating cluster obj, the log shows code works as expected
```
Checking Tkr v1.24.6---vmware.1-tkg.1-zshippable in bootstrap cluster...
waiting for resource v1.24.6---vmware.1-tkg.1-zshippable of type *v1alpha3.TanzuKubernetesRelease to be up and running
tanzukubernetesreleases.run.tanzu.vmware.com "v1.24.6---vmware.1-tkg.1-zshippable" not found, retrying
tanzukubernetesreleases.run.tanzu.vmware.com "v1.24.6---vmware.1-tkg.1-zshippable" not found, retrying
tanzukubernetesreleases.run.tanzu.vmware.com "v1.24.6---vmware.1-tkg.1-zshippable" not found, retrying
Start creating management cluster...
patch cluster object with operation status:
	{
		"metadata": {
			"annotations": {
				"TKGOperationInfo" : "{\"Operation\":\"Create\",\"OperationStartTimestamp\":\"2022-12-20 06:13:27.349471709 +0000 UTC\",\"OperationTimeout\":1800}",
				"TKGOperationLastObservedTimestamp" : "2022-12-20 06:13:27.349471709 +0000 UTC"
			}
		}
	}
zero or multiple KCP objects found for the given cluster, 0 mgmt-2 tkg-system, retrying
control plane is not available yet, retrying
control plane is not available yet, retrying
control plane is not available yet, retrying
control plane is not available yet, retrying
control plane is not available yet, retrying
control plane is not available yet, retrying
control plane is not available yet, retrying
Management cluster control plane is available, means API server is ready to receive requests
```

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
