### PR TITLE
Fix vSphere OSImage labeling

### DIFF
--- a/tkr/util/osimage/osimage.go
+++ b/tkr/util/osimage/osimage.go
@@ -6,6 +6,7 @@ package osimage
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -18,6 +19,12 @@ func SetRefLabels(ls labels.Set, prefix string, ref map[string]interface{}) {
 			SetRefLabels(ls, prefixedName, value)
 			continue
 		}
-		ls[prefixedName] = fmt.Sprint(value)
+		ls[prefixedName] = labelFormat(value)
 	}
+}
+
+func labelFormat(value interface{}) string {
+	s := fmt.Sprint(value)
+	s = strings.ReplaceAll(s, "+", "---")
+	return s
 }

--- a/tkr/webhook/cluster/tkr-resolver/cluster/cluster_test.go
+++ b/tkr/webhook/cluster/tkr-resolver/cluster/cluster_test.go
@@ -403,8 +403,13 @@ var _ = Describe("cluster.Webhook", func() {
 					conditions.MarkTrue(tkr, runv1.ConditionValid)
 					conditions.MarkTrue(osImage, runv1.ConditionCompatible)
 					conditions.MarkTrue(osImage, runv1.ConditionValid)
-					osImage.Spec.Image.Ref[uniqueRefField] = true
+
+					const someVersionString = "v1.24.9+vmware.1-tkg.1-226b7a84930e5368c38aa867f998ce33"
+					osImage.Spec.Image.Ref[uniqueRefField] = someVersionString
 					cw.TKRResolver.Add(tkr, osImage) // make sure tkr and osImage are resolvable
+
+					labelValue := osImage.Labels[osImage.Spec.Image.Type+"-"+uniqueRefField]
+					Expect(labelValue).To(Equal(version.Label(someVersionString)))
 
 					osImageSelector = labels.Set(osImage.Labels).AsSelector()
 					osImageSelectorStr = osImageSelector.String()


### PR DESCRIPTION
### What this PR does / why we need it

For vsphere-nonparavirt provider, OSImage objects have version field their `.spec.image.ref` field, e.g. like this:
```
  image:
    type: ova
    ref:
      version: v1.24.9+vmware.1-tkg.1-226b7a84930e5368c38aa867f998ce33
```

When being added to the TKR Resolver cache (for example, when being updated by the tkr-status-controller), the OSImage `.spec.image.ref` contents are set as the OSImage labels to enable resolution of the OSImage by this data using a label query.

The problem is: "+" cannot be used in label values. This change fixes it by replacing "+" with "---" (same way we derive TKR names from their versions).

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

N/A

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Updated unit tests to expose the problem fixed.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
OSImage objects for vsphere-nonparavirt provider will now have `ova-version` label set to
the value of the OSImage `.spec.image.ref.version` with "+" replaced by "---".
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
