### PR TITLE
Configure Dex to issue refresh tokens with an expiry of 9h

### DIFF
--- a/pinniped-components/post-deploy/pkg/schemas/schemas.go
+++ b/pinniped-components/post-deploy/pkg/schemas/schemas.go
@@ -33,6 +33,9 @@ type expiry struct {
 	IDTokens       string `yaml:"idTokens,omitempty"`
 	AuthRequests   string `yaml:"authRequests,omitempty"`
 	DeviceRequests string `yaml:"deviceRequests,omitempty"`
+	// https://dexidp.io/docs/id-tokens/#expiration-and-rotation-settings
+	// Leave this as map[string]any because the contents do not need to be read
+	RefreshTokens map[string]any `yaml:"refreshTokens,omitempty"`
 }
 
 type logger struct {

--- a/providers/ytt/02_addons/auth/pinniped_addon_secret.lib.yaml
+++ b/providers/ytt/02_addons/auth/pinniped_addon_secret.lib.yaml
@@ -95,10 +95,12 @@ dex:
       tlsCert: /etc/dex/tls/tls.crt
       tlsKey: /etc/dex/tls/tls.key
     expiry:
-      signingKeys: 90m
+      signingKeys: 9h
       idTokens: 5m
       authRequests: 90m
       deviceRequests: 5m
+      refreshTokens:
+        absoluteLifetime: 9h
     logger:
       level: info
       format: json

--- a/providers/yttcb/pinniped_addon_secret.lib.yaml
+++ b/providers/yttcb/pinniped_addon_secret.lib.yaml
@@ -103,10 +103,12 @@ dex:
       tlsCert: /etc/dex/tls/tls.crt
       tlsKey: /etc/dex/tls/tls.key
     expiry:
-      signingKeys: 90m
+      signingKeys: 9h
       idTokens: 5m
       authRequests: 90m
       deviceRequests: 5m
+      refreshTokens:
+        absoluteLifetime: 9h
     logger:
       level: info
       format: json


### PR DESCRIPTION
Configure Dex to issue refresh tokens with an expiry of 9h.

This is to support using the more recent versions of Pinniped, which need a relatively long-lived refresh token from Dex so that it can perform refreshes to verify authentication information.