### PR TITLE
Fix issue when a custom image repository uses a public cert

### DIFF
--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
@@ -896,12 +896,6 @@ spec:
         value: systemctl daemon-reload
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl stop containerd
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl start containerd
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
         valueFrom:
           template: &exportHTTPProxy |
             export HTTP_PROXY= {{- .proxy.httpProxy }}
@@ -936,9 +930,6 @@ spec:
         value: systemctl daemon-reload
       - op: add
         path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
         valueFrom:
           template: *exportHTTPProxy
       - op: add
@@ -967,9 +958,6 @@ spec:
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
         value: '! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)'
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
@@ -1001,9 +989,6 @@ spec:
       - op: add
         path: /spec/template/spec/preKubeadmCommands/-
         value: '! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)'
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/files/-
         valueFrom:
@@ -1076,9 +1061,6 @@ spec:
             {{- end }}
             {{- template "echo" $val -}}
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl restart containerd
-      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
           template: |
@@ -1125,9 +1107,6 @@ spec:
               echo '  {{ . -}} ' >> /etc/containerd/config.toml
             {{- end }}
             {{- template "echo" $val -}}
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/files/-
         valueFrom:

--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/overlay.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/overlay.yaml
@@ -51,3 +51,27 @@ spec:
         matchResources:
           controlPlane: true
     name: KCP_INIT_APISERVER_EMPTY_EXTRAVOLUMES_ARRAY
+  #@overlay/append
+  - name: restartContainerdService
+    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host)) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: systemctl restart containerd
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/preKubeadmCommands/-
+        value: systemctl restart containerd

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -1232,12 +1232,6 @@ spec:
         value: systemctl daemon-reload
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl stop containerd
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl start containerd
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
         valueFrom:
           template: &exportHTTPProxy |
             export HTTP_PROXY= {{- .proxy.httpProxy }}
@@ -1272,9 +1266,6 @@ spec:
         value: systemctl daemon-reload
       - op: add
         path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
         valueFrom:
           template: *exportHTTPProxy
       - op: add
@@ -1303,9 +1294,6 @@ spec:
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
         value: '! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)'
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
@@ -1337,9 +1325,6 @@ spec:
       - op: add
         path: /spec/template/spec/preKubeadmCommands/-
         value: '! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)'
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/files/-
         valueFrom:
@@ -1412,9 +1397,6 @@ spec:
             {{- end }}
             {{- template "echo" $val -}}
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl restart containerd
-      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
           template: |
@@ -1461,9 +1443,6 @@ spec:
               echo '  {{ . -}} ' >> /etc/containerd/config.toml
             {{- end }}
             {{- template "echo" $val -}}
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/files/-
         valueFrom:

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/overlay.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/overlay.yaml
@@ -51,6 +51,30 @@ spec:
         matchResources:
           controlPlane: true
     name: KCP_INIT_APISERVER_EMPTY_EXTRAVOLUMES_ARRAY
+  #@overlay/append
+  - name: restartContainerdService
+    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host)) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: systemctl restart containerd
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/preKubeadmCommands/-
+        value: systemctl restart containerd
 
 #@overlay/match by=overlay.subset({"kind":"KubeadmConfigTemplate"}),expects="1+"
 ---

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -1487,12 +1487,6 @@ spec:
         value: systemctl daemon-reload
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl stop containerd
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl start containerd
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
         valueFrom:
           template: &exportHTTPProxy |
             export HTTP_PROXY= {{- .proxy.httpProxy }}
@@ -1527,9 +1521,6 @@ spec:
         value: systemctl daemon-reload
       - op: add
         path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
         valueFrom:
           template: *exportHTTPProxy
       - op: add
@@ -1558,9 +1549,6 @@ spec:
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
         value: '! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)'
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
@@ -1592,9 +1580,6 @@ spec:
       - op: add
         path: /spec/template/spec/preKubeadmCommands/-
         value: '! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)'
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/files/-
         valueFrom:
@@ -1667,9 +1652,6 @@ spec:
             {{- end }}
             {{- template "echo" $val -}}
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl restart containerd
-      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
           template: |
