### PR TITLE
[WIP] Change scale message

### DIFF
--- a/tkg/client/scale.go
+++ b/tkg/client/scale.go
@@ -66,7 +66,11 @@ func (c *TkgClient) DoScaleCluster(clusterClient clusterclient.Client, options *
 		if err := clusterClient.GetResource(&cluster, options.ClusterName, options.Namespace, nil, nil); err != nil {
 			return errors.Wrap(err, "Unable to retrieve cluster resource")
 		}
-		return DoScaleCCCluster(clusterClient, &cluster, options)
+		err := DoScaleCCCluster(clusterClient, &cluster, options)
+		if err == nil {
+			log.Infof("Cluster '%s' is being scaled, describe cluster object to get results\n", options.ClusterName)
+		}
+		return err
 	}
 
 	isPacific, err := clusterClient.IsPacificRegionalCluster()
@@ -102,6 +106,7 @@ func (c *TkgClient) DoScaleCluster(clusterClient clusterclient.Client, options *
 	}
 
 	if len(errList) == 0 {
+		log.Infof("Cluster '%s' is being scaled\n", options.ClusterName)
 		return nil
 	}
 	return kerrors.NewAggregate(errList)

--- a/tkg/tkgctl/scale_cluster.go
+++ b/tkg/tkgctl/scale_cluster.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-framework/tkg/client"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/constants"
-	"github.com/vmware-tanzu/tanzu-framework/tkg/log"
 )
 
 // ScaleClusterOptions options that can be passed while scaling a cluster
@@ -43,7 +42,5 @@ func (t *tkgctl) ScaleCluster(options ScaleClusterOptions) error {
 	if err != nil {
 		return err
 	}
-
-	log.Infof("Workload cluster '%s' is being scaled\n", scaleClusterOptions.ClusterName)
 	return nil
 }


### PR DESCRIPTION
### What this PR does / why we need it
After CC is enabled, scale cluster wont patch kcp/md directly, instead, it will update cluster CR, then, if scale number is not acceptable, cli wont get errors directly, instead, capi controller will catch erros from admin hook and print in logs.

user may get 
`Workload cluster 'azure-wc-1' is being scaled` 
even if scaling is failing

### Which issue(s) this PR fixes
change scale command return message
1. change `Workload cluster XXX is being scaled` to `Cluster XXX is being scaled` as it applies to both mc and wc
2. for cc, change return message to `Cluster XXX is being scaled, describe cluster object to get results`

if scale failed, describe cluster object will get
```
Status:
  Conditions:
    Last Transition Time:  2023-01-04T08:08:36Z
    Status:                True
    Type:                  Ready
    Last Transition Time:  2023-01-04T06:31:46Z
    Status:                True
    Type:                  ControlPlaneInitialized
    Last Transition Time:  2023-01-04T08:08:36Z
    Status:                True
    Type:                  ControlPlaneReady
    Last Transition Time:  2023-01-04T06:30:26Z
    Status:                True
    Type:                  InfrastructureReady
    Last Transition Time:  2023-01-04T08:56:14Z
    Message:               error reconciling the Cluster topology: failed to create patch helper for KubeadmControlPlane/azure-wc-1-wrvvr: failed to request dry-run server side apply: admission webhook "validation.kubeadmcontrolplane.controlplane.cluster.x-k8s.io" denied the request: KubeadmControlPlane.controlplane.cluster.x-k8s.io "azure-wc-1-wrvvr" is invalid: spec.replicas: Forbidden: cannot be an even number when etcd is stacked
    Reason:                TopologyReconcileFailed
    Severity:              Error
    Status:                False
    Type:                  TopologyReconciled
    Last Transition Time:  2023-01-04T06:29:03Z
    Reason:                AlreadyUpToDate
    Severity:              Info
    Status:                False
    Type:                  UpdatesAvailable
```

error message above should be informative

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
