### PR TITLE
Update autoscaler related annotations and Add filter to node-group-auto-discovery arg

### DIFF
--- a/providers/ytt/03_customizations/autoscaler/autoscaler_overlay.yaml
+++ b/providers/ytt/03_customizations/autoscaler/autoscaler_overlay.yaml
@@ -10,8 +10,8 @@ kind: MachineDeployment
 metadata:
   #@overlay/match missing_ok=True
   annotations:
-    cluster.k8s.io/cluster-api-autoscaler-node-group-min-size: #@ "{}".format(data.values.AUTOSCALER_MIN_SIZE_0 or data.values.WORKER_MACHINE_COUNT_0)
-    cluster.k8s.io/cluster-api-autoscaler-node-group-max-size: #@ "{}".format(data.values.AUTOSCALER_MAX_SIZE_0 or data.values.WORKER_MACHINE_COUNT_0)
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: #@ "{}".format(data.values.AUTOSCALER_MIN_SIZE_0 or data.values.WORKER_MACHINE_COUNT_0)
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: #@ "{}".format(data.values.AUTOSCALER_MAX_SIZE_0 or data.values.WORKER_MACHINE_COUNT_0)
 
 #@overlay/match by=overlay.subset({"kind":"MachineDeployment", "metadata": {"name": data.values.CLUSTER_NAME + "-md-1"}}), missing_ok=True
 ---
@@ -20,8 +20,8 @@ kind: MachineDeployment
 metadata:
   #@overlay/match missing_ok=True
   annotations:
-    cluster.k8s.io/cluster-api-autoscaler-node-group-min-size: #@ "{}".format(data.values.AUTOSCALER_MIN_SIZE_1 or data.values.WORKER_MACHINE_COUNT_1)
-    cluster.k8s.io/cluster-api-autoscaler-node-group-max-size: #@ "{}".format(data.values.AUTOSCALER_MAX_SIZE_1 or data.values.WORKER_MACHINE_COUNT_1)
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: #@ "{}".format(data.values.AUTOSCALER_MIN_SIZE_1 or data.values.WORKER_MACHINE_COUNT_1)
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: #@ "{}".format(data.values.AUTOSCALER_MAX_SIZE_1 or data.values.WORKER_MACHINE_COUNT_1)
 
 #@overlay/match by=overlay.subset({"kind":"MachineDeployment", "metadata": {"name": data.values.CLUSTER_NAME + "-md-2"}}), missing_ok=True
 ---
@@ -30,7 +30,7 @@ kind: MachineDeployment
 metadata:
   #@overlay/match missing_ok=True
   annotations:
-    cluster.k8s.io/cluster-api-autoscaler-node-group-min-size: #@ "{}".format(data.values.AUTOSCALER_MIN_SIZE_2 or data.values.WORKER_MACHINE_COUNT_2)
-    cluster.k8s.io/cluster-api-autoscaler-node-group-max-size: #@ "{}".format(data.values.AUTOSCALER_MAX_SIZE_2 or data.values.WORKER_MACHINE_COUNT_2)
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: #@ "{}".format(data.values.AUTOSCALER_MIN_SIZE_2 or data.values.WORKER_MACHINE_COUNT_2)
+    cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: #@ "{}".format(data.values.AUTOSCALER_MAX_SIZE_2 or data.values.WORKER_MACHINE_COUNT_2)
 
 #@ end

--- a/providers/ytt/03_customizations/autoscaler/enable_autoscaler.yaml
+++ b/providers/ytt/03_customizations/autoscaler/enable_autoscaler.yaml
@@ -38,7 +38,7 @@
 #@   args.append("--v=4")
 #@   args.append("--clusterapi-cloud-config-authoritative")
 #@   args.append("--kubeconfig=" + autoscaler_kubeconfig_mount_path() + "/value")
-#@   args.append("--node-group-auto-discovery=clusterapi:clusterName=" + data.values.CLUSTER_NAME)
+#@   args.append("--node-group-auto-discovery=clusterapi:clusterName=" + data.values.CLUSTER_NAME + ",namespace=" +data.values.NAMESPACE)
 #@   args.append("--scale-down-delay-after-add=" + data.values.AUTOSCALER_SCALE_DOWN_DELAY_AFTER_ADD)
 #@   args.append("--scale-down-delay-after-delete=" + data.values.AUTOSCALER_SCALE_DOWN_DELAY_AFTER_DELETE)
 #@   args.append("--scale-down-delay-after-failure=" + data.values.AUTOSCALER_SCALE_DOWN_DELAY_AFTER_FAILURE)
@@ -234,5 +234,12 @@ rules:
   verbs:
   - get
   - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
 
 #@ end

--- a/providers/yttcc/02_customizations/autoscaler/enable_autoscaler.yaml
+++ b/providers/yttcc/02_customizations/autoscaler/enable_autoscaler.yaml
@@ -38,7 +38,7 @@
 #@   args.append("--v=4")
 #@   args.append("--clusterapi-cloud-config-authoritative")
 #@   args.append("--kubeconfig=" + autoscaler_kubeconfig_mount_path() + "/value")
-#@   args.append("--node-group-auto-discovery=clusterapi:clusterName=" + data.values.CLUSTER_NAME)
+#@   args.append("--node-group-auto-discovery=clusterapi:clusterName=" + data.values.CLUSTER_NAME +",namespace=" +data.values.NAMESPACE)
 #@   args.append("--scale-down-delay-after-add=" + data.values.AUTOSCALER_SCALE_DOWN_DELAY_AFTER_ADD)
 #@   args.append("--scale-down-delay-after-delete=" + data.values.AUTOSCALER_SCALE_DOWN_DELAY_AFTER_DELETE)
 #@   args.append("--scale-down-delay-after-failure=" + data.values.AUTOSCALER_SCALE_DOWN_DELAY_AFTER_FAILURE)
@@ -234,5 +234,12 @@ rules:
     verbs:
       - get
       - update
+  - apiGroups:
+      - infrastructure.cluster.x-k8s.io
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
 
 #@ end


### PR DESCRIPTION
### What this PR does / why we need it
1. Add a filter "namespace" for autoscaler arg "--node-group-auto-discovery". Otherwise, in the case of creating a cluster but not in the default namespace, autoscaler can't find the node group.
2. These two annotations have been deprecated since v1.25.0, use new annotations.
```
deprecated:
cluster.k8s.io/cluster-api-autoscaler-node-group-max-size: "5"
cluster.k8s.io/cluster-api-autoscaler-node-group-min-size: "0"

new:
cluster.x-k8s.io/cluster-api-autoscaler-node-group-max-size: "5"
cluster.x-k8s.io/cluster-api-autoscaler-node-group-min-size: "0"
```
3. Since scale-from-zero feature checked in: https://github.com/kubernetes/autoscaler/pull/4840/files we need to add get/list privilege into ClusterRole.