@@ -1716,9 +1698,6 @@ spec:
               echo '  {{ . -}} ' >> /etc/containerd/config.toml
             {{- end }}
             {{- template "echo" $val -}}
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/files/-
         valueFrom:

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/overlay.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/overlay.yaml
@@ -69,3 +69,27 @@ spec:
         matchResources:
           controlPlane: true
     name: KCP_INIT_APISERVER_EMPTY_EXTRAVOLUMES_ARRAY
+  #@overlay/append
+  - name: restartContainerdService
+    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host)) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: systemctl restart containerd
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/preKubeadmCommands/-
+        value: systemctl restart containerd

--- a/providers/infrastructure-aws/v2.0.2/cconly/base.yaml
+++ b/providers/infrastructure-aws/v2.0.2/cconly/base.yaml
@@ -896,12 +896,6 @@ spec:
         value: systemctl daemon-reload
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl stop containerd
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl start containerd
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
         valueFrom:
           template: &exportHTTPProxy |
             export HTTP_PROXY= {{- .proxy.httpProxy }}
@@ -936,9 +930,6 @@ spec:
         value: systemctl daemon-reload
       - op: add
         path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
         valueFrom:
           template: *exportHTTPProxy
       - op: add
@@ -967,9 +958,6 @@ spec:
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
         value: '! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)'
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
@@ -1001,9 +989,6 @@ spec:
       - op: add
         path: /spec/template/spec/preKubeadmCommands/-
         value: '! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)'
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/files/-
         valueFrom:
@@ -1076,9 +1061,6 @@ spec:
             {{- end }}
             {{- template "echo" $val -}}
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl restart containerd
-      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
           template: |
@@ -1125,9 +1107,6 @@ spec:
               echo '  {{ . -}} ' >> /etc/containerd/config.toml
             {{- end }}
             {{- template "echo" $val -}}
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/files/-
         valueFrom:

--- a/providers/infrastructure-aws/v2.0.2/cconly/overlay.yaml
+++ b/providers/infrastructure-aws/v2.0.2/cconly/overlay.yaml
@@ -51,3 +51,27 @@ spec:
         matchResources:
           controlPlane: true
     name: KCP_INIT_APISERVER_EMPTY_EXTRAVOLUMES_ARRAY
+  #@overlay/append
+  - name: restartContainerdService
+    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host)) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: systemctl restart containerd
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/preKubeadmCommands/-
+        value: systemctl restart containerd

--- a/providers/infrastructure-azure/v1.6.1/cconly/base.yaml
+++ b/providers/infrastructure-azure/v1.6.1/cconly/base.yaml
@@ -1232,12 +1232,6 @@ spec:
         value: systemctl daemon-reload
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl stop containerd
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl start containerd
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
         valueFrom:
           template: &exportHTTPProxy |
             export HTTP_PROXY= {{- .proxy.httpProxy }}
@@ -1272,9 +1266,6 @@ spec:
         value: systemctl daemon-reload
       - op: add
         path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
         valueFrom:
           template: *exportHTTPProxy
       - op: add
@@ -1303,9 +1294,6 @@ spec:
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
         value: '! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)'
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
@@ -1337,9 +1325,6 @@ spec:
       - op: add
         path: /spec/template/spec/preKubeadmCommands/-
         value: '! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)'
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/files/-
         valueFrom:
@@ -1412,9 +1397,6 @@ spec:
             {{- end }}
             {{- template "echo" $val -}}
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl restart containerd
-      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
           template: |
@@ -1461,9 +1443,6 @@ spec:
               echo '  {{ . -}} ' >> /etc/containerd/config.toml
             {{- end }}
             {{- template "echo" $val -}}
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/files/-
         valueFrom:

--- a/providers/infrastructure-azure/v1.6.1/cconly/overlay.yaml
+++ b/providers/infrastructure-azure/v1.6.1/cconly/overlay.yaml
@@ -51,6 +51,30 @@ spec:
         matchResources:
           controlPlane: true
     name: KCP_INIT_APISERVER_EMPTY_EXTRAVOLUMES_ARRAY
+  #@overlay/append
+  - name: restartContainerdService
+    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host)) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: systemctl restart containerd
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/preKubeadmCommands/-
+        value: systemctl restart containerd
 
 #@overlay/match by=overlay.subset({"kind":"KubeadmConfigTemplate"}),expects="1+"
 ---

