### PR TITLE
Using jsonpatch to fix Windows MD class values for CloudBase-init

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -1851,6 +1851,15 @@ spec:
       - op: add
         path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/register-with-taints
         value: os=windows:NoSchedule
+      - op: replace
+        path: /spec/template/spec/joinConfiguration/nodeRegistration/name
+        value: '{{ ds.meta_data.hostname }}'
+      - op: replace
+        path: /spec/template/spec/preKubeadmCommands
+        valueFrom:
+          template: |
+            - echo | set /p="::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6" > C:\etc\hosts & echo. >> C:\etc\hosts
+            - echo | set /p="127.0.0.1   {{" {{ ds.meta_data.hostname }} "}} localhost localhost.localdomain localhost4 localhost4.localdomain4" >> C:\etc\hosts
       - op: add
         path: /spec/template/spec/files/-
         value:
@@ -1900,6 +1909,9 @@ spec:
                 } while ($SaToken -eq $null)
                 return $SaToken
             }
+
+            # Disable firewall temporarily for SSH and other internal ports access
+            Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
             $TempFolder = 'C:\programdata\temp'
             $AntreaInTempFolder = "$TempFolder\antrea-windows-advanced.zip"
@@ -1967,7 +1979,6 @@ spec:
             & Install-AntreaAgent -KubernetesHome "C:\k" -KubeConfig "C:\etc\kubernetes\kubelet.conf" -AntreaHome "C:\k\antrea" -AntreaVersion "1.7.1"
             New-KubeProxyServiceInterface
             & C:\k\antrea\Install-OVS.ps1 -ImportCertificate $false -LocalFile C:\k\antrea\ovs-win64.zip
-            Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
             # Setup Services
             $nssm = (Get-Command nssm).Source

--- a/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
@@ -1851,6 +1851,15 @@ spec:
       - op: add
         path: /spec/template/spec/joinConfiguration/nodeRegistration/kubeletExtraArgs/register-with-taints
         value: os=windows:NoSchedule
+      - op: replace
+        path: /spec/template/spec/joinConfiguration/nodeRegistration/name
+        value: '{{ ds.meta_data.hostname }}'
+      - op: replace
+        path: /spec/template/spec/preKubeadmCommands
+        valueFrom:
+          template: |
+            - echo | set /p="::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6" > C:\etc\hosts & echo. >> C:\etc\hosts
+            - echo | set /p="127.0.0.1   {{" {{ ds.meta_data.hostname }} "}} localhost localhost.localdomain localhost4 localhost4.localdomain4" >> C:\etc\hosts
       - op: add
         path: /spec/template/spec/files/-
         value:
@@ -1900,6 +1909,9 @@ spec:
                 } while ($SaToken -eq $null)
                 return $SaToken
             }
+
+            # Disable firewall temporarily for SSH and other internal ports access
+            Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
             $TempFolder = 'C:\programdata\temp'
             $AntreaInTempFolder = "$TempFolder\antrea-windows-advanced.zip"
@@ -1967,7 +1979,6 @@ spec:
             & Install-AntreaAgent -KubernetesHome "C:\k" -KubeConfig "C:\etc\kubernetes\kubelet.conf" -AntreaHome "C:\k\antrea" -AntreaVersion "1.7.1"
             New-KubeProxyServiceInterface
             & C:\k\antrea\Install-OVS.ps1 -ImportCertificate $false -LocalFile C:\k\antrea\ovs-win64.zip
-            Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
             # Setup Services
             $nssm = (Get-Command nssm).Source

--- a/providers/infrastructure-vsphere/v1.5.1/ytt/overlay-windows.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/ytt/overlay-windows.yaml
@@ -314,6 +314,9 @@ spec:
               return $SaToken
           }
 
+          # Disable firewall temporarily for SSH and other internal ports access
+          Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+
           $TempFolder = 'C:\programdata\temp'
           $AntreaInTempFolder = "$TempFolder\antrea-windows-advanced.zip"
           $KubeproxyInTempFolder = "$TempFolder\kube-proxy.exe"
@@ -379,13 +382,12 @@ spec:
           # TODO:
           #   Install-AntreaAgent is too heavy, since Kubernetes and Antrea binaries have already been pre-installed, we don't
           #   depend on Install-AntreaAgent to downloading them, KubernetesVersion and AntreaVersion are not used anymore, will
-          #   refine the invoke of Install-AntreaAgent in the future. Keep AntreaVersion for 1.2.3, guessing latest from the script
+          #   refine the invoke of Install-AntreaAgent in the future. Keep AntreaVersion for 1.7.1, guessing latest from the script
           #   on this version is breaking the installation.
           Import-Module C:\k\antrea\helper.psm1
-          & Install-AntreaAgent -KubernetesHome "C:\k" -KubeConfig "C:\etc\kubernetes\kubelet.conf" -AntreaHome "C:\k\antrea" -AntreaVersion "v1.2.3"
+          & Install-AntreaAgent -KubernetesHome "C:\k" -KubeConfig "C:\etc\kubernetes\kubelet.conf" -AntreaHome "C:\k\antrea" -AntreaVersion "v1.7.1"
           New-KubeProxyServiceInterface
           & C:\k\antrea\Install-OVS.ps1 -ImportCertificate $false -LocalFile C:\k\antrea\ovs-win64.zip
-          Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
           # Setup Services
           $nssm = (Get-Command nssm).Source


### PR DESCRIPTION
### What this PR does / why we need it
Two changes on this PR:
1. Disabling the firewall before installing Antrea, if something goes wrong in the antrea installation there's no way to access SSH  since there's no rule enabling it (https://github.com/kubernetes-sigs/image-builder/pull/1039) - it should go on next bump.
2. Replacing the nodeRegistration name variable and fixing the /etc/hosts template since Cloudbase-Init do not have a `local_hostname` variable (after this change https://github.com/vmware-tanzu/tanzu-framework/pull/3926)

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/4207

### Describe testing done for PR
<!-- Example: Created vSphere workload cluster to verify change. -->
The kubeadmConfigTemplate is created as required.
```
      name: '{{ ds.meta_data.hostname }}'
  preKubeadmCommands:
   - echo | set /p="::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6"
    > C:\etc\hosts
  - echo | set /p="127.0.0.1    {{ ds.meta_data.hostname }}  localhost localhost.localdomain
    localhost4 localhost4.localdomain4" >> C:\etc\hosts
```

`C:\etc\hosts` content
```
::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6
127.0.0.1    tkg2-md-1-6hglh-6dc5f96494-lhmrp  localhost localhost.localdomain localhost4 localhost4.localdomain4
```

Cluster was created with success with prod cluster plan.
```
Using this new Cluster configuration '/home/kubo/.config/tanzu/tkg/clusterconfigs/tkg2.yaml' to create the cluster.
creating workload cluster 'tkg2'...
waiting for cluster to be initialized...
...
Workload cluster 'tkg2' created

tkg2-md-0-plrr7-768cdbdc6-cs6q5    Ready    <none>          9m37s   v1.24.6+vmware.1 x x Windows Server 2019 Standard   10.0.17763.2114   containerd://1.6.6
tkg2-md-1-6hglh-6dc5f96494-lhmrp   Ready    <none>          10m     v1.24.6+vmware.1 x x Windows Server 2019 Standard   10.0.17763.2114   containerd://1.6.6
tkg2-md-2-lsws5-b89b6d5fc-dsvb5    Ready    <none>          8m56s   v1.24.6+vmware.1 x x Windows Server 2019 Standard   10.0.17763.2114   containerd://1.6.6
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
