### PR TITLE
Add comment notifications for cherry-pick workflow result

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -1,3 +1,5 @@
+name: Cherry-pick
+
 on:
   pull_request:
     branches:
@@ -7,15 +9,18 @@ on:
 jobs:
   cherry_pick_release_v0_28:
     runs-on: ubuntu-latest
-    name: Cherry pick into release-0.28 brach
+    name: Cherry-pick into release-0.28 brach
     if: ${{ contains(github.event.pull_request.labels.*.name, 'cherry-pick/release-0.28') && github.event.pull_request.merged == true }}
+    outputs:
+      pr_url: ${{ steps.cherrypick.outputs.html_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
       - name: Cherry pick into release-0.28
-        uses: carloscastrojumo/github-cherry-pick-action@v1.0.6
+        id: cherrypick
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
         with:
           token: ${{ secrets.ALFRED_PAT }}
           committer: Alfred the Narwhal <noreply@github.com>
@@ -24,3 +29,35 @@ jobs:
           title: '[release-0.28] cherry-pick ${{github.event.number}} : {old_title}'
           body: 'Cherry-pick of #{old_pull_request_id} into release-0.28 branch'
           labels: "backports/release-0.28"
+  notify_cherrypick_status:
+    runs-on: ubuntu-latest
+    name: Notify release-0.28 cherry-pick status
+    needs: [cherry_pick_release_v0_28]
+    if: always()
+    steps:
+      - id: check
+        uses: martialonline/workflow-status@v3
+      - name: post failure message
+        uses: peter-evans/create-or-update-comment@v2
+        if: steps.check.outputs.status == 'failure'
+        with:
+          token: ${{ secrets.ALFRED_PAT }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Failed to create cherry-pick PR, workflow failed (usually due to merge conflicts), please create the cherry-pick PR manually.
+      - name: post success message
+        uses: peter-evans/create-or-update-comment@v2
+        if: steps.check.outputs.status == 'success'
+        with:
+          token: ${{ secrets.ALFRED_PAT }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Created cherry-pick PR ${{ needs.cherry_pick_release_v0_28.outputs.pr_url }}
+      - name: post cancelled workflow message
+        uses: peter-evans/create-or-update-comment@v2
+        if: steps.check.outputs.status == 'cancelled'
+        with:
+          token: ${{ secrets.ALFRED_PAT }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Cherry-pick workflow is cancelled, please re-run the workflow manually.

--- a/docs/release/cherry-pick.md
+++ b/docs/release/cherry-pick.md
@@ -4,5 +4,5 @@ Cherry-pick process
 - Know the target release branches your PR must be cherry-picked into
 - Raise your PR against main branch and add label `cherry-pick/release-0.28` where `release-0.28` is branch name, where you'd like to cherry-pick this change
 - Get your PR against main tested, reviewed and merged. Once merged, github action workflow will create cherry-pick PR against desired release branch.
-- You can specify multiple labels for multiple cherry-pick PRs, just add respective labels for example: `cherry-pick/release-0.28` `cherry-pick/release-0.29`
-- The workflow expects no conflicts while raising cherry-pick PRs, otherwise you'll have to create the cherry-picks manually. Monitor the workflow in your original PR against main for success/failure.
+- The workflow adds a comment on the PR about the status of cherry-pick workflow for success (comment the resulting cherry-pick PR), failure or cancelled (if workflow is cancelled).
+- If there are merge conflicts while raising the cherry-pick PR, the workflow fails and adds respective comment on the merged PR. In this case, please raise the cherry-pick PR manually.


### PR DESCRIPTION
### What this PR does / why we need it
- Add a comment if cherry-pick workflow operation was succesful, failed or cancelled
- Links the created PR if successful
- Update docs
- follow up to https://github.com/vmware-tanzu/tanzu-framework/pull/4343

Signed-off-by: Navid Shaikh <navids@vmware.com>

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
Success case: https://github.com/navidshaikh/tanzu-framework/pull/35#issuecomment-1428735654
Failure case: https://github.com/navidshaikh/tanzu-framework/pull/37#issuecomment-1428739255

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
