### PR TITLE
Handle equal sign in Extra Args

### DIFF
--- a/providers/yttcc/lib/config_variable_association.star
+++ b/providers/yttcc/lib/config_variable_association.star
@@ -353,7 +353,7 @@ def get_cluster_variables():
                         "httpProxy": data.values["TKG_HTTP_PROXY"],
                         "httpsProxy": data.values["TKG_HTTPS_PROXY"],
                         "noProxy": data.values["TKG_NO_PROXY"].split(","),
-                        "systemWide": data.values["TKG_NODE_SYSTEM_WIDE_PROXY"], 
+                        "systemWide": data.values["TKG_NODE_SYSTEM_WIDE_PROXY"],
                     }
                 end
             end
@@ -410,6 +410,25 @@ def get_cluster_variables():
         vars["auditLogging"] = {
             "enabled": data.values["ENABLE_AUDIT_LOGGING"]
         }
+    end
+
+    if data.values["ETCD_EXTRA_ARGS"] != None and data.values["ETCD_EXTRA_ARGS"] != "":
+        vars["etcdExtraArgs"] = get_extra_args_map_from_string(data.values["ETCD_EXTRA_ARGS"])
+    end
+    if data.values["APISERVER_EXTRA_ARGS"] != None and data.values["APISERVER_EXTRA_ARGS"] != "":
+        vars["apiServerExtraArgs"] = get_extra_args_map_from_string(data.values["APISERVER_EXTRA_ARGS"])
+    end
+    if data.values["KUBE_SCHEDULER_EXTRA_ARGS"] != None and data.values["KUBE_SCHEDULER_EXTRA_ARGS"] != "":
+        vars["kubeSchedulerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_SCHEDULER_EXTRA_ARGS"])
+    end
+    if data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"] != None and data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"] != "":
+        vars["kubeControllerManagerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"])
+    end
+    if data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"] != None and data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"] != "":
+        vars["controlPlaneKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"])
+    end
+    if data.values["WORKER_KUBELET_EXTRA_ARGS"] != None and data.values["WORKER_KUBELET_EXTRA_ARGS"] != "":
+        vars["workerKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["WORKER_KUBELET_EXTRA_ARGS"])
     end
 
     additionalTrustedCAs = []
@@ -631,25 +650,6 @@ def get_aws_vars():
 
     vars["worker"] = worker
 
-    if data.values["ETCD_EXTRA_ARGS"] != None:
-        vars["etcdExtraArgs"] = get_extra_args_map_from_string(data.values["ETCD_EXTRA_ARGS"])
-    end
-    if data.values["APISERVER_EXTRA_ARGS"] != None:
-        vars["apiServerExtraArgs"] = get_extra_args_map_from_string(data.values["APISERVER_EXTRA_ARGS"])
-    end
-    if data.values["KUBE_SCHEDULER_EXTRA_ARGS"] != None:
-        vars["kubeSchedulerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_SCHEDULER_EXTRA_ARGS"])
-    end
-    if data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"] != None:
-        vars["kubeControllerManagerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"])
-    end
-    if data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"] != None:
-        vars["controlPlaneKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"])
-    end
-    if data.values["WORKER_KUBELET_EXTRA_ARGS"] != None:
-        vars["workerKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["WORKER_KUBELET_EXTRA_ARGS"])
-    end
-
     controlPlane = {}
     if data.values["CONTROL_PLANE_MACHINE_TYPE"] != None:
         controlPlane["instanceType"] = data.values["CONTROL_PLANE_MACHINE_TYPE"]
@@ -781,25 +781,6 @@ def get_azure_vars():
 
     if controlPlane != {}:
         vars["controlPlane"] = controlPlane
-    end
-
-    if data.values["ETCD_EXTRA_ARGS"] != None:
-        vars["etcdExtraArgs"] = get_extra_args_map_from_string(data.values["ETCD_EXTRA_ARGS"])
-    end
-    if data.values["APISERVER_EXTRA_ARGS"] != None:
-        vars["apiServerExtraArgs"] = get_extra_args_map_from_string(data.values["APISERVER_EXTRA_ARGS"])
-    end
-    if data.values["KUBE_SCHEDULER_EXTRA_ARGS"] != None:
-        vars["kubeSchedulerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_SCHEDULER_EXTRA_ARGS"])
-    end
-    if data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"] != None:
-        vars["kubeControllerManagerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"])
-    end
-    if data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"] != None:
-        vars["controlPlaneKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"])
-    end
-    if data.values["WORKER_KUBELET_EXTRA_ARGS"] != None:
-        vars["workerKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["WORKER_KUBELET_EXTRA_ARGS"])
     end
 
     worker = {}
@@ -936,25 +917,6 @@ def get_vsphere_vars():
 
     if controlPlane != {}:
         vars["controlPlane"] = controlPlane
-    end
-
-    if data.values["ETCD_EXTRA_ARGS"] != None:
-        vars["etcdExtraArgs"] = get_extra_args_map_from_string(data.values["ETCD_EXTRA_ARGS"])
-    end
-    if data.values["APISERVER_EXTRA_ARGS"] != None:
-        vars["apiServerExtraArgs"] = get_extra_args_map_from_string(data.values["APISERVER_EXTRA_ARGS"])
-    end
-    if data.values["KUBE_SCHEDULER_EXTRA_ARGS"] != None:
-        vars["kubeSchedulerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_SCHEDULER_EXTRA_ARGS"])
-    end
-    if data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"] != None:
-        vars["kubeControllerManagerExtraArgs"] = get_extra_args_map_from_string(data.values["KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"])
-    end
-    if data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"] != None:
-        vars["controlPlaneKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["CONTROLPLANE_KUBELET_EXTRA_ARGS"])
-    end
-    if data.values["WORKER_KUBELET_EXTRA_ARGS"] != None:
-        vars["workerKubeletExtraArgs"] = get_extra_args_map_from_string(data.values["WORKER_KUBELET_EXTRA_ARGS"])
     end
 
     worker = {}

--- a/providers/yttcc/lib/helpers.star
+++ b/providers/yttcc/lib/helpers.star
@@ -335,7 +335,7 @@ end
 def get_map_from_string(argsString, delimiter):
    argsMap = {}
    for val in argsString.split(delimiter):
-    kv = val.split('=')
+    kv = val.split('=', 1)
     if len(kv) != 2:
       assert.fail("given args string \""+argsString+"\" must be in the  \"key1=label1"+delimiter+"key2=label2\" format ")
     end

--- a/tkg/client/cluster.go
+++ b/tkg/client/cluster.go
@@ -738,11 +738,44 @@ func (c *TkgClient) ConfigureAndValidateWorkloadClusterConfiguration(options *Cr
 		return err
 	}
 
+	if err = c.ValidateExtraArgs(); err != nil {
+		return err
+	}
+
 	if err = c.ValidateKubeVipLBConfiguration(TkgLabelClusterRoleWorkload); err != nil {
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
 	return c.ValidateSupportOfK8sVersionForManagmentCluster(clusterClient, options.KubernetesVersion, skipValidation)
+}
+
+func (c *TkgClient) ValidateExtraArgs() error {
+	supportedList := []string{
+		constants.ConfigVariableEtcdExtraArgs,
+		constants.ConfigVariableAPIServerExtraArgs,
+		constants.ConfigVariableKubeSchedulerExtraArgs,
+		constants.ConfigVariableKubeControllerManagerExtraArgs,
+		constants.ConfigVariableControlPlaneKubeletExtraArgs,
+		constants.ConfigVariableWorkerKubeletExtraArgs,
+	}
+	for _, extraArgsName := range supportedList {
+		if args, err := c.TKGConfigReaderWriter().Get(extraArgsName); err != nil {
+			c.TKGConfigReaderWriter().Set(extraArgsName, "")
+		} else if args != "" {
+			argList := strings.Split(args, ";")
+			for _, arg := range argList {
+				if index := strings.Index(arg, "="); index >= 0 {
+					key := arg[0:index]
+					if strings.TrimSpace(key) == "" {
+						return errors.New(fmt.Sprintf("%s contains empty keys: %s", extraArgsName, args))
+					}
+				} else {
+					return errors.New(fmt.Sprintf("%s is not format key1=value1;key2=value2: %s", extraArgsName, args))
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // ValidateProviderConfig configure and validate based on provider

--- a/tkg/client/cluster_test.go
+++ b/tkg/client/cluster_test.go
@@ -490,6 +490,12 @@ func populateConfigMap() map[string]string {
 	configMap[constants.ConfigVariableWorkerMachineCount0] = "0"
 	configMap[constants.ConfigVariableWorkerMachineCount1] = "0"
 	configMap[constants.ConfigVariableWorkerMachineCount2] = "0"
+	configMap[constants.ConfigVariableEtcdExtraArgs] = ""
+	configMap[constants.ConfigVariableAPIServerExtraArgs] = ""
+	configMap[constants.ConfigVariableKubeSchedulerExtraArgs] = ""
+	configMap[constants.ConfigVariableKubeControllerManagerExtraArgs] = ""
+	configMap[constants.ConfigVariableControlPlaneKubeletExtraArgs] = ""
+	configMap[constants.ConfigVariableWorkerKubeletExtraArgs] = ""
 	return configMap
 }
 

--- a/tkg/client/validate.go
+++ b/tkg/client/validate.go
@@ -605,6 +605,10 @@ func (c *TkgClient) ConfigureAndValidateManagementClusterConfiguration(options *
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
+	if err = c.ValidateExtraArgs(); err != nil {
+		return NewValidationError(ValidationErrorCode, err.Error())
+	}
+
 	if err = c.ValidateKubeVipLBConfiguration(TkgLabelClusterRoleManagement); err != nil {
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}

--- a/tkg/constants/config_variables.go
+++ b/tkg/constants/config_variables.go
@@ -18,6 +18,12 @@ const (
 	ConfigVariableClusterAPIServerPort                = "CLUSTER_API_SERVER_PORT"
 	ConfigVariableBastionHostEnabled                  = "BASTION_HOST_ENABLED"
 	ConfigVariableVipNetworkInterface                 = "VIP_NETWORK_INTERFACE"
+	ConfigVariableEtcdExtraArgs                       = "ETCD_EXTRA_ARGS"
+	ConfigVariableAPIServerExtraArgs                  = "APISERVER_EXTRA_ARGS"
+	ConfigVariableKubeSchedulerExtraArgs              = "KUBE_SCHEDULER_EXTRA_ARGS"
+	ConfigVariableKubeControllerManagerExtraArgs      = "KUBE_CONTROLLER_MANAGER_EXTRA_ARGS"
+	ConfigVariableControlPlaneKubeletExtraArgs        = "CONTROLPLANE_KUBELET_EXTRA_ARGS"
+	ConfigVariableWorkerKubeletExtraArgs              = "WORKER_KUBELET_EXTRA_ARGS"
 
 	ConfigVariableAWSRegion          = "AWS_REGION"
 	ConfigVariableAWSSecretAccessKey = "AWS_SECRET_ACCESS_KEY" //nolint:gosec


### PR DESCRIPTION
Various EXTRA_ARGS are required of format "key1=value1;key2=value2", and some of arg value also contains equal sign, for example: feature-gates=RotateKubeletServerCertificate=true,QOSReserved=true We should take everything after the the first equal sign as its value in this case.

Move converting legacy variables to Cluster variables to the common method get_cluster_variables() because there is no difference among providers.

Validate legacy variables on various EXTRA_ARGS.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
