### PR TITLE
Registering cleanup Antrea interface

### DIFF
--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -2058,6 +2058,61 @@ spec:
             start-service kube-proxy
             start-service antrea-agent
       - op: add
+        path: /spec/template/spec/files/-
+        value:
+          path: 'C:\k\antrea_cleanup.ps1'
+          content: |
+            stop-service antrea-agent -ErrorAction SilentlyContinue
+            C:\k\antrea\Clean-AntreaNetwork.ps1
+      - op: add
+        path: /spec/template/spec/files/-
+        value:
+          path: 'C:\k\register_antrea_cleanup.ps1'
+          content: |
+            $methodScript = "C:\k\antrea\Clean-AntreaNetwork.ps1"
+            if (Test-Path "$methodScript") {
+                $cleanScriptPath = "C:\k\antrea_cleanup.ps1"
+                $method = "Shutdown"
+                $RegPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Group Policy"
+                $RegScriptsPath = "$RegPath\Scripts\$method\0"
+                $RegSmScriptsPath = "$RegPath\State\Machine\Scripts\$method\0"
+                # Create the path if not exist
+                $gpoPath = "$ENV:systemRoot\System32\GroupPolicy\Machine"
+                $methodPath = "$gpoPath\Scripts\$method"
+                if (-not (Test-Path $methodPath)) {
+                    New-Item -path $methodPath -itemType Directory
+                }
+                # Create sub-path
+                $items = @("$RegScriptsPath\0", "$RegSmScriptsPath\0")
+                foreach ($item in $items) {
+                    if (-not (Test-Path $item)) {
+                        New-Item -path $item -force
+                    }
+                }
+                # Register callback script to GPO
+                $items = @("$RegScriptsPath", "$RegSmScriptsPath")
+                foreach ($item in $items) {
+                    New-ItemProperty -path "$item" -name DisplayName -propertyType String -value "Local Group Policy" -force
+                    New-ItemProperty -path "$item" -name FileSysPath -propertyType String -value "$gpoPath" -force
+                    New-ItemProperty -path "$item" -name GPO-ID -propertyType String -value "LocalGPO" -force
+                    New-ItemProperty -path "$item" -name GPOName -propertyType String -value "Local Group Policy" -force
+                    New-ItemProperty -path "$item" -name PSScriptOrder -propertyType DWord -value 2 -force
+                    New-ItemProperty -path "$item" -name SOM-ID -propertyType String -value "Local" -force
+                }
+                $BinaryString = "00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00"
+                $ExecTime = $BinaryString.Split(',') | ForEach-Object {"0x$_"}
+                $items = @("$RegScriptsPath\0", "$RegSmScriptsPath\0")
+                foreach ($item in $items) {
+                    New-ItemProperty -path "$item" -name Script -propertyType String -value $cleanScriptPath -force
+                    New-ItemProperty -path "$item" -name Parameters -propertyType String -value $method -force
+                    New-ItemProperty -path "$item" -name IsPowershell -propertyType DWord -value 1 -force
+                    New-ItemProperty -path "$item" -name ExecTime -propertyType Binary -value ([byte[]]$ExecTime) -force
+                }
+            }
+      - op: add
+        path: /spec/template/spec/postKubeadmCommands/-
+        value: powershell C:/k/register_antrea_cleanup.ps1 -ExecutionPolicy Bypass
+      - op: add
         path: /spec/template/spec/postKubeadmCommands/-
         value: powershell C:/Temp/antrea.ps1 -ExecutionPolicy Bypass
   - name: ntpServers

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -2111,10 +2111,10 @@ spec:
             }
       - op: add
         path: /spec/template/spec/postKubeadmCommands/-
-        value: powershell C:/k/register_antrea_cleanup.ps1 -ExecutionPolicy Bypass
+        value: powershell C:/Temp/antrea.ps1 -ExecutionPolicy Bypass
       - op: add
         path: /spec/template/spec/postKubeadmCommands/-
-        value: powershell C:/Temp/antrea.ps1 -ExecutionPolicy Bypass
+        value: powershell C:/k/register_antrea_cleanup.ps1 -ExecutionPolicy Bypass
   - name: ntpServers
     enabledIf: '{{ not (empty .ntpServers) }}'
     definitions:

--- a/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
@@ -2058,6 +2058,61 @@ spec:
             start-service kube-proxy
             start-service antrea-agent
       - op: add
