### PR TITLE
UI: Fix management cluster deployment on vSphere

### DIFF
--- a/tkg/web/angular.json
+++ b/tkg/web/angular.json
@@ -26,6 +26,7 @@
             "allowedCommonJsDependencies": [
               "@ctrl/ngx-codemirror",
               "is-ip",
+              "sort-paths",
               "xregexp"
             ],
             "assets": [

--- a/tkg/web/server/handlers/init.go
+++ b/tkg/web/server/handlers/init.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/vmware-tanzu/tanzu-framework/tkg/vc"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/pkg/errors"
 
@@ -65,6 +67,7 @@ func (app *App) CreateVSphereRegionalCluster(params vsphere.CreateVSphereRegiona
 		TKGConfigUpdater:         allClients.TKGConfigUpdaterClient,
 		TKGPathsClient:           allClients.TKGConfigPathsClient,
 		ClusterClientFactory:     clusterclient.NewClusterClientFactory(),
+		VcClientFactory:          vc.NewVcClientFactory(),
 		FeatureFlagClient:        getFeatureFlagClient(),
 	})
 	if err != nil {

--- a/tkg/web/src/app/app.component.ts
+++ b/tkg/web/src/app/app.component.ts
@@ -1,7 +1,8 @@
 // Angular imports
 import { Component } from '@angular/core';
 import { takeUntil } from 'rxjs/operators';
-
+import '@clr/icons';
+import '@clr/icons/shapes/all-shapes';
 // App imports
 import { BasicSubscriber } from './shared/abstracts/basic-subscriber';
 import { APIClient } from './swagger/api-client.service';

--- a/tkg/web/src/app/views/landing/vsphere-wizard/node-setting-step/node-setting-step.component.html
+++ b/tkg/web/src/app/views/landing/vsphere-wizard/node-setting-step/node-setting-step.component.html
@@ -161,7 +161,7 @@
                     MACHINE HEALTH CHECKS
                     <clr-tooltip>
                         <clr-icon aria-live="assertive" a11yTooltipTrigger shape="info-circle" size="22"></clr-icon>
-                        <clr-tooltip-content clrPosition="top-left" clrSize="lg" *clrIfOpen>
+                        <clr-tooltip-content clrPosition="top-right" clrSize="lg" *clrIfOpen>
                             <span>
                                 Enable Machine Health Checks to provide node health monitoring on the clusters that you
                                 deploy with this {{ clusterTypeDescriptor }} cluster.

--- a/tkg/web/src/app/views/landing/vsphere-wizard/provider-step/vsphere-provider-step.component.ts
+++ b/tkg/web/src/app/views/landing/vsphere-wizard/provider-step/vsphere-provider-step.component.ts
@@ -5,6 +5,7 @@ import { Validators } from '@angular/forms';
 // Third party imports
 import { debounceTime, distinctUntilChanged, finalize, takeUntil } from 'rxjs/operators';
 import * as _ from 'lodash';
+import * as sortPaths from 'sort-paths';
 import { ClrLoadingState } from '@clr/angular';
 // App imports
 import { AppEdition } from 'src/app/shared/constants/branding.constants';
@@ -20,8 +21,6 @@ import { ValidationService } from '../../wizard/shared/validation/validation.ser
 import { VSphereDatacenter } from 'src/app/swagger/models/v-sphere-datacenter.model';
 import { VsphereField } from "../vsphere-wizard.constants";
 import { VsphereProviderStepFieldMapping } from './vsphere-provider-step.fieldmapping';
-
-declare var sortPaths: any;
 
 const SupervisedField = [VsphereField.PROVIDER_VCENTER_ADDRESS, VsphereField.PROVIDER_USER_NAME, VsphereField.PROVIDER_USER_PASSWORD];
 

--- a/tkg/web/src/app/views/landing/vsphere-wizard/resource-step/resource-step.component.ts
+++ b/tkg/web/src/app/views/landing/vsphere-wizard/resource-step/resource-step.component.ts
@@ -1,6 +1,10 @@
 // Angular imports
 import { Component, OnInit } from '@angular/core';
 import { Validators } from '@angular/forms';
+
+// Library imports
+import * as sortPaths from 'sort-paths';
+
 // App imports
 import AppServices from '../../../../shared/service/appServices';
 import { StepFormDirective } from '../../wizard/shared/step-form/step-form';
@@ -11,8 +15,6 @@ import { VsphereField } from "../vsphere-wizard.constants";
 import { VSphereFolder } from '../../../../swagger/models/v-sphere-folder.model';
 import { VSphereResourcePool } from '../../../../swagger/models';
 import { VsphereResourceStepMapping } from './resource-step.fieldmapping';
-
-declare var sortPaths: any;
 
 export interface ResourcePool {
     moid?: string;

--- a/tkg/web/src/app/views/landing/vsphere-wizard/vsphere-network-step/vsphere-network-step.component.ts
+++ b/tkg/web/src/app/views/landing/vsphere-wizard/vsphere-network-step/vsphere-network-step.component.ts
@@ -1,6 +1,10 @@
 // Angular imports
 import { Component } from '@angular/core';
 import { Validators } from '@angular/forms';
+
+// Library imports
+import * as sortPaths from 'sort-paths';
+
 // App imports
 import AppServices from '../../../../shared/service/appServices';
 import { NetworkField } from '../../wizard/shared/components/steps/network-step/network-step.fieldmapping';
@@ -12,7 +16,6 @@ import { VsphereField } from '../vsphere-wizard.constants';
 import { VSphereNetwork } from '../../../../swagger/models';
 import { VsphereNetworkFieldMappings } from './vsphere-network-step.fieldmapping';
 
-declare var sortPaths: any;
 @Component({
     selector: 'app-vsphere-network-step',
     templateUrl: '../../wizard/shared/components/steps/network-step/network-step.component.html',


### PR DESCRIPTION
Addresses issues around UI management cluster creation on vSphere:
 - Datacenter dropdown was not functioning correctly due to npm dependency issue
 - Clarity icons were not appearing also due to npm dependency issue
 - Unable to start MC creation due to VcClientFactory not being initialized in web/handlers/init.go

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes # 16108

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

Verified that user is able to complete the vSphere workflow in the installer UI and trigger management cluster creation

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
