### PR TITLE
Set proxy env variable where tanzu cli is running, because now instal…

### DIFF
--- a/tkg/carvelhelpers/registry.go
+++ b/tkg/carvelhelpers/registry.go
@@ -4,6 +4,7 @@
 package carvelhelpers
 
 import (
+	"fmt"
 	"os"
 	"runtime"
 	"strings"
@@ -34,6 +35,12 @@ func DownloadImageBundleAndSaveFilesToDir(imageWithTag, dir string) error {
 	if err != nil {
 		return errors.Wrapf(err, "unable to initialize registry")
 	}
+	fmt.Println("Get env http_proxy")
+	fmt.Println(os.Getenv(constants.HTTPProxy))
+	fmt.Println("Get env https_proxy")
+	fmt.Println(os.Getenv(constants.HTTPSProxy))
+	fmt.Println("Get env no_proxy")
+	fmt.Println(os.Getenv(constants.NoProxy))
 	err = reg.DownloadBundle(imageWithTag, dir)
 	if err != nil {
 		return errors.Wrap(err, "error downloading bundle")

--- a/tkg/client/upgrade_region.go
+++ b/tkg/client/upgrade_region.go
@@ -6,6 +6,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -317,6 +318,9 @@ func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterCl
 		// no variable configuration is needed to deploy Docker provider as
 		// infrastructure-components.yaml for docker does not require any variable
 	}
+
+	c.SetProxyEnvironmentVariable()
+
 	return nil
 }
 
@@ -737,4 +741,31 @@ func (c *TkgClient) ConfigureAMIID(options *UpgradeClusterOptions, regionalClust
 	c.TKGConfigReaderWriter().Set(constants.ConfigVariableOSVersion, amiInfo.OSInfo.Version)
 	c.TKGConfigReaderWriter().Set(constants.ConfigVariableOSArch, amiInfo.OSInfo.Arch)
 	return nil
+}
+
+func (c *TkgClient) SetProxyEnvironmentVariable() {
+	log.V(6).Info("Trying to set proxy related environment variable if necessary...")
+	httpProxy, err := c.TKGConfigReaderWriter().Get(constants.TKGHTTPProxy)
+	if err != nil || httpProxy == "" {
+		log.V(6).Infof("no %s set, skip", constants.TKGHTTPProxy)
+	} else {
+		log.V(6).Infof("set %s to %s", constants.HTTPProxy, httpProxy)
+		os.Setenv(constants.HTTPProxy, httpProxy)
+	}
+
+	httpsProxy, err := c.TKGConfigReaderWriter().Get(constants.TKGHTTPSProxy)
+	if err != nil || httpsProxy == "" {
+		log.V(6).Infof("no %s set", constants.TKGHTTPSProxy)
+	} else {
+		log.V(6).Infof("set %s to %s", constants.HTTPSProxy, httpsProxy)
+		os.Setenv(constants.HTTPSProxy, httpsProxy)
+	}
+
+	noProxy, err := c.TKGConfigReaderWriter().Get(constants.TKGNoProxy)
+	if err != nil || noProxy == "" {
+		log.V(6).Infof("no %s set", constants.TKGNoProxy)
+	} else {
+		log.V(6).Infof("set %s to %s", constants.NoProxy, noProxy)
+		os.Setenv(constants.NoProxy, noProxy)
+	}
 }

--- a/tkg/client/upgrade_region.go
+++ b/tkg/client/upgrade_region.go
@@ -319,8 +319,6 @@ func (c *TkgClient) configureVariablesForProvidersInstallation(regionalClusterCl
 		// infrastructure-components.yaml for docker does not require any variable
 	}
 
-	c.SetProxyEnvironmentVariable()
-
 	return nil
 }
 

--- a/tkg/kind/client.go
+++ b/tkg/kind/client.go
@@ -466,13 +466,16 @@ func (k *KindClusterProxy) setupProxyConfigurationForKindCluster() {
 	}
 
 	if httpProxy != "" {
+		log.V(6).Infof("set the %s environment variable with value: %s", constants.HTTPProxy, httpProxy)
 		os.Setenv(constants.HTTPProxy, httpProxy)
 	}
 	if httpsProxy != "" {
+		log.V(6).Infof("set the %s environment variable with value: %s", constants.HTTPSProxy, httpsProxy)
 		os.Setenv(constants.HTTPSProxy, httpsProxy)
 	}
 	if noProxy != "" {
 		noProxyList := strings.Split(noProxy, ",")
+		log.V(6).Infof("set the %s environment variable with value: %s", constants.NoProxy, strings.Join(append(noProxyList, fmt.Sprintf("%s-control-plane", k.options.ClusterName)), ","))
 		os.Setenv(constants.NoProxy, strings.Join(append(noProxyList, fmt.Sprintf("%s-control-plane", k.options.ClusterName)), ","))
 	}
 }


### PR DESCRIPTION
…ling KAPP requires talking to repository now

### What this PR does / why we need it
Right now with CC, need to install KAPP controller by pulling the source code from repository directly. When customer has env that needs proxy to access repository, it will fail
```
Kapp-controller values-file: /tmp/650094154.yaml
Deleting kind cluster: tkg-kind-cfc50dmlcgd73h3u8ktg
Error: unable to set up management cluster: unable to install kapp-controller to bootstrap cluster: failed to get resource files from discovery: error downloading bundle: Checking if image is bundle: Fetching image: Get "https://projects.registry.vmware.com/v2/": dial tcp 10.188.25.227:443: connect: connection refused
```

So proxy environment variable is needed. In CLI

Added code to set proxy variable if presented in customer's config. When creating or upgrading management cluster, `configureVariablesForProvidersInstallation` will be called, these environmement variables will be set
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
