### PR TITLE
isolated-cluster plugin writes incorrect image files

### DIFF
--- a/cmd/cli/plugin/isolated-cluster/imagepullop/publishimagestotar.go
+++ b/cmd/cli/plugin/isolated-cluster/imagepullop/publishimagestotar.go
@@ -127,8 +127,8 @@ func (p *PublishImagesToTarOptions) DownloadTkgBomAndComponentImages() (string, 
 				imageInfo.ImagePath = imgpkginterface.ReplaceSlash(imageInfo.ImagePath)
 				tarname := imageInfo.ImagePath + "-" + imageInfo.Tag + ".tar"
 				tempImageDetails[tarname] = imageInfo.ImagePath
-                                i := sourceImageName
-                                j := tarname
+				i := sourceImageName
+				j := tarname
 				group.Go(func() error {
 					return p.PkgClient.CopyImageToTar(i, j, p.CaCertificate, p.Insecure)
 				})
@@ -239,8 +239,8 @@ func (p *PublishImagesToTarOptions) DownloadTkrBomAndComponentImages(tkrVersion 
 				imageInfo.ImagePath = imgpkginterface.ReplaceSlash(imageInfo.ImagePath)
 				tarname := imageInfo.ImagePath + "-" + imageInfo.Tag + ".tar"
 				tempImageDetails[tarname] = imageInfo.ImagePath
-                                i := sourceImageName
-                                j := tarname
+				i := sourceImageName
+				j := tarname
 				group.Go(func() error {
 					return p.PkgClient.CopyImageToTar(i, j, p.CaCertificate, p.Insecure)
 				})
@@ -293,8 +293,8 @@ func (p *PublishImagesToTarOptions) DownloadTkgPackagesImages(tkrVersions []stri
 			sourceImageName := filepath.Join(p.TkgImageRepo, imageName) + ":" + tkrVersion
 			tarname := imageName + "-" + tkrVersion + ".tar"
 			tempImageDetails[tarname] = imageName
-                        i := sourceImageName
-                        j := tarname
+			i := sourceImageName
+			j := tarname
 			group.Go(func() error {
 				return p.PkgClient.CopyImageToTar(i, j, p.CaCertificate, p.Insecure)
 			})
@@ -304,8 +304,8 @@ func (p *PublishImagesToTarOptions) DownloadTkgPackagesImages(tkrVersions []stri
 			sourceImageName := filepath.Join(p.TkgImageRepo, imageName) + ":" + tkrVersion
 			tarname := imageName + "-" + tkrVersion + ".tar"
 			tempImageDetails[tarname] = imageName
-                        i := sourceImageName
-                        j := tarname
+			i := sourceImageName
+			j := tarname
 			group.Go(func() error {
 				return p.PkgClient.CopyImageToTar(i, j, p.CaCertificate, p.Insecure)
 			})

--- a/cmd/cli/plugin/isolated-cluster/imagepullop/publishimagestotar.go
+++ b/cmd/cli/plugin/isolated-cluster/imagepullop/publishimagestotar.go
@@ -127,8 +127,10 @@ func (p *PublishImagesToTarOptions) DownloadTkgBomAndComponentImages() (string, 
 				imageInfo.ImagePath = imgpkginterface.ReplaceSlash(imageInfo.ImagePath)
 				tarname := imageInfo.ImagePath + "-" + imageInfo.Tag + ".tar"
 				tempImageDetails[tarname] = imageInfo.ImagePath
+                                i := sourceImageName
+                                j := tarname
 				group.Go(func() error {
-					return p.PkgClient.CopyImageToTar(sourceImageName, tarname, p.CaCertificate, p.Insecure)
+					return p.PkgClient.CopyImageToTar(i, j, p.CaCertificate, p.Insecure)
 				})
 			}
 		}
@@ -237,8 +239,10 @@ func (p *PublishImagesToTarOptions) DownloadTkrBomAndComponentImages(tkrVersion 
 				imageInfo.ImagePath = imgpkginterface.ReplaceSlash(imageInfo.ImagePath)
 				tarname := imageInfo.ImagePath + "-" + imageInfo.Tag + ".tar"
 				tempImageDetails[tarname] = imageInfo.ImagePath
+                                i := sourceImageName
+                                j := tarname
 				group.Go(func() error {
-					return p.PkgClient.CopyImageToTar(sourceImageName, tarname, p.CaCertificate, p.Insecure)
+					return p.PkgClient.CopyImageToTar(i, j, p.CaCertificate, p.Insecure)
 				})
 			}
 		}
@@ -289,8 +293,10 @@ func (p *PublishImagesToTarOptions) DownloadTkgPackagesImages(tkrVersions []stri
 			sourceImageName := filepath.Join(p.TkgImageRepo, imageName) + ":" + tkrVersion
 			tarname := imageName + "-" + tkrVersion + ".tar"
 			tempImageDetails[tarname] = imageName
+                        i := sourceImageName
+                        j := tarname
 			group.Go(func() error {
-				return p.PkgClient.CopyImageToTar(sourceImageName, tarname, p.CaCertificate, p.Insecure)
+				return p.PkgClient.CopyImageToTar(i, j, p.CaCertificate, p.Insecure)
 			})
 		}
 		for i := 0; i < tkgPackageStruct.NumField(); i++ {
@@ -298,8 +304,10 @@ func (p *PublishImagesToTarOptions) DownloadTkgPackagesImages(tkrVersions []stri
 			sourceImageName := filepath.Join(p.TkgImageRepo, imageName) + ":" + tkrVersion
 			tarname := imageName + "-" + tkrVersion + ".tar"
 			tempImageDetails[tarname] = imageName
+                        i := sourceImageName
+                        j := tarname
 			group.Go(func() error {
-				return p.PkgClient.CopyImageToTar(sourceImageName, tarname, p.CaCertificate, p.Insecure)
+				return p.PkgClient.CopyImageToTar(i, j, p.CaCertificate, p.Insecure)
 			})
 		}
 	}

--- a/cmd/cli/plugin/isolated-cluster/imagepushop/publishimagesfromtar.go
+++ b/cmd/cli/plugin/isolated-cluster/imagepushop/publishimagesfromtar.go
@@ -5,7 +5,6 @@
 package imagepushop
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -74,14 +73,11 @@ func (p *PublishImagesFromTarOptions) PushImageToRepo() error {
 	for tarfile, path := range data {
 		fileName := filepath.Join(p.TkgTarFilePath, tarfile)
 		destPath := filepath.Join(p.DestinationRepository, path)
-		group.Go(
-			func() error {
-				err = p.PkgClient.CopyImageFromTar(fileName, destPath, p.CustomImageRepoCertificate, p.Insecure)
-				if err != nil {
-					return err
-				}
-				return nil
-			})
+		i := fileName
+		j := destPath
+		group.Go(func() error {
+			return p.PkgClient.CopyImageFromTar(i, j, p.CustomImageRepoCertificate, p.Insecure)
+		})
 	}
 	err = group.Wait()
 	if err != nil {
@@ -93,9 +89,6 @@ func (p *PublishImagesFromTarOptions) PushImageToRepo() error {
 
 func publishImagesFromTar(cmd *cobra.Command, args []string) error {
 	pushImage.PkgClient = &imgpkginterface.Imgpkg{}
-	if !pushImage.Insecure && pushImage.CustomImageRepoCertificate == "" {
-		return fmt.Errorf("CA certificate is empty and Insecure option is disabled")
-	}
 
 	err := pushImage.PushImageToRepo()
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Vandana Pathak <pathakv@sjc-ubu-eng-127.vmware.com>

### What this PR does / why we need it
isolated-cluster plugin writes incorrect image files , correcting the code login for parallel execution of pull request
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #4190 

### Describe testing done for PR
After download command , tested the downloaded image by describing it with following command 
`tar xfv tarfilename && jq '.[0].Image.Refs[0]' < manifest.json`
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
NA
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
