### PR TITLE
workflow: Update condition for notification on PR

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Notify release-0.28 cherry-pick status
     needs: [cherry_pick_release_v0_28]
-    if: always()
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'cherry-pick/release-0.28') && github.event.pull_request.merged == true }}
     steps:
       - id: check
         uses: martialonline/workflow-status@v3


### PR DESCRIPTION
### What this PR does / why we need it
The notification job in cherry-pick workflow should only be triggered if the cherry pick label was set and the MR was merged.

Currently notification job is running and posting messages for every PR merges even if the cherry-pick label wasnt set, see https://github.com/vmware-tanzu/tanzu-framework/pull/4425#issuecomment-1442147331

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

- when cherry-pick status message shouldn't be posted (no cherry-pick label): https://github.com/navidshaikh/tanzu-framework/pull/38
- when cherry-pick status message should be posted (cherry-pick label): https://github.com/navidshaikh/tanzu-framework/pull/39#issuecomment-1442371663

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
