### PR TITLE
Ignore zshippable in minor version during upgrade

### DIFF
--- a/addons/pkg/constants/constants.go
+++ b/addons/pkg/constants/constants.go
@@ -371,6 +371,9 @@ const (
 	TKGDevCCPan = "devcc"
 
 	TKRAnnotationKey = "run.tanzu.vmware.com/tkr-spec"
+
+	// Zshippable postscrip added to mark a component as in development
+	Zshippable = "-zshippable"
 )
 
 var (


### PR DESCRIPTION
During dev testing of cluster upgrade functionality, some  of the package versions will have the postfix "-zshippable".

The libraries used to compare versions of packages during upgrade look at a version string like "0.12.1+vmware.2-tkg.2-zshippable", and assume the minor version, "2-zshippable", is a non-number.

The libraries also look at a version string like "0.12.1+vmware.2-tkg.3", and assume the minor version "3" is a number.

The problem comes about because the same libraries see a non-number minor version as newer than any number version.
So the version 0.12.1+vmware.2-tkg.2-zshippable is newer than 0.12.1+vmware.2-tkg.3, which is incorrect

To allow for dev testing to proceed we remove the "-zshippable" postfix right before the version strings are compared.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #4379

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
Unit test added

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
the postfix "-zshippable" is ignore when comparing package versions during upgrade.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
