### PR TITLE
TKR Resolver: exact TKR version match (if exists) should be the only result

### DIFF
--- a/tkr/resolver/internal/resolver_impl.go
+++ b/tkr/resolver/internal/resolver_impl.go
@@ -324,12 +324,21 @@ func (cache *cache) filterOSImageDetails(osImageQuery *data.OSImageQuery) *osIma
 	}
 
 	consideredTKRs := cache.consideredTKRs(*osImageQuery)
+	consideredTKRs = possiblyNarrowToExactMatch(*osImageQuery, consideredTKRs)
 	filteredOSImagesByTKR := cache.filterOSImagesByTKR(*osImageQuery, consideredTKRs)
 
 	return &osImageDetails{
 		tkrs:          filterTKRsWithOSImages(filteredOSImagesByTKR, consideredTKRs),
 		osImagesByTKR: filteredOSImagesByTKR,
 	}
+}
+
+func possiblyNarrowToExactMatch(osImageQuery data.OSImageQuery, consideredTKRs data.TKRs) data.TKRs {
+	name := version.Label(osImageQuery.K8sVersionPrefix)
+	if tkr := consideredTKRs[name]; tkr != nil {
+		return data.TKRs{name: tkr}
+	}
+	return consideredTKRs
 }
 
 // consideredTKRs returns the initial set of TKRs satisfying the query.


### PR DESCRIPTION
### What this PR does / why we need it

When the exact TKR version is specified as the version prefix AND such TKR exists, it should be the only result in the returned resolution result set.

This fixes a problem, where there are TKRs whose versions are _longer_ than the provided exactly matching TKR version.

For example, the provided prefix is `v1.22.13+vmware.1-tkg.1`. There are two TKRs with versions satisfying this version prefix:
- `v1.22.13+vmware.1-tkg.1`,
- `v1.22.13+vmware.1-tkg.1-zshippable`.

Of the above two, `v1.22.13+vmware.1-tkg.1` must be used, because it is the exact match, and is least surprising for the user specifying `v1.22.13+vmware.1-tkg.1` as the version prefix.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #4262 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Updated unit tests with the test case exposing the issue.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->

```release-note
Fixed a problem when resolving TKRs, where there are TKRs whose versions are longer 
than the matching TKR's version.

For example, the provided version prefix is `v1.22.13+vmware.1-tkg.1`. There are two TKRs 
with versions satisfying this prefix:
- `v1.22.13+vmware.1-tkg.1`,
- `v1.22.13+vmware.1-tkg.1-zshippable`.

Of the above, `v1.22.13+vmware.1-tkg.1` will now be returned, because it is the exact match. 
When the version prefix is shorter (e.g. `v1.22.13+vmware.1`), the result will still be 
`v1.22.13+vmware.1-tkg.1-zshippable` because it is considered a "more recent" version from 
the alpha-numerical comparison point of view.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
