### PR TITLE
Kickstart UI: remove AWS option for new VPC creation

### DIFF
--- a/tkg/web/src/app/views/landing/aws-wizard/aws-wizard.component.ts
+++ b/tkg/web/src/app/views/landing/aws-wizard/aws-wizard.component.ts
@@ -122,9 +122,7 @@ export class AwsWizardComponent extends WizardBaseDirective implements OnInit {
         const machineHealthChecksEnabled = this.getFieldValue(AwsForm.NODESETTING, NodeSettingField.MACHINE_HEALTH_CHECKS_ENABLED);
         payload.machineHealthCheckEnabled = (machineHealthChecksEnabled === true);
         payload.vpc = {
-            cidr: (this.getFieldValue(AwsForm.VPC, AwsField.VPC_TYPE) === VpcType.EXISTING) ?
-                this.getFieldValue(AwsForm.VPC, AwsField.VPC_EXISTING_CIDR) :
-                this.getFieldValue(AwsForm.VPC, AwsField.VPC_NEW_CIDR),
+            cidr: this.getFieldValue(AwsForm.VPC, AwsField.VPC_EXISTING_CIDR),
             vpcID: this.getFieldValue(AwsForm.VPC, AwsField.VPC_EXISTING_ID),
             azs: this.getAwsNodeAzs(payload)
         };

--- a/tkg/web/src/app/views/landing/aws-wizard/node-setting-step/node-setting-step.component.html
+++ b/tkg/web/src/app/views/landing/aws-wizard/node-setting-step/node-setting-step.component.html
@@ -247,67 +247,67 @@
         </div>
     </div>
 
-    <!-- AZ 1 -->
-    <div class="clr-row">
-        <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
-            <clr-select-container>
-                <label i18n="existing vpc label">
-                    {{htmlFieldLabels['awsNodeAz1']}}
-                    <clr-tooltip>
-                        <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
-                        <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
-                            <span>
-                                Choose an AWS availability zone (AWS subregion). If using an existing VPC, selecting an
-                                availability zone first is required for retrieving existing public and private subnets.
-                            </span>
-                        </clr-tooltip-content>
-                    </clr-tooltip>
-                </label>
-                <select
-                        clrSelect
-                        name="awsNodeAz1"
-                        formControlName="awsNodeAz1">
-                    <option aria-label="blank" title="blank"></option>
-                    <ng-container *ngFor="let nodeAz of nodeAzs">
-                        <option [value]="nodeAz.name">
-                            {{ nodeAz.name }}
-                        </option>
-                    </ng-container>
-                </select>
-                <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
-                <clr-control-helper></clr-control-helper>
-                <clr-control-error
-                        i18n="availability zone required msg"
-                        *clrIfError="validatorEnum.REQUIRED">
-                    Selecting an availability zone is required
-                </clr-control-error>
-                <clr-control-error
-                        i18n="availability zone unique msg"
-                        *clrIfError="validatorEnum.AVAILABILITY_ZONE_UNIQUE">
-                    Availability zone selection must be unique
-                </clr-control-error>
-            </clr-select-container>
-        </div>
-        <ng-container *ngIf="isVpcTypeExisting">
+    <ng-container>
+        <!-- AZ 1 -->
+        <div class="clr-row">
             <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
                 <clr-select-container>
-                    <label i18n="existing vpc label">
-                        {{htmlFieldLabels['vpcPublicSubnet1']}}
+                    <label i18n="availability zone label">
+                        {{htmlFieldLabels['awsNodeAz1']}}
                         <clr-tooltip>
                             <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                             <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
-                                <span>
-                                    {{
-                                        getVpcSubnetTooltip('public')
-                                    }}
-                                </span>
+                            <span>
+                                Choose an AWS availability zone (AWS subregion). Selecting an availability zone first is
+                                required for retrieving existing public and private subnets.
+                            </span>
                             </clr-tooltip-content>
                         </clr-tooltip>
                     </label>
                     <select
-                        clrSelect
-                        name="vpcPublicSubnet1"
-                        formControlName="vpcPublicSubnet1">
+                            clrSelect
+                            name="awsNodeAz1"
+                            formControlName="awsNodeAz1">
+                        <option aria-label="blank" title="blank"></option>
+                        <ng-container *ngFor="let nodeAz of nodeAzs">
+                            <option [value]="nodeAz.name">
+                                {{ nodeAz.name }}
+                            </option>
+                        </ng-container>
+                    </select>
+                    <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
+                    <clr-control-helper></clr-control-helper>
+                    <clr-control-error
+                            i18n="availability zone required msg"
+                            *clrIfError="validatorEnum.REQUIRED">
+                        Selecting an availability zone is required
+                    </clr-control-error>
+                    <clr-control-error
+                            i18n="availability zone unique msg"
+                            *clrIfError="validatorEnum.AVAILABILITY_ZONE_UNIQUE">
+                        Availability zone selection must be unique
+                    </clr-control-error>
+                </clr-select-container>
+            </div>
+            <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
+                <clr-select-container>
+                    <label i18n="vpc public subnet label">
+                        {{htmlFieldLabels['vpcPublicSubnet1']}}
+                        <clr-tooltip>
+                            <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
+                            <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
+                            <span>
+                                {{
+                                getVpcSubnetTooltip('public')
+                                }}
+                            </span>
+                            </clr-tooltip-content>
+                        </clr-tooltip>
+                    </label>
+                    <select
+                            clrSelect
+                            name="vpcPublicSubnet1"
+                            formControlName="vpcPublicSubnet1">
                         <option aria-label="blank" title="blank"></option>
                         <ng-container *ngFor="let subnet of filteredAzs?.awsNodeAz1?.publicSubnets">
                             <option [value]="subnet.id">
@@ -319,30 +319,30 @@
                     <clr-control-helper></clr-control-helper>
                     <clr-control-error>
                         {{
-                            getVpcSubnetErrorMsg('public')
+                        getVpcSubnetErrorMsg('public')
                         }}
                     </clr-control-error>
                 </clr-select-container>
             </div>
             <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
                 <clr-select-container>
-                    <label i18n="existing vpc label">
+                    <label i18n="vpc private subnet label">
                         {{htmlFieldLabels['vpcPrivateSubnet1']}}
                         <clr-tooltip>
                             <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                             <clr-tooltip-content clrPosition="top-left" clrSize="lg" *clrIfOpen>
-                                <span>
-                                    {{
-                                        getVpcSubnetTooltip('private')
-                                    }}
-                                </span>
+                            <span>
+                                {{
+                                getVpcSubnetTooltip('private')
+                                }}
+                            </span>
                             </clr-tooltip-content>
                         </clr-tooltip>
                     </label>
                     <select
-                        clrSelect
-                        name="vpcPrivateSubnet1"
-                        formControlName="vpcPrivateSubnet1">
+                            clrSelect
+                            name="vpcPrivateSubnet1"
+                            formControlName="vpcPrivateSubnet1">
                         <option aria-label="blank" title="blank"></option>
                         <ng-container *ngFor="let subnet of filteredAzs?.awsNodeAz1?.privateSubnets">
                             <option [value]="subnet.id">
@@ -354,334 +354,335 @@
                     <clr-control-helper></clr-control-helper>
                     <clr-control-error>
                         {{
-                            getVpcSubnetErrorMsg('private')
+                        getVpcSubnetErrorMsg('private')
                         }}
                     </clr-control-error>
                 </clr-select-container>
             </div>
             <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4"></div>
-        </ng-container>
-        <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4" *featureToggle="'!management-cluster.standalone-cluster-mode'">
-            <clr-datalist-container>
-                <label i18n="worker node instance type label" class="clr-col-12 clr-col-md-12">
-                    {{htmlFieldLabels['workerNodeInstanceType']}}
-                    <clr-tooltip>
-                        <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
-                        <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
+            <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4" *featureToggle="'!management-cluster.standalone-cluster-mode'">
+                <clr-datalist-container>
+                    <label i18n="worker node instance type label" class="clr-col-12 clr-col-md-12">
+                        {{htmlFieldLabels['workerNodeInstanceType']}}
+                        <clr-tooltip>
+                            <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
+                            <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
                             <span>
                                 Choose the configuration for worker nodes for this AZ.
                             </span>
-                        </clr-tooltip-content>
-                    </clr-tooltip>
-                </label>
-                <input clrDatalistInput
-                       name="workerNodeInstanceType"
-                       formControlName="workerNodeInstanceType"
-                       role="listbox"
-                       aria-label="worker node instance type for az1"
-                       autocomplete="off"
-                       [attr.disabled]="azNodeTypes.awsNodeAz1.length ? null : 'disabled'"/>
-                <datalist id="workerNodeInstanceType">
-                    <option *ngFor="let nodeType of azNodeTypes.awsNodeAz1" [value]="nodeType"></option>
-                </datalist>
-                <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
-                <clr-control-helper></clr-control-helper>
-            </clr-datalist-container>
-            <clr-control-error *ngIf="showFormError('workerNodeInstanceType')">
-                Selecting worker node instance type is required for this AZ
-            </clr-control-error>
+                            </clr-tooltip-content>
+                        </clr-tooltip>
+                    </label>
+                    <input clrDatalistInput
+                           name="workerNodeInstanceType"
+                           formControlName="workerNodeInstanceType"
+                           role="listbox"
+                           aria-label="worker node instance type for az1"
+                           autocomplete="off"
+                           [attr.disabled]="azNodeTypes.awsNodeAz1.length ? null : 'disabled'"/>
+                    <datalist id="workerNodeInstanceType">
+                        <option *ngFor="let nodeType of azNodeTypes.awsNodeAz1" [value]="nodeType"></option>
+                    </datalist>
+                    <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
+                    <clr-control-helper></clr-control-helper>
+                </clr-datalist-container>
+                <clr-control-error *ngIf="showFormError('workerNodeInstanceType')">
+                    Selecting worker node instance type is required for this AZ
+                </clr-control-error>
+            </div>
         </div>
-    </div>
 
-    <!-- AZ 2 -->
-    <div class="clr-row" *ngIf="isClusterPlanProd">
-        <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
-            <clr-select-container>
-                <label i18n="existing vpc label">
-                    {{htmlFieldLabels['awsNodeAz2']}}
-                    <clr-tooltip>
-                        <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
-                        <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
-                            <span>
-                                Choose an AWS availability zone (AWS subregion). If using an existing VPC, selecting an
-                                availability zone first is required for retrieving existing public and private subnets.
-                            </span>
-                        </clr-tooltip-content>
-                    </clr-tooltip>
-                </label>
-                <select
-                        clrSelect
-                        name="awsNodeAz2"
-                        formControlName="awsNodeAz2">
-                    <option aria-label="blank" title="blank"></option>
-                    <ng-container *ngFor="let nodeAz of nodeAzs">
-                        <option [value]="nodeAz.name">
-                            {{ nodeAz.name }}
-                        </option>
-                    </ng-container>
-                </select>
-                <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
-                <clr-control-helper></clr-control-helper>
-                <clr-control-error
-                        i18n="availability zone required msg"
-                        *clrIfError="validatorEnum.REQUIRED">
-                    Selecting an availability zone is required
-                </clr-control-error>
-                <clr-control-error
-                        i18n="availability zone unique msg"
-                        *clrIfError="validatorEnum.AVAILABILITY_ZONE_UNIQUE">
-                    Availability zone selection must be unique
-                </clr-control-error>
-            </clr-select-container>
-        </div>
-        <ng-container *ngIf="isClusterPlanProd && isVpcTypeExisting">
-            <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4" >
+        <!-- AZ 2 -->
+        <div class="clr-row" *ngIf="isClusterPlanProd">
+            <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
                 <clr-select-container>
-                    <label i18n="existing vpc label">
-                        {{htmlFieldLabels['vpcPublicSubnet2']}}
+                    <label i18n="availability zone label">
+                        {{htmlFieldLabels['awsNodeAz2']}}
                         <clr-tooltip>
                             <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                             <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
-                                <span>
-                                    {{
-                                        getVpcSubnetTooltip('public')
-                                    }}
-                                </span>
-                            </clr-tooltip-content>
-                        </clr-tooltip>
-                    </label>
-                    <select
-                        clrSelect
-                        name="vpcPublicSubnet2"
-                        formControlName="vpcPublicSubnet2">
-                        <option aria-label="blank" title="blank"></option>
-                        <ng-container *ngFor="let subnet of filteredAzs?.awsNodeAz2?.publicSubnets">
-                            <option [value]="subnet.id">
-                                {{ subnet.cidr }}
-                            </option>
-                        </ng-container>
-                    </select>
-                    <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
-                    <clr-control-helper></clr-control-helper>
-                    <clr-control-error>
-                        {{
-                            getVpcSubnetErrorMsg('public')
-                        }}
-                    </clr-control-error>
-                </clr-select-container>
-            </div>
-            <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
-                <clr-select-container>
-                    <label i18n="existing vpc label">
-                        {{htmlFieldLabels['vpcPrivateSubnet2']}}
-                        <clr-tooltip>
-                            <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
-                            <clr-tooltip-content clrPosition="top-left" clrSize="lg" *clrIfOpen>
-                                <span>
-                                    {{
-                                        getVpcSubnetTooltip('private')
-                                    }}
-                                </span>
-                            </clr-tooltip-content>
-                        </clr-tooltip>
-                    </label>
-                    <select
-                        clrSelect
-                        name="vpcPrivateSubnet2"
-                        formControlName="vpcPrivateSubnet2">
-                        <option aria-label="blank" title="blank"></option>
-                        <ng-container *ngFor="let subnet of filteredAzs?.awsNodeAz2?.privateSubnets">
-                            <option [value]="subnet.id">
-                                {{ subnet.cidr }}
-                            </option>
-                        </ng-container>
-                    </select>
-                    <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
-                    <clr-control-helper></clr-control-helper>
-                    <clr-control-error>
-                        {{
-                            getVpcSubnetErrorMsg('private')
-                        }}
-                    </clr-control-error>
-                </clr-select-container>
-            </div>
-            <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4"></div>
-        </ng-container>
-        <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4" *featureToggle="'!management-cluster.standalone-cluster-mode'">
-            <clr-datalist-container>
-                <label i18n="worker node instance type label" class="clr-col-12 clr-col-md-12">
-                    {{htmlFieldLabels['workerNodeInstanceType2']}}
-                    <clr-tooltip>
-                        <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
-                        <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
-                        <span>
-                            Choose the configuration for worker nodes for this AZ.
-                        </span>
-                        </clr-tooltip-content>
-                    </clr-tooltip>
-                </label>
-                <input clrDatalistInput
-                       name="workerNodeInstanceType2"
-                       formControlName="workerNodeInstanceType2"
-                       role="listbox"
-                       aria-label="worker node instance type for az2"
-                       autocomplete="off"
-                       [attr.disabled]="azNodeTypes.awsNodeAz2.length ? null : 'disabled'"/>
-                <datalist id="workerNodeInstanceType2">
-                    <option *ngFor="let nodeType of azNodeTypes.awsNodeAz2" [value]="nodeType"></option>
-                </datalist>
-                <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
-                <clr-control-helper></clr-control-helper>
-            </clr-datalist-container>
-            <clr-control-error *ngIf="showFormError('workerNodeInstanceType2')">
-                Selecting worker node instance type is required for this AZ
-            </clr-control-error>
-        </div>
-    </div>
-
-    <!-- AZ 3 -->
-    <div class="clr-row" *ngIf="isClusterPlanProd">
-        <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
-            <clr-select-container>
-                <label i18n="existing vpc label">
-                    {{htmlFieldLabels['awsNodeAz3']}}
-                    <clr-tooltip>
-                        <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
-                        <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
                             <span>
-                                Choose an AWS availability zone (AWS subregion). If using an existing VPC, selecting an
-                                availability zone first is required for retrieving existing public and private subnets.
+                                Choose an AWS availability zone (AWS subregion). Selecting an availability zone first is
+                                required for retrieving existing public and private subnets.
                             </span>
-                        </clr-tooltip-content>
-                    </clr-tooltip>
-                </label>
-                <select
-                        clrSelect
-                        name="awsNodeAz3"
-                        formControlName="awsNodeAz3">
-                    <option aria-label="blank" title="blank"></option>
-                    <ng-container *ngFor="let nodeAz of nodeAzs">
-                        <option [value]="nodeAz.name">
-                            {{ nodeAz.name }}
-                        </option>
-                    </ng-container>
-                </select>
-                <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
-                <clr-control-helper></clr-control-helper>
-                <clr-control-error
-                        i18n="availability zone required msg"
-                        *clrIfError="validatorEnum.REQUIRED">
-                    Selecting an availability zone is required
-                </clr-control-error>
-                <clr-control-error
-                        i18n="availability zone unique msg"
-                        *clrIfError="validatorEnum.AVAILABILITY_ZONE_UNIQUE">
-                    Availability zone selection must be unique
-                </clr-control-error>
-            </clr-select-container>
-        </div>
-        <ng-container *ngIf="isClusterPlanProd && isVpcTypeExisting">
+                            </clr-tooltip-content>
+                        </clr-tooltip>
+                    </label>
+                    <select
+                            clrSelect
+                            name="awsNodeAz2"
+                            formControlName="awsNodeAz2">
+                        <option aria-label="blank" title="blank"></option>
+                        <ng-container *ngFor="let nodeAz of nodeAzs">
+                            <option [value]="nodeAz.name">
+                                {{ nodeAz.name }}
+                            </option>
+                        </ng-container>
+                    </select>
+                    <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
+                    <clr-control-helper></clr-control-helper>
+                    <clr-control-error
+                            i18n="availability zone required msg"
+                            *clrIfError="validatorEnum.REQUIRED">
+                        Selecting an availability zone is required
+                    </clr-control-error>
+                    <clr-control-error
+                            i18n="availability zone unique msg"
+                            *clrIfError="validatorEnum.AVAILABILITY_ZONE_UNIQUE">
+                        Availability zone selection must be unique
+                    </clr-control-error>
+                </clr-select-container>
+            </div>
+            <ng-container *ngIf="isClusterPlanProd">
+                <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4" >
+                    <clr-select-container>
+                        <label i18n="vpc public subnet label">
+                            {{htmlFieldLabels['vpcPublicSubnet2']}}
+                            <clr-tooltip>
+                                <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
+                                <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
+                                <span>
+                                    {{
+                                    getVpcSubnetTooltip('public')
+                                    }}
+                                </span>
+                                </clr-tooltip-content>
+                            </clr-tooltip>
+                        </label>
+                        <select
+                                clrSelect
+                                name="vpcPublicSubnet2"
+                                formControlName="vpcPublicSubnet2">
+                            <option aria-label="blank" title="blank"></option>
+                            <ng-container *ngFor="let subnet of filteredAzs?.awsNodeAz2?.publicSubnets">
+                                <option [value]="subnet.id">
+                                    {{ subnet.cidr }}
+                                </option>
+                            </ng-container>
+                        </select>
+                        <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
+                        <clr-control-helper></clr-control-helper>
+                        <clr-control-error>
+                            {{
+                            getVpcSubnetErrorMsg('public')
+                            }}
+                        </clr-control-error>
+                    </clr-select-container>
+                </div>
+                <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
+                    <clr-select-container>
+                        <label i18n="vpc private subnet label">
+                            {{htmlFieldLabels['vpcPrivateSubnet2']}}
+                            <clr-tooltip>
+                                <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
+                                <clr-tooltip-content clrPosition="top-left" clrSize="lg" *clrIfOpen>
+                                <span>
+                                    {{
+                                    getVpcSubnetTooltip('private')
+                                    }}
+                                </span>
+                                </clr-tooltip-content>
+                            </clr-tooltip>
+                        </label>
+                        <select
+                                clrSelect
+                                name="vpcPrivateSubnet2"
+                                formControlName="vpcPrivateSubnet2">
+                            <option aria-label="blank" title="blank"></option>
+                            <ng-container *ngFor="let subnet of filteredAzs?.awsNodeAz2?.privateSubnets">
+                                <option [value]="subnet.id">
+                                    {{ subnet.cidr }}
+                                </option>
+                            </ng-container>
+                        </select>
+                        <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
+                        <clr-control-helper></clr-control-helper>
+                        <clr-control-error>
+                            {{
+                            getVpcSubnetErrorMsg('private')
+                            }}
+                        </clr-control-error>
+                    </clr-select-container>
+                </div>
+                <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4"></div>
+            </ng-container>
             <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
-                <clr-select-container>
-                    <label i18n="existing vpc label">
-                        {{htmlFieldLabels['vpcPublicSubnet3']}}
+                <clr-datalist-container>
+                    <label i18n="worker node instance type label" class="clr-col-12 clr-col-md-12">
+                        {{htmlFieldLabels['workerNodeInstanceType2']}}
                         <clr-tooltip>
                             <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
                             <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
-                                <span>
-                                    {{
-                                        getVpcSubnetTooltip('public')
-                                    }}
-                                </span>
-                            </clr-tooltip-content>
-                        </clr-tooltip>
-                    </label>
-                    <select
-                        clrSelect
-                        name="vpcPublicSubnet3"
-                        formControlName="vpcPublicSubnet3">
-                        <option aria-label="blank" title="blank"></option>
-                        <ng-container *ngFor="let subnet of filteredAzs?.awsNodeAz3?.publicSubnets">
-                            <option [value]="subnet.id">
-                                {{ subnet.cidr }}
-                            </option>
-                        </ng-container>
-                    </select>
-                    <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
-                    <clr-control-helper></clr-control-helper>
-                    <clr-control-error>
-                        {{
-                            getVpcSubnetErrorMsg('public')
-                        }}
-                    </clr-control-error>
-                </clr-select-container>
-            </div>
-            <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
-                <clr-select-container>
-                    <label i18n="existing vpc label">
-                        {{htmlFieldLabels['vpcPrivateSubnet3']}}
-                        <clr-tooltip>
-                            <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
-                            <clr-tooltip-content clrPosition="top-left" clrSize="lg" *clrIfOpen>
-                                <span>
-                                    {{
-                                        getVpcSubnetTooltip('private')
-                                    }}
-                                </span>
-                            </clr-tooltip-content>
-                        </clr-tooltip>
-                    </label>
-                    <select
-                        clrSelect
-                        name="vpcPrivateSubnet3"
-                        formControlName="vpcPrivateSubnet3">
-                        <option aria-label="blank" title="blank"></option>
-                        <ng-container *ngFor="let subnet of filteredAzs?.awsNodeAz3?.privateSubnets">
-                            <option [value]="subnet.id">
-                                {{ subnet.cidr }}
-                            </option>
-                        </ng-container>
-                    </select>
-                    <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
-                    <clr-control-helper></clr-control-helper>
-                    <clr-control-error>
-                        {{
-                            getVpcSubnetErrorMsg('private')
-                        }}
-                    </clr-control-error>
-                </clr-select-container>
-            </div>
-            <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4"></div>
-        </ng-container>
-        <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4" *featureToggle="'!management-cluster.standalone-cluster-mode'">
-            <clr-datalist-container>
-                <label i18n="worker node instance type label" class="clr-col-12 clr-col-md-12">
-                    {{htmlFieldLabels['workerNodeInstanceType3']}}
-                    <clr-tooltip>
-                        <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
-                        <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
                         <span>
                             Choose the configuration for worker nodes for this AZ.
                         </span>
-                        </clr-tooltip-content>
-                    </clr-tooltip>
-                </label>
-                <input clrDatalistInput
-                       name="workerNodeInstanceType3"
-                       formControlName="workerNodeInstanceType3"
-                       role="listbox"
-                       aria-label="worker node instance type for az3"
-                       autocomplete="off"
-                       [attr.disabled]="azNodeTypes.awsNodeAz3.length ? null : 'disabled'"/>
-                <datalist id="workerNodeInstanceType3">
-                    <option *ngFor="let nodeType of azNodeTypes.awsNodeAz3" [value]="nodeType"></option>
-                </datalist>
-                <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
-                <clr-control-helper></clr-control-helper>
-            </clr-datalist-container>
-            <clr-control-error *ngIf="showFormError('workerNodeInstanceType3')">
-                Selecting worker node instance type is required for this AZ
-            </clr-control-error>
+                            </clr-tooltip-content>
+                        </clr-tooltip>
+                    </label>
+                    <input clrDatalistInput
+                           name="workerNodeInstanceType2"
+                           formControlName="workerNodeInstanceType2"
+                           role="listbox"
+                           aria-label="worker node instance type for az2"
+                           autocomplete="off"
+                           [attr.disabled]="azNodeTypes.awsNodeAz2.length ? null : 'disabled'"/>
+                    <datalist id="workerNodeInstanceType2">
+                        <option *ngFor="let nodeType of azNodeTypes.awsNodeAz2" [value]="nodeType"></option>
+                    </datalist>
+                    <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
+                    <clr-control-helper></clr-control-helper>
+                </clr-datalist-container>
+                <clr-control-error *ngIf="showFormError('workerNodeInstanceType2')">
+                    Selecting worker node instance type is required for this AZ
+                </clr-control-error>
+            </div>
         </div>
-    </div>
+
+        <!-- AZ 3 -->
+        <div class="clr-row" *ngIf="isClusterPlanProd">
+            <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
+                <clr-select-container>
+                    <label i18n="availability zone label">
+                        {{htmlFieldLabels['awsNodeAz3']}}
+                        <clr-tooltip>
+                            <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
+                            <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
+                            <span>
+                                Choose an AWS availability zone (AWS subregion). Selecting an availability zone first is
+                                required for retrieving existing public and private subnets.
+                            </span>
+                            </clr-tooltip-content>
+                        </clr-tooltip>
+                    </label>
+                    <select
+                            clrSelect
+                            name="awsNodeAz3"
+                            formControlName="awsNodeAz3">
+                        <option aria-label="blank" title="blank"></option>
+                        <ng-container *ngFor="let nodeAz of nodeAzs">
+                            <option [value]="nodeAz.name">
+                                {{ nodeAz.name }}
+                            </option>
+                        </ng-container>
+                    </select>
+                    <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
+                    <clr-control-helper></clr-control-helper>
+                    <clr-control-error
+                            i18n="availability zone required msg"
+                            *clrIfError="validatorEnum.REQUIRED">
+                        Selecting an availability zone is required
+                    </clr-control-error>
+                    <clr-control-error
+                            i18n="availability zone unique msg"
+                            *clrIfError="validatorEnum.AVAILABILITY_ZONE_UNIQUE">
+                        Availability zone selection must be unique
+                    </clr-control-error>
+                </clr-select-container>
+            </div>
+            <ng-container *ngIf="isClusterPlanProd">
+                <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
+                    <clr-select-container>
+                        <label i18n="vpc public subnet label">
+                            {{htmlFieldLabels['vpcPublicSubnet3']}}
+                            <clr-tooltip>
+                                <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
+                                <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
+                                <span>
+                                    {{
+                                    getVpcSubnetTooltip('public')
+                                    }}
+                                </span>
+                                </clr-tooltip-content>
+                            </clr-tooltip>
+                        </label>
+                        <select
+                                clrSelect
+                                name="vpcPublicSubnet3"
+                                formControlName="vpcPublicSubnet3">
+                            <option aria-label="blank" title="blank"></option>
+                            <ng-container *ngFor="let subnet of filteredAzs?.awsNodeAz3?.publicSubnets">
+                                <option [value]="subnet.id">
+                                    {{ subnet.cidr }}
+                                </option>
+                            </ng-container>
+                        </select>
+                        <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
+                        <clr-control-helper></clr-control-helper>
+                        <clr-control-error>
+                            {{
+                            getVpcSubnetErrorMsg('public')
+                            }}
+                        </clr-control-error>
+                    </clr-select-container>
+                </div>
+                <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
+                    <clr-select-container>
+                        <label i18n="vpc private subnet label">
+                            {{htmlFieldLabels['vpcPrivateSubnet3']}}
+                            <clr-tooltip>
+                                <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
+                                <clr-tooltip-content clrPosition="top-left" clrSize="lg" *clrIfOpen>
+                                <span>
+                                    {{
+                                    getVpcSubnetTooltip('private')
+                                    }}
+                                </span>
+                                </clr-tooltip-content>
+                            </clr-tooltip>
+                        </label>
+                        <select
+                                clrSelect
+                                name="vpcPrivateSubnet3"
+                                formControlName="vpcPrivateSubnet3">
+                            <option aria-label="blank" title="blank"></option>
+                            <ng-container *ngFor="let subnet of filteredAzs?.awsNodeAz3?.privateSubnets">
+                                <option [value]="subnet.id">
+                                    {{ subnet.cidr }}
+                                </option>
+                            </ng-container>
+                        </select>
+                        <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
+                        <clr-control-helper></clr-control-helper>
+                        <clr-control-error>
+                            {{
+                            getVpcSubnetErrorMsg('private')
+                            }}
+                        </clr-control-error>
+                    </clr-select-container>
+                </div>
+                <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4"></div>
+            </ng-container>
+            <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
+                <clr-datalist-container>
+                    <label i18n="worker node instance type label" class="clr-col-12 clr-col-md-12">
+                        {{htmlFieldLabels['workerNodeInstanceType3']}}
+                        <clr-tooltip>
+                            <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
+                            <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
+                        <span>
+                            Choose the configuration for worker nodes for this AZ.
+                        </span>
+                            </clr-tooltip-content>
+                        </clr-tooltip>
+                    </label>
+                    <input clrDatalistInput
+                           name="workerNodeInstanceType3"
+                           formControlName="workerNodeInstanceType3"
+                           role="listbox"
+                           aria-label="worker node instance type for az3"
+                           autocomplete="off"
+                           [attr.disabled]="azNodeTypes.awsNodeAz3.length ? null : 'disabled'"/>
+                    <datalist id="workerNodeInstanceType3">
+                        <option *ngFor="let nodeType of azNodeTypes.awsNodeAz3" [value]="nodeType"></option>
+                    </datalist>
+                    <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
+                    <clr-control-helper></clr-control-helper>
+                </clr-datalist-container>
+                <clr-control-error *ngIf="showFormError('workerNodeInstanceType3')">
+                    Selecting worker node instance type is required for this AZ
+                </clr-control-error>
+            </div>
+        </div>
+    </ng-container>
+
 </form>

--- a/tkg/web/src/app/views/landing/aws-wizard/node-setting-step/node-setting-step.component.spec.ts
+++ b/tkg/web/src/app/views/landing/aws-wizard/node-setting-step/node-setting-step.component.spec.ts
@@ -150,7 +150,7 @@ describe('NodeSettingStepComponent', () => {
         });
     });
 
