### PR TITLE
Set node-ip in /etc/hosts instead of node-ip flag

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -1281,7 +1281,7 @@ spec:
           permissions: "0640"
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: echo "KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)" >> /etc/sysconfig/kubelet
+        value: "echo \"$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local) $(hostname)\" >> /etc/hosts"
   - name: nodeLabels
     definitions:
     - selector:

--- a/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
@@ -1281,7 +1281,7 @@ spec:
           permissions: "0640"
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: echo "KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)" >> /etc/sysconfig/kubelet
+        value: "echo \"$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local) $(hostname)\" >> /etc/hosts"
   - name: nodeLabels
     definitions:
     - selector:

--- a/providers/infrastructure-vsphere/v1.5.1/ytt/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/ytt/overlay.yaml
@@ -402,15 +402,16 @@ spec:
       - #@ data.values.VSPHERE_SSH_AUTHORIZED_KEY
       sudo: ALL=(ALL) NOPASSWD:ALL
     #! When using kube-vip as the control plane endpoint provider with IPv6 as
-    #! the primary IP family, set --node-ip on kubelet so that host network pods
-    #! do not get the kube-vip address as their pod IP.
+    #! the primary IP family, set the node ip in /etc/hosts for kubelet to
+    #! discover so so that host network pods do not get the kube-vip address as
+    #! their pod IP.
     #! See: https://github.com/vmware-tanzu/tanzu-framework/issues/2098
     #@ if data.values.TKG_IP_FAMILY in ["ipv6", "ipv6,ipv4"]:
     preKubeadmCommands:
     - echo "::1         localhost" >> /etc/hosts
     #@ if not data.values.AVI_CONTROL_PLANE_HA_PROVIDER and compare_semver_versions(tkrVersion, "v1.22.8") >= 0:
     #@overlay/append
-    - echo "KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)" >> /etc/sysconfig/kubelet
+    - "echo \"$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local) $(hostname)\" >> /etc/hosts"
     #@ end
     #@ end
   replicas: #@ data.values.CONTROL_PLANE_MACHINE_COUNT

--- a/providers/tests/unit/ip_family_test.go
+++ b/providers/tests/unit/ip_family_test.go
@@ -443,7 +443,7 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].owner", "root:root"))
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].path", "/etc/sysconfig/kubelet"))
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].permissions", "0640"))
-					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.preKubeadmCommands[6]", "echo \"KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)\" >> /etc/sysconfig/kubelet"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.preKubeadmCommands[6]", "echo \"$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local) $(hostname)\" >> /etc/hosts"))
 				},
 					Entry("when the tkr is 1.22.8", "v1.22.8---vmware.1-tkg.1"),
 					Entry("when the tkr is 1.22.11", "v1.22.11---vmware.1-tkg.1"),
@@ -472,7 +472,7 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 
 					Expect(kubeadmControlPlaneDocs).To(HaveLen(1))
 					Expect(kubeadmControlPlaneDocs[0]).NotTo(HaveYAMLPath("$.spec.kubeadmConfigSpec.files[1]"))
-					Expect(kubeadmControlPlaneDocs[0]).NotTo(ContainSubstring("KUBELET_EXTRA_ARGS=--node-ip="))
+					Expect(kubeadmControlPlaneDocs[0]).NotTo(ContainSubstring("echo \"$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local) $(hostname)\" >> /etc/hosts"))
 				},
 					Entry("when the tkr is 1.22.7", "v1.22.7---vmware.1-tkg.1"),
 					Entry("when the tkr is 1.21.20", "v1.21.20---vmware.1-tkg.1"),
@@ -699,7 +699,7 @@ var _ = Describe("TKG_IP_FAMILY Ytt Templating", func() {
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].owner", "root:root"))
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].path", "/etc/sysconfig/kubelet"))
 					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.files[1].permissions", "0640"))
-					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.preKubeadmCommands[6]", "echo \"KUBELET_EXTRA_ARGS=--node-ip=$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local)\" >> /etc/sysconfig/kubelet"))
+					Expect(kubeadmControlPlaneDocs[0]).To(HaveYAMLPathWithValue("$.spec.kubeadmConfigSpec.preKubeadmCommands[6]", "echo \"$(ip -6 -json addr show dev eth0 scope global | jq -r .[0].addr_info[0].local) $(hostname)\" >> /etc/hosts"))
 				})
 			})
 		})


### PR DESCRIPTION
### What this PR does / why we need it

Setting the --node-ip on the kubelet can prevent the vsphere-cpi from configuring the node ip itself if its ip selection process detects a different IP for some reason. One occurance of this happening was the kubelet selecting the slaac address and the vsphere-cpi selecting the dhcpv6 address. This usually shouldn't occur because they both should normally select the first global ip on the nic, but timing may have caused kubelet to not select the dhcpv6 address.

When running with kube-vip, configuing the node ip in kubelet is desireable so that pods on the hostNetwork will not run on the kube-vip IP when the kubelet selects an IP for the node.

Kubelet can be informed of what IP to use by DNS lookup of the hostname instead of using --node-ip. This approach is advantageous because if the CPI were to choose a different IP, kubelet would not reject the IP. Setting a non floating kube-vip IP in the /etc/hosts file gives the desired DNS answer, allowing kubelet to launch pods on the host network, while also avoiding the kube-vip IP.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes n/a

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

We deployed an ipv6 cluster with kube-vip and everything worked successfully.
We also forced kubelet to select an IP address that vsphere-cpi wouldn't select and see that vsphere-cpi is able to update the node addresses to a different ip successfully.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Fix issue where vsphere-cpi cannot set the node address after kubelet is configured with a different address on IPv6 clusters.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
