### PR TITLE
Fix typo in enable spelling

### DIFF
--- a/tkg/client/common.go
+++ b/tkg/client/common.go
@@ -361,7 +361,7 @@ func (c *TkgClient) ShouldDeployClusterClassBasedCluster(isManagementCluster boo
 		// Return error if user has customized template overlays
 		// but the feature gate FeatureFlagAllowLegacyCluster or ALLOW_LEGACY_CLUSTER parameter is disabled for workload cluster
 		if isCustomOverlayPresent && !isSuppressProvidersUpdateSet {
-			return false, errors.Errorf("It seems like you have done some customizations to the template overlays. However, the feature gate %v is %v. Please enabe it and try again", constants.FeatureFlagAllowLegacyCluster, allowLegacyClusterCreated)
+			return false, errors.Errorf("It seems like you have done some customizations to the template overlays. However, the feature gate %v is %v. Please enable it and try again", constants.FeatureFlagAllowLegacyCluster, allowLegacyClusterCreated)
 		} else {
 			// Deploy clusterclass based workload cluster when template overlays don't be customized
 			// and feature gate FeatureFlagAllowLegacyCluster or ALLOW_LEGACY_CLUSTER parameter is disabled


### PR DESCRIPTION
### What this PR does / why we need it

### Which issue(s) this PR fixes
Fix typo in enable in error message about legacy cluster config

Fixes #

### Describe testing done for PR

NA as it was a typo

### Release note
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer
