### PR TITLE
[release-0.28] cherry-pick #4415: return error if context canceled during getting virtual machine image…

### DIFF
--- a/tkg/vc/client.go
+++ b/tkg/vc/client.go
@@ -697,6 +697,9 @@ func (c *DefaultClient) GetVirtualMachineImages(ctx context.Context, datacenterM
 		if ovaVersion, distroName, distroVersion, distroArch := c.getVMMetadata(&vms[i]); ovaVersion != "" {
 			path, _, err := c.GetPath(ctx, vms[i].Self.Value)
 			if err != nil {
+				if ctx.Err() != nil {
+					return results, err
+				}
 				continue
 			}
 			obj := &tkgtypes.VSphereVirtualMachine{

--- a/tkg/vsphere-template-resolver/templateresolver/resolver_impl.go
+++ b/tkg/vsphere-template-resolver/templateresolver/resolver_impl.go
@@ -38,6 +38,7 @@ func (r *Resolver) GetVSphereEndpoint(svrContext *VSphereContext) (vc.Client, er
 	vcURL.Path = "/sdk"
 
 	r.Log.Info(fmt.Sprintf("Creating client with endpoint: %v", vcURL))
+	// TODO: setup a cache to reuse vc sessions
 	vcClient, err := vc.NewClient(vcURL, svrContext.TLSThumbprint, svrContext.InsecureSkipVerify)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create vc client")


### PR DESCRIPTION
…s (#4415)

if context deadline exceeded when retrieving vm metadata

we need correct error message instead of partially retrieving results (cherry picked from commit e403941f731d00b6cbb144257138175480c6f6a1)

cherry-picked https://github.com/vmware-tanzu/tanzu-framework/pull/4415

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
