### PR TITLE
Fix deadlock for mgmt cluster upgrade and tkr fetch

### DIFF
--- a/packages/tkr-source-controller/bundle/config/upstream/default-compatible-tkr.yaml
+++ b/packages/tkr-source-controller/bundle/config/upstream/default-compatible-tkr.yaml
@@ -13,6 +13,8 @@ metadata:
     run.tanzu.vmware.com/additional-compatible-tkrs: ""
   name: tkg-compatibility-versions
   namespace: #@ data.values.namespace
+  annotations:
+    kapp.k14s.io/change-group: "tkr-source-controller.tanzu.vmware.com/ConfigMap"
 data:
   tkrVersions: #@ yaml.encode(getCompatibleTKRs())
 
@@ -22,6 +24,8 @@ kind: ConfigMap
 metadata:
   name: tkr-controller-config
   namespace: #@ data.values.namespace
+  annotations:
+    kapp.k14s.io/change-group: "tkr-source-controller.tanzu.vmware.com/ConfigMap"
 data:
   caCerts: ""
   imageRepository: #@ data.values.imageRepository

--- a/packages/tkr-source-controller/bundle/config/upstream/tkr-source-controller-deployment.yaml
+++ b/packages/tkr-source-controller/bundle/config/upstream/tkr-source-controller-deployment.yaml
@@ -17,6 +17,7 @@ metadata:
   annotations:
     kapp.k14s.io/change-rule.0: "upsert after upserting tkr-source-controller.tanzu.vmware.com/ClusterRoleBinding"
     kapp.k14s.io/change-rule.1: "delete before deleting tkr-source-controller.tanzu.vmware.com/ClusterRoleBinding"
+    kapp.k14s.io/change-rule.3: "upsert after upserting tkr-source-controller.tanzu.vmware.com/ConfigMap"
 spec:
   replicas: 1
   selector:

--- a/tkg/client/upgrade_cluster_test.go
+++ b/tkg/client/upgrade_cluster_test.go
@@ -982,7 +982,7 @@ var _ = Describe("Unit tests for clusterclass-based upgrade", func() {
 	})
 	Context("When cluster patch fails", func() {
 		BeforeEach(func() {
-			regionalClusterClient.PatchClusterObjectReturns(errors.New("fake-patch-error"))
+			regionalClusterClient.PatchClusterObjectWithPollOptionsReturns(errors.New("fake-patch-error"))
 		})
 		It("should return an error", func() {
 			Expect(err).To(HaveOccurred())
@@ -991,7 +991,7 @@ var _ = Describe("Unit tests for clusterclass-based upgrade", func() {
 	})
 	Context("When failure happens while waiting for control-plane node upgrade", func() {
 		BeforeEach(func() {
-			regionalClusterClient.PatchClusterObjectReturns(nil)
+			regionalClusterClient.PatchClusterObjectWithPollOptionsReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForCPNodesReturns(errors.New("fake-error-kcp-upgrade"))
 		})
 		It("should return an error", func() {
@@ -1001,7 +1001,7 @@ var _ = Describe("Unit tests for clusterclass-based upgrade", func() {
 	})
 	Context("When failure happens while waiting for worker node upgrade", func() {
 		BeforeEach(func() {
-			regionalClusterClient.PatchClusterObjectReturns(nil)
+			regionalClusterClient.PatchClusterObjectWithPollOptionsReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForCPNodesReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForWorkerNodesReturns(errors.New("fake-error-worker-upgrade"))
 		})
@@ -1012,7 +1012,7 @@ var _ = Describe("Unit tests for clusterclass-based upgrade", func() {
 	})
 	Context("When failure happens while applyPatch for autoscaler upgrade", func() {
 		BeforeEach(func() {
-			regionalClusterClient.PatchClusterObjectReturns(nil)
+			regionalClusterClient.PatchClusterObjectWithPollOptionsReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForCPNodesReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForWorkerNodesReturns(nil)
 			regionalClusterClient.ApplyPatchForAutoScalerDeploymentReturns(errors.Errorf("autoscaler image not available for kubernetes minor version %s", k8sVersionPrefix))
@@ -1024,7 +1024,7 @@ var _ = Describe("Unit tests for clusterclass-based upgrade", func() {
 	})
 	Context("When cluster patch is successful and cluster get's upgraded successfully", func() {
 		BeforeEach(func() {
-			regionalClusterClient.PatchClusterObjectReturns(nil)
+			regionalClusterClient.PatchClusterObjectWithPollOptionsReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForCPNodesReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForWorkerNodesReturns(nil)
 			regionalClusterClient.ApplyPatchForAutoScalerDeploymentReturns(nil)


### PR DESCRIPTION
### What this PR does / why we need it
-  Fix the management cluster upgrade deadlock that
     A. tkr-source-controller is fetching tkrs which are compatible with old tkg version, since the TKGVERSION annotation is not updated.
     B. The TKGVERSION annotation should be updated after cluster upgrade, but the cluster cannot be upgraded due to the missing of the target new tkrs
- Extend the k8s version patch timeout to 15 mins which is longer than the fetcher's frequency of pulling tkrs.
- Put the configmap update before the deployment in tkr-source-controller, to prevent old configurations in configmaps got loaded into the updated  tkr-source-controller pods.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