-    it('should fiter subnet', () => {
+    it('should filter subnet', () => {
         component.vpcType = 'existing';
         component.publicSubnets = [{
             availabilityZoneId: 'us-west-a',

--- a/tkg/web/src/app/views/landing/aws-wizard/node-setting-step/node-setting-step.component.ts
+++ b/tkg/web/src/app/views/landing/aws-wizard/node-setting-step/node-setting-step.component.ts
@@ -431,14 +431,6 @@ export class NodeSettingStepComponent extends NodeSettingStepDirective<string> i
             ].forEach(field => {
                 this.resurrectFieldWithStoredValue(field.toString(), this.supplyStepMapping(), [Validators.required]);
             });
-            // [
-            //     AwsField.NODESETTING_VPC_PRIVATE_SUBNET_2,
-            //     AwsField.NODESETTING_VPC_PRIVATE_SUBNET_3,
-            //     AwsField.NODESETTING_VPC_PUBLIC_SUBNET_2,
-            //     AwsField.NODESETTING_VPC_PUBLIC_SUBNET_3
-            // ].forEach(field => {
-            //     this.disarmField(field.toString(), false);
-            // });
         }
 
         if (this.airgappedVPC) {

--- a/tkg/web/src/app/views/landing/aws-wizard/vpc-step/vpc-step.component.html
+++ b/tkg/web/src/app/views/landing/aws-wizard/vpc-step/vpc-step.component.html
@@ -4,51 +4,6 @@
     </h4>
     <app-step-form-notification [errorNotification]="errorNotification"></app-step-form-notification>
     <div class="clr-row">
-        <div class="clr-col-8">
-            <clr-radio-container clrInline>
-                <clr-radio-wrapper>
-                    <input type="radio" name="vpcType" clrRadio value="existing" formControlName="vpcType">
-                    <label>
-                        Select an existing VPC
-                    </label>
-                </clr-radio-wrapper>
-                <clr-radio-wrapper>
-                    <input type="radio" name="vpcType" clrRadio value="new" formControlName="vpcType">
-                    <label>
-                        Create new VPC on AWS
-                    </label>
-                </clr-radio-wrapper>
-            </clr-radio-container>
-        </div>
-    </div>
-
-    <div class="clr-row" *ngIf="formGroup.value.vpcType == 'new'">
-        <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
-            <clr-input-container>
-                <label i18n="aws vpc cidr label" clr-control-label>
-                    {{htmlFieldLabels['vpc']}}
-                    <clr-tooltip>
-                        <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
-                        <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
-                            <span>
-                                The CIDR block to be used when the provider creates a managed VPC.
-                            </span>
-                        </clr-tooltip-content>
-                    </clr-tooltip>
-                </label>
-                <input clrInput formControlName="vpc" placeholder="" />
-                <!-- Add a empty helper to avoid accessibility aria-describeby issue -->
-                <clr-control-helper></clr-control-helper>
-                <clr-control-error i18n="aws vpc cidr required msg" *clrIfError="validatorEnum.REQUIRED">
-                    VPC CIDR cannot be empty
-                </clr-control-error>
-                <clr-control-error i18n="aws vpc cidr invalid msg" *clrIfError="validatorEnum.VALID_IP">
-                    VPC CIDR format is invalid
-                </clr-control-error>
-            </clr-input-container>
-        </div>
-    </div>
-    <div class="clr-row" *ngIf="formGroup.value.vpcType == 'existing'">
         <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
             <clr-select-container>
                 <label i18n="existing vpc label">
@@ -96,7 +51,7 @@
         </div>
     </div>
 
-    <div class="clr-row" *ngIf="formGroup.value.vpcType == 'existing'">
+    <div class="clr-row">
         <div class="clr-col-12 clr-col-sm-6 clr-col-lg-4">
             <clr-checkbox-container>
                 <clr-checkbox-wrapper>

--- a/tkg/web/src/app/views/landing/aws-wizard/vpc-step/vpc-step.component.ts
+++ b/tkg/web/src/app/views/landing/aws-wizard/vpc-step/vpc-step.component.ts
@@ -96,7 +96,6 @@ export class VpcStepComponent extends StepFormDirective implements OnInit {
 
         this.registerOnValueChange(AwsField.VPC_TYPE, this.onVpcTypeChange.bind(this));
 
-        // const cidrFields = [AwsField.VPC_NEW_CIDR, AwsField.VPC_EXISTING_CIDR];
         const cidrFields = [AwsField.VPC_EXISTING_CIDR];
         cidrFields.forEach(cidrField => {
             this.registerOnValueChange(cidrField, (cidr) => {
@@ -140,7 +139,6 @@ export class VpcStepComponent extends StepFormDirective implements OnInit {
     }
 
     chooseInitialVpcType() {
-        // const vpcType = this.getStoredValue(AwsField.VPC_NEW_CIDR, AwsVpcStepMapping) ? VpcType.NEW : VpcType.EXISTING;
         const vpcType = VpcType.EXISTING;
         this.formGroup.get(AwsField.VPC_TYPE).setValue(vpcType);
     }
@@ -152,13 +150,6 @@ export class VpcStepComponent extends StepFormDirective implements OnInit {
      */
     setNewVpcValidators() {
         this.defaultVpcHasChanged = false;
-
-        // this.setFieldWithStoredValue(AwsField.VPC_NEW_CIDR, AwsVpcStepMapping, this.defaultVpcAddress);
-        // this.formGroup.get(AwsField.VPC_NEW_CIDR).setValidators([
-        //     Validators.required,
-        //     this.validationService.noWhitespaceOnEnds(),
-        //     this.validationService.isValidIpNetworkSegment()
-        // ]);
     }
 
     setExistingVpcValidators() {

--- a/tkg/web/src/app/views/landing/aws-wizard/vpc-step/vpc-step.component.ts
+++ b/tkg/web/src/app/views/landing/aws-wizard/vpc-step/vpc-step.component.ts
@@ -69,8 +69,6 @@ export class VpcStepComponent extends StepFormDirective implements OnInit {
     }
 
     private clearNewVpcControls() {
-        this.formGroup.get(AwsField.VPC_NEW_CIDR).clearValidators();
-        this.clearControlValue(AwsField.VPC_NEW_CIDR);
         this.clearFieldSavedData(AwsField.VPC_NEW_CIDR);
     }
 
@@ -98,7 +96,8 @@ export class VpcStepComponent extends StepFormDirective implements OnInit {
 
         this.registerOnValueChange(AwsField.VPC_TYPE, this.onVpcTypeChange.bind(this));
 
-        const cidrFields = [AwsField.VPC_NEW_CIDR, AwsField.VPC_EXISTING_CIDR];
+        // const cidrFields = [AwsField.VPC_NEW_CIDR, AwsField.VPC_EXISTING_CIDR];
+        const cidrFields = [AwsField.VPC_EXISTING_CIDR];
         cidrFields.forEach(cidrField => {
             this.registerOnValueChange(cidrField, (cidr) => {
                 AppServices.messenger.publish({
@@ -141,7 +140,8 @@ export class VpcStepComponent extends StepFormDirective implements OnInit {
     }
 
     chooseInitialVpcType() {
-        const vpcType = this.getStoredValue(AwsField.VPC_NEW_CIDR, AwsVpcStepMapping) ? VpcType.NEW : VpcType.EXISTING;
+        // const vpcType = this.getStoredValue(AwsField.VPC_NEW_CIDR, AwsVpcStepMapping) ? VpcType.NEW : VpcType.EXISTING;
+        const vpcType = VpcType.EXISTING;
         this.formGroup.get(AwsField.VPC_TYPE).setValue(vpcType);
     }
 
@@ -153,12 +153,12 @@ export class VpcStepComponent extends StepFormDirective implements OnInit {
     setNewVpcValidators() {
         this.defaultVpcHasChanged = false;
 
-        this.setFieldWithStoredValue(AwsField.VPC_NEW_CIDR, AwsVpcStepMapping, this.defaultVpcAddress);
-        this.formGroup.get(AwsField.VPC_NEW_CIDR).setValidators([
-            Validators.required,
-            this.validationService.noWhitespaceOnEnds(),
-            this.validationService.isValidIpNetworkSegment()
-        ]);
+        // this.setFieldWithStoredValue(AwsField.VPC_NEW_CIDR, AwsVpcStepMapping, this.defaultVpcAddress);
+        // this.formGroup.get(AwsField.VPC_NEW_CIDR).setValidators([
+        //     Validators.required,
+        //     this.validationService.noWhitespaceOnEnds(),
+        //     this.validationService.isValidIpNetworkSegment()
+        // ]);
     }
 
     setExistingVpcValidators() {
@@ -199,13 +199,12 @@ export class VpcStepComponent extends StepFormDirective implements OnInit {
         const vpcType = this.getFieldValue(AwsField.VPC_TYPE);
         const vpcExistingCidr = this.getFieldValue(AwsField.VPC_EXISTING_CIDR, true);
         const vpcExistingId = this.getFieldValue(AwsField.VPC_EXISTING_ID, true);
-        const vpcNewCidr = this.getFieldValue(AwsField.VPC_NEW_CIDR, true);
 
         if (vpcType === VpcType.EXISTING && vpcExistingId && vpcExistingCidr) {
             return 'VPC: ' + vpcExistingId + ' CIDR: ' + vpcExistingCidr;
         }
-        if (vpcType === VpcType.NEW && vpcNewCidr) {
-            return 'VPC: (new) CIDR: ' + vpcNewCidr;
+        if (vpcType === VpcType.NEW) {
+            return 'VPC: New';
         }
         return 'Specify VPC settings for AWS';
     }

--- a/tkg/web/src/app/views/landing/wizard/shared/components/steps/identity-step/identity-step.component.html
+++ b/tkg/web/src/app/views/landing/wizard/shared/components/steps/identity-step/identity-step.component.html
@@ -249,7 +249,7 @@
                                     </clr-tooltip-content>
                                 </clr-tooltip>
                             </label>
-                            <div>
+                            <div class="inline-block-override">
                                 <input clrInput
                                        class="endpoint-ip-input"
                                        formControlName="endpointIp"
@@ -265,7 +265,7 @@
                                        aria-label="ldap endpoint colon"
                                        value=":"/>
                             </div>
-                            <div>
+                            <div class="inline-block-override">
                                 <input clrInput
                                        class="endpoint-port-input"
                                        formControlName="endpointPort"

--- a/tkg/web/src/app/views/landing/wizard/shared/components/steps/identity-step/identity-step.component.scss
+++ b/tkg/web/src/app/views/landing/wizard/shared/components/steps/identity-step/identity-step.component.scss
@@ -54,6 +54,10 @@ clr-select-container.ldap-header {
         color: properties.$label-color-light-theme;
     }
 
+    .inline-block-override {
+        display: inline-block;
+    }
+
     .clr-input-wrapper {
         display: inline-block;
 


### PR DESCRIPTION
Due to CAPA bump, new VPC creation is no longer supported in the CLI. This PR removes the option to create a new VPC from the UI as well.

User is no longer presented with an option to choose between use existing/new; instead they are only presented with form controls for using an existing VPC.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
When creating a management cluster on AWS through the Installer Interface (kickstart UI), new VPC creation is no longer supported. User must follow steps to select an existing VPC. This is a result of a CAPA bump that inhibits new VPC creation by the CLI and therefore also the UI.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
![Screen Shot 2023-01-03 at 11 34 01 AM](https://user-images.githubusercontent.com/13439013/210429015-abc24c80-48c6-4bd7-9c81-cf6a2e62c4fa.png)
