### PR TITLE
Parse insecure flag from cluster.tlsThumbprint

### DIFF
--- a/tkg/constants/clusterclass_mapping.go
+++ b/tkg/constants/clusterclass_mapping.go
@@ -217,6 +217,7 @@ var ClusterAttributesToLegacyVariablesMapVsphere = map[string]string{
 	"spec.topology.variables.vcenter.datastore":     ConfigVariableVsphereDatastore,     // VSPHERE_DATASTORE
 	"spec.topology.variables.vcenter.folder":        ConfigVariableVsphereFolder,        // VSPHERE_FOLDER
 	"spec.topology.variables.vcenter.server":        ConfigVariableVsphereServer,        // VSPHERE_SERVER
+	"spec.topology.variables.vcenter.insecure":      ConfigVariableVsphereInsecure,      // VSPHERE_INSECURE this variable doesn't exist in clusterclass, will be infer from tlsThumbprint
 
 	"spec.topology.variables.user.sshAuthorizedKeys": ConfigVariableVsphereSSHAuthorizedKey, // VSPHERE_SSH_AUTHORIZED_KEY
 

--- a/tkg/fakes/config/cluster_vsphere_insecure.yaml
+++ b/tkg/fakes/config/cluster_vsphere_insecure.yaml
@@ -1,0 +1,143 @@
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  annotations:
+    osInfo: ",,"
+  labels:
+    cluster-role.tkg.tanzu.vmware.com/management: ""
+    tanzuKubernetesRelease: v1.23.5---vmware.1-tkg.1-zshippable
+    tkg.tanzu.vmware.com/cluster-name: c1
+  name: vsphere-workload-cluster1 # CLUSTER_NAME
+  namespace: namespace-test1
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks: # CLUSTER_CIDR
+        - 10.10.10.10/18
+    services:
+      cidrBlocks: # SERVICE_CIDR
+        - 100.64.0.0/18
+  topology:
+    class: tkg-vsphere-default # CLUSTER_CLASS
+    controlPlane:
+      replicas: 5 # CONTROL_PLANE_MACHINE_COUNT
+    variables:
+      - name: network
+        value:
+          ipv6Primary: false #TKG_IP_FAMILY (if true expect TKG_IP_FAMILY="ipv6,ipv4")
+          addressesFromPools:
+          - apiGroup: ipam.cluster.x-k8s.io
+            kind: InClusterIPPool
+            name: inclusterpool
+      - name: proxy
+        value: #TKG_HTTP_PROXY_ENABLED (under this if any value is not null then set TKG_HTTP_PROXY_ENABLED)
+          httpProxy: http://10.0.200.100 #TKG_HTTP_PROXY
+          httpsProxy: http://10.0.200.100 #TKG_HTTPS_PROXY
+          noProxy: #TKG_NO_PROXY
+            - 127.0.0.1
+            - 100.64.0.0/18
+            - 10.0.0.0/16
+            - 169.254.0.0/16
+            - .svc.cluster.local
+            - .svc
+            - localhost
+      - name: imageRepository
+        value:
+          host: imageRepositoryHost #TKG_CUSTOM_IMAGE_REPOSITORY
+          tlsCertificateValidation: true #TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY
+      - name: clusterRole #TKG_CLUSTER_ROLE
+        value: workload
+      - name: auditLogging
+        value:
+          enabled: false #ENABLE_AUDIT_LOGGING
+      - name: trust
+        value:
+          - name: proxy
+            data: LS0tLS= #TKG_PROXY_CA_CERT
+          - name: imageRepository
+            data: trust.imageRepository.val #TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE
+      - name: apiServerPort
+        value: 443 #CLUSTER_API_SERVER_PORT
+      - name: apiServerEndpoint # VSPHERE_CONTROL_PLANE_ENDPOINT
+        value: http://10.0.200.101
+      - name: vipNetworkInterface # VIP_NETWORK_INTERFACE
+        value: networkinter
+      - name: aviAPIServerHAProvider # AVI_CONTROL_PLANE_HA_PROVIDER
+        value: true
+      - name: vcenter
+        value:
+          cloneMode: fullClone # VSPHERE_CLONE_MODE
+          network: TESTNETWORK # VSPHERE_NETWORK
+          datacenter: /dc0 # VSPHERE_DATACENTER
+          datastore: ds1 # VSPHERE_DATASTORE
+          folder: vm0 #  VSPHERE_FOLDER
+          resourcePool: /dc0/host/cluster0/Resources/rp0 # VSPHERE_RESOURCE_POOL
+          storagePolicyID: "" # VSPHERE_STORAGE_POLICY_ID
+          server: some.fqdn.com # VSPHERE_SERVER
+          tlsThumbprint: "" # VSPHERE_TLS_THUMBPRINT
+          template: photon-3-v1.19.3+vmware.1 # VSPHERE_TEMPLATE
+      - name: user
+        value:
+          sshAuthorizedKeys: # VSPHERE_SSH_AUTHORIZED_KEY
+            - authkeyss11
+            - authkeyss22
+      - name: controlPlane
+        value:
+          machine:
+            diskGiB: 40 # VSPHERE_CONTROL_PLANE_DISK_GIB
+            memoryMiB: 8192 # VSPHERE_CONTROL_PLANE_MEM_MIB
+            numCPUs: 2 # VSPHERE_CONTROL_PLANE_NUM_CPUS
+          network:
+            nameservers: 100.64.0.0 # CONTROL_PLANE_NODE_NAMESERVERS
+      - name: worker
+        value:
+          count: 3 # WORKER_MACHINE_COUNT -- Removed
+          machine:
+            diskGiB: 40 # VSPHERE_WORKER_DISK_GIB
+            memoryMiB: 16384 # VSPHERE_WORKER_MEM_MIB
+            numCPUs: 4 # VSPHERE_WORKER_NUM_CPUS
+          network:
+            nameservers: 100.64.0.0 # WORKER_NODE_NAMESERVERS
+      - name: TKR_DATA
+        value:
+          v1.21.2:
+            kubernetesSpec:
+              coredns:
+                imageTag: v1.8.6_vmware.5
+              etcd:
+                imageTag: v3.5.2_vmware.4
+              imageRepository: projects.registry.vmware.com/tkg
+              kube-vip:
+                imageTag: dummy-kube-vip-image-tag
+              version: v1.21.2
+            labels:
+              os-arch: amd64
+              os-name: ubuntu
+              os-type: linux
+      - name: kubeVipLoadBalancerProvider
+        value: false
+
+    version: v1.21.2
+    workers:
+      machineDeployments:
+        - class: tkg-worker
+          failureDomain: us-east-1a # VSPHERE_AZ_0
+          name: md-0
+          replicas: 1 #WORKER_MACHINE_COUNT
+        - class: tkg-worker
+          failureDomain: us-east-1b # VSPHERE_AZ_1
+          name: md-1
+          replicas: 2 # WORKER_MACHINE_COUNT_1
+        - class: tkg-worker
+          failureDomain: us-east-1c # VSPHERE_AZ_2
+          name: md-2
+          replicas: 3 # WORKER_MACHINE_COUNT_2
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-workload-cluster1
+  namespace: namespace-test1
+stringData:
+  password: Admin!23
+  username: administrator@vsphere.local

--- a/tkg/tkgctl/helpers.go
+++ b/tkg/tkgctl/helpers.go
@@ -356,6 +356,9 @@ func processYamlObjectAndAddToMap(value interface{}, clusterAttributePath string
 			if strings.HasPrefix(clusterAttributePath, "spec.topology.variables.proxy") {
 				inputVariablesMap["spec.topology.variables.proxy"] = true
 			}
+		} else if clusterAttributePath == "spec.topology.variables.vcenter.tlsThumbprint" {
+			// if tlsThumbprint is empty, then insecure is true
+			inputVariablesMap["spec.topology.variables.vcenter.insecure"] = true
 		}
 	default:
 		if value != nil {


### PR DESCRIPTION
### What this PR does / why we need it
Currently, the VSPHERE_INSECURE flag is not retrieved from cluster object
Thus it will throw error when VSPHERE_INSECURE is passed from cluster config file 
We need to parse the value of insecure from tlsthumbprint variable
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