--- a/providers/infrastructure-vsphere/v1.5.3/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.3/cconly/base.yaml
@@ -1487,12 +1487,6 @@ spec:
         value: systemctl daemon-reload
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl stop containerd
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl start containerd
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
         valueFrom:
           template: &exportHTTPProxy |
             export HTTP_PROXY= {{- .proxy.httpProxy }}
@@ -1527,9 +1521,6 @@ spec:
         value: systemctl daemon-reload
       - op: add
         path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
         valueFrom:
           template: *exportHTTPProxy
       - op: add
@@ -1558,9 +1549,6 @@ spec:
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
         value: '! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)'
-      - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
@@ -1592,9 +1580,6 @@ spec:
       - op: add
         path: /spec/template/spec/preKubeadmCommands/-
         value: '! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt && update-ca-trust extract)'
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/files/-
         valueFrom:
@@ -1667,9 +1652,6 @@ spec:
             {{- end }}
             {{- template "echo" $val -}}
       - op: add
-        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
-        value: systemctl restart containerd
-      - op: add
         path: /spec/template/spec/kubeadmConfigSpec/files/-
         valueFrom:
           template: |
@@ -1716,9 +1698,6 @@ spec:
               echo '  {{ . -}} ' >> /etc/containerd/config.toml
             {{- end }}
             {{- template "echo" $val -}}
-      - op: add
-        path: /spec/template/spec/preKubeadmCommands/-
-        value: systemctl restart containerd
       - op: add
         path: /spec/template/spec/files/-
         valueFrom:

--- a/providers/infrastructure-vsphere/v1.5.3/cconly/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.5.3/cconly/overlay.yaml
@@ -69,3 +69,27 @@ spec:
         matchResources:
           controlPlane: true
     name: KCP_INIT_APISERVER_EMPTY_EXTRAVOLUMES_ARRAY
+  #@overlay/append
+  - name: restartContainerdService
+    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host)) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: systemctl restart containerd
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/preKubeadmCommands/-
+        value: systemctl restart containerd


### PR DESCRIPTION
When a custom image repository uses a public cert, we don't restart containerd service so configurations of the image repository does not take effect.

Since containerd configurations will change and need restart in the following cases, add a patch for restarting it only once.
1. There is a proxy in an air-gaped environment.
2. There is a custom image repository for tkg.
3. There is a custom image repository for user's workload.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR
Validate `preKubeadmCommands` output of KubeadmControlPlane and KubeadmConfigTemplate with dry-run `clusterctl alpha topology plan`:

