### PR TITLE
Fix the logic to upgrade kube-vip image during cluster upgrade

### DIFF
--- a/tkg/client/client_suite_test.go
+++ b/tkg/client/client_suite_test.go
@@ -1723,6 +1723,7 @@ var _ = Describe("ApplyClusterBootstrap()", func() {
 
 	JustBeforeEach(func() {
 		rw, err := tkgconfigreaderwriter.NewReaderWriterFromConfigFile("", tkgConfigPath)
+		Expect(err).NotTo(HaveOccurred())
 		tkgClient, err = CreateTKGClientWithConfigReaderWriter(tkgConfigPath, testingDir, defaultTKGBoMFileForTesting, 2*time.Second, rw)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/tkg/client/kubevip_update_helper.go
+++ b/tkg/client/kubevip_update_helper.go
@@ -139,6 +139,7 @@ func (c *TkgClient) getNewKubeVipParameters() (string, string, string) {
 
 // UpdateKubeVipConfigInKCP updates the kube-vip parameters and image tag within the contents of the file inside the KCP
 func (c *TkgClient) UpdateKubeVipConfigInKCP(currentKCP *capikubeadmv1beta1.KubeadmControlPlane, upgradeComponentInfo ComponentInfo) (*capikubeadmv1beta1.KubeadmControlPlane, error) {
+	log.V(6).Info("Updating Kube-vip manifest")
 	newKCP := currentKCP.DeepCopy()
 
 	currentKubeVipPod, err := c.DecodeKubevipPodManifestFromKCP(currentKCP)
@@ -175,9 +176,9 @@ func (c *TkgClient) DecodeKubevipPodManifestFromKCP(kcp *capikubeadmv1beta1.Kube
 	var currentKubeVipPod *corev1.Pod
 	for _, curFile := range kcp.Spec.KubeadmConfigSpec.Files {
 		log.V(6).Infof("Current KCP Pod: %s", curFile.Content)
+		log.V(6).Infof("Current KCP Pod Path: %s", curFile.Path)
 		sc := runtime.NewScheme()
 		_ = corev1.AddToScheme(sc)
-
 		// kube-vip pod spec has a specific config path
 		if curFile.Path == kubeVipConfigPath {
 			// it should be one kube-vip pod manifest in each kubeadmControlPlane

--- a/tkg/client/kubevip_update_helper.go
+++ b/tkg/client/kubevip_update_helper.go
@@ -179,8 +179,10 @@ func (c *TkgClient) DecodeKubevipPodManifestFromKCP(kcp *capikubeadmv1beta1.Kube
 		log.V(6).Infof("Current KCP Pod Path: %s", curFile.Path)
 		sc := runtime.NewScheme()
 		_ = corev1.AddToScheme(sc)
+
 		// kube-vip pod spec has a specific config path
 		if curFile.Path == kubeVipConfigPath {
+			log.V(6).Infof("fond kube-vipi pod manifest")
 			// it should be one kube-vip pod manifest in each kubeadmControlPlane
 			s := apimachineryjson.NewSerializerWithOptions(apimachineryjson.DefaultMetaFactory, sc, sc,
 				apimachineryjson.SerializerOptions{Yaml: true, Pretty: false, Strict: false})
@@ -191,6 +193,7 @@ func (c *TkgClient) DecodeKubevipPodManifestFromKCP(kcp *capikubeadmv1beta1.Kube
 			if currentKubeVipPod.Name != kubeVipName {
 				return nil, errors.New("pod name is not kube-vip")
 			}
+			log.V(6).Infof("return the pod manifest")
 			return currentKubeVipPod, nil
 		}
 	}

--- a/tkg/client/kubevip_update_helper.go
+++ b/tkg/client/kubevip_update_helper.go
@@ -202,6 +202,7 @@ func (c *TkgClient) DecodeKubevipPodManifestFromKCP(kcp *capikubeadmv1beta1.Kube
 }
 
 func (c *TkgClient) GetKubevipImageAndTag(kcp *capikubeadmv1beta1.KubeadmControlPlane) (string, string, error) {
+	log.V(6).Infof("get kube-vip pod image and tag from kcp")
 	kubeVipManifest, err := c.DecodeKubevipPodManifestFromKCP(kcp)
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to get kube-vip manifest")

--- a/tkg/client/upgrade_cluster.go
+++ b/tkg/client/upgrade_cluster.go
@@ -85,7 +85,7 @@ type ComponentInfo struct {
 	AwsRegionToAMIMap                  map[string][]tkgconfigbom.AMIInfo
 	AzureImage                         tkgconfigbom.AzureInfo
 	OsInfo                             tkgconfigbom.OSInfo
-	KubeVipImageRepository             string
+	KubeVipFullImagePath               string
 	KubeVipTag                         string
 }
 
@@ -509,6 +509,7 @@ func (c *TkgClient) getUpgradeClusterConfig(options *UpgradeClusterOptions) (*Cl
 		if len(com) >= 1 {
 			if img, ok := com[0].Images["kubeVipImage"]; ok {
 				upgradeInfo.UpgradeComponentInfo.KubeVipTag = img.Tag
+				upgradeInfo.UpgradeComponentInfo.KubeVipFullImagePath = bomConfiguration.ImageConfig.ImageRepository + "/" + img.ImagePath
 			} else {
 				log.Warning("not able to find kube-vip image tag image from bom bom kubeVipImage")
 			}
@@ -516,7 +517,6 @@ func (c *TkgClient) getUpgradeClusterConfig(options *UpgradeClusterOptions) (*Cl
 			log.Warning("not able to find kube-vip from bom components list")
 		}
 	}
-	upgradeInfo.UpgradeComponentInfo.KubeVipImageRepository = bomConfiguration.ImageConfig.ImageRepository
 
 	// We are hard-coding the assumption that during upgrade imageConfig.ImageRepository should take precedence
 	// over whatever is spelled out in the KubeAdmConfigSpec section.
@@ -571,7 +571,7 @@ func (c *TkgClient) createInfrastructureTemplateForUpgrade(regionalClusterClient
 		if err != nil {
 			errors.Wrapf(err, "unable to extract kube-vip image")
 		}
-		clusterUpgradeConfig.ActualComponentInfo.KubeVipImageRepository = image
+		clusterUpgradeConfig.ActualComponentInfo.KubeVipFullImagePath = image
 		clusterUpgradeConfig.ActualComponentInfo.KubeVipTag = tag
 	}
 

--- a/tkg/client/upgrade_cluster.go
+++ b/tkg/client/upgrade_cluster.go
@@ -85,6 +85,8 @@ type ComponentInfo struct {
 	AwsRegionToAMIMap                  map[string][]tkgconfigbom.AMIInfo
 	AzureImage                         tkgconfigbom.AzureInfo
 	OsInfo                             tkgconfigbom.OSInfo
+	KubeVipImageRepository             string
+	KubeVipTag                         string
 }
 
 type upgradeStatus string
@@ -502,6 +504,20 @@ func (c *TkgClient) getUpgradeClusterConfig(options *UpgradeClusterOptions) (*Cl
 		upgradeInfo.UpgradeComponentInfo.OsInfo = azureVMImage.OSInfo
 	}
 
+	// get kube-vip image from bom
+	if com, ok := bomConfiguration.Components["kube-vip"]; ok {
+		if len(com) >= 1 {
+			if img, ok := com[0].Images["kubeVipImage"]; ok {
+				upgradeInfo.UpgradeComponentInfo.KubeVipTag = img.Tag
+			} else {
+				log.Warning("not able to find kube-vip image tag image from bom bom kubeVipImage")
+			}
+		} else {
+			log.Warning("not able to find kube-vip from bom components list")
+		}
+	}
+	upgradeInfo.UpgradeComponentInfo.KubeVipImageRepository = bomConfiguration.ImageConfig.ImageRepository
+
 	// We are hard-coding the assumption that during upgrade imageConfig.ImageRepository should take precedence
 	// over whatever is spelled out in the KubeAdmConfigSpec section.
 	// This change also implies when imageConfig.ImageRepository differs from kubeadmConfigSpec's repository,
@@ -549,6 +565,15 @@ func (c *TkgClient) createInfrastructureTemplateForUpgrade(regionalClusterClient
 	clusterUpgradeConfig.ActualComponentInfo.EtcdImageRepository = kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ImageRepository
 	clusterUpgradeConfig.ActualComponentInfo.EtcdImageTag = kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ImageTag
 	clusterUpgradeConfig.ActualComponentInfo.EtcdExtraArgs = kcp.Spec.KubeadmConfigSpec.ClusterConfiguration.Etcd.Local.ExtraArgs
+
+	if kcp.Spec.MachineTemplate.InfrastructureRef.Kind == constants.KindVSphereMachineTemplate {
+		image, tag, err := c.GetKubevipImageAndTag(kcp)
+		if err != nil {
+			errors.Wrapf(err, "unable to extract kube-vip image")
+		}
+		clusterUpgradeConfig.ActualComponentInfo.KubeVipImageRepository = image
+		clusterUpgradeConfig.ActualComponentInfo.KubeVipTag = tag
+	}
 
 	clusterUpgradeConfig.ActualComponentInfo.KCPInfrastructureTemplateName = kcp.Spec.MachineTemplate.InfrastructureRef.Name
 	clusterUpgradeConfig.ActualComponentInfo.KCPInfrastructureTemplateNamespace = kcp.Spec.MachineTemplate.InfrastructureRef.Namespace
@@ -1077,7 +1102,7 @@ func (c *TkgClient) PatchKubernetesVersionToKubeadmControlPlane(regionalClusterC
 	// If iaas == vsphere, attempt increasing kube-vip parameters
 	if currentKCP.Spec.MachineTemplate.InfrastructureRef.Kind == constants.KindVSphereMachineTemplate {
 		log.V(6).Infof("Kind %s", currentKCP.Spec.MachineTemplate.InfrastructureRef.Kind)
-		newKCP, _ = c.UpdateKCPObjectWithIncreasedKubeVip(currentKCP)
+		newKCP, _ = c.UpdateKubeVipConfigInKCP(currentKCP, clusterUpgradeConfig.UpgradeComponentInfo)
 		if newKCP != nil {
 			currentKCP = newKCP
 		}

--- a/tkg/client/upgrade_cluster.go
+++ b/tkg/client/upgrade_cluster.go
@@ -1102,7 +1102,10 @@ func (c *TkgClient) PatchKubernetesVersionToKubeadmControlPlane(regionalClusterC
 	// If iaas == vsphere, attempt increasing kube-vip parameters
 	if currentKCP.Spec.MachineTemplate.InfrastructureRef.Kind == constants.KindVSphereMachineTemplate {
 		log.V(6).Infof("Kind %s", currentKCP.Spec.MachineTemplate.InfrastructureRef.Kind)
-		newKCP, _ = c.UpdateKubeVipConfigInKCP(currentKCP, clusterUpgradeConfig.UpgradeComponentInfo)
+		newKCP, err = c.UpdateKubeVipConfigInKCP(currentKCP, clusterUpgradeConfig.UpgradeComponentInfo)
+		if err != nil {
+			return errors.Wrapf(err, "unable to update kube-vip config")
+		}
 		if newKCP != nil {
 			currentKCP = newKCP
 		}

--- a/tkg/client/upgrade_cluster.go
+++ b/tkg/client/upgrade_cluster.go
@@ -569,7 +569,7 @@ func (c *TkgClient) createInfrastructureTemplateForUpgrade(regionalClusterClient
 	if kcp.Spec.MachineTemplate.InfrastructureRef.Kind == constants.KindVSphereMachineTemplate {
 		image, tag, err := c.GetKubevipImageAndTag(kcp)
 		if err != nil {
-			errors.Wrapf(err, "unable to extract kube-vip image")
+			return errors.Wrapf(err, "unable to extract kube-vip image")
 		}
 		clusterUpgradeConfig.ActualComponentInfo.KubeVipFullImagePath = image
 		clusterUpgradeConfig.ActualComponentInfo.KubeVipTag = tag

--- a/tkg/client/upgrade_cluster_test.go
+++ b/tkg/client/upgrade_cluster_test.go
@@ -793,9 +793,8 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 					KCPObjectName:      "fake-name",
 					KCPObjectNamespace: "fake-namespace",
 					UpgradeComponentInfo: ComponentInfo{
-						KubernetesVersion:      "v1.18.0+vmware.2",
-						KubeVipImageRepository: kubeVipImage,
-						KubeVipTag:             KubeVipTag,
+						KubernetesVersion: "v1.18.0+vmware.2",
+						KubeVipTag:        KubeVipTag,
 					},
 					ActualComponentInfo: ComponentInfo{
 						KubernetesVersion: "v1.18.0+vmware.1",

--- a/tkg/client/upgrade_cluster_test.go
+++ b/tkg/client/upgrade_cluster_test.go
@@ -781,13 +781,34 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 		})
 
 		var _ = Describe("Test helper functions", func() {
+			var (
+				clusterUpgradeConfig *ClusterUpgradeInfo
+				kubeVipImage         = "gcr.io/kube-vip"
+				KubeVipTag           = "3.1"
+			)
+			BeforeEach(func() {
+				clusterUpgradeConfig = &ClusterUpgradeInfo{
+					ClusterName:        "cluster-1",
+					ClusterNamespace:   constants.DefaultNamespace,
+					KCPObjectName:      "fake-name",
+					KCPObjectNamespace: "fake-namespace",
+					UpgradeComponentInfo: ComponentInfo{
+						KubernetesVersion:      "v1.18.0+vmware.2",
+						KubeVipImageRepository: kubeVipImage,
+						KubeVipTag:             KubeVipTag,
+					},
+					ActualComponentInfo: ComponentInfo{
+						KubernetesVersion: "v1.18.0+vmware.1",
+					},
+				}
+			})
 			Context("Testing the kube-vip modifier helper function", func() {
 				It("modifies the kube-vip parameters", func() {
 					pod := corev1.Pod{}
 					err := yaml.Unmarshal([]byte(kubeVipPodString), &pod)
 					Expect(err).To(BeNil())
 
-					newPodString, err := ModifyKubeVipAndSerialize(&pod, "30", "20", "4")
+					newPodString, err := ModifyKubeVipAndSerialize(&pod, "30", "20", "4", kubeVipImage, KubeVipTag)
 					Expect(err).To(BeNil())
 
 					Expect(newPodString).ToNot(BeNil())
@@ -796,13 +817,14 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 			Context("Testing the KCP modifier helper function", func() {
 				It("Updates the KCP object with increased timeouts", func() {
 					currentKCP := getDummyKCP(constants.KindVSphereMachineTemplate)
-					newKCP, err := tkgClient.UpdateKCPObjectWithIncreasedKubeVip(currentKCP)
+					newKCP, err := tkgClient.UpdateKubeVipConfigInKCP(currentKCP, clusterUpgradeConfig.UpgradeComponentInfo)
 
 					Expect(err).To(BeNil())
 					Expect(len(newKCP.Spec.KubeadmConfigSpec.Files)).To(Equal(1))
 					Expect(newKCP.Spec.KubeadmConfigSpec.Files[0].Content).To(ContainSubstring("value: \"30\""))
 					Expect(newKCP.Spec.KubeadmConfigSpec.Files[0].Content).To(ContainSubstring("name: cp_enable"))
 					Expect(newKCP.Spec.KubeadmConfigSpec.Files[0].Content).To(ContainSubstring("NET_RAW"))
+					Expect(newKCP.Spec.KubeadmConfigSpec.Files[0].Content).To(ContainSubstring(fmt.Sprintf("%s:%s", kubeVipImage, KubeVipTag)))
 				})
 			})
 		})

--- a/tkg/client/upgrade_cluster_test.go
+++ b/tkg/client/upgrade_cluster_test.go
@@ -53,8 +53,6 @@ metadata:
   creationTimestamp: ~
   name: kube-vip
   namespace: kube-system
-owner: "root:root"
-path: /etc/kubernetes/manifests/kube-vip.yaml
 spec:
   containers:
     -
@@ -102,9 +100,7 @@ spec:
         path: /etc/kubernetes/admin.conf
         type: FileOrCreate
       name: kubeconfig
-status: {}
-owner: root:root
-path: /etc/kubernetes/manifests/kube-vip.yaml`
+status: {}`
 )
 
 var _ = Describe("Unit tests for upgrading legacy cluster", func() {
@@ -793,8 +789,9 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 					KCPObjectName:      "fake-name",
 					KCPObjectNamespace: "fake-namespace",
 					UpgradeComponentInfo: ComponentInfo{
-						KubernetesVersion: "v1.18.0+vmware.2",
-						KubeVipTag:        KubeVipTag,
+						KubernetesVersion:    "v1.18.0+vmware.2",
+						KubeVipFullImagePath: kubeVipImage,
+						KubeVipTag:           KubeVipTag,
 					},
 					ActualComponentInfo: ComponentInfo{
 						KubernetesVersion: "v1.18.0+vmware.1",
@@ -1150,7 +1147,7 @@ var _ = Describe("Unit test for handleKappControllerUpgrade", func() {
 })
 
 func getDummyKCP(machineTemplateKind string) *capikubeadmv1beta1.KubeadmControlPlane {
-	file := capibootstrapkubeadmv1beta1.File{Content: kubeVipPodString}
+	file := capibootstrapkubeadmv1beta1.File{Content: kubeVipPodString, Path: "/etc/kubernetes/manifests/kube-vip.yaml", Owner: "root:root"}
 	kcp := &capikubeadmv1beta1.KubeadmControlPlane{}
 	kcp.Name = "fake-kcp-name"
 	kcp.Namespace = "fake-kcp-namespace"


### PR DESCRIPTION
### What this PR does / why we need it
Update kube-vip image during upgrade.
Previously, during upgrade, only the kube-vip parameter is updated, not the image version

kube-vip in bom is like below format, we need imagePath and tag.
```
  kube-vip:
  - version: v0.5.7+vmware.1
    images:
      kubeVipImage:
        imagePath: kube-vip
        tag: v0.5.7_vmware.1
```
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
