### PR TITLE
enable delete of cluster when tkr is not present on supervisor

### DIFF
--- a/addons/controllers/cluster_metadata_controller.go
+++ b/addons/controllers/cluster_metadata_controller.go
@@ -92,7 +92,7 @@ func (r *ClusterMetadataReconciler) Reconcile(ctx context.Context, req reconcile
 		}
 	}
 
-	tkr, err := util.GetTKRByNameV1Alpha3(r.context, r.Client, tkrName)
+	tkr, err := util.GetTKRByNameV1Alpha3(r.context, r.Client, cluster, tkrName)
 	if err != nil {
 		log.Error(err, "unable to fetch TKR object", "name", tkrName)
 		return ctrl.Result{}, err

--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -4,8 +4,12 @@
 package controllers
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"fmt"
+	"io/ioutil"
 	"strings"
 	"time"
 
@@ -158,8 +162,11 @@ func (r *ClusterBootstrapReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// if tkr is not found, should not requeue for the reconciliation
 	if tkr == nil {
-		log.Info("TKR object not found", "name", tkrName)
-		return ctrl.Result{}, nil
+		tkr, err = FetchTKRSpecFromAnnotations(cluster.Annotations)
+		if err != nil {
+			log.Info("TKR object not found", "name", tkrName)
+			return ctrl.Result{}, nil
+		}
 	}
 
 	if _, labelFound := tkr.Labels[constants.TKRLabelLegacyClusters]; labelFound {
@@ -1619,4 +1626,37 @@ func (r *ClusterBootstrapReconciler) generateSecretForPackagesWithEmptyValuesFro
 
 	r.Log.Info(fmt.Sprintf("created secret %v for ClusterBootstrapPackage.RefName: %s", packageSecret.Name, cbPkg.RefName))
 	return packageSecret.Name, nil
+}
+
+func FetchTKRSpecFromAnnotations(tkc map[string]string) (*runtanzuv1alpha3.TanzuKubernetesRelease, error) {
+	controlPlaneTKR := &runtanzuv1alpha3.TanzuKubernetesRelease{}
+
+	tkrSpec, ok := tkc["run.tanzu.vmware.com/tkr-spec"]
+	if ok {
+		unzipOut, err := gunzipAndBase64Decode(tkrSpec)
+		if err != nil {
+			return nil, err
+		}
+
+		err = yaml.Unmarshal(unzipOut, controlPlaneTKR)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return controlPlaneTKR, nil
+}
+
+// GunzipAndBase64Decode extracts a gzip archive to a byte array
+func gunzipAndBase64Decode(input string) ([]byte, error) {
+	decodedData, err := base64.StdEncoding.DecodeString(input)
+	if err != nil {
+		return nil, err
+	}
+
+	r, err := gzip.NewReader(bytes.NewReader(decodedData))
+	if err != nil {
+		return nil, err
+	}
+
+	return ioutil.ReadAll(r)
 }

--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -1627,36 +1627,3 @@ func (r *ClusterBootstrapReconciler) generateSecretForPackagesWithEmptyValuesFro
 	r.Log.Info(fmt.Sprintf("created secret %v for ClusterBootstrapPackage.RefName: %s", packageSecret.Name, cbPkg.RefName))
 	return packageSecret.Name, nil
 }
-
-func FetchTKRSpecFromAnnotations(tkc map[string]string) (*runtanzuv1alpha3.TanzuKubernetesRelease, error) {
-	controlPlaneTKR := &runtanzuv1alpha3.TanzuKubernetesRelease{}
-
-	tkrSpec, ok := tkc["run.tanzu.vmware.com/tkr-spec"]
-	if ok {
-		unzipOut, err := gunzipAndBase64Decode(tkrSpec)
-		if err != nil {
-			return nil, err
-		}
-
-		err = yaml.Unmarshal(unzipOut, controlPlaneTKR)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return controlPlaneTKR, nil
-}
-
-// GunzipAndBase64Decode extracts a gzip archive to a byte array
-func gunzipAndBase64Decode(input string) ([]byte, error) {
-	decodedData, err := base64.StdEncoding.DecodeString(input)
-	if err != nil {
-		return nil, err
-	}
-
-	r, err := gzip.NewReader(bytes.NewReader(decodedData))
-	if err != nil {
-		return nil, err
-	}
-
-	return ioutil.ReadAll(r)
-}

--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -4,12 +4,8 @@
 package controllers
 
 import (
-	"bytes"
-	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -154,7 +150,7 @@ func (r *ClusterBootstrapReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	tkr, err := util.GetTKRByNameV1Alpha3(r.context, r.Client, tkrName)
+	tkr, err := util.GetTKRByNameV1Alpha3(r.context, r.Client, cluster, tkrName)
 	if err != nil {
 		log.Error(err, "unable to fetch TKR object", "name", tkrName)
 		return ctrl.Result{}, err
@@ -162,11 +158,8 @@ func (r *ClusterBootstrapReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// if tkr is not found, should not requeue for the reconciliation
 	if tkr == nil {
-		tkr, err = FetchTKRSpecFromAnnotations(cluster.Annotations)
-		if err != nil {
-			log.Info("TKR object not found", "name", tkrName)
-			return ctrl.Result{}, nil
-		}
+		log.Info("TKR object not found", "name", tkrName)
+		return ctrl.Result{}, nil
 	}
 
 	if _, labelFound := tkr.Labels[constants.TKRLabelLegacyClusters]; labelFound {

--- a/addons/controllers/packageinstallstatus_controller.go
+++ b/addons/controllers/packageinstallstatus_controller.go
@@ -138,7 +138,7 @@ func (r *PackageInstallStatusReconciler) Reconcile(_ context.Context, req reconc
 		return ctrl.Result{}, nil
 	}
 
-	tkr, err := util.GetTKRByNameV1Alpha3(r.ctx, r.Client, tkrName)
+	tkr, err := util.GetTKRByNameV1Alpha3(r.ctx, r.Client, cluster, tkrName)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "unable to fetch TKR object '%s'", tkrName)
 	}

--- a/addons/pkg/util/tkr_util.go
+++ b/addons/pkg/util/tkr_util.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -135,5 +135,5 @@ func gunzipAndBase64Decode(input string) ([]byte, error) {
 		return nil, err
 	}
 
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }

--- a/addons/pkg/util/tkr_util_test.go
+++ b/addons/pkg/util/tkr_util_test.go
@@ -54,7 +54,7 @@ var _ = Describe("TKR utils", func() {
 			BeforeEach(func() {
 				crtCtl = &fakeclusterclient.CRTClusterClient{}
 				tkrName = ""
-				tkrV1Alpha3, err = GetTKRByNameV1Alpha3(ctx, crtCtl, tkrName)
+				tkrV1Alpha3, err = GetTKRByNameV1Alpha3(ctx, crtCtl, nil, tkrName)
 			})
 
 			It("should return nil TKR", func() {
@@ -82,7 +82,7 @@ var _ = Describe("TKR utils", func() {
 				crtCtl = &fakeclusterclient.CRTClusterClient{}
 				tkrName = testTKR
 				crtCtl.GetReturns(apierrors.NewNotFound(schema.GroupResource{Resource: "TanzuKubernetesRelease"}, testTKR))
-				tkrV1Alpha3, err = GetTKRByNameV1Alpha3(ctx, crtCtl, tkrName)
+				tkrV1Alpha3, err = GetTKRByNameV1Alpha3(ctx, crtCtl, nil, tkrName)
 			})
 
 			It("should return nil TKR", func() {
@@ -111,7 +111,7 @@ var _ = Describe("TKR utils", func() {
 				crtCtl = &fakeclusterclient.CRTClusterClient{}
 				tkrName = testTKR
 				crtCtl.GetReturns(errors.New("some error"))
-				tkrV1Alpha3, err = GetTKRByNameV1Alpha3(ctx, crtCtl, tkrName)
+				tkrV1Alpha3, err = GetTKRByNameV1Alpha3(ctx, crtCtl, nil, tkrName)
 			})
 
 			It("should return nil TKR", func() {
@@ -138,7 +138,7 @@ var _ = Describe("TKR utils", func() {
 			BeforeEach(func() {
 				crtCtl = &fakeclusterclient.CRTClusterClient{}
 				tkrName = testTKR
-				tkrV1Alpha3, err = GetTKRByNameV1Alpha3(ctx, crtCtl, tkrName)
+				tkrV1Alpha3, err = GetTKRByNameV1Alpha3(ctx, crtCtl, nil, tkrName)
 			})
 
 			It("should return nil TKR", func() {

--- a/addons/pkg/util/tkr_util_test.go
+++ b/addons/pkg/util/tkr_util_test.go
@@ -180,6 +180,36 @@ var _ = Describe("TKR utils", func() {
 				Expect(tkrV1Alpha3).ShouldNot(BeNil())
 			})
 		})
+
+		When("tkr is not available calling GetTKRByNameV1Alpha3()", func() {
+			BeforeEach(func() {
+				crtCtl = &fakeclusterclient.CRTClusterClient{}
+				tkrName = testTKR
+				var buf bytes.Buffer
+				out, _ := yaml.Marshal(tkrV1Alpha3)
+				w, _ := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+				_, err = w.Write(out)
+				w.Close()
+				tkrString := base64.StdEncoding.EncodeToString(buf.Bytes())
+				annotation := make(map[string]string)
+				annotation["run.tanzu.vmware.com/tkr-spec"] = tkrString
+				cluster := &clusterapiv1beta1.Cluster{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Cluster",
+						APIVersion: "v1beta1",
+					},
+					ObjectMeta: metav1.ObjectMeta{Name: testClusterName, Namespace: testNamespace, Labels: map[string]string{}, Annotations: annotation},
+				}
+				tkrName = testTKR
+				crtCtl.GetReturns(apierrors.NewNotFound(schema.GroupResource{Resource: "TanzuKubernetesRelease"}, testTKR))
+				tkrV1Alpha3, err = GetTKRByNameV1Alpha3(ctx, crtCtl, cluster, tkrName)
+			})
+
+			It("should return non nil TKR", func() {
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(tkrV1Alpha3).ShouldNot(BeNil())
+			})
+		})
 	})
 
 	Context("GetBootstrapPackageNameFromTKR()", func() {


### PR DESCRIPTION
### What this PR does / why we need it
Today in TKGs (vSphere with supervisor) user cannot delete TKC/Classy cluster when the TKR associated to the cluster is no longer available on the supervisor.

If the VMImage associated to a TKR is no longer available in the content library associated to the TKG service on supervisor, the TKR is no longer available on the supervisor cluster. 

In such cases, the addons controller does not have access to the TKR as a result blocking the reconcile loops which in turn blocks the delete cluster workflow.

### Which issue(s) this PR fixes

Fixes #
#4304 

### Describe testing done for PR

Patched addons controller with this change on a testbed. verified that TKG 2.0 cluster was successfully deleted

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
