### PR TITLE
enable delete of cluster when tkr is not present on supervisor

### DIFF
--- a/addons/controllers/cluster_metadata_controller.go
+++ b/addons/controllers/cluster_metadata_controller.go
@@ -92,7 +92,7 @@ func (r *ClusterMetadataReconciler) Reconcile(ctx context.Context, req reconcile
 		}
 	}
 
-	tkr, err := util.GetTKRByNameV1Alpha3(r.context, r.Client, tkrName)
+	tkr, err := util.GetTKRByNameV1Alpha3(r.context, r.Client, cluster, tkrName)
 	if err != nil {
 		log.Error(err, "unable to fetch TKR object", "name", tkrName)
 		return ctrl.Result{}, err

--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -150,7 +150,7 @@ func (r *ClusterBootstrapReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
-	tkr, err := util.GetTKRByNameV1Alpha3(r.context, r.Client, tkrName)
+	tkr, err := util.GetTKRByNameV1Alpha3(r.context, r.Client, cluster, tkrName)
 	if err != nil {
 		log.Error(err, "unable to fetch TKR object", "name", tkrName)
 		return ctrl.Result{}, err

--- a/addons/controllers/packageinstallstatus_controller.go
+++ b/addons/controllers/packageinstallstatus_controller.go
@@ -138,7 +138,7 @@ func (r *PackageInstallStatusReconciler) Reconcile(_ context.Context, req reconc
 		return ctrl.Result{}, nil
 	}
 
-	tkr, err := util.GetTKRByNameV1Alpha3(r.ctx, r.Client, tkrName)
+	tkr, err := util.GetTKRByNameV1Alpha3(r.ctx, r.Client, cluster, tkrName)
 	if err != nil {
 		return ctrl.Result{}, errors.Wrapf(err, "unable to fetch TKR object '%s'", tkrName)
 	}

--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -369,6 +369,8 @@ const (
 	TKGDevPlan = "dev"
 	// TKGDevCCPan is the tkg plan name, mean that that cluster is in a dev env
 	TKGDevCCPan = "devcc"
+
+	TKRAnnotationKey = "run.tanzu.vmware.com/tkr-spec"
 )
 
 var (


### PR DESCRIPTION
### What this PR does / why we need it

Today in TKGs (vSphere with supervisor) user cannot delete TKC/Classy cluster when the TKR associated to the cluster is no longer available on the supervisor.

If the VMImage associated to a TKR is no longer available in the content library associated to the TKG service on supervisor, the TKR is no longer available on the supervisor cluster.

In such cases, the addons controller does not have access to the TKR as a result blocking the reconcile loops which in turn blocks the delete cluster workflow

### Which issue(s) this PR fixes
Fixes #4304 

### Describe testing done for PR

Patched addons controller with this change on a testbed.
1. created TKG 2.0 cluster
2. on successfull bringup of the cluster, deleted the TKR resource on supervisor
3. was able to successfully delete the TKG 2.0 cluster

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
