### PR TITLE
[release-0.28] cherry-pick 4365 : raise timeout for tkr-vsphere-resolver webhook

### DIFF
--- a/packages/tkr-vsphere-resolver/bundle/config/upstream/webhook.yaml
+++ b/packages/tkr-vsphere-resolver/bundle/config/upstream/webhook.yaml
@@ -31,3 +31,4 @@ webhooks:
     resources:
     - "clusters"
   sideEffects: None
+  timeoutSeconds: 30


### PR DESCRIPTION
Cherry-pick of #4365 into release-0.28 branch