### PR TITLE
Ensure legacy cluster upgrade does not overwrite kube-apiserver admission-control-config-file flag

### DIFF
--- a/tkg/client/admission_upgrade_helper.go
+++ b/tkg/client/admission_upgrade_helper.go
@@ -7,6 +7,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	capibootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 	controlplanev1 "sigs.k8s.io/cluster-api/controlplane/kubeadm/api/v1beta1"
+
+	"github.com/vmware-tanzu/tanzu-framework/tkg/log"
 )
 
 const (
@@ -53,8 +55,11 @@ func (c *TkgClient) configurePodSecurityStandard(old *controlplanev1.KubeadmCont
 		}
 	}
 
-	if fileExists && volumeMountExists && old.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs[admissionPodSecurityConfigFlagName] == admissionPodSecurityConfigFilePath {
-		return old
+	if old.Spec.KubeadmConfigSpec.ClusterConfiguration != nil && old.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs != nil {
+		if _, flagExists := old.Spec.KubeadmConfigSpec.ClusterConfiguration.APIServer.ExtraArgs[admissionPodSecurityConfigFlagName]; flagExists {
+			log.Warningf("Skipping to enable Pod Security Standard for KCP: flag %q already exists", admissionPodSecurityConfigFlagName)
+			return nil
+		}
 	}
 
 	kcp := old.DeepCopy()


### PR DESCRIPTION
### What this PR does / why we need it

Fixes the legacy cluster upgrade to not overwrite an previously existing kube-apiserver flag `admission-control-config-file` in KCP.

Only affects Cluster upgrades to Kubernetes v1.24

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
