### PR TITLE
Adds GPU related variables to VSphere Cluster Class

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -413,6 +413,11 @@ spec:
               memoryMiB:
                 type: integer
                 default: 8192
+              customVMXKeys:
+                type: object
+                additionalProperties:
+                  type: string
+                default: {}
           network:
             type: object
             properties:
@@ -454,6 +459,11 @@ spec:
               memoryMiB:
                 type: integer
                 default: 4096
+              customVMXKeys:
+                type: object
+                additionalProperties:
+                  type: string
+                default: {}
           network:
             type: object
             properties:
@@ -600,6 +610,50 @@ spec:
         properties:
           certificate:
             type: string
+  - name: pci
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          worker:
+            type: object
+            properties:
+              devices:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    vendorId:
+                      type: number
+                    deviceId:
+                      type: number
+                  required:
+                  - deviceId
+                  - vendorId
+                default: []
+              hardwareVersion:
+                type: string
+                default: vmx-15
+          controlPlane:
+            type: object
+            properties:
+              devices:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    vendorId:
+                      type: number
+                    deviceId:
+                      type: number
+                  required:
+                  - deviceId
+                  - vendorId
+                default: []
+              hardwareVersion:
+                type: string
+                default: vmx-15
   patches:
   - name: etcdExtraArgs
     definitions:
@@ -2237,3 +2291,81 @@ spec:
         valueFrom:
           template: |
             echo 'export NO_PROXY={{- list "localhost" "127.0.0.1" ".svc" ".svc.cluster.local" ((list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily) | ternary  "::1" nil) | concat .proxy.noProxy .builtin.cluster.network.services .builtin.cluster.network.pods | uniq | sortAlpha | join "," }}' >> /etc/environment
+  - name: pciWorker
+    enabledIf: '{{ not (empty .pci.worker.devices) }}'
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/pciDevices
+        valueFrom:
+          template: |
+            {{- range .pci.worker.devices}}
+            - deviceId: {{ .deviceId }}
+              vendorId: {{ .vendorId }}
+            {{- end }}
+      - op: add
+        path: /spec/template/spec/hardwareVersion
+        valueFrom:
+          variable: pci.worker.hardwareVersion
+  - name: pciControlPlane
+    enabledIf: '{{ not (empty .pci.controlPlane.devices) }}'
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/pciDevices
+        valueFrom:
+          template: |
+            {{- range .pci.controlPlane.devices}}
+            - deviceId: {{ .deviceId }}
+              vendorId: {{ .vendorId }}
+            {{- end }}
+      - op: add
+        path: /spec/template/spec/hardwareVersion
+        valueFrom:
+          variable: pci.controlPlane.hardwareVersion
+  - name: workerVMCustomizations
+    enabledIf: '{{ not (empty .worker.machine.customVMXKeys) }}'
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/customVMXKeys
+        valueFrom:
+          template: |
+            {{- range $key, $val := .worker.machine.customVMXKeys}}
+            {{ $key }} : "{{ $val }}"
+            {{- end }}
+  - name: controlPlaneVMCustomizations
+    enabledIf: '{{ not (empty .controlPlane.machine.customVMXKeys) }}'
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/customVMXKeys
+        valueFrom:
+          template: |
+            {{- range $key, $val := .controlPlane.machine.customVMXKeys}}
+            {{ $key }} : "{{ $val }}"
+            {{- end }}

--- a/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
@@ -413,6 +413,11 @@ spec:
               memoryMiB:
                 type: integer
                 default: 8192
+              customVMXKeys:
+                type: object
+                additionalProperties:
+                  type: string
+                default: {}
           network:
             type: object
             properties:
@@ -454,6 +459,11 @@ spec:
               memoryMiB:
                 type: integer
                 default: 4096
+              customVMXKeys:
+                type: object
+                additionalProperties:
+                  type: string
+                default: {}
           network:
             type: object
             properties:
@@ -600,6 +610,50 @@ spec:
         properties:
           certificate:
             type: string
+  - name: pci
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          worker:
+            type: object
+            properties:
+              devices:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    vendorId:
+                      type: number
+                    deviceId:
+                      type: number
+                  required:
+                  - deviceId
+                  - vendorId
+                default: []
+              hardwareVersion:
+                type: string
+                default: vmx-15
+          controlPlane:
+            type: object
+            properties:
+              devices:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    vendorId:
+                      type: number
+                    deviceId:
+                      type: number
+                  required:
+                  - deviceId
+                  - vendorId
+                default: []
+              hardwareVersion:
+                type: string
+                default: vmx-15
   patches:
   - name: etcdExtraArgs
     definitions:
@@ -2237,3 +2291,81 @@ spec:
         valueFrom:
           template: |
             echo 'export NO_PROXY={{- list "localhost" "127.0.0.1" ".svc" ".svc.cluster.local" ((list "IPv6" "DualStack" | has .builtin.cluster.network.ipFamily) | ternary  "::1" nil) | concat .proxy.noProxy .builtin.cluster.network.services .builtin.cluster.network.pods | uniq | sortAlpha | join "," }}' >> /etc/environment
+  - name: pciWorker
+    enabledIf: '{{ not (empty .pci.worker.devices) }}'
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/pciDevices
+        valueFrom:
+          template: |
+            {{- range .pci.worker.devices}}
+            - deviceId: {{ .deviceId }}
+              vendorId: {{ .vendorId }}
+            {{- end }}
+      - op: add
+        path: /spec/template/spec/hardwareVersion
+        valueFrom:
+          variable: pci.worker.hardwareVersion
+  - name: pciControlPlane
+    enabledIf: '{{ not (empty .pci.controlPlane.devices) }}'
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/pciDevices
+        valueFrom:
+          template: |
+            {{- range .pci.controlPlane.devices}}
+            - deviceId: {{ .deviceId }}
+              vendorId: {{ .vendorId }}
+            {{- end }}
+      - op: add
+        path: /spec/template/spec/hardwareVersion
+        valueFrom:
+          variable: pci.controlPlane.hardwareVersion
+  - name: workerVMCustomizations
+    enabledIf: '{{ not (empty .worker.machine.customVMXKeys) }}'
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/customVMXKeys
+        valueFrom:
+          template: |
+            {{- range $key, $val := .worker.machine.customVMXKeys}}
+            {{ $key }} : "{{ $val }}"
+            {{- end }}
+  - name: controlPlaneVMCustomizations
+    enabledIf: '{{ not (empty .controlPlane.machine.customVMXKeys) }}'
+    definitions:
+    - selector:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: VSphereMachineTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/customVMXKeys
+        valueFrom:
+          template: |
+            {{- range $key, $val := .controlPlane.machine.customVMXKeys}}
+            {{ $key }} : "{{ $val }}"
+            {{- end }}

--- a/providers/infrastructure-vsphere/v1.5.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/yttcc/overlay.yaml
@@ -138,7 +138,7 @@ spec:
     variables:
     #@ vars = get_vsphere_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["workerKubeletExtraArgs","controlPlaneKubeletExtraArgs","kubeControllerManagerExtraArgs","kubeSchedulerExtraArgs","apiServerExtraArgs","etcdExtraArgs", "apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "cni", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider", "additionalFQDN", "controlPlaneCertificateRotation", "podSecurityStandard", "eventRateLimitConf", "customTDNFRepository"]:
+    #@  if vars[configVariable] != None and configVariable in ["workerKubeletExtraArgs","controlPlaneKubeletExtraArgs","kubeControllerManagerExtraArgs","kubeSchedulerExtraArgs","apiServerExtraArgs","etcdExtraArgs", "apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "cni", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider", "additionalFQDN", "controlPlaneCertificateRotation", "podSecurityStandard", "eventRateLimitConf", "customTDNFRepository", "pci"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/providers/yttcc/lib/config_variable_association.star
+++ b/providers/yttcc/lib/config_variable_association.star
@@ -1,9 +1,8 @@
 load("@ytt:data", "data")
 load("@ytt:overlay", "overlay")
 load("@ytt:yaml", "yaml")
-load("/lib/helpers.star", "get_default_tkg_bom_data")
-load("/lib/helpers.star", "get_labels_array_from_string")
-load("/lib/helpers.star", "get_extra_args_map_from_string")
+load("/lib/helpers.star", "get_default_tkg_bom_data", "get_labels_array_from_string", "get_extra_args_map_from_string")
+load("/lib/helpers.star",  "get_custom_keys", "valid_pci_devices_list", "get_pci_devices")
 
 #! This file contains function 'config_variable_association' which specifies all configuration variables
 #! mentioned in 'config_default.yaml' and describes association of each configuration variable with
