### PR TITLE
Azure Omnibus Bug Fixes

### DIFF
--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -1059,6 +1059,7 @@ spec:
         valueFrom:
           template: |
             - "if [ -f /tmp/kubeadm-join-config.yaml ] || [ -f /run/kubeadm/kubeadm-join-config.yaml ]; then echo '127.0.0.1   apiserver. {{- .builtin.cluster.name -}} .capz.io apiserver' >> /etc/hosts; fi"
+            - "crictl pods -q | xargs -n1 crictl stop"
   - name: ACT_EnableControlPlaneOutboundLB
     enabledIf: '{{ and .privateCluster.enabled .controlPlane.outboundLB.enabled }}'
     definitions:

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -1726,7 +1726,8 @@ spec:
           scheduler:
             extraArgs: {}
           controllerManager:
-            extraArgs: {}
+            extraArgs:
+              configure-cloud-routes: "false"
             extraVolumes:
             - hostPath: /etc/kubernetes/azure.json
               mountPath: /etc/kubernetes/azure.json

--- a/providers/infrastructure-azure/v1.6.1/cconly/base.yaml
+++ b/providers/infrastructure-azure/v1.6.1/cconly/base.yaml
@@ -1059,6 +1059,7 @@ spec:
         valueFrom:
           template: |
             - "if [ -f /tmp/kubeadm-join-config.yaml ] || [ -f /run/kubeadm/kubeadm-join-config.yaml ]; then echo '127.0.0.1   apiserver. {{- .builtin.cluster.name -}} .capz.io apiserver' >> /etc/hosts; fi"
+            - "crictl pods -q | xargs -n1 crictl stop"
   - name: ACT_EnableControlPlaneOutboundLB
     enabledIf: '{{ and .privateCluster.enabled .controlPlane.outboundLB.enabled }}'
     definitions:

--- a/providers/infrastructure-azure/v1.6.1/cconly/base.yaml
+++ b/providers/infrastructure-azure/v1.6.1/cconly/base.yaml
@@ -1726,7 +1726,8 @@ spec:
           scheduler:
             extraArgs: {}
           controllerManager:
-            extraArgs: {}
+            extraArgs:
+              configure-cloud-routes: "false"
             extraVolumes:
             - hostPath: /etc/kubernetes/azure.json
               mountPath: /etc/kubernetes/azure.json

--- a/providers/infrastructure-azure/v1.6.1/ytt/base-template.yaml
+++ b/providers/infrastructure-azure/v1.6.1/ytt/base-template.yaml
@@ -76,6 +76,7 @@ spec:
           cloud-config: /etc/kubernetes/azure.json
           cloud-provider: azure
           cluster-name: ${CLUSTER_NAME}
+          configure-cloud-routes: "false"
         extraVolumes:
           - hostPath: /etc/kubernetes/azure.json
             mountPath: /etc/kubernetes/azure.json

--- a/providers/infrastructure-azure/v1.6.1/ytt/overlay.yaml
+++ b/providers/infrastructure-azure/v1.6.1/ytt/overlay.yaml
@@ -358,5 +358,5 @@ spec:
     name: #@ "{}-identity-secret".format(data.values.CLUSTER_NAME)
     namespace: tkg-system
   tenantID: #@ data.values.AZURE_TENANT_ID
-  type: ServicePrincipal
+  type: ManualServicePrincipal
 #@ end

--- a/providers/infrastructure-azure/v1.6.1/ytt/overlay.yaml
+++ b/providers/infrastructure-azure/v1.6.1/ytt/overlay.yaml
@@ -182,7 +182,8 @@ spec:
       #@overlay/match missing_ok=True
     postKubeadmCommands:
       - #@ "if [ -f /tmp/kubeadm-join-config.yaml ] || [ -f /run/kubeadm/kubeadm-join-config.yaml ]; then echo '127.0.0.1   apiserver.{}.capz.io apiserver' >> /etc/hosts; fi".format(data.values.CLUSTER_NAME)
-      #@ end
+      - "crictl pods -q | xargs -n1 crictl stop"
+    #@ end
     clusterConfiguration:
       imageRepository: #@ kubeadm_image_repo(bomDataForK8sVersion.kubeadmConfigSpec.imageRepository)
       etcd:

--- a/providers/infrastructure-azure/v1.6.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-azure/v1.6.1/yttcc/overlay.yaml
@@ -170,5 +170,5 @@ spec:
     name: #@ "{}-identity-secret".format(data.values.CLUSTER_NAME)
     namespace: tkg-system
   tenantID: #@ data.values.AZURE_TENANT_ID
-  type: ServicePrincipal
+  type: ManualServicePrincipal
 #@ end


### PR DESCRIPTION
Omnibus PR of #4254, #4250 and #4259

Fixes: #2798
Partial fix for #2777

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
* Azure: Disable use of AAD Pod Identity for resolution of Azure credentials
* Azure: Restart pods during private cluster initialisation to work around lack of hairpin LB support for control planes
* Azure: Disable extraneous route table entries
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
