### PR TITLE
Omits PCI related params from tkg vsphere config

### DIFF
--- a/providers/yttcc/lib/config_variable_association.star
+++ b/providers/yttcc/lib/config_variable_association.star
@@ -902,7 +902,7 @@ def get_vsphere_vars():
     if data.values["VSPHERE_CONTROL_PLANE_MEM_MIB"] != "":
         machine["memoryMiB"] = data.values["VSPHERE_CONTROL_PLANE_MEM_MIB"]
     end
-    if data.values["VSPHERE_CONTROL_PLANE_CUSTOM_VMX_KEYS"] != None:
+    if data.values["VSPHERE_CONTROL_PLANE_CUSTOM_VMX_KEYS"] != None and data.values["VSPHERE_CONTROL_PLANE_CUSTOM_VMX_KEYS"] != "":
         machine["customVMXKeys"] = get_custom_keys(data.values["VSPHERE_CONTROL_PLANE_CUSTOM_VMX_KEYS"])
     end
     if machine != {}:
@@ -942,7 +942,7 @@ def get_vsphere_vars():
     if data.values["VSPHERE_WORKER_MEM_MIB"] != "":
         machine["memoryMiB"] = data.values["VSPHERE_WORKER_MEM_MIB"]
     end
-    if data.values["VSPHERE_WORKER_CUSTOM_VMX_KEYS"] != None:
+    if data.values["VSPHERE_WORKER_CUSTOM_VMX_KEYS"] != None and data.values["VSPHERE_WORKER_CUSTOM_VMX_KEYS"] != "":
         machine["customVMXKeys"] = get_custom_keys(data.values["VSPHERE_WORKER_CUSTOM_VMX_KEYS"])
     end
     if machine != {}:
@@ -986,10 +986,10 @@ def get_vsphere_vars():
 
     pci = {}
     pciControlPlane = {}
-    if data.values["VSPHERE_CONTROL_PLANE_PCI_DEVICES"] != None:
+    if data.values["VSPHERE_CONTROL_PLANE_PCI_DEVICES"] != None and data.values["VSPHERE_CONTROL_PLANE_PCI_DEVICES"] != "":
         pciControlPlane["devices"] = get_pci_devices(data.values["VSPHERE_CONTROL_PLANE_PCI_DEVICES"], data.values["VSPHERE_IGNORE_PCI_DEVICES_ALLOW_LIST"])
     end
-    if data.values["VSPHERE_CONTROL_PLANE_HARDWARE_VERSION"] != None:
+    if data.values["VSPHERE_CONTROL_PLANE_HARDWARE_VERSION"] != None and data.values["VSPHERE_CONTROL_PLANE_HARDWARE_VERSION"] != "":
         pciControlPlane["hardwareVersion"] = data.values["VSPHERE_CONTROL_PLANE_HARDWARE_VERSION"]
     end
     if pciControlPlane != {}:
@@ -997,10 +997,10 @@ def get_vsphere_vars():
     end
 
     pciWorker = {}
-    if data.values["VSPHERE_WORKER_PCI_DEVICES"] != None:
+    if data.values["VSPHERE_WORKER_PCI_DEVICES"] != None and data.values["VSPHERE_WORKER_PCI_DEVICES"] != "":
         pciWorker["devices"] = get_pci_devices(data.values["VSPHERE_WORKER_PCI_DEVICES"], data.values["VSPHERE_IGNORE_PCI_DEVICES_ALLOW_LIST"])
     end
-    if data.values["VSPHERE_WORKER_HARDWARE_VERSION"] != None:
+    if data.values["VSPHERE_WORKER_HARDWARE_VERSION"] != None and data.values["VSPHERE_WORKER_HARDWARE_VERSION"] != "":
         pciWorker["hardwareVersion"] = data.values["VSPHERE_WORKER_HARDWARE_VERSION"]
     end
     if pciWorker != {}:

--- a/tkg/tkgconfigproviders/vsphere.go
+++ b/tkg/tkgconfigproviders/vsphere.go
@@ -91,14 +91,14 @@ type VSphereConfig struct {
 	AviManagementClusterVipNetworkCidr             string `yaml:"AVI_MANAGEMENT_CLUSTER_VIP_NETWORK_CIDR"`
 	AviManagementClusterControlPlaneVipNetworkName string `yaml:"AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_NAME"`
 	AviManagementClusterControlPlaneVipNetworkCIDR string `yaml:"AVI_MANAGEMENT_CLUSTER_CONTROL_PLANE_VIP_NETWORK_CIDR"`
-	VSphereWorkerPCIDevices                        string `yaml:"VSPHERE_WORKER_PCI_DEVICES"`
-	VSphereControlPlanePCIDevices                  string `yaml:"VSPHERE_CONTROL_PLANE_PCI_DEVICES"`
+	VSphereWorkerPCIDevices                        string `yaml:"VSPHERE_WORKER_PCI_DEVICES,omitempty"`
+	VSphereControlPlanePCIDevices                  string `yaml:"VSPHERE_CONTROL_PLANE_PCI_DEVICES,omitempty"`
 	WorkerRolloutStrategy                          string `yaml:"WORKER_ROLLOUT_STRATEGY"`
-	VSphereControlPlaneCustomVMXKeys               string `yaml:"VSPHERE_CONTROL_PLANE_CUSTOM_VMX_KEYS"`
-	VSphereWorkerCustomVMXKeys                     string `yaml:"VSPHERE_WORKER_CUSTOM_VMX_KEYS"`
-	VSphereIgnorePCIDevicesAllowList               string `yaml:"VSPHERE_IGNORE_PCI_DEVICES_ALLOW_LIST"`
-	VSphereControlPlaneHardwareVersion             string `yaml:"VSPHERE_CONTROL_PLANE_HARDWARE_VERSION"`
-	VSphereWorkerHardwareVersion                   string `yaml:"VSPHERE_WORKER_HARDWARE_VERSION"`
+	VSphereControlPlaneCustomVMXKeys               string `yaml:"VSPHERE_CONTROL_PLANE_CUSTOM_VMX_KEYS,omitempty"`
+	VSphereWorkerCustomVMXKeys                     string `yaml:"VSPHERE_WORKER_CUSTOM_VMX_KEYS,omitempty"`
+	VSphereIgnorePCIDevicesAllowList               string `yaml:"VSPHERE_IGNORE_PCI_DEVICES_ALLOW_LIST,omitempty"`
+	VSphereControlPlaneHardwareVersion             string `yaml:"VSPHERE_CONTROL_PLANE_HARDWARE_VERSION,omitempty"`
+	VSphereWorkerHardwareVersion                   string `yaml:"VSPHERE_WORKER_HARDWARE_VERSION,omitempty"`
 	IDPConfig                                      `yaml:",inline"`
 	OsInfo                                         `yaml:",inline"`
 }


### PR DESCRIPTION
### What this PR does / why we need it
Omits the PCI and VMX related keys from the VSphere configuration used for management and workload cluster creation. This also implements a stricter validation on the PCI and VMX parameters such that empty string values are also discarded.

### Which issue(s) this PR fixes
Fixes #

### Describe testing done for PR
- Management cluster creation via the installer UI
- Management cluster creation via the CLI 
- Workload cluster creation via the CLI
- GPU Workload cluster creation via the CLI

### Release note
```release-note
NONE
```
