### PR TITLE
tanzu isolated cluster plugin was pushing the images with different f…

### DIFF
--- a/cmd/cli/plugin/isolated-cluster/imagepullop/publishimagestotar.go
+++ b/cmd/cli/plugin/isolated-cluster/imagepullop/publishimagestotar.go
@@ -124,8 +124,7 @@ func (p *PublishImagesToTarOptions) DownloadTkgBomAndComponentImages() (string, 
 		for _, compInfo := range compInfos {
 			for _, imageInfo := range compInfo.Images {
 				sourceImageName = path.Join(p.TkgImageRepo, imageInfo.ImagePath) + ":" + imageInfo.Tag
-				imageInfo.ImagePath = imgpkginterface.ReplaceSlash(imageInfo.ImagePath)
-				tarname := imageInfo.ImagePath + "-" + imageInfo.Tag + ".tar"
+				tarname := imgpkginterface.ReplaceSlash(imageInfo.ImagePath) + "-" + imageInfo.Tag + ".tar"
 				tempImageDetails[tarname] = imageInfo.ImagePath
 				i := sourceImageName
 				j := tarname
@@ -236,8 +235,7 @@ func (p *PublishImagesToTarOptions) DownloadTkrBomAndComponentImages(tkrVersion 
 		for _, compInfo := range compInfos {
 			for _, imageInfo := range compInfo.Images {
 				sourceImageName = filepath.Join(p.TkgImageRepo, imageInfo.ImagePath) + ":" + imageInfo.Tag
-				imageInfo.ImagePath = imgpkginterface.ReplaceSlash(imageInfo.ImagePath)
-				tarname := imageInfo.ImagePath + "-" + imageInfo.Tag + ".tar"
+				tarname := imgpkginterface.ReplaceSlash(imageInfo.ImagePath) + "-" + imageInfo.Tag + ".tar"
 				tempImageDetails[tarname] = imageInfo.ImagePath
 				i := sourceImageName
 				j := tarname


### PR DESCRIPTION
…ormat

Signed-off-by: Vandana Pathak <pathakv@sjc-ubu-eng-127.vmware.com>

### What this PR does / why we need it
TKG Airgap: Tanzu isolated cluster plugin pushes the images with different format
### Which issue(s) this PR fixes
 Tanzu isolated cluster plugin pushes the images with different format
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #None

### Describe testing done for PR
Tested/check the path of each and every images for correct path 
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NA
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->
