### PR TITLE
[release-0.28] cherry-pick 4383 : Fix TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY user env setting

### DIFF
--- a/tkg/managementcomponents/helper_test.go
+++ b/tkg/managementcomponents/helper_test.go
@@ -262,18 +262,40 @@ tkr-package:
 			tkgBomConfig = &tkgconfigbom.BOMConfiguration{}
 			err = yaml.Unmarshal([]byte(tkgBomConfigData), tkgBomConfig)
 			Expect(err).NotTo(HaveOccurred())
-
-			// invoke GetTKGPackageConfigValuesFileFromUserConfig for testing using addonsManagerPackageVersion = managementPackageVersion
-			valuesFile, err = GetTKGPackageConfigValuesFileFromUserConfig(managementPackageVersion, managementPackageVersion, userProviderConfigValues, tkgBomConfig, nil, true)
 		})
 
 		It("should not return error", func() {
+			// invoke GetTKGPackageConfigValuesFileFromUserConfig for testing using addonsManagerPackageVersion = managementPackageVersion
+			valuesFile, err = GetTKGPackageConfigValuesFileFromUserConfig(managementPackageVersion, managementPackageVersion, userProviderConfigValues, tkgBomConfig, nil, true)
+
 			Expect(err).NotTo(HaveOccurred())
 			f1, err := os.ReadFile(valuesFile)
 			Expect(err).NotTo(HaveOccurred())
 			f2, err := os.ReadFile(outputFile)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(string(f1)).To(Equal(string(f2)))
+		})
+
+		When("skipVerifyCert is set in user config", func() {
+
+			It("skipVerify should be correctly parsed", func() {
+				userProviderConfigValues["TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY"] = 1
+			})
+			It("skipVerify should be correctly parsed", func() {
+				userProviderConfigValues["TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY"] = "1"
+			})
+			It("skipVerify should be correctly parsed", func() {
+				userProviderConfigValues["TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY"] = true
+			})
+			It("skipVerify should be correctly parsed", func() {
+				userProviderConfigValues["TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY"] = "true"
+			})
+
+			AfterEach(func() {
+				tkgPackageConfig, err := GetTKGPackageConfigFromUserConfig(managementPackageVersion, managementPackageVersion, userProviderConfigValues, tkgBomConfig, nil, true)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(tkgPackageConfig.TKRSourceControllerPackage.TKRSourceControllerPackageValues.SkipVerifyCert).To(BeTrue())
+			})
 		})
 	})
 

--- a/tkg/managementcomponents/test/config.yaml
+++ b/tkg/managementcomponents/test/config.yaml
@@ -1,2 +1,4 @@
 # a fake config file for reader writer
 foo: bar
+
+TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY: true

--- a/tkg/managementcomponents/test/output_vsphere_with_custom_repo_ca_rw.yaml
+++ b/tkg/managementcomponents/test/output_vsphere_with_custom_repo_ca_rw.yaml
@@ -4,6 +4,7 @@ configvalues:
     PROVIDER_TYPE: vsphere
     TKG_CUSTOM_IMAGE_REPOSITORY: fake-repo
     TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE: fake-ca
+    TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY: "true"
     TKG_HTTP_PROXY: http://192.168.116.1:3128
     TKG_HTTPS_PROXY: http://192.168.116.1:3128
     TKG_NO_PROXY: .svc,100.64.0.0/13,192.168.118.0/24,192.168.119.0/24,192.168.120.0/24
@@ -40,6 +41,7 @@ tkrSourceControllerPackage:
         tkrRepoImagePath: fake.custom.repo/tkr-repository-vsphere-nonparavirt
         defaultCompatibleTKR: v1.23.5+vmware.1-tkg.1-fake
         caCerts: fake-ca-2
+        skipVerifyRegistryCert: true
         imageRepository: fake-repo-2
         deployment:
             httpProxy: http://192.168.116.1:3128

--- a/tkg/managementcomponents/types.go
+++ b/tkg/managementcomponents/types.go
@@ -34,6 +34,7 @@ type TKRSourceControllerPackageValues struct {
 	TKRRepoImagePath     string                                     `yaml:"tkrRepoImagePath,omitempty"`
 	DefaultCompatibleTKR string                                     `yaml:"defaultCompatibleTKR,omitempty"`
 	CaCerts              string                                     `yaml:"caCerts,omitempty"`
+	SkipVerifyCert       bool                                       `yaml:"skipVerifyRegistryCert,omitempty"`
 	ImageRepo            string                                     `yaml:"imageRepository,omitempty"`
 	Deployment           TKRSourceControllerPackageValuesDeployment `yaml:"deployment,omitempty"`
 }


### PR DESCRIPTION
Cherry-pick of #4383 into release-0.28 branch