### PR TITLE
Add VolumeSnapshot related RBACs to provider service account for TKC/GC

### DIFF
--- a/addons/controllers/csi/vspherecsiconfig_controller.go
+++ b/addons/controllers/csi/vspherecsiconfig_controller.go
@@ -75,6 +75,11 @@ var providerServiceAccountRBACRules = []rbacv1.PolicyRule{
 		Resources: []string{"events"},
 		Verbs:     []string{"list"},
 	},
+	{
+		APIGroups: []string{""},
+		Resources: []string{"volumesnapshots"},
+		Verbs:     []string{"create", "delete", "get", "list", "patch"},
+	},
 }
 
 // VsphereCSIProviderServiceAccountAggregatedClusterRole is the cluster role to assign permissions to capv provider

--- a/addons/controllers/vspherecsiconfig_controller_test.go
+++ b/addons/controllers/vspherecsiconfig_controller_test.go
@@ -402,7 +402,7 @@ var _ = Describe("VSphereCSIConfig Reconciler", func() {
 				}
 				Expect(serviceAccount.Spec.Ref.Name).To(Equal(vsphereClusterName))
 				Expect(serviceAccount.Spec.Ref.Namespace).To(Equal(configKey.Namespace))
-				Expect(serviceAccount.Spec.Rules).To(HaveLen(6))
+				Expect(serviceAccount.Spec.Rules).To(HaveLen(7))
 				Expect(serviceAccount.Spec.TargetNamespace).To(Equal("vmware-system-csi"))
 				Expect(serviceAccount.Spec.TargetSecretName).To(Equal("pvcsi-provider-creds"))
 				return nil
@@ -421,7 +421,7 @@ var _ = Describe("VSphereCSIConfig Reconciler", func() {
 				Expect(clusterRole.Labels).To(Equal(map[string]string{
 					constants.CAPVClusterRoleAggregationRuleLabelSelectorKey: constants.CAPVClusterRoleAggregationRuleLabelSelectorValue,
 				}))
-				Expect(clusterRole.Rules).To(HaveLen(6))
+				Expect(clusterRole.Rules).To(HaveLen(7))
 				return nil
 			}, waitTimeout, pollingInterval).Should(Succeed())
 		})


### PR DESCRIPTION
### What this PR does / why we need it
This PR adds RBAC rules for volume snapshot objects to provider service account when CSI controller is running in paravirtual mode. That provides the guest cluster with all the permissions to operate volume snapshot objects.
This is being done for adding snapshot support in WCP.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note
Add VolumeSnapshot related RBACs to provider service account for TKC/GC
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
