### PR TITLE
Support additional image registries with self-signed CA certificates

### DIFF
--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/base.yaml
@@ -298,6 +298,23 @@ spec:
               required:
               - name
               - data
+  - name: additionalImageRegistries
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          required:
+          - host
+          properties:
+            host:
+              type: string
+            skipTlsVerify:
+              type: boolean
+              default: false
+            caCert:
+              type: string
   - name: auditLogging
     required: false
     schema:
@@ -1125,6 +1142,52 @@ spec:
             content: {{or $proxy $image}}
             encoding: base64
             permissions: "0444"
+  - name: additionalRegistryCACerts
+    enabledIf: '{{ not (empty .additionalImageRegistries) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: /tmp/insert_registry_ca_certs.sh
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: &insertCAScript |
+            path: /tmp/insert_registry_ca_certs.sh
+            content: |
+              #!/bin/bash
+              set -e
+              {{- range .additionalImageRegistries }}
+                {{- if eq .skipTlsVerify false }}
+              echo '{{ .caCert }}' | base64 -d > /etc/containerd/{{ .host }}.crt
+              echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .host }}".tls]' >> /etc/containerd/config.toml
+              echo '  ca_file = "/etc/containerd/{{ .host }}.crt"' >> /etc/containerd/config.toml
+                {{- else }}
+              echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .host }}".tls]' >> /etc/containerd/config.toml
+              echo "  insecure_skip_verify = true" >> /etc/containerd/config.toml
+                {{- end }}
+              {{- end }}
+            permissions: "0755"
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/preKubeadmCommands/-
+        value: /tmp/insert_registry_ca_certs.sh
+      - op: add
+        path: /spec/template/spec/files/-
+        valueFrom:
+          template: *insertCAScript
   - name: auditLogging
     enabledIf: '{{ .auditLogging.enabled }}'
     definitions:

--- a/packages/tkg-clusterclass-aws/bundle/config/upstream/overlay.yaml
+++ b/packages/tkg-clusterclass-aws/bundle/config/upstream/overlay.yaml
@@ -53,7 +53,7 @@ spec:
     name: KCP_INIT_APISERVER_EMPTY_EXTRAVOLUMES_ARRAY
   #@overlay/append
   - name: restartContainerdService
-    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host)) }}'
+    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host) (empty .additionalImageRegistries)) }}'
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/base.yaml
@@ -354,6 +354,23 @@ spec:
               required:
               - name
               - data
+  - name: additionalImageRegistries
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          required:
+          - host
+          properties:
+            host:
+              type: string
+            skipTlsVerify:
+              type: boolean
+              default: false
+            caCert:
+              type: string
   - name: auditLogging
     required: false
     schema:
@@ -1461,6 +1478,52 @@ spec:
             content: {{or $proxy $image}}
             encoding: base64
             permissions: "0444"
+  - name: additionalRegistryCACerts
+    enabledIf: '{{ not (empty .additionalImageRegistries) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: /tmp/insert_registry_ca_certs.sh
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: &insertCAScript |
+            path: /tmp/insert_registry_ca_certs.sh
+            content: |
+              #!/bin/bash
+              set -e
+              {{- range .additionalImageRegistries }}
+                {{- if eq .skipTlsVerify false }}
+              echo '{{ .caCert }}' | base64 -d > /etc/containerd/{{ .host }}.crt
+              echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .host }}".tls]' >> /etc/containerd/config.toml
+              echo '  ca_file = "/etc/containerd/{{ .host }}.crt"' >> /etc/containerd/config.toml
+                {{- else }}
+              echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .host }}".tls]' >> /etc/containerd/config.toml
+              echo "  insecure_skip_verify = true" >> /etc/containerd/config.toml
+                {{- end }}
+              {{- end }}
+            permissions: "0755"
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/preKubeadmCommands/-
+        value: /tmp/insert_registry_ca_certs.sh
+      - op: add
+        path: /spec/template/spec/files/-
+        valueFrom:
+          template: *insertCAScript
   - name: auditLogging
     enabledIf: '{{ .auditLogging.enabled }}'
     definitions:

--- a/packages/tkg-clusterclass-azure/bundle/config/upstream/overlay.yaml
+++ b/packages/tkg-clusterclass-azure/bundle/config/upstream/overlay.yaml
@@ -53,7 +53,7 @@ spec:
     name: KCP_INIT_APISERVER_EMPTY_EXTRAVOLUMES_ARRAY
   #@overlay/append
   - name: restartContainerdService
-    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host)) }}'
+    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host) (empty .additionalImageRegistries)) }}'
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/base.yaml
@@ -373,6 +373,23 @@ spec:
               required:
               - name
               - data
+  - name: additionalImageRegistries
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          required:
+          - host
+          properties:
+            host:
+              type: string
+            skipTlsVerify:
+              type: boolean
+              default: false
+            caCert:
+              type: string
   - name: auditLogging
     required: false
     schema:
@@ -1716,6 +1733,52 @@ spec:
             content: {{or $proxy $image}}
             encoding: base64
             permissions: "0444"
