### PR TITLE
Dc log mssg

### DIFF
--- a/tkg/vsphere-template-resolver/templateresolver/resolver_impl.go
+++ b/tkg/vsphere-template-resolver/templateresolver/resolver_impl.go
@@ -81,7 +81,7 @@ func getVirtualMachineTemplateForOVAs(ctx context.Context, dc string, vcClient v
 	// Get all vcVMs.
 	vcVMs, err := vcClient.GetVirtualMachineImages(ctx, dcMOID)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get K8s VM templates")
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to get K8s VM templates from datacenter %v", dc))
 	}
 
 	return vcVMs, nil


### PR DESCRIPTION
Quick logging improvement to clarify the data center connection that is failing and that the vsphere- resolver is talking to V center when it fails at getting k8s vm templates for users to understand the lifecycle and failure modes better when they get errors about 

```failed to get K8s VM Templates```