@@ -60,6 +59,13 @@ return {
 "VSPHERE_INSECURE": ["vsphere"],
 "VSPHERE_CONTROL_PLANE_ENDPOINT": ["vsphere"],
 "VSPHERE_CONTROL_PLANE_ENDPOINT_PORT": ["vsphere"],
+"VSPHERE_WORKER_PCI_DEVICES": ["vsphere"],
+"VSPHERE_CONTROL_PLANE_PCI_DEVICES": ["vsphere"],
+"VSPHERE_IGNORE_PCI_DEVICES_ALLOW_LIST": ["vsphere"],
+"VSPHERE_CONTROL_PLANE_CUSTOM_VMX_KEYS": ["vsphere"],
+"VSPHERE_WORKER_CUSTOM_VMX_KEYS": ["vsphere"],
+"VSPHERE_CONTROL_PLANE_HARDWARE_VERSION": ["vsphere"],
+"VSPHERE_WORKER_HARDWARE_VERSION": ["vsphere"],
 
 "NSXT_POD_ROUTING_ENABLED": ["vsphere"],
 "NSXT_ROUTER_PATH": ["vsphere"],
@@ -915,6 +921,9 @@ def get_vsphere_vars():
     if data.values["VSPHERE_CONTROL_PLANE_MEM_MIB"] != "":
         machine["memoryMiB"] = data.values["VSPHERE_CONTROL_PLANE_MEM_MIB"]
     end
+    if data.values["VSPHERE_CONTROL_PLANE_CUSTOM_VMX_KEYS"] != None:
+        machine["customVMXKeys"] = get_custom_keys(data.values["VSPHERE_CONTROL_PLANE_CUSTOM_VMX_KEYS"])
+    end
     if machine != {}:
         controlPlane["machine"] = machine
     end
@@ -971,6 +980,9 @@ def get_vsphere_vars():
     if data.values["VSPHERE_WORKER_MEM_MIB"] != "":
         machine["memoryMiB"] = data.values["VSPHERE_WORKER_MEM_MIB"]
     end
+    if data.values["VSPHERE_WORKER_CUSTOM_VMX_KEYS"] != None:
+        machine["customVMXKeys"] = get_custom_keys(data.values["VSPHERE_WORKER_CUSTOM_VMX_KEYS"])
+    end
     if machine != {}:
         worker["machine"] = machine
     end
@@ -1008,6 +1020,33 @@ def get_vsphere_vars():
     end
     if customTDNFRepository != {}:
         vars["customTDNFRepository"] = customTDNFRepository
+    end
+
+    pci = {}
+    pciControlPlane = {}
+    if data.values["VSPHERE_CONTROL_PLANE_PCI_DEVICES"] != None:
+        pciControlPlane["devices"] = get_pci_devices(data.values["VSPHERE_CONTROL_PLANE_PCI_DEVICES"], data.values["VSPHERE_IGNORE_PCI_DEVICES_ALLOW_LIST"])
+    end
+    if data.values["VSPHERE_CONTROL_PLANE_HARDWARE_VERSION"] != None:
+        pciControlPlane["hardwareVersion"] = data.values["VSPHERE_CONTROL_PLANE_HARDWARE_VERSION"]
+    end
+    if pciControlPlane != {}:
+        pci["controlPlane"] = pciControlPlane
+    end
+
+    pciWorker = {}
+    if data.values["VSPHERE_WORKER_PCI_DEVICES"] != None:
+        pciWorker["devices"] = get_pci_devices(data.values["VSPHERE_WORKER_PCI_DEVICES"], data.values["VSPHERE_IGNORE_PCI_DEVICES_ALLOW_LIST"])
+    end
+    if data.values["VSPHERE_WORKER_HARDWARE_VERSION"] != None:
+        pciWorker["hardwareVersion"] = data.values["VSPHERE_WORKER_HARDWARE_VERSION"]
+    end
+    if pciWorker != {}:
+        pci["worker"] = pciWorker
+    end
+
+    if pci != {}:
+        vars["pci"] = pci
     end
 
     return vars

--- a/tkg/constants/clusterclass_mapping.go
+++ b/tkg/constants/clusterclass_mapping.go
@@ -232,6 +232,9 @@ var ClusterAttributesToLegacyVariablesMapVsphere = map[string]string{
 	"spec.topology.variables.worker.machine.numCPUs":     ConfigVariableVsphereWorkerNumCpus,  // VSPHERE_WORKER_NUM_CPUS
 	"spec.topology.variables.worker.network.nameservers": ConfigVariableWorkerNodeNameservers, // WORKER_NODE_NAMESERVERS
 
+	"spec.topology.variables.pci.controlPlane.hardwareVersion": ConfigVariableVSphereControlPlaneHardwareVersion, // VSPHERE_CONTROL_PLANE_HARDWARE_VERSION
+	"spec.topology.variables.pci.worker.hardwareVersion":       ConfigVariableVSphereWorkerHardwareVersion,       // VSPHERE_WORKER_HARDWARE_VERSION
+
 	TopologyWorkersMachineDeploymentsClass0:         "",
 	TopologyWorkersMachineDeploymentsName0:          "",
 	TopologyWorkersMachineDeploymentsReplicas0:      ConfigVariableWorkerMachineCount,


### PR DESCRIPTION
### What this PR does / why we need it
- Augments the VSphere ClusterClass to expose GPU related parameters for control plane as well as worker nodes.
- Maps the variables from the workload cluster config to the variables section in the spec.topology of the Cluster object.
 
### Which issue(s) this PR fixes
No support for GPU based workload cluster creation is exposed on the vSphere Cluster Class. This patch introduces the missing GPU features to maintain parity between legacy and CC based workload clusters.

### Describe testing done for PR


### Release note
```release-note
Adds GPU related variables to VSphere Cluster Class
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