1. Without variables imageRepository, trust or proxy:
```
    preKubeadmCommands:
    - hostname "{{ ds.meta_data.hostname }}"
    - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
    - echo "127.0.0.1   localhost" >>/etc/hosts
    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
```
2. Set variable imageRepository but without variable trust
```
    - name: imageRepository
      value:
        host: airgap-180-10-10-15.eng.vmware.com/registry
```
output:
```
    preKubeadmCommands:
    - hostname "{{ ds.meta_data.hostname }}"
    - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
    - echo "127.0.0.1   localhost" >>/etc/hosts
    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
    - sed -i 's|".*/pause|"airgap-180-10-10-15.eng.vmware.com/registry/pause|' /etc/containerd/config.toml
    - systemctl restart containerd
```
3. Set both variables imageRepository and trust:
```
    - name: imageRepository
      value:
        host: airgap-180-10-10-15.eng.vmware.com/registry
    - name: trust
      value:
        additionalTrustedCAs:
        - data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM2akNDQWRLZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJek1ESXlNekF6TWprek1Gb1hEVE16TURJeU1EQXpNelF6TUZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTDBvCjlTVVNFL1NPeHBFbDR3S21JUlhXM2lrMHRPODhJbjVURndEOU9OYUgwSEUxdmU0TS9zVGQxY2FlOEZMVDRCaTkKWHNYUTg2N2dTTmZWMHJCUnMvcU41REJ5ZjMydVFzU2tPU1FaUkY5QXZhTUZQaFM1RFFJRmI4WnhnY24vdzRaMQppZEZLYkxVWmNhcSsyQjJ3MG8wNU40YWw1cFZHOWNKWENwcGEwMVl6eFFUV0kzSDZEOW5Kb0JINVR2OU1uZ1AyCnlUNThNbmlEcHl6UTgxZlZyaGp4aldYWjhPeFJBc01zckhSemxRVmhpMFJ0U1VldllBYmVXNTJEUnNRTkF4NzEKd1BJYWdHd0VoT1Z1a3lBai9JS3h1VEtXOFVVclUxNExWNVpCRjlBSm1wbEJjUlY4OVhqeitzVzhhTUQ1QlU3SgpFa2dyRldqc21rYU9TR1hQallrQ0F3RUFBYU5GTUVNd0RnWURWUjBQQVFIL0JBUURBZ0trTUJJR0ExVWRFd0VCCi93UUlNQVlCQWY4Q0FRQXdIUVlEVlIwT0JCWUVGT2R4OGUxbnNac0Z1VzdiVjVKeGcrRi8wdm9ZTUEwR0NTcUcKU0liM0RRRUJDd1VBQTRJQkFRQnpsbDlNZDY3Yy9OcEFHZFprMjd1M3VxMElpbENrQk1XWEI1V1FXcDdha3YzegpOcTExYTdodVQyVGRUUEhCUURGWlhtemd6NitUSXJSWG9zNnhwbmlaODhNYVZ3aXc1Njl3cG56OWYvOWNtalBMCjRtYktRcXJ6ZStuWVpNUjA3Q1lGQmRxOHZ6NnB1c0RhN3VmRjlRVnBzUmN3bUlPVE1OWW9DZ0xSMStHV29mMlcKWDFvMkVGYWttMHBDSTNUSGt6SHQvZFo5cFZWUnlPeVRvdml0dUFCd0gzTE9IMmY5am8yd2RSSHZvRndtR014UQpwb2d1RmVDL091TGRiTklkcVFYRkVMeGx6eEVHMElMdkY4R2dOOFpGZmRsT2VoSVo3bFYvSHFFQlllcEl6YzkyCmdjaVhGSmh2VEF1YzMzaFk4TVVsb2I0cWZHSkdXRGtwSnI2dTl6WUwKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
          name: imageRepository
```
Output:
```
    preKubeadmCommands:
    - hostname "{{ ds.meta_data.hostname }}"
    - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
    - echo "127.0.0.1   localhost" >>/etc/hosts
    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
    - sed -i 's|".*/pause|"airgap-180-10-10-15.eng.vmware.com/registry/pause|' /etc/containerd/config.toml
    - echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."airgap-180-10-10-15.eng.vmware.com".tls]'
      >> /etc/containerd/config.toml
    - echo '  ca_file = "/etc/containerd/airgap-180-10-10-15.eng.vmware.com.crt"'
      >> /etc/containerd/config.toml
    - systemctl restart containerd
```
4. Set both variables proxy and trust:
```
    - name: proxy
      value:
        httpProxy: http://proxy.vmware.com:3128
        httpsProxy: http://proxy.vmware.com:3128
        noProxy:
        - localhost
        - 127.0.0.1
        - 100.64.0.0/13
        - 100.96.0.0/11
        - 10.161.100.232
        - 10.161.101.251
        - .svc.cluster.local
        - .svc
        systemWide: false
    - name: trust
      value:
        additionalTrustedCAs:
        - data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM2akNDQWRLZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJek1ESXlNekF6TWprek1Gb1hEVE16TURJeU1EQXpNelF6TUZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTDBvCjlTVVNFL1NPeHBFbDR3S21JUlhXM2lrMHRPODhJbjVURndEOU9OYUgwSEUxdmU0TS9zVGQxY2FlOEZMVDRCaTkKWHNYUTg2N2dTTmZWMHJCUnMvcU41REJ5ZjMydVFzU2tPU1FaUkY5QXZhTUZQaFM1RFFJRmI4WnhnY24vdzRaMQppZEZLYkxVWmNhcSsyQjJ3MG8wNU40YWw1cFZHOWNKWENwcGEwMVl6eFFUV0kzSDZEOW5Kb0JINVR2OU1uZ1AyCnlUNThNbmlEcHl6UTgxZlZyaGp4aldYWjhPeFJBc01zckhSemxRVmhpMFJ0U1VldllBYmVXNTJEUnNRTkF4NzEKd1BJYWdHd0VoT1Z1a3lBai9JS3h1VEtXOFVVclUxNExWNVpCRjlBSm1wbEJjUlY4OVhqeitzVzhhTUQ1QlU3SgpFa2dyRldqc21rYU9TR1hQallrQ0F3RUFBYU5GTUVNd0RnWURWUjBQQVFIL0JBUURBZ0trTUJJR0ExVWRFd0VCCi93UUlNQVlCQWY4Q0FRQXdIUVlEVlIwT0JCWUVGT2R4OGUxbnNac0Z1VzdiVjVKeGcrRi8wdm9ZTUEwR0NTcUcKU0liM0RRRUJDd1VBQTRJQkFRQnpsbDlNZDY3Yy9OcEFHZFprMjd1M3VxMElpbENrQk1XWEI1V1FXcDdha3YzegpOcTExYTdodVQyVGRUUEhCUURGWlhtemd6NitUSXJSWG9zNnhwbmlaODhNYVZ3aXc1Njl3cG56OWYvOWNtalBMCjRtYktRcXJ6ZStuWVpNUjA3Q1lGQmRxOHZ6NnB1c0RhN3VmRjlRVnBzUmN3bUlPVE1OWW9DZ0xSMStHV29mMlcKWDFvMkVGYWttMHBDSTNUSGt6SHQvZFo5cFZWUnlPeVRvdml0dUFCd0gzTE9IMmY5am8yd2RSSHZvRndtR014UQpwb2d1RmVDL091TGRiTklkcVFYRkVMeGx6eEVHMElMdkY4R2dOOFpGZmRsT2VoSVo3bFYvSHFFQlllcEl6YzkyCmdjaVhGSmh2VEF1YzMzaFk4TVVsb2I0cWZHSkdXRGtwSnI2dTl6WUwKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
          name: proxy
```
Output
```
    preKubeadmCommands:
    - hostname "{{ ds.meta_data.hostname }}"
    - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
    - echo "127.0.0.1   localhost" >>/etc/hosts
    - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
    - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
    - systemctl daemon-reload
    - export HTTP_PROXY=http://proxy.vmware.com:3128
    - export HTTPS_PROXY=http://proxy.vmware.com:3128
    - export NO_PROXY=.svc,.svc.cluster.local,10.161.100.232,10.161.101.251,100.64.0.0/13,100.96.0.0/11,127.0.0.1,localhost
    - '! which rehash_ca_certificates.sh 2>/dev/null || rehash_ca_certificates.sh'
    - '! which update-ca-certificates 2>/dev/null || (mv /etc/ssl/certs/tkg-custom-ca.pem
      /usr/local/share/ca-certificates/tkg-custom-ca.crt && update-ca-certificates)'
    - '! which update-ca-trust 2>/dev/null || (update-ca-trust force-enable && mv
      /etc/ssl/certs/tkg-custom-ca.pem /etc/pki/ca-trust/source/anchors/tkg-custom-ca.crt
      && update-ca-trust extract)'
    - echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."projects.registry.vmware.com".tls]'
      >> /etc/containerd/config.toml
    - echo '  ca_file = "/etc/containerd/projects.registry.vmware.com.crt"' >> /etc/containerd/config.toml
    - systemctl restart containerd
```
5. Set variable proxy without variable trust:
```
    - name: proxy
      value:
        httpProxy: http://proxy.vmware.com:3128
        httpsProxy: http://proxy.vmware.com:3128
        noProxy:
        - localhost
        - 127.0.0.1
        - 100.64.0.0/13
        - 100.96.0.0/11
        - 10.161.100.232
        - 10.161.101.251
        - .svc.cluster.local
        - .svc
        systemWide: false
```
Output:
```
      preKubeadmCommands:
      - hostname "{{ ds.meta_data.hostname }}"
      - echo "::1         ipv6-localhost ipv6-loopback" >/etc/hosts
      - echo "127.0.0.1   localhost" >>/etc/hosts
      - echo "127.0.0.1   {{ ds.meta_data.hostname }}" >>/etc/hosts
      - echo "{{ ds.meta_data.hostname }}" >/etc/hostname
      - systemctl daemon-reload
      - export HTTP_PROXY=http://proxy.vmware.com:3128
      - export HTTPS_PROXY=http://proxy.vmware.com:3128
      - export NO_PROXY=.svc,.svc.cluster.local,10.161.100.232,10.161.101.251,100.64.0.0/13,100.96.0.0/11,127.0.0.1,localhost
      - systemctl restart containerd
```

