### PR TITLE
check cluster name length when ako needs to be deployed in the cluster

### DIFF
--- a/tkg/client/cluster.go
+++ b/tkg/client/cluster.go
@@ -746,6 +746,10 @@ func (c *TkgClient) ConfigureAndValidateWorkloadClusterConfiguration(options *Cr
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
+	if err = c.ValidateAviMaxAllowedClusterNameLength(TkgLabelClusterRoleWorkload, options, clusterClient); err != nil {
+		return NewValidationError(ValidationErrorCode, err.Error())
+	}
+
 	return c.ValidateSupportOfK8sVersionForManagmentCluster(clusterClient, options.KubernetesVersion, skipValidation)
 }
 
@@ -949,6 +953,44 @@ func (c *TkgClient) ValidateKubeVipLBConfiguration(clusterRole string) error {
 		return errors.Errorf("%s is enabled, either %s or %s has to be set", constants.ConfigVariableKubevipLoadbalancerEnable, constants.ConfigVariableKubevipLoadbalancerCIDRs, constants.ConfigVariableKubevipLoadbalancerIPRanges)
 	}
 
+	return nil
+}
+
+// ValidateAviMaxAllowedClusterNameLength validates if AVI enabled cluster's name has no more than 25 characters
+func (c *TkgClient) ValidateAviMaxAllowedClusterNameLength(clusterRole string, options *CreateClusterOptions, regionalClusterClient clusterclient.Client) error {
+	aviLabels, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviLabels)
+	kvlbEnabled, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableKubevipLoadbalancerEnable)
+
+	// skip when:
+	// 1. cluster is management cluster, that check has already been done in ConfigureAndValidateAviConfiguration func
+	// 2. workload cluster doesn't enable avi
+	// 3. workload cluster is not clusterclass based cluster
+	if clusterRole != TkgLabelClusterRoleWorkload || kvlbEnabled == "true" || !options.IsInputFileClusterClassBased {
+		return nil
+	}
+
+	mgmtClusterName, _, err := c.getRegionalClusterNameAndNamespace(regionalClusterClient)
+	if err != nil {
+		return errors.Wrap(err, "unable to get name and namespace of current management cluster")
+	}
+	akooAddonSecretValues, found, err := GetAKOOAddonSecretValues(regionalClusterClient, mgmtClusterName, options.IsInputFileClusterClassBased)
+	if err != nil {
+		return errors.Wrap(err, "unable to get akoo addon secret values")
+	}
+
+	if found {
+		configValues := make(map[string]interface{})
+		if err = RetrieveAKOOVariablesFromAddonSecretValues(mgmtClusterName, configValues, akooAddonSecretValues); err != nil {
+			return errors.Wrap(err, "unable to handle the akoo specific variables")
+		}
+		// mgmt avi labels is specified & workload cluster avi labels not specify, workload cluster doesn't enable Avi, skip
+		if !utils.IsAviInputEmpty(configValues[constants.ConfigVariableAviLabels]) && aviLabels == "" {
+			return nil
+		}
+		if len(options.ClusterName) > constants.AkoMaxAllowedClusterNameLen {
+			return errors.Errorf("%s is more than %d, which will cause AKO package deployment failure", options.ClusterName, constants.AkoMaxAllowedClusterNameLen)
+		}
+	}
 	return nil
 }
 

