### PR TITLE
Update the image path of kube-vip

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -1038,7 +1038,7 @@ spec:
                     value: "20"
                   - name: vip_retryperiod
                     value: "4"
-                  image: {{ if (index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageRepository }}{{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageRepository}}{{ else }}{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}{{ end }}/kube-vip:{{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageTag}}
+                  image: {{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}/kube-vip:{{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageTag}}
                   imagePullPolicy: IfNotPresent
                   name: kube-vip
                   resources: {}

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -1038,7 +1038,7 @@ spec:
                     value: "20"
                   - name: vip_retryperiod
                     value: "4"
-                  image: {{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageRepository}}/kube-vip:{{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageTag}}
+                  image: {{ if (index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageRepository }}{{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageRepository}}{{ else }}{{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}{{ end }}/kube-vip:{{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageTag}}
                   imagePullPolicy: IfNotPresent
                   name: kube-vip
                   resources: {}

--- a/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
@@ -1038,7 +1038,7 @@ spec:
                     value: "20"
                   - name: vip_retryperiod
                     value: "4"
-                  image: {{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageRepository}}/kube-vip:{{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageTag}}
+                  image: {{(index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec.imageRepository}}/kube-vip:{{(index (index .TKR_DATA .builtin.controlPlane.version).kubernetesSpec "kube-vip").imageTag}}
                   imagePullPolicy: IfNotPresent
                   name: kube-vip
                   resources: {}


### PR DESCRIPTION
### What this PR does / why we need it
Currently, kube-vip imageRepository was fetched from `TKR_DATA.value.(k8s-version).kubernetesSpec.kube-vip.imageRepository`
```
- name: TKR_DATA
        value:
          v1.24.9+vmware.1:
            kubernetesSpec:
              coredns:
                imageRepository: projects-stg.registry.vmware.com/tkg
                imageTag: v1.8.6_vmware.15
              etcd:
                imageRepository: projects-stg.registry.vmware.com/tkg
                imageTag: v3.5.6_vmware.3
              imageRepository: projects-stg.registry.vmware.com/tkg   
              kube-vip:
                imageRepository: projects-stg.registry.vmware.com/tkg  <- ------ here   
                imageTag: v0.5.7_vmware.1
              pause:
                imageRepository: projects-stg.registry.vmware.com/tkg
                imageTag: "3.7"
              version: v1.24.9+vmware.1
```
But this value won't be there if `TKG_CUSTOM_IMAGE_REPOSITORY ` is not set
```
              coredns:
                imageTag: v1.8.6_vmware.15
              etcd:
                imageTag: v3.5.6_vmware.3
              imageRepository: projects.registry.vmware.com/tkg
              kube-vip:
                imageTag: v0.5.7_vmware.1
              pause:
                imageTag: "3.7"
              version: v1.24.9+vmware.1
            labels:
```
Since these two values will always be the same, kube-vip should also extract imageRepository from top level

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
