### PR TITLE
workflow: Add cherry-pick job for release-0.28

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -1,0 +1,26 @@
+on:
+  pull_request:
+    branches:
+      - main
+    types: ["closed"]
+
+jobs:
+  cherry_pick_release_v0_28:
+    runs-on: ubuntu-latest
+    name: Cherry pick into release-0.28 brach
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'cherry-pick/release-0.28') && github.event.pull_request.merged == true }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Cherry pick into release-0.28
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.6
+        with:
+          token: ${{ secrets.ALFRED_PAT }}
+          committer: Alfred the Narwhal <noreply@github.com>
+          author: Alfred the Narwhal <noreply@github.com>
+          branch: release-0.28
+          title: '[release-0.28] cherry-pick ${{github.event.number}} : {old_title}'
+          body: 'Cherry-pick of #{old_pull_request_id} into release-0.28 branch'
+          labels: "backports/release-0.28"

--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ Thanks for taking the time to join our community and start contributing! We welc
 ## Roadmap
 
 Check out Framework's project [Roadmap](ROADMAP.md) and consider contributing!
+
+## Cherry-pick process
+
+Check quick instructions [here](./docs/release/cherry-pick.md)

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -8,3 +8,4 @@ Documentation for the release process.
 * [Release Notes](release-notes.md)
 * [Release Process](release-process.md)
 * [Release Notes Gathering Process](release-notes-gathering-process.md)
+* [Cherry Pick process](cherry-pick.md)

--- a/docs/release/cherry-pick.md
+++ b/docs/release/cherry-pick.md
@@ -1,0 +1,8 @@
+Cherry-pick process
+===================
+
+- Know the target release branches your PR must be cherry-picked into
+- Raise your PR against main branch and add label `cherry-pick/release-0.28` where `release-0.28` is branch name, where you'd like to cherry-pick this change
+- Get your PR against main tested, reviewed and merged. Once merged, github action workflow will create cherry-pick PR against desired release branch.
+- You can specify multiple labels for multiple cherry-pick PRs, just add respective labels for example: `cherry-pick/release-0.28` `cherry-pick/release-0.29`
+- The workflow expects no conflicts while raising cherry-pick PRs, otherwise you'll have to create the cherry-picks manually. Monitor the workflow in your original PR against main for success/failure.


### PR DESCRIPTION
### What this PR does / why we need it
- Add github workflow for cherry-picking to release-0.28 branch.
- Workflow triggers for your merged PR if it has 'cherry-pick/release-0.28' label
- It creates a cherry-pick PR against release-0.28 branch and adds 'backports/release-0.28' label
- Titles the cherry-pick PR referring to original PR number and its title with [release-0.28] branch prefix
- Refers to original PR number in the PR body
- It uses bot 'Alfred the Narwhal' as the cherry-pick PR author, so the CLA could pass, github-actions bot is not added to our CLA
- Workflow uses `ALFRED_PAT` token, the respective token is created and configured in the repo
- `cherry-pick/release-0.28` and `backports/release-0.28` labels are created in t-f repo
- add docs

Signed-off-by: Navid Shaikh <navids@vmware.com>

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
See test PR created by https://github.com/navidshaikh/tanzu-framework/pull/31

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