Validated end to end scenario against a private image registry with a public CA. Replicated tkg images and set:
```
TKG_CUSTOM_IMAGE_REPOSITORY: "demo.goharbor.io/yifengx/tkg"
```
After creation, ssh into a kcp node and check all images are pulled from `demo.goharbor.io/yifengx/tkg`.
```
root [ /home/capv ]# crictl img
IMAGE                                                             TAG                 IMAGE ID            SIZE
demo.goharbor.io/yifengx/tkg/coredns                              v1.8.6_vmware.17    2080efe54ba09       45.4MB
projects.registry.vmware.com/tkg/coredns                          v1.8.6_vmware.17    2080efe54ba09       45.4MB
demo.goharbor.io/yifengx/tkg/etcd                                 v3.5.6_vmware.6     6a31078ac246d       142MB
projects.registry.vmware.com/tkg/etcd                             v3.5.6_vmware.6     6a31078ac246d       142MB
demo.goharbor.io/yifengx/tkg/kube-apiserver                       v1.24.10_vmware.1   a2c4fa6e9953c       132MB
projects.registry.vmware.com/tkg/kube-apiserver                   v1.24.10_vmware.1   a2c4fa6e9953c       132MB
demo.goharbor.io/yifengx/tkg/kube-controller-manager              v1.24.10_vmware.1   3b6a0326db74b       121MB
projects.registry.vmware.com/tkg/kube-controller-manager          v1.24.10_vmware.1   3b6a0326db74b       121MB
demo.goharbor.io/yifengx/tkg/kube-proxy                           v1.24.10_vmware.1   8fb893605b99d       112MB
projects.registry.vmware.com/tkg/kube-proxy                       v1.24.10_vmware.1   8fb893605b99d       112MB
demo.goharbor.io/yifengx/tkg/kube-scheduler                       v1.24.10_vmware.1   729c30aa723e9       52.8MB
projects.registry.vmware.com/tkg/kube-scheduler                   v1.24.10_vmware.1   729c30aa723e9       52.8MB
demo.goharbor.io/yifengx/tkg/kube-vip                             v0.5.7_vmware.1     f682f68cf3413       14.5MB
demo.goharbor.io/yifengx/tkg/packages/core/kapp-controller        <none>              9ff7de533f9af       260MB
demo.goharbor.io/yifengx/tkg/pause                                3.7                 8e1f3511424e2       747kB
projects.registry.vmware.com/tkg/pause                            3.7                 8e1f3511424e2       747kB
demo.goharbor.io/yifengx/tkg/tkr-repository-vsphere-nonparavirt   <none>              f67ca4354a9ea       12.1MB
demo.goharbor.io/yifengx/tkg/tkr-repository-vsphere-nonparavirt   <none>              df9a14f16b755       109MB
demo.goharbor.io/yifengx/tkg/tkr-repository-vsphere-nonparavirt   <none>              555238bb3354f       12MB
demo.goharbor.io/yifengx/tkg/tkr-repository-vsphere-nonparavirt   <none>              103ddb144c969       5.39MB
demo.goharbor.io/yifengx/tkg/tkr-repository-vsphere-nonparavirt   <none>              2b60724b1a4a7       50.5MB
demo.goharbor.io/yifengx/tkg/tkr-repository-vsphere-nonparavirt   <none>              edfd5fffe507d       4.92MB
demo.goharbor.io/yifengx/tkg/tkr-repository-vsphere-nonparavirt   <none>              97ccd96cd3b5a       12MB
demo.goharbor.io/yifengx/tkg/tkr-repository-vsphere-nonparavirt   <none>              b177502a556d4       13.8MB
demo.goharbor.io/yifengx/tkg/tkr-repository-vsphere-nonparavirt   <none>              6ed4425bfdd10       250MB
demo.goharbor.io/yifengx/tkg/tkr-repository-vsphere-nonparavirt   <none>              ef9eb4aa695d6       17.5MB
demo.goharbor.io/yifengx/tkg/tkr-repository-vsphere-nonparavirt   <none>              28591a73301ac       23.5MB
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
