### PR TITLE
Change capz pipeline to create cc mc and legacy wc

### DIFF
--- a/tkg/client/upgrade_region.go
+++ b/tkg/client/upgrade_region.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
-	betav1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -702,7 +702,7 @@ func (c *TkgClient) upgradeTelemetryImageIfExists(regionalClusterClient clusterc
 	}
 
 	if CEIPJobExists {
-		telemetryJob := &betav1.CronJob{}
+		telemetryJob := &batchv1.CronJob{}
 		err := regionalClusterClient.GetResource(telemetryJob, "tkg-telemetry", "tkg-system-telemetry", nil, nil)
 		if err != nil {
 			return errors.Wrap(err, "Failed to determine if telemetry job is installed or not")

--- a/tkg/clusterclient/clusterclient.go
+++ b/tkg/clusterclient/clusterclient.go
@@ -24,7 +24,7 @@ import (
 	"github.com/yalp/jsonpath"
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
-	betav1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	extensionsV1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -483,7 +483,7 @@ func init() {
 	_ = capdv1.AddToScheme(scheme)
 	_ = bootstrapv1.AddToScheme(scheme)
 	_ = runv1alpha1.AddToScheme(scheme)
-	_ = betav1.AddToScheme(scheme)
+	_ = batchv1.AddToScheme(scheme)
 	_ = tmcv1alpha1.AddToScheme(scheme)
 	_ = extensionsV1.AddToScheme(scheme)
 	_ = rbacv1.AddToScheme(scheme)
@@ -2566,7 +2566,7 @@ func (c *client) RemoveCEIPTelemetryJob(clusterName string) error {
 		// Don't attempt to delete cronjob if it doesn't exist
 		return nil
 	}
-	jobResource := &betav1.CronJob{}
+	jobResource := &batchv1.CronJob{}
 	jobResource.Namespace = constants.CeipNamespace
 	jobResource.Name = constants.CeipJobName
 	err = c.DeleteResource(jobResource)
@@ -2613,7 +2613,7 @@ func (c *client) AddCEIPTelemetryJob(clusterName, providerName string, bomConfig
 
 // HasCEIPTelemetryJob check whether CEIP telemetry job is present or not
 func (c *client) HasCEIPTelemetryJob(clusterName string) (bool, error) {
-	cronJobs := &betav1.CronJobList{}
+	cronJobs := &batchv1.CronJobList{}
 	err := c.GetResourceList(cronJobs, clusterName, constants.CeipNamespace, nil, nil)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to find telemetry cronjob")

--- a/tkg/constants/cluster_internal.go
+++ b/tkg/constants/cluster_internal.go
@@ -29,7 +29,7 @@ const (
 
 	CronJobKind    = "CronJob"
 	CeipNamespace  = "tkg-system-telemetry"
-	CeipAPIVersion = "batch/v1beta1"
+	CeipAPIVersion = "batch/v1"
 	CeipJobName    = "tkg-telemetry"
 
 	AntreaDeploymentName      = "antrea-controller"

--- a/tkg/manifest/telemetry/config-aws.yaml
+++ b/tkg/manifest/telemetry/config-aws.yaml
@@ -45,7 +45,7 @@ roleRef:
   name: tkg-telemetry-cluster-role
 
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: tkg-telemetry

--- a/tkg/manifest/telemetry/config-azure.yaml
+++ b/tkg/manifest/telemetry/config-azure.yaml
@@ -48,7 +48,7 @@ roleRef:
   name: tkg-telemetry-cluster-role
 
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: tkg-telemetry

--- a/tkg/manifest/telemetry/config-docker.yaml
+++ b/tkg/manifest/telemetry/config-docker.yaml
@@ -48,7 +48,7 @@ roleRef:
   name: tkg-telemetry-cluster-role
 
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: tkg-telemetry

--- a/tkg/manifest/telemetry/config-vsphere.yaml
+++ b/tkg/manifest/telemetry/config-vsphere.yaml
@@ -48,7 +48,7 @@ roleRef:
   name: tkg-telemetry-cluster-role
 
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: tkg-telemetry

--- a/tkg/test/framework/schemes.go
+++ b/tkg/test/framework/schemes.go
@@ -5,7 +5,7 @@ package framework
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
-	v1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -52,7 +52,7 @@ func AddDefaultSchemes(scheme *runtime.Scheme) {
 	_ = clusterctlv1.AddToScheme(scheme)
 
 	// Add the v1beta1 scheme
-	_ = v1beta1.AddToScheme(scheme)
+	_ = batchv1.AddToScheme(scheme)
 
 	// Add the run v1alpha3 scheme
 	_ = runv1.AddToScheme(scheme)

--- a/tkg/test/scripts/legacy_hack.sh
+++ b/tkg/test/scripts/legacy_hack.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# Copyright 2021 VMware, Inc. All Rights Reserved.
+# Copyright 2023 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-tanzu config set features.management-cluster.package-based-cc false
+# Use clusterclass based management cluster until we need legacy mc again
+#tanzu config set features.management-cluster.package-based-cc false
 tanzu config set features.cluster.allow-legacy-cluster true
 tanzu config get

--- a/tkg/test/tkgctl/shared/ceip.go
+++ b/tkg/test/tkgctl/shared/ceip.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -117,7 +116,7 @@ func E2ECEIPSpec(context context.Context, inputGetter func() E2ECEIPSpecInput) {
 
 func verifyTelemetryJobURL(context context.Context, url string, mcProxy *framework.ClusterProxy) error {
 	client := mcProxy.GetClient()
-	cronJob := &v1beta1.CronJob{}
+	cronJob := &batchv1.CronJob{}
 
 	_, _ = GinkgoWriter.Write([]byte(fmt.Sprintf("Context : %s \n", context)))
 	err := client.Get(context, types.NamespacedName{Name: telemetryName, Namespace: telemetryNamespace}, cronJob)
@@ -149,7 +148,7 @@ func verifyTelemetryJobRunning(context context.Context, mcProxy *framework.Clust
 	scheme := mcProxy.GetScheme()
 	batchv1.AddToScheme(scheme)
 
-	cronJob := &v1beta1.CronJob{}
+	cronJob := &batchv1.CronJob{}
 	if err = client.Get(context, types.NamespacedName{Name: telemetryName, Namespace: telemetryNamespace}, cronJob); err != nil {
 		return err
 	}
@@ -216,7 +215,7 @@ func verifyTelemetryJobRunning(context context.Context, mcProxy *framework.Clust
 	}
 
 	// returning the telemetry cron job schedule back to "0 */6 * * *"
-	cronJob = &v1beta1.CronJob{}
+	cronJob = &batchv1.CronJob{}
 	if err = client.Get(context, types.NamespacedName{Name: telemetryName, Namespace: telemetryNamespace}, cronJob); err != nil {
 		return err
 	}


### PR DESCRIPTION
### What this PR does / why we need it
Since we will not support legacy management cluster anymore, change capz pipeline
to create a cc based mc with legacy workload clusters.
Update cronjobs version from v1beta1 to v1 as v1beta is deprecated in k8s 1.25.