+  - name: additionalRegistryCACerts
+    enabledIf: '{{ not (empty .additionalImageRegistries) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: /tmp/insert_registry_ca_certs.sh
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: &insertCAScript |
+            path: /tmp/insert_registry_ca_certs.sh
+            content: |
+              #!/bin/bash
+              set -e
+              {{- range .additionalImageRegistries }}
+                {{- if eq .skipTlsVerify false }}
+              echo '{{ .caCert }}' | base64 -d > /etc/containerd/{{ .host }}.crt
+              echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .host }}".tls]' >> /etc/containerd/config.toml
+              echo '  ca_file = "/etc/containerd/{{ .host }}.crt"' >> /etc/containerd/config.toml
+                {{- else }}
+              echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .host }}".tls]' >> /etc/containerd/config.toml
+              echo "  insecure_skip_verify = true" >> /etc/containerd/config.toml
+                {{- end }}
+              {{- end }}
+            permissions: "0755"
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/preKubeadmCommands/-
+        value: /tmp/insert_registry_ca_certs.sh
+      - op: add
+        path: /spec/template/spec/files/-
+        valueFrom:
+          template: *insertCAScript
   - name: auditLogging
     enabledIf: '{{ .auditLogging.enabled }}'
     definitions:

--- a/packages/tkg-clusterclass-vsphere/bundle/config/upstream/overlay.yaml
+++ b/packages/tkg-clusterclass-vsphere/bundle/config/upstream/overlay.yaml
@@ -71,7 +71,7 @@ spec:
     name: KCP_INIT_APISERVER_EMPTY_EXTRAVOLUMES_ARRAY
   #@overlay/append
   - name: restartContainerdService
-    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host)) }}'
+    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host) (empty .additionalImageRegistries)) }}'
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/providers/config_default.yaml
+++ b/providers/config_default.yaml
@@ -496,6 +496,25 @@ TKG_CUSTOM_IMAGE_REPOSITORY: ""
 TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY: false
 TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE: ""
 
+#! When user's application images are from a registry with a self-signed CA
+#! set this value to configure the cluster to trust it. For a registry with
+#! a public CA nothing need to change. This is only for user's application
+#! images, to configure TKG image repository for cluster creation, use
+#! TKG_CUSTOM_IMAGE_REPOSITORY instead.
+#! Example image registry host name: 10.191.247.30:8443
+ADDITIONAL_IMAGE_REGISTRY_1: ""
+ADDITIONAL_IMAGE_REGISTRY_1_SKIP_TLS_VERIFY: false
+#! Base64 encoded self-signed CA certificate
+ADDITIONAL_IMAGE_REGISTRY_1_CA_CERTIFICATE: ""
+
+ADDITIONAL_IMAGE_REGISTRY_2: ""
+ADDITIONAL_IMAGE_REGISTRY_2_SKIP_TLS_VERIFY: false
+ADDITIONAL_IMAGE_REGISTRY_2_CA_CERTIFICATE: ""
+
+ADDITIONAL_IMAGE_REGISTRY_3: ""
+ADDITIONAL_IMAGE_REGISTRY_3_SKIP_TLS_VERIFY: false
+ADDITIONAL_IMAGE_REGISTRY_3_CA_CERTIFICATE: ""
+
 #! PROXY configuration
 #! If `TKG_PROXY_CA_CERT` is specified it gets used instead of
 #! `TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE` while communicating

--- a/providers/infrastructure-aws/v2.0.2/cconly/base.yaml
+++ b/providers/infrastructure-aws/v2.0.2/cconly/base.yaml
@@ -298,6 +298,23 @@ spec:
               required:
               - name
               - data
+  - name: additionalImageRegistries
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          required:
+          - host
+          properties:
+            host:
+              type: string
+            skipTlsVerify:
+              type: boolean
+              default: false
+            caCert:
+              type: string
   - name: auditLogging
     required: false
     schema:
@@ -1125,6 +1142,52 @@ spec:
             content: {{or $proxy $image}}
             encoding: base64
             permissions: "0444"
+  - name: additionalRegistryCACerts
+    enabledIf: '{{ not (empty .additionalImageRegistries) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: /tmp/insert_registry_ca_certs.sh
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: &insertCAScript |
+            path: /tmp/insert_registry_ca_certs.sh
+            content: |
+              #!/bin/bash
+              set -e
+              {{- range .additionalImageRegistries }}
+                {{- if eq .skipTlsVerify false }}
+              echo '{{ .caCert }}' | base64 -d > /etc/containerd/{{ .host }}.crt
+              echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .host }}".tls]' >> /etc/containerd/config.toml
+              echo '  ca_file = "/etc/containerd/{{ .host }}.crt"' >> /etc/containerd/config.toml
+                {{- else }}
+              echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .host }}".tls]' >> /etc/containerd/config.toml
+              echo "  insecure_skip_verify = true" >> /etc/containerd/config.toml
+                {{- end }}
+              {{- end }}
+            permissions: "0755"
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/preKubeadmCommands/-
+        value: /tmp/insert_registry_ca_certs.sh
+      - op: add
+        path: /spec/template/spec/files/-
+        valueFrom:
+          template: *insertCAScript
   - name: auditLogging
     enabledIf: '{{ .auditLogging.enabled }}'
     definitions:

--- a/providers/infrastructure-aws/v2.0.2/cconly/overlay.yaml
+++ b/providers/infrastructure-aws/v2.0.2/cconly/overlay.yaml
@@ -53,7 +53,7 @@ spec:
     name: KCP_INIT_APISERVER_EMPTY_EXTRAVOLUMES_ARRAY
   #@overlay/append
   - name: restartContainerdService
