### PR TITLE
Suppress provider update if developer needs

### DIFF
--- a/tkg/client/common.go
+++ b/tkg/client/common.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -364,11 +365,14 @@ func (c *TkgClient) ShouldDeployClusterClassBasedCluster(isManagementCluster boo
 		return true, nil
 	}
 
+	// Ignore the checksum check if config variable 'SUPPRESS_PROVIDERS_UPDATE' is set.
+	isSuppressProvidersUpdateSet := os.Getenv(constants.SuppressProvidersUpdate) != ""
+
 	allowLegacyClusterCreated = c.SetAllowLegacyClusterConfiguration()
 	if allowLegacyClusterCreated == "false" {
 		// Return error if user has customized template overlays
 		// but the feature gate FeatureFlagAllowLegacyCluster or ALLOW_LEGACY_CLUSTER parameter is disabled for workload cluster
-		if isCustomOverlayPresent {
+		if isCustomOverlayPresent && !isSuppressProvidersUpdateSet {
 			return false, errors.Errorf("It seems like you have done some customizations to the template overlays. However, the feature gate %v is %v. Please enabe it and try again", constants.FeatureFlagAllowLegacyCluster, allowLegacyClusterCreated)
 		} else {
 			// Deploy clusterclass based workload cluster when template overlays don't be customized

--- a/tkg/client/common_test.go
+++ b/tkg/client/common_test.go
@@ -4,6 +4,7 @@ package client_test
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -147,7 +148,7 @@ var _ = Describe("ensureAllowLegacyClusterConfiguration", func() {
 
 })
 
-var _ = Describe("shouldDeployClusterCLass", func() {
+var _ = Describe("shouldDeployClusterClass", func() {
 	var (
 		err                    error
 		tkgClient              *client.TkgClient
@@ -248,6 +249,15 @@ var _ = Describe("shouldDeployClusterCLass", func() {
 			result, err := tkgClient.ShouldDeployClusterClassBasedCluster(isManagementCluster)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(false))
+		})
+
+		It("Should return true when AllowLeagcyCluster is false and SUPPRESS_PROVIDERS_UPDATE is set", func() {
+			os.Setenv("SUPPRESS_PROVIDERS_UPDATE", "1")
+			featureFlagClient.FeatureFlags[constants.FeatureFlagAllowLegacyCluster] = false
+			result, err := tkgClient.ShouldDeployClusterClassBasedCluster(isManagementCluster)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(true))
+			os.Unsetenv("SUPPRESS_PROVIDERS_UPDATE")
 		})
 	})
 })


### PR DESCRIPTION
### What this PR does / why we need it

For our internal development, sometimes, we need to update ytt/yttcc/yttcb template, and test if our changes work.
Also we don't want to build the whole things so that we can save more time for developing. In this situation, we can set SUPPRESS_PROVIDERS_UPDATE env var, and create legacy or classy cluster depends on yourself.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #4187 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
