### PR TITLE
Do not set CniType in package plugin tests

### DIFF
--- a/cmd/cli/plugin/package/test/package_plugin_integration_test.go
+++ b/cmd/cli/plugin/package/test/package_plugin_integration_test.go
@@ -197,7 +197,6 @@ var _ = Describe("Package plugin integration test", func() {
 				ClusterName:            config.ClusterNameMC,
 				InfrastructureProvider: "docker",
 				Timeout:                clusterCreationTimeout,
-				CniType:                "calico",
 				Edition:                "tkg",
 			})
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
### What this PR does / why we need it
Do not set CniType in package plugin tests.
Calico management cluster creation is forbidden, so let's use the default CniType (antrea).