-    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host)) }}'
+    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host) (empty .additionalImageRegistries)) }}'
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/providers/infrastructure-aws/v2.0.2/yttcc/overlay.yaml
+++ b/providers/infrastructure-aws/v2.0.2/yttcc/overlay.yaml
@@ -109,7 +109,7 @@ spec:
     variables:
     #@ vars = get_aws_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["workerKubeletExtraArgs","controlPlaneKubeletExtraArgs","kubeControllerManagerExtraArgs","kubeSchedulerExtraArgs","apiServerExtraArgs","etcdExtraArgs", "region", "sshKeyName", "bastion", "network", "controlPlane", "worker", "loadBalancerSchemeInternal", "identityRef", "imageRepository", "trust", "auditLogging", "cni", "TKR_DATA", "proxy", "controlPlaneCertificateRotation", "podSecurityStandard", "eventRateLimitConf"]:
+    #@  if vars[configVariable] != None and configVariable in ["additionalImageRegistries","workerKubeletExtraArgs","controlPlaneKubeletExtraArgs","kubeControllerManagerExtraArgs","kubeSchedulerExtraArgs","apiServerExtraArgs","etcdExtraArgs", "region", "sshKeyName", "bastion", "network", "controlPlane", "worker", "loadBalancerSchemeInternal", "identityRef", "imageRepository", "trust", "auditLogging", "cni", "TKR_DATA", "proxy", "controlPlaneCertificateRotation", "podSecurityStandard", "eventRateLimitConf"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/providers/infrastructure-azure/v1.6.1/cconly/base.yaml
+++ b/providers/infrastructure-azure/v1.6.1/cconly/base.yaml
@@ -354,6 +354,23 @@ spec:
               required:
               - name
               - data
+  - name: additionalImageRegistries
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          required:
+          - host
+          properties:
+            host:
+              type: string
+            skipTlsVerify:
+              type: boolean
+              default: false
+            caCert:
+              type: string
   - name: auditLogging
     required: false
     schema:
@@ -1461,6 +1478,52 @@ spec:
             content: {{or $proxy $image}}
             encoding: base64
             permissions: "0444"
+  - name: additionalRegistryCACerts
+    enabledIf: '{{ not (empty .additionalImageRegistries) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: /tmp/insert_registry_ca_certs.sh
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: &insertCAScript |
+            path: /tmp/insert_registry_ca_certs.sh
+            content: |
+              #!/bin/bash
+              set -e
+              {{- range .additionalImageRegistries }}
+                {{- if eq .skipTlsVerify false }}
+              echo '{{ .caCert }}' | base64 -d > /etc/containerd/{{ .host }}.crt
+              echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .host }}".tls]' >> /etc/containerd/config.toml
+              echo '  ca_file = "/etc/containerd/{{ .host }}.crt"' >> /etc/containerd/config.toml
+                {{- else }}
+              echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .host }}".tls]' >> /etc/containerd/config.toml
+              echo "  insecure_skip_verify = true" >> /etc/containerd/config.toml
+                {{- end }}
+              {{- end }}
+            permissions: "0755"
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/preKubeadmCommands/-
+        value: /tmp/insert_registry_ca_certs.sh
+      - op: add
+        path: /spec/template/spec/files/-
+        valueFrom:
+          template: *insertCAScript
   - name: auditLogging
     enabledIf: '{{ .auditLogging.enabled }}'
     definitions:

--- a/providers/infrastructure-azure/v1.6.1/cconly/overlay.yaml
+++ b/providers/infrastructure-azure/v1.6.1/cconly/overlay.yaml
@@ -53,7 +53,7 @@ spec:
     name: KCP_INIT_APISERVER_EMPTY_EXTRAVOLUMES_ARRAY
   #@overlay/append
   - name: restartContainerdService
-    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host)) }}'
+    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host) (empty .additionalImageRegistries)) }}'
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/providers/infrastructure-azure/v1.6.1/yttcc/overlay.yaml
+++ b/providers/infrastructure-azure/v1.6.1/yttcc/overlay.yaml
@@ -138,7 +138,7 @@ spec:
     variables:
     #@ vars = get_azure_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["workerKubeletExtraArgs","controlPlaneKubeletExtraArgs","kubeControllerManagerExtraArgs","kubeSchedulerExtraArgs","apiServerExtraArgs","etcdExtraArgs", "location", "network", "controlPlane", "worker", "resourceGroup", "subscriptionID", "identityRef", "clusterRole", "environment", "sshPublicKey", "acceleratedNetworking", "privateCluster", "frontendPrivateIP", "imageRepository", "auditLogging", "customTags", "apiServerPort", "trust", "TKR_DATA", "proxy", "controlPlaneCertificateRotation", "podSecurityStandard", "eventRateLimitConf"]:
+    #@  if vars[configVariable] != None and configVariable in ["additionalImageRegistries","workerKubeletExtraArgs","controlPlaneKubeletExtraArgs","kubeControllerManagerExtraArgs","kubeSchedulerExtraArgs","apiServerExtraArgs","etcdExtraArgs", "location", "network", "controlPlane", "worker", "resourceGroup", "subscriptionID", "identityRef", "clusterRole", "environment", "sshPublicKey", "acceleratedNetworking", "privateCluster", "frontendPrivateIP", "imageRepository", "auditLogging", "customTags", "apiServerPort", "trust", "TKR_DATA", "proxy", "controlPlaneCertificateRotation", "podSecurityStandard", "eventRateLimitConf"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/providers/infrastructure-vsphere/v1.5.3/cconly/base.yaml
+++ b/providers/infrastructure-vsphere/v1.5.3/cconly/base.yaml
@@ -373,6 +373,23 @@ spec:
               required:
               - name
               - data
