### PR TITLE
[tanzu cli] use tkrVersion in topology.version for cc clusters

### DIFF
--- a/providers/infrastructure-aws/v2.0.2/yttcc/overlay.yaml
+++ b/providers/infrastructure-aws/v2.0.2/yttcc/overlay.yaml
@@ -1,6 +1,6 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
-#@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "kubeadm_image_repo", "get_az_from_region", "get_default_tkg_bom_data")
+#@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "kubeadm_image_repo", "get_az_from_region", "get_default_tkg_bom_data","get_tkr_version_from_tkr_name")
 #@ load("lib/validate.star", "validate_configuration")
 #@ load("/lib/config_variable_association.star", "config_variable_association", "get_cluster_variables", "get_aws_vars")
 
@@ -17,6 +17,8 @@
 #@ end
 
 #@ bomData = get_default_tkg_bom_data()
+
+#@ tkrVersion = get_tkr_version_from_tkr_name(data.values.KUBERNETES_RELEASE)
 
 #@overlay/match by=overlay.subset({"kind":"Cluster"})
 ---
@@ -47,8 +49,7 @@ spec:
       - #@ data.values.SERVICE_CIDR
   topology:
     class: #@ data.values.CLUSTER_CLASS
-    #! VVV TODO(vui) compute
-    version: #@ data.values.KUBERNETES_VERSION
+    version: #@ tkrVersion
     controlPlane:
       replicas: #@ data.values.CONTROL_PLANE_MACHINE_COUNT
       metadata:

--- a/providers/infrastructure-azure/v1.6.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-azure/v1.6.1/yttcc/overlay.yaml
@@ -7,7 +7,7 @@
 #@ load("@ytt:struct", "struct")
 #@ load("/lib/config_variable_association.star", "config_variable_association", "get_azure_vars")
 
-#@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "kubeadm_image_repo", "get_azure_image", "get_default_tkg_bom_data")
+#@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "kubeadm_image_repo", "get_azure_image", "get_default_tkg_bom_data","get_tkr_version_from_tkr_name")
 #@ load("lib/validate.star", "validate_configuration")
 
 #@ validate_configuration("azure")
@@ -50,6 +50,8 @@
 
 #@ bomData = get_default_tkg_bom_data()
 
+#@ tkrVersion = get_tkr_version_from_tkr_name(data.values.KUBERNETES_RELEASE)
+
 #@overlay/match by=overlay.subset({"kind":"Cluster"})
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -79,8 +81,7 @@ spec:
       - #@ data.values.SERVICE_CIDR
   topology:
     class: #@ data.values.CLUSTER_CLASS
-    #! VVV TODO(vui) compute
-    version: #@ data.values.KUBERNETES_VERSION
+    version: #@ tkrVersion
     controlPlane:
       replicas: #@ data.values.CONTROL_PLANE_MACHINE_COUNT
       #@overlay/match missing_ok=True

--- a/providers/infrastructure-oci/v0.4.0/yttcc/overlay.yaml
+++ b/providers/infrastructure-oci/v0.4.0/yttcc/overlay.yaml
@@ -7,7 +7,7 @@
 #@ load("@ytt:struct", "struct")
 #@ load("/lib/config_variable_association.star", "config_variable_association", "get_oci_vars", "oci_var_keys")
 
-#@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "kubeadm_image_repo", "get_default_tkg_bom_data")
+#@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "kubeadm_image_repo", "get_default_tkg_bom_data","get_tkr_version_from_tkr_name")
 #@ load("lib/validate.star", "validate_configuration")
 
 #@ validate_configuration("oci")
@@ -15,6 +15,8 @@
 #@ bomDataForK8sVersion = get_bom_data_for_tkr_name()
 
 #@ bomData = get_default_tkg_bom_data()
+
+#@ tkrVersion = get_tkr_version_from_tkr_name(data.values.KUBERNETES_RELEASE)
 
 #@overlay/match by=overlay.subset({"kind":"Cluster"})
 ---
@@ -45,7 +47,7 @@ spec:
         - #@ data.values.SERVICE_CIDR
   topology:
     class: #@ data.values.CLUSTER_CLASS
-    version: #@ data.values.KUBERNETES_VERSION
+    version: #@ tkrVersion
     controlPlane:
       replicas: #@ data.values.CONTROL_PLANE_MACHINE_COUNT
       metadata:

--- a/providers/infrastructure-vsphere/v1.5.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/yttcc/overlay.yaml
@@ -1,7 +1,7 @@
 #@ load("@ytt:overlay", "overlay")
 #@ load("@ytt:data", "data")
 
-#@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "get_default_tkg_bom_data", "kubeadm_image_repo", "get_image_repo_for_component", "get_vsphere_thumbprint")
+#@ load("lib/helpers.star", "get_bom_data_for_tkr_name", "get_default_tkg_bom_data", "kubeadm_image_repo", "get_image_repo_for_component", "get_vsphere_thumbprint","get_tkr_version_from_tkr_name")
 
 #@ load("lib/validate.star", "validate_configuration")
 #@ load("@ytt:yaml", "yaml")
