### PR TITLE
TKR Source Controller: Airgap Image Resolution Fix

### DIFF
--- a/tkr/controller/tkr-source/fetcher/fetcher.go
+++ b/tkr/controller/tkr-source/fetcher/fetcher.go
@@ -396,7 +396,7 @@ func (f *Fetcher) filterTKRPackages(imageName string, bundleContent map[string][
 		f.Log.Error(err, "failed to parse .imgpkg/images.yml")
 	}
 	imgpkgutil.ResolveImages(imageMap, bundleContent)
-	f.Log.Info("$$$$$ Replaced images in the TKR package", "imageMap", imageMap, "bundleContent", bundleContent)
+	f.Log.Info("Replaced images in the TKR package", "imageMap", imageMap)
 
 	result := make([]*kapppkgv1.Package, 0, len(bundleContent))
 	for path, bytes := range bundleContent {

--- a/tkr/controller/tkr-source/fetcher/fetcher.go
+++ b/tkr/controller/tkr-source/fetcher/fetcher.go
@@ -378,7 +378,7 @@ func (f *Fetcher) createTKRPackages(ctx context.Context, tag string) error {
 	}
 
 	f.Log.Info("Getting TKR package(s) from", "image", imageName)
-	packages := f.filterTKRPackages(bundleContent)
+	packages := f.filterTKRPackages(imageName, bundleContent)
 
 	for _, pkg := range packages {
 		f.Log.Info("Creating package", "name", pkg.Name)
@@ -390,12 +390,13 @@ func (f *Fetcher) createTKRPackages(ctx context.Context, tag string) error {
 	return nil
 }
 
-func (f *Fetcher) filterTKRPackages(bundleContent map[string][]byte) []*kapppkgv1.Package {
-	imageMap, err := imgpkgutil.ParseImagesLock(bundleContent[".imgpkg/images.yml"])
+func (f *Fetcher) filterTKRPackages(imageName string, bundleContent map[string][]byte) []*kapppkgv1.Package {
+	imageMap, err := imgpkgutil.ParseImagesLock(imageName, bundleContent[".imgpkg/images.yml"])
 	if err != nil {
 		f.Log.Error(err, "failed to parse .imgpkg/images.yml")
 	}
 	imgpkgutil.ResolveImages(imageMap, bundleContent)
+	f.Log.Info("$$$$$ Replaced images in the TKR package", "imageMap", imageMap, "bundleContent", bundleContent)
 
 	result := make([]*kapppkgv1.Package, 0, len(bundleContent))
 	for path, bytes := range bundleContent {

--- a/tkr/controller/tkr-source/imgpkgutil/imgpkgutil_test.go
+++ b/tkr/controller/tkr-source/imgpkgutil/imgpkgutil_test.go
@@ -17,7 +17,7 @@ func TestReconciler(t *testing.T) {
 	RunSpecs(t, "Fetcher Unit Tests", suiteConfig)
 }
 
-const validImagesLockYAML = `
+const imagesLockYAML = `
 ---
 apiVersion: imgpkg.carvel.dev/v1alpha1
 images:
@@ -27,7 +27,7 @@ images:
       - resolved:
           tag: v1.24.9_vmware.1-tkg.1-zshippable
           url: projects-stg.registry.vmware.com/tkg/tkr-vsphere-nonparavirt:v1.24.9_vmware.1-tkg.1-zshippable
-  image: 10.92.174.209:8443/library/tkg/tkr-vsphere-nonparavirt@sha256:b56a4c11a3eef1d3fef51c66b1571f92d45f17cf11de8f89e7706dbbb9b6a287
+  image: projects-stg.registry.vmware.com/tkg/tkr-vsphere-nonparavirt@sha256:b56a4c11a3eef1d3fef51c66b1571f92d45f17cf11de8f89e7706dbbb9b6a287
 kind: ImagesLock
 `
 
@@ -35,20 +35,23 @@ var _ = Describe("parseImagesLock", func() {
 	var (
 		imagesLockBytes  []byte
 		expectedImageMap map[string]string
+		bundleImage      string
 	)
 	BeforeEach(func() {
 		imagesLockBytes = nil
 		expectedImageMap = nil
+		bundleImage = ""
 	})
 	Context("valid input", func() {
 		BeforeEach(func() {
-			imagesLockBytes = []byte(validImagesLockYAML)
+			imagesLockBytes = []byte(imagesLockYAML)
+			bundleImage = "10.92.174.209:8443/library/tkg/tkr-repository-vsphere-nonparavirt:v1.24.9_vmware.1-tkg.1-zshippable"
 			expectedImageMap = map[string]string{
-				"projects-stg.registry.vmware.com/tkg/tkr-vsphere-nonparavirt:v1.24.9_vmware.1-tkg.1-zshippable": "10.92.174.209:8443/library/tkg/tkr-vsphere-nonparavirt@sha256:b56a4c11a3eef1d3fef51c66b1571f92d45f17cf11de8f89e7706dbbb9b6a287",
+				"projects-stg.registry.vmware.com/tkg/tkr-vsphere-nonparavirt:v1.24.9_vmware.1-tkg.1-zshippable": "10.92.174.209:8443/library/tkg/tkr-repository-vsphere-nonparavirt@sha256:b56a4c11a3eef1d3fef51c66b1571f92d45f17cf11de8f89e7706dbbb9b6a287",
 			}
 		})
 		It("should return the expected map of images", func() {
-			imageMap, err := ParseImagesLock(imagesLockBytes)
+			imageMap, err := ParseImagesLock(bundleImage, imagesLockBytes)
 			Expect(imageMap).To(Equal(expectedImageMap))
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -59,7 +62,7 @@ var _ = Describe("parseImagesLock", func() {
 			imagesLockBytes = nil
 		})
 		It("should return nil", func() {
-			Expect(ParseImagesLock(imagesLockBytes)).To(BeNil())
+			Expect(ParseImagesLock(bundleImage, imagesLockBytes)).To(BeNil())
 		})
 	})
 
@@ -68,12 +71,78 @@ var _ = Describe("parseImagesLock", func() {
 			imagesLockBytes = []byte(`%%%%`)
 		})
 		It("should return nil", func() {
-			imageMap, err := ParseImagesLock(imagesLockBytes)
+			imageMap, err := ParseImagesLock(bundleImage, imagesLockBytes)
 			Expect(imageMap).To(BeNil())
 			Expect(err).To(HaveOccurred())
 		})
 	})
 })
+
+const origFile = `kind: Package
+apiVersion: data.packaging.carvel.dev/v1alpha1
+metadata:
+  name: tkr-vsphere-nonparavirt.tanzu.vmware.com.1.24.9+vmware.1-tkg.1-zshippable
+  labels:
+    run.tanzu.vmware.com/tkr-package: ""
+spec:
+  refName: tkr-vsphere-nonparavirt.tanzu.vmware.com
+  version: 1.24.9+vmware.1-tkg.1-zshippable
+  licenses:
+  - 'VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)'
+  releasedAt: "2023-01-07T14:52:02Z"
+  releaseNotes: tkr release
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: projects-stg.registry.vmware.com/tkg/tkr-vsphere-nonparavirt:v1.24.9_vmware.1-tkg.1-zshippable
+      template:
+      - ytt:
+          ignoreUnknownComments: true
+          paths:
+          - config/
+          - packages/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
+      deploy:
+      - kapp:
+          intoNs: tkg-system
+`
+
+const resolvedFile = `kind: Package
+apiVersion: data.packaging.carvel.dev/v1alpha1
+metadata:
+  name: tkr-vsphere-nonparavirt.tanzu.vmware.com.1.24.9+vmware.1-tkg.1-zshippable
+  labels:
+    run.tanzu.vmware.com/tkr-package: ""
+spec:
+  refName: tkr-vsphere-nonparavirt.tanzu.vmware.com
+  version: 1.24.9+vmware.1-tkg.1-zshippable
+  licenses:
+  - 'VMware’s End User License Agreement (Underlying OSS license: Apache License 2.0)'
+  releasedAt: "2023-01-07T14:52:02Z"
+  releaseNotes: tkr release
+  template:
+    spec:
+      fetch:
+      - imgpkgBundle:
+          image: 10.92.174.209:8443/library/tkg/tkr-repository-vsphere-nonparavirt@sha256:b56a4c11a3eef1d3fef51c66b1571f92d45f17cf11de8f89e7706dbbb9b6a287
+      template:
+      - ytt:
+          ignoreUnknownComments: true
+          paths:
+          - config/
+          - packages/
+      - kbld:
+          paths:
+          - '-'
+          - .imgpkg/images.yml
+      deploy:
+      - kapp:
+          intoNs: tkg-system
+`
 
 var _ = Describe("resolveImages", func() {
 	var (
@@ -83,14 +152,14 @@ var _ = Describe("resolveImages", func() {
 	)
 	BeforeEach(func() {
 		imageMap = map[string]string{
-			"projects-stg.registry.vmware.com/tkg/tkr-vsphere-nonparavirt:v1.24.9_vmware.1-tkg.1-zshippable": "10.92.174.209:8443/library/tkg/tkr-vsphere-nonparavirt@sha256:b56a4c11a3eef1d3fef51c66b1571f92d45f17cf11de8f89e7706dbbb9b6a287",
+			"projects-stg.registry.vmware.com/tkg/tkr-vsphere-nonparavirt:v1.24.9_vmware.1-tkg.1-zshippable": "10.92.174.209:8443/library/tkg/tkr-repository-vsphere-nonparavirt@sha256:b56a4c11a3eef1d3fef51c66b1571f92d45f17cf11de8f89e7706dbbb9b6a287",
 		}
 		bundle = map[string][]byte{
-			"path1": []byte("projects-stg.registry.vmware.com/tkg/tkr-vsphere-nonparavirt:v1.24.9_vmware.1-tkg.1-zshippable"),
+			"path1": []byte(origFile),
 			"path2": []byte("image2"),
 		}
 		wantBundle = map[string][]byte{
-			"path1": []byte("10.92.174.209:8443/library/tkg/tkr-vsphere-nonparavirt@sha256:b56a4c11a3eef1d3fef51c66b1571f92d45f17cf11de8f89e7706dbbb9b6a287"),
+			"path1": []byte(resolvedFile),
 			"path2": []byte("image2"),
 		}
 	})
@@ -108,7 +177,7 @@ var _ = Describe("resolveImages", func() {
 				"image3": "image3:v1",
 			}
 			wantBundle = map[string][]byte{
-				"path1": []byte("projects-stg.registry.vmware.com/tkg/tkr-vsphere-nonparavirt:v1.24.9_vmware.1-tkg.1-zshippable"),
+				"path1": []byte(origFile),
 				"path2": []byte("image2"),
 			}
 		})

--- a/tkr/controller/tkr-source/imgpkgutil/imgpkgutil_test.go
+++ b/tkr/controller/tkr-source/imgpkgutil/imgpkgutil_test.go
@@ -55,6 +55,20 @@ var _ = Describe("parseImagesLock", func() {
 			Expect(imageMap).To(Equal(expectedImageMap))
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		When("bundleImage comes from the same registry (i.e. no air-gap)", func() {
+			BeforeEach(func() {
+				bundleImage = "projects-stg.registry.vmware.com/tkg/tkr-repository-vsphere-nonparavirt:v1.24.9_vmware.1-tkg.1-zshippable"
+				expectedImageMap = map[string]string{
+					"projects-stg.registry.vmware.com/tkg/tkr-vsphere-nonparavirt:v1.24.9_vmware.1-tkg.1-zshippable": "projects-stg.registry.vmware.com/tkg/tkr-vsphere-nonparavirt@sha256:b56a4c11a3eef1d3fef51c66b1571f92d45f17cf11de8f89e7706dbbb9b6a287",
+				}
+			})
+			It("should return the expected map of images", func() {
+				imageMap, err := ParseImagesLock(bundleImage, imagesLockBytes)
+				Expect(imageMap).To(Equal(expectedImageMap))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
 	})
 
 	Context("nil input", func() {

--- a/tkr/controller/tkr-source/pkgcr/reconciler.go
+++ b/tkr/controller/tkr-source/pkgcr/reconciler.go
@@ -188,16 +188,17 @@ func (r *Reconciler) doInstall(ctx context.Context, pkg *kapppkgv1.Package, cm *
 		cm.Data[FieldInstallData] = marshalInstallData(installData)
 	}()
 
-	packageContent, err := r.fetchPackageContent(pkg)
+	packageContent, bundleImage, err := r.fetchPackageContent(pkg)
 	if err != nil {
 		return false, err
 	}
 
-	imageMap, err := imgpkgutil.ParseImagesLock(packageContent[".imgpkg/images.yml"])
+	imageMap, err := imgpkgutil.ParseImagesLock(bundleImage, packageContent[".imgpkg/images.yml"])
 	if err != nil {
 		r.Log.Error(err, "failed to parse .imgpkg/images.yml")
 	}
 	imgpkgutil.ResolveImages(imageMap, packageContent)
+	r.Log.Info("$$$$$ Replaced images in the TKR package", "imageMap", imageMap, "bundleContent", packageContent)
 
 	for path, bytes := range packageContent {
 		if strings.HasPrefix(path, ".") {
@@ -239,21 +240,21 @@ func parseObject(cm *corev1.ConfigMap, bytes []byte) (*unstructured.Unstructured
 	return u, nil
 }
 
-func (r *Reconciler) fetchPackageContent(pkg *kapppkgv1.Package) (map[string][]byte, error) {
+func (r *Reconciler) fetchPackageContent(pkg *kapppkgv1.Package) (map[string][]byte, string, error) {
 	if pkg.Spec.Template.Spec == nil {
-		return nil, nil
+		return nil, "", nil
 	}
 	for _, fetch := range pkg.Spec.Template.Spec.Fetch {
 		if fetch.ImgpkgBundle == nil {
-			return nil, nil
+			return nil, "", nil
 		}
 		files, err := r.Registry.GetFiles(fetch.ImgpkgBundle.Image)
 		if err != nil {
-			return nil, err
+			return nil, "", err
 		}
-		return files, nil // nolint:staticcheck // loop is unconditionally terminated: there's only one Fetch
+		return files, fetch.ImgpkgBundle.Image, nil // nolint:staticcheck // loop is unconditionally terminated: there's only one Fetch
 	}
-	return nil, nil
+	return nil, "", nil
 }
 
 func (r *Reconciler) create(ctx context.Context, u *unstructured.Unstructured) error {

--- a/tkr/controller/tkr-source/pkgcr/reconciler.go
+++ b/tkr/controller/tkr-source/pkgcr/reconciler.go
@@ -198,7 +198,7 @@ func (r *Reconciler) doInstall(ctx context.Context, pkg *kapppkgv1.Package, cm *
 		r.Log.Error(err, "failed to parse .imgpkg/images.yml")
 	}
 	imgpkgutil.ResolveImages(imageMap, packageContent)
-	r.Log.Info("$$$$$ Replaced images in the TKR package", "imageMap", imageMap, "bundleContent", packageContent)
+	r.Log.Info("Replaced images in the TKR package", "imageMap", imageMap)
 
 	for path, bytes := range packageContent {
 		if strings.HasPrefix(path, ".") {


### PR DESCRIPTION
### What this PR does / why we need it

ImagesLock, as it turns out, isn't published with the right image registry DNS name. It is completely up to the client to resolve images based on the `@sha256:<hash>`. This change implements mapping of images based on the image name of the bundle being pulled.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes airgap support.

### Describe testing done for PR

Updated unit tests to reflect the problem being fixed.

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
