### PR TITLE
error out when getting virtual machine images fails for context related error

### DIFF
--- a/tkg/vc/client.go
+++ b/tkg/vc/client.go
@@ -697,6 +697,9 @@ func (c *DefaultClient) GetVirtualMachineImages(ctx context.Context, datacenterM
 		if ovaVersion, distroName, distroVersion, distroArch := c.getVMMetadata(&vms[i]); ovaVersion != "" {
 			path, _, err := c.GetPath(ctx, vms[i].Self.Value)
 			if err != nil {
+				if ctx.Err() != nil {
+					return results, err
+				}
 				continue
 			}
 			obj := &tkgtypes.VSphereVirtualMachine{

--- a/tkg/vsphere-template-resolver/templateresolver/resolver_impl.go
+++ b/tkg/vsphere-template-resolver/templateresolver/resolver_impl.go
@@ -38,6 +38,7 @@ func (r *Resolver) GetVSphereEndpoint(svrContext *VSphereContext) (vc.Client, er
 	vcURL.Path = "/sdk"
 
 	r.Log.Info(fmt.Sprintf("Creating client with endpoint: %v", vcURL))
+	// TODO: setup a cache to reuse vc sessions
 	vcClient, err := vc.NewClient(vcURL, svrContext.TLSThumbprint, svrContext.InsecureSkipVerify)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create vc client")


### PR DESCRIPTION
if errors like context deadline exceeded happens, we need correct error message instead of partially retrieving results

### What this PR does / why we need it
if context deadline exceeded in the mid way of retrieving vm images, tkr vsphere resolver could only get part of vm images, and if the target vm template is not included in the response, it errors out like
```
1.6768841257280843e+09    DEBUG    controller-runtime.webhook.webhooks    wrote response    {"webhook": "/resolve-template", "code": 403, "reason": "unable to find VM Template associated with OVA Version v1.24.9+vmware.1-tkg.1-f5e94dab9dfbb9988aeb94f1ffdc6e5e. Please upload at least one VM Template to continue", "UID": "15a0500e-2ae9-4089-832f-76ef27f92e91", "allowed": false}
```
which is incorrect.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
could get the correct message from tkr vsphere resolver
```
1.6769495279332488e+09	DEBUG	controller-runtime.webhook.webhooks	wrote response	{"webhook": "/resolve-template", "code": 403, "reason": "failed to get K8s VM templates: Post \"https://10.202.228.120/sdk\": context canceled", "UID": "19e0b414-64f9-4895-b675-f7f32c490751", "allowed": false}
```
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