@@ -10,6 +10,7 @@
 
 #@ bomDataForK8sVersion = get_bom_data_for_tkr_name()
 #@ bomData = get_default_tkg_bom_data()
+#@ tkrVersion = get_tkr_version_from_tkr_name(data.values.KUBERNETES_RELEASE)
 
 #@overlay/match by=overlay.subset({"kind":"Cluster"})
 ---
@@ -39,7 +40,7 @@ spec:
       cidrBlocks: #@ data.values.SERVICE_CIDR.split(",")
   topology:
     class: #@ data.values.CLUSTER_CLASS
-    version: #@ data.values.KUBERNETES_VERSION
+    version: #@ tkrVersion
     controlPlane:
       replicas: #@ data.values.CONTROL_PLANE_MACHINE_COUNT
       #@overlay/match missing_ok=True

--- a/tkg/client/upgrade_cluster_clusterclass.go
+++ b/tkg/client/upgrade_cluster_clusterclass.go
@@ -16,9 +16,10 @@ func (c *TkgClient) DoClassyClusterUpgrade(regionalClusterClient clusterclient.C
 	currentClusterClient clusterclient.Client, options *UpgradeClusterOptions) error {
 
 	kubernetesVersion := options.KubernetesVersion
+	tkrVersion := options.TkrVersion
 
-	log.Infof("Upgrading kubernetes cluster to `%v` version", kubernetesVersion)
-	patchJSONString := fmt.Sprintf(`{"spec": {"topology": {"version": "%v"}}}`, kubernetesVersion)
+	log.Infof("Upgrading kubernetes cluster to `%v` version, tkr version: `%s`", kubernetesVersion, tkrVersion)
+	patchJSONString := fmt.Sprintf(`{"spec": {"topology": {"version": "%v"}}}`, tkrVersion)
 
 	err := regionalClusterClient.PatchClusterObject(options.ClusterName, options.Namespace, patchJSONString)
 	if err != nil {

--- a/tkg/client/upgrade_cluster_test.go
+++ b/tkg/client/upgrade_cluster_test.go
@@ -812,6 +812,7 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 
 		BeforeEach(func() {
 			upgradeClusterOptions.KubernetesVersion = "v1.18.2+vmware.1"
+			upgradeClusterOptions.TkrVersion = "v1.18.2+vmware.1-tkg.1"
 			currentK8sVersion = "v1.17.3+vmware.2"
 			setupBomFile("../fakes/config/bom/tkg-bom-v1.3.1.yaml", testingDir)
 			os.Setenv("SKIP_VSPHERE_TEMPLATE_VERIFICATION", "1")
@@ -888,7 +889,7 @@ var _ = Describe("When upgrading cluster with fake controller runtime client", f
 				cluster := &capi.Cluster{}
 				err = regionalClusterClient.GetResource(cluster, upgradeClusterOptions.ClusterName, upgradeClusterOptions.Namespace, nil, nil)
 				Expect(err).To(BeNil())
-				Expect(cluster.Spec.Topology.Version).To(Equal(upgradeClusterOptions.KubernetesVersion))
+				Expect(cluster.Spec.Topology.Version).To(Equal(upgradeClusterOptions.TkrVersion))
 			})
 		})
 	})

--- a/tkg/tkgctl/upgrade_cluster.go
+++ b/tkg/tkgctl/upgrade_cluster.go
@@ -69,7 +69,7 @@ func (t *tkgctl) UpgradeCluster(options UpgradeClusterOptions) error {
 
 	// if --yes is set, kick off the upgrade process without waiting for confirmation
 	if !options.SkipPrompt {
-		if err := askForConfirmation(fmt.Sprintf("Upgrading workload cluster '%s' to kubernetes version '%s'. Are you sure?", options.ClusterName, k8sVersion)); err != nil {
+		if err := askForConfirmation(fmt.Sprintf("Upgrading workload cluster '%s' to kubernetes version '%s', tkr version '%s'. Are you sure?", options.ClusterName, k8sVersion, options.TkrVersion)); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
if `--tkr` flag is configured as tkr name, should set topology.version to tkr version to make it effective.

tkr resolver will resolve k8s version for cluster cr.

### What this PR does / why we need it
tkr resolver resolves tkr version based on `topology.version` field in cluster cr. it is expected to consume tkr prefix or tkr version instead of k8s version.

If multiple tkrs with same k8s version exists in mc, k8s version(as a prefix for tkr version) is not enough for tkr resolver to resolve the desired tkr version. 



### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

cluster created successfully with tkr prefix /exact tkr name/ default tkr as input in vsphere testbed
could upgrade to specific tkr version as well

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
