### PR TITLE
Handle TKR package bundleImage being a `@sha:<hash>` image itself

### DIFF
--- a/tkr/controller/tkr-source/imgpkgutil/imgpkgutil.go
+++ b/tkr/controller/tkr-source/imgpkgutil/imgpkgutil.go
@@ -50,7 +50,7 @@ func bundleImagePrefix(bundleImageName string) string {
 	if lastIndex == -1 {
 		return bundleImageName
 	}
-	return bundleImageName[:lastIndex]
+	return strings.TrimSuffix(bundleImageName[:lastIndex], "@sha256")
 }
 
 func comesFromTheSameRegistry(bundleImageName string, sourceImage string) bool {

--- a/tkr/controller/tkr-source/imgpkgutil/imgpkgutil_test.go
+++ b/tkr/controller/tkr-source/imgpkgutil/imgpkgutil_test.go
@@ -56,6 +56,20 @@ var _ = Describe("parseImagesLock", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		When("bundleImage comes from different registry AND it is a @sha:<hash>", func() {
+			BeforeEach(func() {
+				bundleImage = "10.92.174.209:8443/library/tkr-repository-vsphere-nonparavirt@sha256:80531da198daf051a6e20bc150acf56e51da7b8491154aa1056fa7b366064e92"
+				expectedImageMap = map[string]string{
+					"projects-stg.registry.vmware.com/tkg/tkr-vsphere-nonparavirt:v1.24.9_vmware.1-tkg.1-zshippable": "10.92.174.209:8443/library/tkr-repository-vsphere-nonparavirt@sha256:b56a4c11a3eef1d3fef51c66b1571f92d45f17cf11de8f89e7706dbbb9b6a287",
+				}
+			})
+			It("should return the expected map of images", func() {
+				imageMap, err := ParseImagesLock(bundleImage, imagesLockBytes)
+				Expect(imageMap).To(Equal(expectedImageMap))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
 		When("bundleImage comes from the same registry (i.e. no air-gap)", func() {
 			BeforeEach(func() {
 				bundleImage = "projects-stg.registry.vmware.com/tkg/tkr-repository-vsphere-nonparavirt:v1.24.9_vmware.1-tkg.1-zshippable"


### PR DESCRIPTION
### What this PR does / why we need it

Without this, in air-gap environments, packages created by TKRs, will have bundle images with `@sha256@sha256:` in their names, e.g. like this:
```
image: `10.206.106.78:8443/library/tkr-repository-vsphere-nonparavirt@sha256@sha256:8b794c2f3508d28e4176830aada519a0cb0b65f1c70e2351124aab11ea3c910e`
```

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes air-gap support.

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Updated unit tests to reflect the problem.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
NONE
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