--- a/tkg/client/cluster.go
+++ b/tkg/client/cluster.go
@@ -746,7 +746,7 @@ func (c *TkgClient) ConfigureAndValidateWorkloadClusterConfiguration(options *Cr
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
-	if err = c.ValidateAviMaxAllowedClusterNameLength(TkgLabelClusterRoleWorkload, options, clusterClient); err != nil {
+	if err = c.ValidateAviMaxAllowedClusterNameLength(TkgLabelClusterRoleWorkload, options.ClusterName, clusterClient, skipValidation); err != nil {
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
@@ -957,15 +957,15 @@ func (c *TkgClient) ValidateKubeVipLBConfiguration(clusterRole string) error {
 }
 
 // ValidateAviMaxAllowedClusterNameLength validates if AVI enabled cluster's name has no more than 25 characters
-func (c *TkgClient) ValidateAviMaxAllowedClusterNameLength(clusterRole string, options *CreateClusterOptions, regionalClusterClient clusterclient.Client) error {
+func (c *TkgClient) ValidateAviMaxAllowedClusterNameLength(clusterRole, clusterName string, regionalClusterClient clusterclient.Client, skipValidation bool) error {
 	aviLabels, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviLabels)
 	kvlbEnabled, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableKubevipLoadbalancerEnable)
 
 	// skip when:
 	// 1. cluster is management cluster, that check has already been done in ConfigureAndValidateAviConfiguration func
 	// 2. workload cluster doesn't enable avi
-	// 3. workload cluster is not clusterclass based cluster
-	if clusterRole != TkgLabelClusterRoleWorkload || kvlbEnabled == "true" || !options.IsInputFileClusterClassBased {
+	// 3. skip validation
+	if clusterRole != TkgLabelClusterRoleWorkload || kvlbEnabled == "true" || skipValidation {
 		return nil
 	}
 
@@ -973,7 +973,7 @@ func (c *TkgClient) ValidateAviMaxAllowedClusterNameLength(clusterRole string, o
 	if err != nil {
 		return errors.Wrap(err, "unable to get name and namespace of current management cluster")
 	}
-	akooAddonSecretValues, found, err := GetAKOOAddonSecretValues(regionalClusterClient, mgmtClusterName, options.IsInputFileClusterClassBased)
+	akooAddonSecretValues, found, err := GetAKOOAddonSecretValues(regionalClusterClient, mgmtClusterName, true)
 	if err != nil {
 		return errors.Wrap(err, "unable to get akoo addon secret values")
 	}
@@ -987,8 +987,8 @@ func (c *TkgClient) ValidateAviMaxAllowedClusterNameLength(clusterRole string, o
 		if !utils.IsAviInputEmpty(configValues[constants.ConfigVariableAviLabels]) && aviLabels == "" {
 			return nil
 		}
-		if len(options.ClusterName) > constants.AkoMaxAllowedClusterNameLen {
-			return errors.Errorf("%s is more than %d, which will cause AKO package deployment failure", options.ClusterName, constants.AkoMaxAllowedClusterNameLen)
+		if len(clusterName) > constants.AkoMaxAllowedClusterNameLen {
+			return errors.Errorf("%s contains more than %d character, which will cause AKO package deployment failure", clusterName, constants.AkoMaxAllowedClusterNameLen)
 		}
 	}
 	return nil

--- a/tkg/client/management_components.go
+++ b/tkg/client/management_components.go
@@ -287,7 +287,7 @@ func (c *TkgClient) getUserConfigVariableValueMapFromSecret(clusterClient cluste
 		}
 
 		// retrieve the akoo variables from legacy addon secret.
-		akooAddonSecretValues, found, err := GetAKOOAddonSecretValues(clusterClient, clusterName)
+		akooAddonSecretValues, found, err := GetAKOOAddonSecretValues(clusterClient, clusterName, false)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to get akoo addon secret values")
 		}
@@ -528,8 +528,11 @@ func ProcessAKOPackageInstallFile(akoPackageInstallTemplateDir, userConfigValues
 	return akoPackageInstallFile, nil
 }
 
-func GetAKOOAddonSecretValues(clusterClient clusterclient.Client, clusterName string) ([]byte, bool, error) {
+func GetAKOOAddonSecretValues(clusterClient clusterclient.Client, clusterName string, isClusterClassBased bool) ([]byte, bool, error) {
 	akoOperatorAddonName := fmt.Sprintf("%s-%s-addon", clusterName, constants.AkoOperatorName)
+	if isClusterClassBased {
+		akoOperatorAddonName = fmt.Sprintf("%s-v2-values", constants.AkoOperatorName)
+	}
 	pollOptions := &clusterclient.PollOptions{Interval: clusterclient.CheckResourceInterval, Timeout: 3 * clusterclient.CheckResourceInterval}
 	log.V(6).Infof("trying to fetch akoo addon secret %s/%s", constants.TkgNamespace, akoOperatorAddonName)
 	bytes, err := clusterClient.GetSecretValue(akoOperatorAddonName, "values.yaml", constants.TkgNamespace, pollOptions)

--- a/tkg/client/management_components.go
+++ b/tkg/client/management_components.go
@@ -537,7 +537,7 @@ func GetAKOOAddonSecretValues(clusterClient clusterclient.Client, clusterName st
 	log.V(6).Infof("trying to fetch akoo addon secret %s/%s", constants.TkgNamespace, akoOperatorAddonName)
 	bytes, err := clusterClient.GetSecretValue(akoOperatorAddonName, "values.yaml", constants.TkgNamespace, pollOptions)
 	if err != nil && apierrors.IsNotFound(err) {
-		log.V(6).Infof("akoo addon secret %s/%s not found, akoo was not installed on this legacy management cluster", constants.TkgNamespace, akoOperatorAddonName)
+		log.V(6).Infof("akoo addon secret %s/%s not found, akoo was not installed on this management cluster", constants.TkgNamespace, akoOperatorAddonName)
 		return []byte{}, false, nil
 	} else if err != nil {
 		return []byte{}, false, err

--- a/tkg/client/management_components_test.go
+++ b/tkg/client/management_components_test.go
@@ -367,7 +367,7 @@ var _ = Describe("Unit tests for GetAKOOAddonSecretValues", func() {
 		secretContent = "foo"
 	})
 	JustBeforeEach(func() {
-		bytes, found, err = GetAKOOAddonSecretValues(clusterClient, clusterName)
+		bytes, found, err = GetAKOOAddonSecretValues(clusterClient, clusterName, false)
 	})
 	Describe("When the ako-operator addon secret is not found", func() {
 		BeforeEach(func() {

--- a/tkg/client/upgrade_region.go
+++ b/tkg/client/upgrade_region.go
@@ -266,7 +266,11 @@ func (c *TkgClient) validateAndconfigure(options *UpgradeClusterOptions, regiona
 	}
 
 	if providerType == VSphereProviderName {
-		if akooAddonSecretValues, found, err := GetAKOOAddonSecretValues(regionalClusterClient, clusterName); err != nil {
+		isClusterClassBased, err := regionalClusterClient.IsClusterClassBased(options.ClusterName, options.Namespace)
+		if err != nil {
+			return errors.Wrap(err, "unable to determine cluster type")
+		}
+		if akooAddonSecretValues, found, err := GetAKOOAddonSecretValues(regionalClusterClient, clusterName, isClusterClassBased); err != nil {
 			return errors.Wrap(err, "unable to get akoo addon secret values")
 		} else if found {
 			configValues := make(map[string]interface{})

--- a/tkg/client/validate.go
+++ b/tkg/client/validate.go
@@ -601,7 +601,7 @@ func (c *TkgClient) ConfigureAndValidateManagementClusterConfiguration(options *
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
-	if err = c.ConfigureAndValidateAviConfiguration(); err != nil {
+	if err = c.ConfigureAndValidateAviConfiguration(options.ClusterName); err != nil {
 		return NewValidationError(ValidationErrorCode, err.Error())
 	}
 
@@ -1874,11 +1874,15 @@ func getDockerBridgeNetworkCidr() (string, error) {
 }
 
 // ConfigureAndValidateAviConfiguration validates the configuration inputs of Avi aka. NSX Advanced Load Balancer
-func (c *TkgClient) ConfigureAndValidateAviConfiguration() error {
+func (c *TkgClient) ConfigureAndValidateAviConfiguration(clusterName string) error {
 	aviEnable, _ := c.TKGConfigReaderWriter().Get(constants.ConfigVariableAviEnable)
 	// ignoring error because AVI_ENABLE is an optional configuration
 	if aviEnable == "" || aviEnable == "false" {
 		return nil
+	}
+
+	if len(clusterName) > constants.AkoMaxAllowedClusterNameLen {
+		return errors.Errorf("%s is more than %d, which will cause AKO package deployment failure", clusterName, constants.AkoMaxAllowedClusterNameLen)
 	}
 	// init avi client
 	aviClient := avi.New()

--- a/tkg/client/validate.go
+++ b/tkg/client/validate.go
@@ -1882,7 +1882,7 @@ func (c *TkgClient) ConfigureAndValidateAviConfiguration(clusterName string) err
 	}
 
 	if len(clusterName) > constants.AkoMaxAllowedClusterNameLen {
-		return errors.Errorf("%s is more than %d, which will cause AKO package deployment failure", clusterName, constants.AkoMaxAllowedClusterNameLen)
+		return errors.Errorf("%s contains more than %d character, which will cause AKO package deployment failure", clusterName, constants.AkoMaxAllowedClusterNameLen)
 	}
 	// init avi client
 	aviClient := avi.New()

--- a/tkg/client/validate_test.go
+++ b/tkg/client/validate_test.go
@@ -1208,13 +1208,21 @@ var _ = Describe("Validate", func() {
 			})
 			When("avi is not enabled", func() {
 				It("should skip avi validation", func() {
-					err := tkgClient.ConfigureAndValidateAviConfiguration()
+					err := tkgClient.ConfigureAndValidateAviConfiguration("test-mgmt")
 					Expect(err).ShouldNot(HaveOccurred())
 				})
 				It("should skip avi validation", func() {
 					tkgConfigReaderWriter.Set(constants.ConfigVariableAviEnable, "false")
-					err := tkgClient.ConfigureAndValidateAviConfiguration()
+					err := tkgClient.ConfigureAndValidateAviConfiguration("test-mgmt")
 					Expect(err).ShouldNot(HaveOccurred())
+				})
+			})
+
+			When("avi is enabled", func() {
+				It("should throw error if cluster name is longer than avi max allowed length", func() {
+					tkgConfigReaderWriter.Set(constants.ConfigVariableAviEnable, "true")
+					err := tkgClient.ConfigureAndValidateAviConfiguration("test-mgmt-abcdefghigklmnopqrstuvwxyz")
+					Expect(err).Should(HaveOccurred())
 				})
 			})
 

--- a/tkg/constants/cluster_internal.go
+++ b/tkg/constants/cluster_internal.go
@@ -68,7 +68,7 @@ const (
 	AkoCleanUpAnnotationKey     = "AviObjectDeletionStatus"
 	AkoCleanUpFinishedStatus    = "Done"
 	AkoOperatorName             = "ako-operator"
-	AkoMaxAllowedClusterNameLen = 29
+	AkoMaxAllowedClusterNameLen = 25
 
 	ServiceDNSSuffix             = ".svc"
 	ServiceDNSClusterLocalSuffix = ".svc.cluster.local"

--- a/tkg/constants/cluster_internal.go
+++ b/tkg/constants/cluster_internal.go
@@ -62,12 +62,13 @@ const (
 	CoreManagementPluginsPackageName = "tanzu-core-management-plugins"
 	AKODeploymentName                = "load-balancer-and-ingress-service(ako)"
 
-	AkoStatefulSetName       = "ako"
-	AkoAddonName             = "load-balancer-and-ingress-service"
-	AkoNamespace             = "avi-system"
-	AkoCleanUpAnnotationKey  = "AviObjectDeletionStatus"
-	AkoCleanUpFinishedStatus = "Done"
-	AkoOperatorName          = "ako-operator"
+	AkoStatefulSetName          = "ako"
+	AkoAddonName                = "load-balancer-and-ingress-service"
+	AkoNamespace                = "avi-system"
+	AkoCleanUpAnnotationKey     = "AviObjectDeletionStatus"
+	AkoCleanUpFinishedStatus    = "Done"
+	AkoOperatorName             = "ako-operator"
+	AkoMaxAllowedClusterNameLen = 25
 
 	ServiceDNSSuffix             = ".svc"
 	ServiceDNSClusterLocalSuffix = ".svc.cluster.local"
@@ -159,9 +160,6 @@ const (
 	TKGManagementPackageRepositoryName = "tanzu-management"
 	PackageTypeManagement              = "management"
 )
-
-// AviControllerVersionRegex Avi aka. NSX Advanced LoadBalancer version regex expression
-const AviControllerVersionRegex = `^\d+(\.\d+)*$`
 
 const (
 	TanzuCLISystemNamespace = "tanzu-cli-system"

--- a/tkg/constants/cluster_internal.go
+++ b/tkg/constants/cluster_internal.go
@@ -68,7 +68,7 @@ const (
 	AkoCleanUpAnnotationKey     = "AviObjectDeletionStatus"
 	AkoCleanUpFinishedStatus    = "Done"
 	AkoOperatorName             = "ako-operator"
-	AkoMaxAllowedClusterNameLen = 25
+	AkoMaxAllowedClusterNameLen = 29
 
 	ServiceDNSSuffix             = ".svc"
 	ServiceDNSClusterLocalSuffix = ".svc.cluster.local"

--- a/tkg/managementcomponents/helper.go
+++ b/tkg/managementcomponents/helper.go
@@ -152,7 +152,7 @@ func convertToString(config interface{}) string {
 func convertNodeNetworkList(userProviderConfigValues map[string]interface{}) (string, error) {
 	var nodeNetworkList []NodeNetwork
 	config := userProviderConfigValues[constants.ConfigVariableAviIngressNodeNetworkList]
-	if config == nil || config.(string) == "" || config.(string) == `""` {
+	if utils.IsAviInputEmpty(config) {
 		// return vsphere network if node network list is not set
 		network_pathes := strings.Split(convertToString(userProviderConfigValues[constants.ConfigVariableVsphereNetwork]), "/")
 		network := network_pathes[len(network_pathes)-1]

--- a/tkg/utils/common.go
+++ b/tkg/utils/common.go
@@ -308,3 +308,8 @@ func CompareVersions(v1, cmpSign, v2 string) bool {
 	}
 	return false
 }
+
+// IsAviFieldInputEmpty check if the input is empty or not
+func IsAviInputEmpty(input interface{}) bool {
+	return input == nil || input.(string) == "" || input.(string) == `""`
+}

--- a/tkg/utils/common_test.go
+++ b/tkg/utils/common_test.go
@@ -674,3 +674,40 @@ func Test_CompareVersions(t *testing.T) {
 		})
 	}
 }
+
+func Test_IsAviInputEmpty(t *testing.T) {
+	testCases := []struct {
+		description  string
+		input        interface{}
+		expectResult bool
+	}{
+		{
+			description:  "nil should be considered as empty input",
+			input:        nil,
+			expectResult: true,
+		},
+		{
+			description:  "empty string should be considered as empty input",
+			input:        "",
+			expectResult: true,
+		},
+		{
+			description:  "\"\" should be considered as empty input",
+			input:        `""`,
+			expectResult: true,
+		},
+		{
+			description:  "test should not be considered as empty input",
+			input:        "test",
+			expectResult: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := IsAviInputEmpty(tc.input)
+			if result != tc.expectResult {
+				t.Errorf("IsAviInputEmpty result is not expected")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What this PR does / why we need it

- Because carvel package use `label` instead of `annotation`, so the package name has maximum 64 character limitation, if it exceeds 64, the package deployment will fail.
- This PR checks if the cluster name will cause AKO package deployment fail.
- This is a temp solution, we still need a long-term and generic solution for not only ako package, but all packages.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Tanzu Cli will throw out errors when cluster name length is longer than the max allowed in avi enabled workload cluster.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
