### PR TITLE
Cherry pick #4269 - Adding cni from vars on vSphere template

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -1890,8 +1890,18 @@ spec:
           content: |
             Set-Service -Name "wuauserv" -StartupType Disabled -Status Stopped
       - op: add
+        path: /spec/template/spec/files/-
+        value:
+          content: |
+            # Disable firewall for SSH and OVS access
+            Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+          path: C:\k\disable_firewall.ps1
+      - op: add
         path: /spec/template/spec/postKubeadmCommands/-
         value: powershell c:/k/prevent_windows_updates.ps1 -ExecutionPolicy Bypass
+      - op: add
+        path: /spec/template/spec/postKubeadmCommands/-
+        value: powershell c:/k/disable_firewall.ps1
       - op: replace
         path: /spec/template/spec/users
         valueFrom:
@@ -1932,9 +1942,6 @@ spec:
                 } while ($SaToken -eq $null)
                 return $SaToken
             }
-
-            # Disable firewall temporarily for SSH and other internal ports access
-            Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
             $TempFolder = 'C:\programdata\temp'
             $AntreaInTempFolder = "$TempFolder\antrea-windows-advanced.zip"

--- a/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
@@ -1890,8 +1890,18 @@ spec:
           content: |
             Set-Service -Name "wuauserv" -StartupType Disabled -Status Stopped
       - op: add
+        path: /spec/template/spec/files/-
+        value:
+          content: |
+            # Disable firewall for SSH and OVS access
+            Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
+          path: C:\k\disable_firewall.ps1
+      - op: add
         path: /spec/template/spec/postKubeadmCommands/-
         value: powershell c:/k/prevent_windows_updates.ps1 -ExecutionPolicy Bypass
+      - op: add
+        path: /spec/template/spec/postKubeadmCommands/-
+        value: powershell c:/k/disable_firewall.ps1
       - op: replace
         path: /spec/template/spec/users
         valueFrom:
@@ -1932,9 +1942,6 @@ spec:
                 } while ($SaToken -eq $null)
                 return $SaToken
             }
-
-            # Disable firewall temporarily for SSH and other internal ports access
-            Set-NetFirewallProfile -Profile Domain,Public,Private -Enabled False
 
             $TempFolder = 'C:\programdata\temp'
             $AntreaInTempFolder = "$TempFolder\antrea-windows-advanced.zip"

--- a/providers/infrastructure-vsphere/v1.5.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/yttcc/overlay.yaml
@@ -137,7 +137,7 @@ spec:
     variables:
     #@ vars = get_vsphere_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["workerKubeletExtraArgs","controlPlaneKubeletExtraArgs","kubeControllerManagerExtraArgs","kubeSchedulerExtraArgs","apiServerExtraArgs","etcdExtraArgs", "apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider", "additionalFQDN", "controlPlaneCertificateRotation", "podSecurityStandard", "eventRateLimitConf"]:
+    #@  if vars[configVariable] != None and configVariable in ["workerKubeletExtraArgs","controlPlaneKubeletExtraArgs","kubeControllerManagerExtraArgs","kubeSchedulerExtraArgs","apiServerExtraArgs","etcdExtraArgs", "apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "cni", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider", "additionalFQDN", "controlPlaneCertificateRotation", "podSecurityStandard", "eventRateLimitConf"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end


### PR DESCRIPTION
### What this PR does / why we need it

`cni` var on vsphere is not being imported configVariable ACL, this is required for CNI:none, and mapping the default variable from in the ClusterClass.

### Which issue(s) this PR fixes
Fixes #4281

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```
