### PR TITLE
refactor retrying code on azure upgrade and create

### DIFF
--- a/tkg/clusterclient/clusterclient.go
+++ b/tkg/clusterclient/clusterclient.go
@@ -595,6 +595,11 @@ func (c *client) WaitForClusterInitialized(clusterName, namespace string) error 
 				reason := conditions.GetReason(currentClusterInfo.ClusterObject, capi.ReadyCondition)
 				message := conditions.GetMessage(currentClusterInfo.ClusterObject, capi.ReadyCondition)
 				maxTimeoutCounter++
+				if interval*time.Duration(maxTimeoutCounter) > maxTimeout {
+					return true, errors.Errorf("timed out waiting for cluster creation, reason:'%s', message:'%s'",
+						reason,
+						message)
+				}
 				if errorRetry >= maxErrorRetry {
 					return true, errors.Errorf("cluster creation failed, reason:'%s', message:'%s'",
 						reason,
@@ -997,6 +1002,11 @@ func (c *client) waitK8sVersionUpdateGeneric(clusterName, namespace, newK8sVersi
 			reason := conditions.GetReason(curClusterInfo.ClusterObject, capi.ReadyCondition)
 			message := conditions.GetMessage(curClusterInfo.ClusterObject, capi.ReadyCondition)
 			maxTimeoutCounter++
+			if interval*time.Duration(maxTimeoutCounter) > maxTimeout {
+				return true, errors.Errorf("timed out waiting for kubernetes version update, reason:'%s', message:'%s'",
+					reason,
+					message)
+			}
 			if errorRetry >= maxErrorRetry {
 				return true, errors.Errorf("kubernetes version update failed, reason:'%s', message:'%s'",
 					reason,

--- a/tkg/clusterclient/clusterclient.go
+++ b/tkg/clusterclient/clusterclient.go
@@ -980,16 +980,26 @@ func (c *client) waitK8sVersionUpdateGeneric(clusterName, namespace, newK8sVersi
 	// maxTimeout to time-bound wait operation to avoid indefinite wait if the cluster state keeps changing
 	maxTimeout := 3 * c.operationTimeout
 	maxTimeoutCounter := 0
+	errorRetry := 0
+	maxErrorRetry := 3
 
 	getterFunc := func() (interface{}, error) {
 		curClusterInfo = c.GetClusterStatusInfo(clusterName, namespace, workloadClusterClient)
 
-		// If cluster's ReadyCondition is False and severity is Error, it implies non-retriable error, so return error
+		// If cluster's ReadyCondition is False and severity is Error, retry 3 times waiting for cluster ready status
+		// for slow I/O infrastructure or resource constrained environments.
 		if conditions.IsFalse(curClusterInfo.ClusterObject, capi.ReadyCondition) &&
 			(*conditions.GetSeverity(curClusterInfo.ClusterObject, capi.ReadyCondition) == capi.ConditionSeverityError) {
-			return true, errors.Errorf("kubernetes version update failed, reason:'%s', message:'%s' ",
-				conditions.GetReason(curClusterInfo.ClusterObject, capi.ReadyCondition),
-				conditions.GetMessage(curClusterInfo.ClusterObject, capi.ReadyCondition))
+			reason := conditions.GetReason(curClusterInfo.ClusterObject, capi.ReadyCondition)
+			message := conditions.GetMessage(curClusterInfo.ClusterObject, capi.ReadyCondition)
+			maxTimeoutCounter++
+			if errorRetry < maxErrorRetry {
+				errorRetry++
+				return false, errors.Errorf("cluster not ready, reason:'%s', message:'%s'", reason, message)
+			}
+			return true, errors.Errorf("kubernetes version update failed, reason:'%s', message:'%s'",
+				reason,
+				message)
 		}
 		err = verifyKubernetesUpgradeFunc(&curClusterInfo, newK8sVersion)
 		if err == nil {

--- a/tkg/clusterclient/clusterclient_test.go
+++ b/tkg/clusterclient/clusterclient_test.go
@@ -170,8 +170,20 @@ var _ = Describe("Cluster Client", func() {
 			return getterFunc()
 		})
 		poller.PollImmediateInfiniteWithGetterCalls(func(interval time.Duration, getterFunc GetterFunc) error {
-			_, errGetter := getterFunc()
-			return errGetter
+			pollMaxRetry := 10
+			timeout, err := getterFunc()
+			for i := 0; i <= pollMaxRetry; i++ {
+				timeoutBool := timeout.(bool)
+				if timeoutBool {
+					return err
+				}
+				if err == nil {
+					return nil
+				}
+				time.Sleep(time.Second * interval)
+				timeout, err = getterFunc()
+			}
+			return err
 		})
 		clusterClientOptions = NewOptions(poller, crtClientFactory, discoveryClientFactory, nil)
 		discoveryClient.ServerVersionReturns(&version.Info{}, nil)

--- a/tkg/clusterclient/clusterclient_test.go
+++ b/tkg/clusterclient/clusterclient_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Cluster Client", func() {
 			return getterFunc()
 		})
 		poller.PollImmediateInfiniteWithGetterCalls(func(interval time.Duration, getterFunc GetterFunc) error {
-			pollMaxRetry := 10
+			pollMaxRetry := 40
 			timeout, err := getterFunc()
 			for i := 0; i <= pollMaxRetry; i++ {
 				timeoutBool := timeout.(bool)


### PR DESCRIPTION
This PR address tolerating some failures when creating or upgrading an azure cluster, because the cluster status may return 'context deadline exceeded' or 'context canceled' error which is recoverable from capz side.