### PR TITLE
Fix tanzu-auth-controller user to refer by id instead of name and fix psa profile

### DIFF
--- a/packages/tanzu-auth/bundle/config/namespace.yaml
+++ b/packages/tanzu-auth/bundle/config/namespace.yaml
@@ -6,4 +6,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: #@ data.values.namespace
+  labels:
+    #@ if/end data.values.deployment.hostNetwork:
+    pod-security.kubernetes.io/enforce: privileged
 #@ end

--- a/pinniped-components/tanzu-auth-controller-manager/Dockerfile
+++ b/pinniped-components/tanzu-auth-controller-manager/Dockerfile
@@ -38,5 +38,5 @@ RUN --mount=type=cache,target=/root/.cache/go-build --mount=type=cache,target=/r
 FROM $DISTROLESS_BASE_IMAGE
 WORKDIR /
 COPY --from=builder /workspace/tanzu-auth-controller-manager .
-USER nonroot:nonroot
+USER 65532:65532
 ENTRYPOINT ["/tanzu-auth-controller-manager"]


### PR DESCRIPTION
### What this PR does / why we need it

Kubernetes is only able to detect runAsNonroot if either the given user in the image is referred by id or by specifying the user id directly in the pod spec.

Also, if `hostNetwork: true` is set, the pod security profile used will be privilege. Because of that I added the required label to the namespace so the workload does not get blocked by cluster-wide configuration.

Follow-up for #4451

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