+        path: /spec/template/spec/files/-
+        value:
+          path: 'C:\k\antrea_cleanup.ps1'
+          content: |
+            stop-service antrea-agent -ErrorAction SilentlyContinue
+            C:\k\antrea\Clean-AntreaNetwork.ps1
+      - op: add
+        path: /spec/template/spec/files/-
+        value:
+          path: 'C:\k\register_antrea_cleanup.ps1'
+          content: |
+            $methodScript = "C:\k\antrea\Clean-AntreaNetwork.ps1"
+            if (Test-Path "$methodScript") {
+                $cleanScriptPath = "C:\k\antrea_cleanup.ps1"
+                $method = "Shutdown"
+                $RegPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Group Policy"
+                $RegScriptsPath = "$RegPath\Scripts\$method\0"
+                $RegSmScriptsPath = "$RegPath\State\Machine\Scripts\$method\0"
+                # Create the path if not exist
+                $gpoPath = "$ENV:systemRoot\System32\GroupPolicy\Machine"
+                $methodPath = "$gpoPath\Scripts\$method"
+                if (-not (Test-Path $methodPath)) {
+                    New-Item -path $methodPath -itemType Directory
+                }
+                # Create sub-path
+                $items = @("$RegScriptsPath\0", "$RegSmScriptsPath\0")
+                foreach ($item in $items) {
+                    if (-not (Test-Path $item)) {
+                        New-Item -path $item -force
+                    }
+                }
+                # Register callback script to GPO
+                $items = @("$RegScriptsPath", "$RegSmScriptsPath")
+                foreach ($item in $items) {
+                    New-ItemProperty -path "$item" -name DisplayName -propertyType String -value "Local Group Policy" -force
+                    New-ItemProperty -path "$item" -name FileSysPath -propertyType String -value "$gpoPath" -force
+                    New-ItemProperty -path "$item" -name GPO-ID -propertyType String -value "LocalGPO" -force
+                    New-ItemProperty -path "$item" -name GPOName -propertyType String -value "Local Group Policy" -force
+                    New-ItemProperty -path "$item" -name PSScriptOrder -propertyType DWord -value 2 -force
+                    New-ItemProperty -path "$item" -name SOM-ID -propertyType String -value "Local" -force
+                }
+                $BinaryString = "00,00,00,00,00,00,00,00,00,00,00,00,00,00,00,00"
+                $ExecTime = $BinaryString.Split(',') | ForEach-Object {"0x$_"}
+                $items = @("$RegScriptsPath\0", "$RegSmScriptsPath\0")
+                foreach ($item in $items) {
+                    New-ItemProperty -path "$item" -name Script -propertyType String -value $cleanScriptPath -force
+                    New-ItemProperty -path "$item" -name Parameters -propertyType String -value $method -force
+                    New-ItemProperty -path "$item" -name IsPowershell -propertyType DWord -value 1 -force
+                    New-ItemProperty -path "$item" -name ExecTime -propertyType Binary -value ([byte[]]$ExecTime) -force
+                }
+            }
+      - op: add
+        path: /spec/template/spec/postKubeadmCommands/-
+        value: powershell C:/k/register_antrea_cleanup.ps1 -ExecutionPolicy Bypass
+      - op: add
         path: /spec/template/spec/postKubeadmCommands/-
         value: powershell C:/Temp/antrea.ps1 -ExecutionPolicy Bypass
   - name: ntpServers

--- a/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.1/cconly/base.yaml
@@ -2111,10 +2111,10 @@ spec:
             }
       - op: add
         path: /spec/template/spec/postKubeadmCommands/-
-        value: powershell C:/k/register_antrea_cleanup.ps1 -ExecutionPolicy Bypass
+        value: powershell C:/Temp/antrea.ps1 -ExecutionPolicy Bypass
       - op: add
         path: /spec/template/spec/postKubeadmCommands/-
-        value: powershell C:/Temp/antrea.ps1 -ExecutionPolicy Bypass
+        value: powershell C:/k/register_antrea_cleanup.ps1 -ExecutionPolicy Bypass
   - name: ntpServers
     enabledIf: '{{ not (empty .ntpServers) }}'
     definitions:


### PR DESCRIPTION
### What this PR does / why we need it
To ensure the persistence of HNS network Antrea provides a register script to restart the networks after reboot, this patches installs this script to run on each restart.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes https://github.com/vmware-tanzu/tanzu-framework/issues/4395

### Describe testing done for PR
A custom clusterclass was created with this patch and tests were made to ensure the script is installed properly, sequential reboot confirms the script restart the interface.

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Windows Antrea interfaces cleanup script is being installed in the node bootstrap.
```