### PR TITLE
set the node-ip correctly for kube-vip IPv6-only

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -1235,6 +1235,25 @@ spec:
       - op: add
         path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/node-ip
         value: "::"
+  - name: ipv6KubeletNodeIPConfiguration
+    enabledIf: '{{ and (.builtin.cluster.network.ipFamily | eq "IPv6" | or (.builtin.cluster.network.ipFamily | eq "DualStack" | and (.network.ipv6Primary | default false))) (not .aviAPIServerHAProvider) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        value:
+          content: ""
+          owner: root:root
+          path: /etc/sysconfig/kubelet
+          permissions: "0640"
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: echo "KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)" >> /etc/sysconfig/kubelet
   - name: nodeLabels
     definitions:
     - selector:

--- a/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
@@ -1235,6 +1235,25 @@ spec:
       - op: add
         path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/node-ip
         value: "::"
+  - name: ipv6KubeletNodeIPConfiguration
+    enabledIf: '{{ and (.builtin.cluster.network.ipFamily | eq "IPv6" | or (.builtin.cluster.network.ipFamily | eq "DualStack" | and (.network.ipv6Primary | default false))) (not .aviAPIServerHAProvider) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        value:
+          content: ""
+          owner: root:root
+          path: /etc/sysconfig/kubelet
+          permissions: "0640"
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: echo "KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)" >> /etc/sysconfig/kubelet
   - name: nodeLabels
     definitions:
     - selector:


### PR DESCRIPTION
### What this PR does / why we need it
set the node-ip to a valid IPv6 address on the VM before kube-vip starts so that pods do not wind up with the kube-vip address

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Created a vSphere management cluster with kube-vip enabled and verified that the node-ip was set correctly.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
N/A
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