+  - name: additionalImageRegistries
+    required: false
+    schema:
+      openAPIV3Schema:
+        type: array
+        items:
+          type: object
+          required:
+          - host
+          properties:
+            host:
+              type: string
+            skipTlsVerify:
+              type: boolean
+              default: false
+            caCert:
+              type: string
   - name: auditLogging
     required: false
     schema:
@@ -1716,6 +1733,52 @@ spec:
             content: {{or $proxy $image}}
             encoding: base64
             permissions: "0444"
+  - name: additionalRegistryCACerts
+    enabledIf: '{{ not (empty .additionalImageRegistries) }}'
+    definitions:
+    - selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/preKubeadmCommands/-
+        value: /tmp/insert_registry_ca_certs.sh
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/files/-
+        valueFrom:
+          template: &insertCAScript |
+            path: /tmp/insert_registry_ca_certs.sh
+            content: |
+              #!/bin/bash
+              set -e
+              {{- range .additionalImageRegistries }}
+                {{- if eq .skipTlsVerify false }}
+              echo '{{ .caCert }}' | base64 -d > /etc/containerd/{{ .host }}.crt
+              echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .host }}".tls]' >> /etc/containerd/config.toml
+              echo '  ca_file = "/etc/containerd/{{ .host }}.crt"' >> /etc/containerd/config.toml
+                {{- else }}
+              echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."{{ .host }}".tls]' >> /etc/containerd/config.toml
+              echo "  insecure_skip_verify = true" >> /etc/containerd/config.toml
+                {{- end }}
+              {{- end }}
+            permissions: "0755"
+    - selector:
+        apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+        kind: KubeadmConfigTemplate
+        matchResources:
+          machineDeploymentClass:
+            names:
+            - tkg-worker
+      jsonPatches:
+      - op: add
+        path: /spec/template/spec/preKubeadmCommands/-
+        value: /tmp/insert_registry_ca_certs.sh
+      - op: add
+        path: /spec/template/spec/files/-
+        valueFrom:
+          template: *insertCAScript
   - name: auditLogging
     enabledIf: '{{ .auditLogging.enabled }}'
     definitions:

--- a/providers/infrastructure-vsphere/v1.5.3/cconly/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.5.3/cconly/overlay.yaml
@@ -71,7 +71,7 @@ spec:
     name: KCP_INIT_APISERVER_EMPTY_EXTRAVOLUMES_ARRAY
   #@overlay/append
   - name: restartContainerdService
-    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host)) }}'
+    enabledIf: '{{ not (and (empty .proxy) (empty .trust.additionalTrustedCAs) (empty .imageRepository.host) (empty .additionalImageRegistries)) }}'
     definitions:
     - selector:
         apiVersion: controlplane.cluster.x-k8s.io/v1beta1

--- a/providers/infrastructure-vsphere/v1.5.3/yttcc/overlay.yaml
+++ b/providers/infrastructure-vsphere/v1.5.3/yttcc/overlay.yaml
@@ -138,7 +138,7 @@ spec:
     variables:
     #@ vars = get_vsphere_vars()
     #@ for configVariable in vars:
-    #@  if vars[configVariable] != None and configVariable in ["workerKubeletExtraArgs","controlPlaneKubeletExtraArgs","kubeControllerManagerExtraArgs","kubeSchedulerExtraArgs","apiServerExtraArgs","etcdExtraArgs", "apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "cni", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider", "additionalFQDN", "controlPlaneCertificateRotation", "podSecurityStandard", "eventRateLimitConf", "customTDNFRepository", "pci"]:
+    #@  if vars[configVariable] != None and configVariable in ["additionalImageRegistries","workerKubeletExtraArgs","controlPlaneKubeletExtraArgs","kubeControllerManagerExtraArgs","kubeSchedulerExtraArgs","apiServerExtraArgs","etcdExtraArgs", "apiServerPort", "controlPlane", "worker", "vcenter", "VSPHERE_WINDOWS_TEMPLATE", "cni", "apiServerEndpoint", "network", "imageRepository", "trust", "user", "auditLogging", "aviAPIServerHAProvider", "ntpServers", "TKR_DATA", "proxy", "kubeVipLoadBalancerProvider", "additionalFQDN", "controlPlaneCertificateRotation", "podSecurityStandard", "eventRateLimitConf", "customTDNFRepository", "pci"]:
     - name: #@ configVariable
       value: #@ vars[configVariable]
     #@ end

--- a/providers/yttcc/lib/config_variable_association.star
+++ b/providers/yttcc/lib/config_variable_association.star
@@ -2,7 +2,7 @@ load("@ytt:data", "data")
 load("@ytt:overlay", "overlay")
 load("@ytt:yaml", "yaml")
 load("/lib/helpers.star", "get_default_tkg_bom_data", "get_labels_array_from_string", "get_extra_args_map_from_string")
-load("/lib/helpers.star",  "get_custom_keys", "valid_pci_devices_list", "get_pci_devices")
+load("/lib/helpers.star",  "get_custom_keys", "valid_pci_devices_list", "get_pci_devices", "get_image_registry")
 
 #! This file contains function 'config_variable_association' which specifies all configuration variables
 #! mentioned in 'config_default.yaml' and describes association of each configuration variable with
