### PR TITLE
Populate all imageRepository fields in TKR_DATA values

### DIFF
--- a/tkr/webhook/cluster/tkr-resolver/cluster/cluster_test.go
+++ b/tkr/webhook/cluster/tkr-resolver/cluster/cluster_test.go
@@ -418,6 +418,7 @@ var _ = Describe("cluster.Webhook", func() {
 					cluster.Spec.Topology = &clusterv1.Topology{}
 					cluster.Spec.Topology.Version = k8sVersionPrefix
 
+					customImageRepository = ""
 					if rand.Intn(2) != 0 {
 						customImageRepository = rand.String(10)
 					}
@@ -480,8 +481,19 @@ var _ = Describe("cluster.Webhook", func() {
 							Expect(topology.GetVariable(cluster, VarTKRData, &tkrData)).To(Succeed())
 							Expect(tkrData).ToNot(BeNil())
 							Expect(tkrData).To(HaveKey(tkr.Spec.Kubernetes.Version))
-							Expect(tkrData[tkr.Spec.Kubernetes.Version].Labels[runv1.LabelTKR]).To(Equal(tkr.Name))
-							Expect(tkrData[tkr.Spec.Kubernetes.Version].KubernetesSpec).To(Equal(*withCustomImageRepository(customImageRepository, &tkr.Spec.Kubernetes)))
+							dataValue := tkrData[tkr.Spec.Kubernetes.Version]
+							Expect(dataValue.Labels[runv1.LabelTKR]).To(Equal(tkr.Name))
+							Expect(dataValue.KubernetesSpec).To(Equal(*withCustomImageRepository(customImageRepository, defaultImageRepository(&tkr.Spec.Kubernetes))))
+							for _, imageInfo := range []*runv1.ContainerImageInfo{
+								dataValue.KubernetesSpec.Etcd,
+								dataValue.KubernetesSpec.Pause,
+								dataValue.KubernetesSpec.CoreDNS,
+								dataValue.KubernetesSpec.KubeVIP,
+							} {
+								if imageInfo != nil {
+									Expect(imageInfo.ImageRepository).ToNot(BeEmpty())
+								}
+							}
 						})
 					})
 				})


### PR DESCRIPTION
### What this PR does / why we need it

`imageRepository` fields in `TKR.spec.kubernetes.{etcd,pause,coredns,kube-vip}` can be empty. In this case, the clients should be defaulting to `TKR.spec.kubernetes.imageRepository`.

This change allows to simplify ClusterClass JSON patches doing this: they can now assume imageRepository fields in TKR_DATA values are non-empty and have the correct value.


### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #4315

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Updated unit tests to reflect the described situation.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Allow for simpler ClusterClass JSON patches accessing 
kubernetesSpec.{etcd,pause,coredns,kube-vip}.imageRepository fields in TKR_DATA values. 
They can now assume imageRepository fields in TKR_DATA values are non-empty and default to 
kubernetesSpec.imageRepository (if they are empty in the TKR).
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
