### PR TITLE
Update v2.2 management cluster to support k8s v1.25

### DIFF
--- a/tkg/tkgconfighelper/tkgconfighelper_test.go
+++ b/tkg/tkgconfighelper/tkgconfighelper_test.go
@@ -21,6 +21,7 @@ const (
 	k8sVersion1dot18dot1vmware1  = "v1.18.1+vmware.1"
 	k8sVersion1dot19dot1vmware1  = "v1.19.1+vmware.1"
 	k8sVersion2dot16dot1vmware1  = "v2.16.1+vmware.1"
+	k8sVersion1dot25dot6vmware1  = "v1.25.6+vmware.1"
 	tkgVersion1dot0dot0          = "v1.0.0"
 	tkgVersion1dot1dot0          = "v1.1.0"
 	tkgVersion1dot1dot0rc1       = "v1.1.0-rc.1"
@@ -246,6 +247,16 @@ var _ = Describe("ValidateK8sVersionSupport", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
+		Context("mgmtClusterVersion= v2.2.0, kubernetesVersion=v1.25.6+vmware.1", func() {
+			BeforeEach(func() {
+				mgmtClusterVersion = "v2.2.0"
+				kubernetesVersion = k8sVersion1dot25dot6vmware1
+			})
+			It("should not return error", func() {
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
 	})
 })
 

--- a/tkg/tkgconfighelper/validate.go
+++ b/tkg/tkgconfighelper/validate.go
@@ -24,7 +24,7 @@ var ManagementClusterVersionToK8sVersionSupportMatrix = map[string][]string{
 	"v1.6": {"v1.20", "v1.21", "v1.22", "v1.23"},
 	"v1.7": {"v1.21", "v1.22", "v1.23", "v1.24"},
 	"v2.1": {"v1.21", "v1.22", "v1.23", "v1.24"},
-	"v2.2": {"v1.21", "v1.22", "v1.23", "v1.24"},
+	"v2.2": {"v1.21", "v1.22", "v1.23", "v1.24", "v1.25"},
 }
 
 // ValidateK8sVersionSupport validates the k8s version is supported on management cluster or not


### PR DESCRIPTION
### What this PR does / why we need it
This is to unblock the update of tkg bom with tkr 1.25.6, the tests are failing for it with statement : 
`Error: workload cluster configuration validation failed: kubernetes version v1.25.6+vmware.1 is not supported on current v2.2.0-zshippable management cluster. ` 
This PR will update 2.2 management cluster version to support k8s v1.25 
### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