@@ -206,6 +206,16 @@ return {
 "TKG_CUSTOM_IMAGE_REPOSITORY_SKIP_TLS_VERIFY": ["vsphere", "aws", "azure", "docker", "oci"],
 "TKG_CUSTOM_IMAGE_REPOSITORY_CA_CERTIFICATE": ["vsphere", "aws", "azure", "docker", "oci"],
 
+"ADDITIONAL_IMAGE_REGISTRY_1": ["vsphere", "aws", "azure", "docker"],
+"ADDITIONAL_IMAGE_REGISTRY_1_SKIP_TLS_VERIFY": ["vsphere", "aws", "azure", "docker"],
+"ADDITIONAL_IMAGE_REGISTRY_1_CA_CERTIFICATE": ["vsphere", "aws", "azure", "docker"],
+"ADDITIONAL_IMAGE_REGISTRY_2": ["vsphere", "aws", "azure", "docker"],
+"ADDITIONAL_IMAGE_REGISTRY_2_SKIP_TLS_VERIFY": ["vsphere", "aws", "azure", "docker"],
+"ADDITIONAL_IMAGE_REGISTRY_2_CA_CERTIFICATE": ["vsphere", "aws", "azure", "docker"],
+"ADDITIONAL_IMAGE_REGISTRY_3": ["vsphere", "aws", "azure", "docker"],
+"ADDITIONAL_IMAGE_REGISTRY_3_SKIP_TLS_VERIFY": ["vsphere", "aws", "azure", "docker"],
+"ADDITIONAL_IMAGE_REGISTRY_3_CA_CERTIFICATE": ["vsphere", "aws", "azure", "docker"],
+
 "TKG_HTTP_PROXY": ["vsphere", "aws", "azure", "docker", "oci"],
 "TKG_HTTPS_PROXY": ["vsphere", "aws", "azure", "docker", "oci"],
 "TKG_NO_PROXY": ["vsphere", "aws", "azure", "docker", "oci"],
@@ -406,6 +416,23 @@ def get_cluster_variables():
 
     if customImageRepository != {}:
         vars["imageRepository"] = customImageRepository
+    end
+
+    additionalImageRegistries = []
+    imageRegistry1 = get_image_registry(data.values["ADDITIONAL_IMAGE_REGISTRY_1"], data.values["ADDITIONAL_IMAGE_REGISTRY_1_SKIP_TLS_VERIFY"], data.values["ADDITIONAL_IMAGE_REGISTRY_1_CA_CERTIFICATE"])
+    if imageRegistry1 != None:
+        additionalImageRegistries.append(imageRegistry1)
+    end
+    imageRegistry2 = get_image_registry(data.values["ADDITIONAL_IMAGE_REGISTRY_2"], data.values["ADDITIONAL_IMAGE_REGISTRY_2_SKIP_TLS_VERIFY"], data.values["ADDITIONAL_IMAGE_REGISTRY_2_CA_CERTIFICATE"])
+    if imageRegistry2 != None:
+        additionalImageRegistries.append(imageRegistry2)
+    end
+    imageRegistry3 = get_image_registry(data.values["ADDITIONAL_IMAGE_REGISTRY_3"], data.values["ADDITIONAL_IMAGE_REGISTRY_3_SKIP_TLS_VERIFY"], data.values["ADDITIONAL_IMAGE_REGISTRY_3_CA_CERTIFICATE"])
+    if imageRegistry3 != None:
+        additionalImageRegistries.append(imageRegistry3)
+    end
+    if len(additionalImageRegistries) > 0:
+        vars["additionalImageRegistries"] = additionalImageRegistries
     end
 
     if data.values["TKG_CLUSTER_ROLE"] != "":

--- a/providers/yttcc/lib/helpers.star
+++ b/providers/yttcc/lib/helpers.star
@@ -413,6 +413,24 @@ def get_pci_devices(pci_devices_string, pci_ignore_device_validation):
   return pci_devices
 end
 
+def get_image_registry(host, skipTlsVerify, caCert):
+  if host != None and host != "":
+    imageRegistry = {}
+    imageRegistry["host"] = host
+    imageRegistry["skipTlsVerify"] = skipTlsVerify
+    if skipTlsVerify == False:
+      if caCert != None and caCert != "":
+        imageRegistry["caCert"] = caCert
+      else:
+        assert.fail("Must provide CA for host " + host)
+      end
+    end
+    return imageRegistry
+  else:
+    return None
+  end
+end
+
 def map(f, list):
   return [f(x) for x in list]
 end


### PR DESCRIPTION
Users could have application images in private registries with self-signed CA certificates, this patch configure containerd TLS settings for them.

For image registries with a public CA certificates, no additional configurations are required for containerd.

### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

Tested with the following legacy configurations:
```
ADDITIONAL_IMAGE_REGISTRY_1: "10.92.127.192:8443"
ADDITIONAL_IMAGE_REGISTRY_1_CA_CERTIFICATE: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURMekNDQWhlZ0F3SUJBZ0lVWlRFSTgrZWFhK3dQdHdqUnpBQ0RoNmxSSzR3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1J6RUxNQWtHQTFVRUJoTUNWVk14RXpBUkJnTlZCQWdNQ2tOaGJHbG1iM0p1YVdFeEVqQVFCZ05WQkFjTQpDVkJoYkc4Z1FXeDBiekVQTUEwR0ExVUVDZ3dHZG0xM1lYSmxNQjRYRFRJek1ETXdOekE0TkRReE9Gb1hEVEkwCk1ETXdPREE0TkRReE9Gb3dSekVMTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnTUNrTmhiR2xtYjNKdWFXRXgKRWpBUUJnTlZCQWNNQ1ZCaGJHOGdRV3gwYnpFUE1BMEdBMVVFQ2d3R2RtMTNZWEpsTUlJQklqQU5CZ2txaGtpRwo5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBempobWh4TXJTRjlPZ3ZmUGFOUEpObGNaWWNJRmU0bk9yMHhDClBSRVQyMGxCc3JWRUF5a2NGRThUaTZGV3ZZNFBPL0VOODJYdXVZU0JhOEMwQ3ZSK0hjaEhmZDJDbTc0KzZNSkEKT3RqdmszV1RzU0hlWjkxbHVEY0dvQ09XeGFENHdyaCtjRnhtS0FscnNpM3RYcUZiMkQyZHk5c0U5dVBTUEltQwpUR2dRQWdZTTFRM0RSRUNqNjUxRUYxVE9ySXRmYzdjeVNUWXpvOHZYbWtNYXBaVmdtdHFoM01UQ3VHSUdpTXhqCnBsb2kvR3RhclZzSHFmSEJCalBPYTVZOHpuNGgySm55SWJlV0JoYWlQeVpRK3BhWmQ3U2U0cDZ0RUpTVzFqOFkKK2pkbW9PUGE3QmQ1K2tHclprb1Z4cTZ3emFXQkl1czE1QnRlb2ZTZVl2d0JlYS9ha1FJREFRQUJveE13RVRBUApCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ1YvSmRZbVZWSjIvbVY4ZmF6CkhieVlwTUVkNXBJZHdyY1VRNzFpM2ZRZDZBUndZQjdwKys0R1J0NDdRZ01PUU80VUliKzlORXZCcTA3Q0lBKzcKdHI0MFpOYVdEV3BtRW1Fb1RBS3l6cHV4TWJBMHdJdURLSGo4VmhOUTErS29GWG8xU0RyVnZpNlYrcWk0WkVaYgovNm9mdmd0a1YrajFpa0ZkRWxYY0VlNkE2dUpHMUJ0QTdGK0QrSUMxRCtaclIyc3dYQWxuOVJlUXBhOXUvMHVWCnZ3TkFPUEdpR3BnTXdYaXJSVy8rR3JML0Y2RmNQMUZqcHo3aUxXOFZlWGQ1SWY0cVpkc0FqVGhWcEZtdCtQeDcKanNOUEV5RGw3V2hSY0oxbHlVSXlZTm9XUVBqUDBSMjZzaStWbUM3UDBnSkp5a2NuWCs5eUliQ21RbmFrUGx4WgpqV0h2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
ADDITIONAL_IMAGE_REGISTRY_2: "10.191.157.222:8443"
ADDITIONAL_IMAGE_REGISTRY_2_SKIP_TLS_VERIFY: true
```
Tanzu cli generated variable in the cluster manifest
```
    - name: additionalImageRegistries
      value:
      - caCert: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURMekNDQWhlZ0F3SUJBZ0lVWlRFSTgrZWFhK3dQdHdqUnpBQ0RoNmxSSzR3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1J6RUxNQWtHQTFVRUJoTUNWVk14RXpBUkJnTlZCQWdNQ2tOaGJHbG1iM0p1YVdFeEVqQVFCZ05WQkFjTQpDVkJoYkc4Z1FXeDBiekVQTUEwR0ExVUVDZ3dHZG0xM1lYSmxNQjRYRFRJek1ETXdOekE0TkRReE9Gb1hEVEkwCk1ETXdPREE0TkRReE9Gb3dSekVMTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnTUNrTmhiR2xtYjNKdWFXRXgKRWpBUUJnTlZCQWNNQ1ZCaGJHOGdRV3gwYnpFUE1BMEdBMVVFQ2d3R2RtMTNZWEpsTUlJQklqQU5CZ2txaGtpRwo5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBempobWh4TXJTRjlPZ3ZmUGFOUEpObGNaWWNJRmU0bk9yMHhDClBSRVQyMGxCc3JWRUF5a2NGRThUaTZGV3ZZNFBPL0VOODJYdXVZU0JhOEMwQ3ZSK0hjaEhmZDJDbTc0KzZNSkEKT3RqdmszV1RzU0hlWjkxbHVEY0dvQ09XeGFENHdyaCtjRnhtS0FscnNpM3RYcUZiMkQyZHk5c0U5dVBTUEltQwpUR2dRQWdZTTFRM0RSRUNqNjUxRUYxVE9ySXRmYzdjeVNUWXpvOHZYbWtNYXBaVmdtdHFoM01UQ3VHSUdpTXhqCnBsb2kvR3RhclZzSHFmSEJCalBPYTVZOHpuNGgySm55SWJlV0JoYWlQeVpRK3BhWmQ3U2U0cDZ0RUpTVzFqOFkKK2pkbW9PUGE3QmQ1K2tHclprb1Z4cTZ3emFXQkl1czE1QnRlb2ZTZVl2d0JlYS9ha1FJREFRQUJveE13RVRBUApCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ1YvSmRZbVZWSjIvbVY4ZmF6CkhieVlwTUVkNXBJZHdyY1VRNzFpM2ZRZDZBUndZQjdwKys0R1J0NDdRZ01PUU80VUliKzlORXZCcTA3Q0lBKzcKdHI0MFpOYVdEV3BtRW1Fb1RBS3l6cHV4TWJBMHdJdURLSGo4VmhOUTErS29GWG8xU0RyVnZpNlYrcWk0WkVaYgovNm9mdmd0a1YrajFpa0ZkRWxYY0VlNkE2dUpHMUJ0QTdGK0QrSUMxRCtaclIyc3dYQWxuOVJlUXBhOXUvMHVWCnZ3TkFPUEdpR3BnTXdYaXJSVy8rR3JML0Y2RmNQMUZqcHo3aUxXOFZlWGQ1SWY0cVpkc0FqVGhWcEZtdCtQeDcKanNOUEV5RGw3V2hSY0oxbHlVSXlZTm9XUVBqUDBSMjZzaStWbUM3UDBnSkp5a2NuWCs5eUliQ21RbmFrUGx4WgpqV0h2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K
        host: 10.92.127.192:8443
        skipTlsVerify: false
      - host: 10.191.157.222:8443
        skipTlsVerify: true
```
After cluster is ready, launch Pods whose images are from above 2 registries:
```
❯ kubectl run nginx --image=10.92.127.192:8443/library/harbor/nginx-photon:v2.6.3_vmware.1  --restart=Never
pod/nginx created
❯ kubectl run nginx-2 --image=10.191.157.222:8443/library/harbor/nginx-photon:v2.6.3_vmware.1  --restart=Never
pod/nginx-2 created
```
Log into a node to do validation:
```
root [ /home/capv ]# crictl images
IMAGE                                                                TAG                 IMAGE ID            SIZE
10.191.157.222:8443/library/harbor/nginx-photon                      v2.6.3_vmware.1     4652f583ba2fe       60.4MB
10.92.127.192:8443/library/harbor/nginx-photon                       v2.6.3_vmware.1     4652f583ba2fe       60.4MB
...

root [ /home/capv ]# cat /tmp/insert_registry_ca_certs.sh
#!/bin/bash
set -e
echo 'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURMekNDQWhlZ0F3SUJBZ0lVWlRFSTgrZWFhK3dQdHdqUnpBQ0RoNmxSSzR3d0RRWUpLb1pJaHZjTkFRRUwKQlFBd1J6RUxNQWtHQTFVRUJoTUNWVk14RXpBUkJnTlZCQWdNQ2tOaGJHbG1iM0p1YVdFeEVqQVFCZ05WQkFjTQpDVkJoYkc4Z1FXeDBiekVQTUEwR0ExVUVDZ3dHZG0xM1lYSmxNQjRYRFRJek1ETXdOekE0TkRReE9Gb1hEVEkwCk1ETXdPREE0TkRReE9Gb3dSekVMTUFrR0ExVUVCaE1DVlZNeEV6QVJCZ05WQkFnTUNrTmhiR2xtYjNKdWFXRXgKRWpBUUJnTlZCQWNNQ1ZCaGJHOGdRV3gwYnpFUE1BMEdBMVVFQ2d3R2RtMTNZWEpsTUlJQklqQU5CZ2txaGtpRwo5dzBCQVFFRkFBT0NBUThBTUlJQkNnS0NBUUVBempobWh4TXJTRjlPZ3ZmUGFOUEpObGNaWWNJRmU0bk9yMHhDClBSRVQyMGxCc3JWRUF5a2NGRThUaTZGV3ZZNFBPL0VOODJYdXVZU0JhOEMwQ3ZSK0hjaEhmZDJDbTc0KzZNSkEKT3RqdmszV1RzU0hlWjkxbHVEY0dvQ09XeGFENHdyaCtjRnhtS0FscnNpM3RYcUZiMkQyZHk5c0U5dVBTUEltQwpUR2dRQWdZTTFRM0RSRUNqNjUxRUYxVE9ySXRmYzdjeVNUWXpvOHZYbWtNYXBaVmdtdHFoM01UQ3VHSUdpTXhqCnBsb2kvR3RhclZzSHFmSEJCalBPYTVZOHpuNGgySm55SWJlV0JoYWlQeVpRK3BhWmQ3U2U0cDZ0RUpTVzFqOFkKK2pkbW9PUGE3QmQ1K2tHclprb1Z4cTZ3emFXQkl1czE1QnRlb2ZTZVl2d0JlYS9ha1FJREFRQUJveE13RVRBUApCZ05WSFJNQkFmOEVCVEFEQVFIL01BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQ1YvSmRZbVZWSjIvbVY4ZmF6CkhieVlwTUVkNXBJZHdyY1VRNzFpM2ZRZDZBUndZQjdwKys0R1J0NDdRZ01PUU80VUliKzlORXZCcTA3Q0lBKzcKdHI0MFpOYVdEV3BtRW1Fb1RBS3l6cHV4TWJBMHdJdURLSGo4VmhOUTErS29GWG8xU0RyVnZpNlYrcWk0WkVaYgovNm9mdmd0a1YrajFpa0ZkRWxYY0VlNkE2dUpHMUJ0QTdGK0QrSUMxRCtaclIyc3dYQWxuOVJlUXBhOXUvMHVWCnZ3TkFPUEdpR3BnTXdYaXJSVy8rR3JML0Y2RmNQMUZqcHo3aUxXOFZlWGQ1SWY0cVpkc0FqVGhWcEZtdCtQeDcKanNOUEV5RGw3V2hSY0oxbHlVSXlZTm9XUVBqUDBSMjZzaStWbUM3UDBnSkp5a2NuWCs5eUliQ21RbmFrUGx4WgpqV0h2Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K' | base64 -d > /etc/containerd/10.92.127.192:8443.crt
echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."10.92.127.192:8443".tls]' >> /etc/containerd/config.toml
echo '  ca_file = "/etc/containerd/10.92.127.192:8443.crt"' >> /etc/containerd/config.toml
echo '[plugins."io.containerd.grpc.v1.cri".registry.configs."10.191.157.222:8443".tls]' >> /etc/containerd/config.toml
echo "  insecure_skip_verify = true" >> /etc/containerd/config.toml

root [ /home/capv ]# cat /etc/containerd/config.toml
## template: jinja

# Use config version 2 to enable new configuration fields.
# Config file is parsed as version 1 by default.
version = 2

imports = ["/etc/containerd/conf.d/*.toml"]

[plugins]
  [plugins."io.containerd.grpc.v1.cri"]
    sandbox_image = "projects.registry.vmware.com/tkg/pause:3.8"
  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
    runtime_type = "io.containerd.runc.v2"
  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
    SystemdCgroup = true

[plugins."io.containerd.grpc.v1.cri".registry.configs."10.92.127.192:8443".tls]
  ca_file = "/etc/containerd/10.92.127.192:8443.crt"
[plugins."io.containerd.grpc.v1.cri".registry.configs."10.191.157.222:8443".tls]
  insecure_skip_verify = true

root [ /home/capv ]# cat /etc/containerd/10.92.127.192:8443.crt
-----BEGIN CERTIFICATE-----
MIIDLzCCAhegAwIBAgIUZTEI8+eaa+wPtwjRzACDh6lRK4wwDQYJKoZIhvcNAQEL
BQAwRzELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWExEjAQBgNVBAcM
CVBhbG8gQWx0bzEPMA0GA1UECgwGdm13YXJlMB4XDTIzMDMwNzA4NDQxOFoXDTI0
MDMwODA4NDQxOFowRzELMAkGA1UEBhMCVVMxEzARBgNVBAgMCkNhbGlmb3JuaWEx
EjAQBgNVBAcMCVBhbG8gQWx0bzEPMA0GA1UECgwGdm13YXJlMIIBIjANBgkqhkiG
9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzjhmhxMrSF9OgvfPaNPJNlcZYcIFe4nOr0xC
PRET20lBsrVEAykcFE8Ti6FWvY4PO/EN82XuuYSBa8C0CvR+HchHfd2Cm74+6MJA
Otjvk3WTsSHeZ91luDcGoCOWxaD4wrh+cFxmKAlrsi3tXqFb2D2dy9sE9uPSPImC
TGgQAgYM1Q3DRECj651EF1TOrItfc7cySTYzo8vXmkMapZVgmtqh3MTCuGIGiMxj
ploi/GtarVsHqfHBBjPOa5Y8zn4h2JnyIbeWBhaiPyZQ+paZd7Se4p6tEJSW1j8Y
+jdmoOPa7Bd5+kGrZkoVxq6wzaWBIus15BteofSeYvwBea/akQIDAQABoxMwETAP
BgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCV/JdYmVVJ2/mV8faz
HbyYpMEd5pIdwrcUQ71i3fQd6ARwYB7p++4GRt47QgMOQO4UIb+9NEvBq07CIA+7
tr40ZNaWDWpmEmEoTAKyzpuxMbA0wIuDKHj8VhNQ1+KoFXo1SDrVvi6V+qi4ZEZb
/6ofvgtkV+j1ikFdElXcEe6A6uJG1BtA7F+D+IC1D+ZrR2swXAln9ReQpa9u/0uV
vwNAOPGiGpgMwXirRW/+GrL/F6FcP1Fjpz7iLW8VeXd5If4qZdsAjThVpFmt+Px7
jsNPEyDl7WhRcJ1lyUIyYNoWQPjP0R26si+VmC7P0gJJykcnX+9yIbCmQnakPlxZ
jWHv
-----END CERTIFICATE-----
```

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Support trusting self-signed image registry for user's application. Users can configure 3 registries with a legacy config file:
ADDITIONAL_IMAGE_REGISTRY_1: ""
ADDITIONAL_IMAGE_REGISTRY_1_SKIP_TLS_VERIFY: false
#! Base64 encoded self-signed CA certificate
ADDITIONAL_IMAGE_REGISTRY_1_CA_CERTIFICATE: ""

ADDITIONAL_IMAGE_REGISTRY_2: ""
ADDITIONAL_IMAGE_REGISTRY_2_SKIP_TLS_VERIFY: false
ADDITIONAL_IMAGE_REGISTRY_2_CA_CERTIFICATE: ""

ADDITIONAL_IMAGE_REGISTRY_3: ""
ADDITIONAL_IMAGE_REGISTRY_3_SKIP_TLS_VERIFY: false
ADDITIONAL_IMAGE_REGISTRY_3_CA_CERTIFICATE: ""

If there are more than 3, user can add them to generated cluster manifest variable additionalImageRegistries before creating the cluster.
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
