### PR TITLE
Improve the error message for cherry-pick workflow

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -44,7 +44,7 @@ jobs:
           token: ${{ secrets.ALFRED_PAT }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Failed to create cherry-pick PR, workflow failed (usually due to merge conflicts), please create the cherry-pick PR manually.
+            Failed to create cherry-pick PR, workflow failed (usually due to merge conflicts), please create the cherry-pick PR manually against release-0.28 branch.
       - name: post success message
         uses: peter-evans/create-or-update-comment@v2
         if: steps.check.outputs.status == 'success'


### PR DESCRIPTION
### What this PR does / why we need it
Explicitly mention the target branch against which the cherrypick PR need to be created manually in case of failed cherry-pick workflow (due to conflicts etc).

Thanks @vuil for the review and suggestion!

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->
N/A its a text change

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
