### PR TITLE
 Cherry pick #4264 into G.0 release-0.28 branch

### DIFF
--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -500,19 +500,29 @@ func (r *ClusterBootstrapReconciler) mergeClusterBootstrapPackagesWithTemplate(
 	//    4. All packages, including additional packages, can't be deleted (meaning the package refName can't be changed, only allow version bump)
 	//    5. We will keep users' customization on valuesFrom of each package, users are responsible for the correctness of the content they put in will work with the next version.
 	packages := make([]*runtanzuv1alpha3.ClusterBootstrapPackage, 0)
-	if updatedClusterBootstrap.Spec.CNI == nil {
-		log.Info("no CNI package specified in ClusterBootstrap, should not happen. Continue with CNI in ClusterBootstrapTemplate of new TKR")
-		updatedClusterBootstrap.Spec.CNI = clusterBootstrapTemplate.Spec.CNI.DeepCopy()
+
+	_, unmanagedCNI := updatedClusterBootstrap.Annotations[constants.UnmanagedCNI]
+	if unmanagedCNI && updatedClusterBootstrap.Spec.CNI != nil {
+		return nil, errors.New("Spec.CNI should be empty if the clusterbootstrap is annotated to use unmanaged CNI.")
+	}
+
+	if unmanagedCNI {
+		log.Info("Unmanaged CNI")
 	} else {
-		// We don't allow change to the CNI selection once it starts running, however we allow version bump
-		// TODO: check correctness of the following statement, as we still allow version bump
-		// ClusterBootstrap webhook will make sure the package RefName always match the original CNI
-		updatedCNI, cniNamePrefix, err := util.GetBootstrapPackageNameFromTKR(r.context, r.Client, updatedClusterBootstrap.Spec.CNI.RefName, cluster)
-		if err != nil {
-			errorMsg := fmt.Sprintf("unable to find any CNI bootstrap package prefixed with '%s' for ClusterBootstrap %s/%s in TKR", cniNamePrefix, cluster.Namespace, cluster.Name)
-			return nil, errors.Wrap(err, errorMsg)
+		if updatedClusterBootstrap.Spec.CNI == nil {
+			log.Info("no CNI package specified in ClusterBootstrap, and it is not annotated to use a unmanaged CNI. Continue with CNI in ClusterBootstrapTemplate of new TKR")
+			updatedClusterBootstrap.Spec.CNI = clusterBootstrapTemplate.Spec.CNI.DeepCopy()
+		} else {
+			// We don't allow change to the CNI selection once it starts running, however we allow version bump
+			// TODO: check correctness of the following statement, as we still allow version bump
+			// ClusterBootstrap webhook will make sure the package RefName always match the original CNI
+			updatedCNI, cniNamePrefix, err := util.GetBootstrapPackageNameFromTKR(r.context, r.Client, updatedClusterBootstrap.Spec.CNI.RefName, cluster)
+			if err != nil {
+				errorMsg := fmt.Sprintf("unable to find any CNI bootstrap package prefixed with '%s' for ClusterBootstrap %s/%s in TKR", cniNamePrefix, cluster.Namespace, cluster.Name)
+				return nil, errors.Wrap(err, errorMsg)
+			}
+			updatedClusterBootstrap.Spec.CNI.RefName = updatedCNI
 		}
-		updatedClusterBootstrap.Spec.CNI.RefName = updatedCNI
 	}
 
 	if updatedClusterBootstrap.Spec.Kapp == nil {

--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -282,6 +282,9 @@ const (
 	// logic
 	AddCBMissingFieldsAnnotationKey = "tkg.tanzu.vmware.com/add-missing-fields-from-tkr"
 
+	// UnmanagedCNI is the label for clusters that use unmanaged CNI
+	UnmanagedCNI = "tkg.tanzu.vmware.com/unmanaged-cni"
+
 	// VsphereCPIProviderServiceAccountAggregatedClusterRole is the name of ClusterRole created by controllers that use ProviderServiceAccount
 	VsphereCPIProviderServiceAccountAggregatedClusterRole = "addons-vsphere-cpi-providerserviceaccount-aggregatedrole"
 

--- a/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
+++ b/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -62,6 +63,10 @@ func NewHelper(ctx context.Context, k8sClient client.Client, aggregateAPIResourc
 // a fully qualified name(<packageShortName>.<domain>.<version>). The fully qualified name is fetched from TKR.
 func (h *Helper) CompleteCBPackageRefNamesFromTKR(tkr *runtanzuv1alpha3.TanzuKubernetesRelease, clusterBootstrap *runtanzuv1alpha3.ClusterBootstrap) error {
 	var suffix = "*"
+
+	if clusterBootstrap.Spec == nil {
+		return errors.New("missing spec definition")
+	}
 	clusterBootstrapPackages := []*runtanzuv1alpha3.ClusterBootstrapPackage{
 		clusterBootstrap.Spec.CNI,
 		clusterBootstrap.Spec.CPI,
@@ -366,6 +371,10 @@ func (h *Helper) HandleExistingClusterBootstrap(clusterBootstrap *runtanzuv1alph
 			if cbPackage != nil && cbPackage.ValuesFrom != nil && cbPackage.ValuesFrom.Inline != nil {
 				nonEmptyInlinePackages = append(nonEmptyInlinePackages, cbPackage)
 			}
+		}
+
+		if _, ok := clusterBootstrap.Annotations[constants.UnmanagedCNI]; ok {
+			clusterBootstrapTemplate.Spec.CNI = clusterBootstrap.Spec.CNI
 		}
 
 		if err := h.AddMissingSpecFieldsFromTemplate(clusterBootstrapTemplate, clusterBootstrap, nil); err != nil {

--- a/providers/yttcb/clusterbootstrap.yaml
+++ b/providers/yttcb/clusterbootstrap.yaml
@@ -421,6 +421,8 @@ metadata:
   namespace: #@ data.values.NAMESPACE
   annotations:
     tkg.tanzu.vmware.com/add-missing-fields-from-tkr: #@ data.values.KUBERNETES_RELEASE
+    #@ if/end data.values.CNI == "none":
+    tkg.tanzu.vmware.com/unmanaged-cni: ""
 spec:
   #@ if data.values.CNI == "antrea" and antrea_config_customized():
   cni:


### PR DESCRIPTION
Enable custom cni provider support for classy clusters (#4264)

- adds annotation to clusterbootstrap
- webhook checks annotation on clusterbootstrap before validating cni == nil
- controller does not merge CB cni with template CNI if using custom cni provider
- Adds logic for default, create and update webhooks

