### PR TITLE
Extract common PinnipedInfo struct so that it can be used everywhere

### DIFF
--- a/cli/core/go.mod
+++ b/cli/core/go.mod
@@ -7,6 +7,7 @@ replace (
 	github.com/vmware-tanzu/tanzu-framework/apis/run => ../../apis/run
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client => ../../capabilities/client
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime => ../runtime
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common => ../../pinniped-components/common
 )
 
 require (
@@ -38,6 +39,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime v0.0.0-00010101000000-000000000000
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common v0.0.0-00010101000000-000000000000
 	go.uber.org/multierr v1.6.0
 	golang.org/x/mod v0.8.0
 	golang.org/x/oauth2 v0.3.0

--- a/cli/core/pkg/auth/tkg/cluster_pinniped_info_test.go
+++ b/cli/core/pkg/auth/tkg/cluster_pinniped_info_test.go
@@ -16,6 +16,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	fakehelper "github.com/vmware-tanzu/tanzu-framework/cli/core/pkg/fakes/helper"
+	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/common/pkg/pinnipedinfo"
 )
 
 const (
@@ -123,7 +124,7 @@ var _ = Describe("Kubeconfig Tests", func() {
 
 		Context("When the configMap 'pinniped-info' is not present in kube-public namespace", func() {
 			var cluster clientcmdapi.Cluster
-			var gotPinnipedInfo *PinnipedConfigMapInfo
+			var gotPinnipedInfo *pinnipedinfo.PinnipedInfo
 			BeforeEach(func() {
 				tlsserver.AppendHandlers(
 					ghttp.CombineHandlers(
@@ -162,13 +163,13 @@ var _ = Describe("Kubeconfig Tests", func() {
 		})
 		Context("When the configMap 'pinniped-info' is present in kube-public namespace", func() {
 			var cluster clientcmdapi.Cluster
-			var gotPinnipedInfo *PinnipedConfigMapInfo
+			var gotPinnipedInfo *pinnipedinfo.PinnipedInfo
 			BeforeEach(func() {
 				clustername = fakeCluster
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
 				conciergeIsClusterScoped = false
-				pinnipedInfo := fakehelper.GetFakePinnipedInfo(fakehelper.PinnipedInfo{
+				pinnipedInfo := fakehelper.GetFakePinnipedInfo(pinnipedinfo.PinnipedInfo{
 					ClusterName:              clustername,
 					Issuer:                   issuer,
 					IssuerCABundleData:       issuerCA,
@@ -186,15 +187,15 @@ var _ = Describe("Kubeconfig Tests", func() {
 			})
 			It("should return the pinniped-info successfully", func() {
 				Expect(err).ToNot(HaveOccurred())
-				Expect(gotPinnipedInfo.Data.ClusterName).Should(Equal(clustername))
-				Expect(gotPinnipedInfo.Data.Issuer).Should(Equal(issuer))
-				Expect(gotPinnipedInfo.Data.IssuerCABundle).Should(Equal(issuerCA))
-				Expect(gotPinnipedInfo.Data.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
+				Expect(gotPinnipedInfo.ClusterName).Should(Equal(clustername))
+				Expect(gotPinnipedInfo.Issuer).Should(Equal(issuer))
+				Expect(gotPinnipedInfo.IssuerCABundleData).Should(Equal(issuerCA))
+				Expect(gotPinnipedInfo.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
 			})
 		})
 		Context("When a different port is used for discovery of 'pinniped-info'", func() {
 			var cluster clientcmdapi.Cluster
-			var gotPinnipedInfo *PinnipedConfigMapInfo
+			var gotPinnipedInfo *pinnipedinfo.PinnipedInfo
 			var discoveryTLSServer *ghttp.Server
 			BeforeEach(func() {
 				// The second TLS server mimics the different endpoints for
@@ -211,7 +212,7 @@ var _ = Describe("Kubeconfig Tests", func() {
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
 				conciergeIsClusterScoped = false
-				pinnipedInfo := fakehelper.GetFakePinnipedInfo(fakehelper.PinnipedInfo{
+				pinnipedInfo := fakehelper.GetFakePinnipedInfo(pinnipedinfo.PinnipedInfo{
 					ClusterName:              clustername,
 					Issuer:                   issuer,
 					IssuerCABundleData:       issuerCA,
@@ -229,23 +230,22 @@ var _ = Describe("Kubeconfig Tests", func() {
 			})
 			It("should return the pinniped-info successfully", func() {
 				Expect(err).ToNot(HaveOccurred())
-				Expect(gotPinnipedInfo.Data.ClusterName).Should(Equal(clustername))
-				Expect(gotPinnipedInfo.Data.Issuer).Should(Equal(issuer))
-				Expect(gotPinnipedInfo.Data.IssuerCABundle).Should(Equal(issuerCA))
-				Expect(gotPinnipedInfo.Data.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
+				Expect(gotPinnipedInfo.ClusterName).Should(Equal(clustername))
+				Expect(gotPinnipedInfo.Issuer).Should(Equal(issuer))
+				Expect(gotPinnipedInfo.IssuerCABundleData).Should(Equal(issuerCA))
+				Expect(gotPinnipedInfo.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
 			})
 		})
 		Context("When the concierge endpoint is distinct from the cluster endpoint", func() {
 			var cluster clientcmdapi.Cluster
-			var gotPinnipedInfo *PinnipedConfigMapInfo
-			var conciergeEndpoint string
+			var gotPinnipedInfo *pinnipedinfo.PinnipedInfo
+			conciergeEndpoint := "my-favourite-concierge.com"
 			BeforeEach(func() {
 				clustername = fakeCluster
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
-				conciergeEndpoint = "my-favourite-concierge.com"
 				conciergeIsClusterScoped = false
-				pinnipedInfo := fakehelper.GetFakePinnipedInfo(fakehelper.PinnipedInfo{
+				pinnipedInfo := fakehelper.GetFakePinnipedInfo(pinnipedinfo.PinnipedInfo{
 					ClusterName:              clustername,
 					Issuer:                   issuer,
 					IssuerCABundleData:       issuerCA,
@@ -264,11 +264,11 @@ var _ = Describe("Kubeconfig Tests", func() {
 			})
 			It("should return the pinniped-info successfully", func() {
 				Expect(err).ToNot(HaveOccurred())
-				Expect(gotPinnipedInfo.Data.ClusterName).Should(Equal(clustername))
-				Expect(gotPinnipedInfo.Data.Issuer).Should(Equal(issuer))
-				Expect(gotPinnipedInfo.Data.IssuerCABundle).Should(Equal(issuerCA))
-				Expect(gotPinnipedInfo.Data.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
-				Expect(gotPinnipedInfo.Data.ConciergeEndpoint).Should(Equal(conciergeEndpoint))
+				Expect(gotPinnipedInfo.ClusterName).Should(Equal(clustername))
+				Expect(gotPinnipedInfo.Issuer).Should(Equal(issuer))
+				Expect(gotPinnipedInfo.IssuerCABundleData).Should(Equal(issuerCA))
+				Expect(gotPinnipedInfo.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
+				Expect(gotPinnipedInfo.ConciergeEndpoint).Should(Equal(conciergeEndpoint))
 			})
 		})
 	})

--- a/cli/core/pkg/auth/tkg/kube_config.go
+++ b/cli/core/pkg/auth/tkg/kube_config.go
@@ -19,6 +19,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	kubeutils "github.com/vmware-tanzu/tanzu-framework/cli/core/pkg/auth/utils/kubeconfig"
+	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/common/pkg/pinnipedinfo"
 )
 
 const (
@@ -79,7 +80,7 @@ func KubeconfigWithPinnipedAuthLoginPlugin(endpoint string, options *KubeConfigO
 		return
 	}
 
-	config, err := GetPinnipedKubeconfig(clusterInfo, pinnipedInfo, pinnipedInfo.Data.ClusterName, pinnipedInfo.Data.Issuer)
+	config, err := GetPinnipedKubeconfig(clusterInfo, pinnipedInfo, pinnipedInfo.ClusterName, pinnipedInfo.Issuer)
 	if err != nil {
 		err = errors.Wrap(err, "unable to get the kubeconfig")
 		return
@@ -152,7 +153,7 @@ func loadKubeconfigAndEnsureContext(kubeConfigPath, context string) ([]byte, err
 }
 
 // GetPinnipedKubeconfig generate kubeconfig given cluster-info and pinniped-info and the requested audience
-func GetPinnipedKubeconfig(cluster *clientcmdapi.Cluster, pinnipedInfo *PinnipedConfigMapInfo, clustername, audience string) (*clientcmdapi.Config, error) {
+func GetPinnipedKubeconfig(cluster *clientcmdapi.Cluster, pinnipedInfo *pinnipedinfo.PinnipedInfo, clustername, audience string) (*clientcmdapi.Config, error) {
 	execConfig := clientcmdapi.ExecConfig{
 		APIVersion: clientauthenticationv1beta1.SchemeGroupVersion.String(),
 		Args:       []string{},
@@ -162,9 +163,9 @@ func GetPinnipedKubeconfig(cluster *clientcmdapi.Cluster, pinnipedInfo *Pinniped
 	execConfig.Command = "tanzu"
 	execConfig.Args = append([]string{"pinniped-auth", "login"}, execConfig.Args...)
 
-	conciergeEndpoint := pinnipedInfo.Data.ConciergeEndpoint
-	if conciergeEndpoint == "" {
-		conciergeEndpoint = cluster.Server
+	conciergeEndpoint := cluster.Server
+	if pinnipedInfo.ConciergeEndpoint != "" {
+		conciergeEndpoint = pinnipedInfo.ConciergeEndpoint
 	}
 
 	// configure concierge
@@ -172,16 +173,16 @@ func GetPinnipedKubeconfig(cluster *clientcmdapi.Cluster, pinnipedInfo *Pinniped
 		"--enable-concierge",
 		"--concierge-authenticator-name="+ConciergeAuthenticatorName,
 		"--concierge-authenticator-type="+ConciergeAuthenticatorType,
-		"--concierge-is-cluster-scoped="+strconv.FormatBool(pinnipedInfo.Data.ConciergeIsClusterScoped),
+		"--concierge-is-cluster-scoped="+strconv.FormatBool(pinnipedInfo.ConciergeIsClusterScoped),
 		"--concierge-endpoint="+conciergeEndpoint,
 		"--concierge-ca-bundle-data="+base64.StdEncoding.EncodeToString(cluster.CertificateAuthorityData),
-		"--issuer="+pinnipedInfo.Data.Issuer, // configure OIDC
+		"--issuer="+pinnipedInfo.Issuer, // configure OIDC
 		"--scopes="+PinnipedOIDCScopes,
-		"--ca-bundle-data="+pinnipedInfo.Data.IssuerCABundle,
+		"--ca-bundle-data="+pinnipedInfo.IssuerCABundleData,
 		"--request-audience="+audience,
 	)
 
-	if !pinnipedInfo.Data.ConciergeIsClusterScoped {
+	if !pinnipedInfo.ConciergeIsClusterScoped {
 		execConfig.Args = append(execConfig.Args, "--concierge-namespace="+ConciergeNamespace)
 	}
 

--- a/cli/core/pkg/auth/tkg/kube_config_test.go
+++ b/cli/core/pkg/auth/tkg/kube_config_test.go
@@ -24,6 +24,7 @@ import (
 
 	tkgauth "github.com/vmware-tanzu/tanzu-framework/cli/core/pkg/auth/tkg"
 	"github.com/vmware-tanzu/tanzu-framework/cli/core/pkg/fakes/helper"
+	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/common/pkg/pinnipedinfo"
 )
 
 var testingDir string
@@ -103,7 +104,7 @@ var _ = Describe("Unit tests for tkg auth", func() {
 				var clusterInfo, pinnipedInfo string
 				clusterInfo = GetFakeClusterInfo(endpoint, servCert)
 				pinnipedInfo = helper.GetFakePinnipedInfo(
-					helper.PinnipedInfo{
+					pinnipedinfo.PinnipedInfo{
 						ClusterName:        clustername,
 						Issuer:             issuer,
 						IssuerCABundleData: issuerCA,
@@ -146,7 +147,7 @@ var _ = Describe("Unit tests for tkg auth", func() {
 				var clusterInfo, pinnipedInfo string
 				clusterInfo = GetFakeClusterInfo(endpoint, servCert)
 				pinnipedInfo = helper.GetFakePinnipedInfo(
-					helper.PinnipedInfo{
+					pinnipedinfo.PinnipedInfo{
 						ClusterName:              clustername,
 						Issuer:                   issuer,
 						IssuerCABundleData:       issuerCA,
@@ -191,7 +192,7 @@ var _ = Describe("Unit tests for tkg auth", func() {
 				conciergeIsClusterScoped = false
 				clusterInfo = GetFakeClusterInfo(endpoint, servCert)
 				pinnipedInfo = helper.GetFakePinnipedInfo(
-					helper.PinnipedInfo{
+					pinnipedinfo.PinnipedInfo{
 						ClusterName:              clustername,
 						Issuer:                   issuer,
 						IssuerCABundleData:       issuerCA,

--- a/cli/core/pkg/fakes/helper/fakeobjectcreater.go
+++ b/cli/core/pkg/fakes/helper/fakeobjectcreater.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
+	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/common/pkg/pinnipedinfo"
 )
 
 // ###################### Fake CAPI objects creation helper ######################
@@ -38,17 +39,8 @@ func GetFakeClusterInfo(server string, cert *x509.Certificate) string {
 	return clusterInfoJSON
 }
 
-// PinnipedInfo contains settings for the supervisor.
-type PinnipedInfo struct {
-	ClusterName              string `json:"cluster_name"`
-	ConciergeEndpoint        string `json:"concierge_endpoint"`
-	Issuer                   string `json:"issuer"`
-	IssuerCABundleData       string `json:"issuer_ca_bundle_data"`
-	ConciergeIsClusterScoped bool   `json:"concierge_is_cluster_scoped,string"`
-}
-
 // GetFakePinnipedInfo returns the pinniped-info configmap
-func GetFakePinnipedInfo(pinnipedInfo PinnipedInfo) string {
+func GetFakePinnipedInfo(pinnipedInfo pinnipedinfo.PinnipedInfo) string {
 	data, err := json.Marshal(pinnipedInfo)
 	if err != nil {
 		err = fmt.Errorf("could not marshal Pinniped info into JSON: %w", err)

--- a/cmd/cli/plugin-admin/builder/go.mod
+++ b/cmd/cli/plugin-admin/builder/go.mod
@@ -8,6 +8,7 @@ replace (
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client => ../../../../capabilities/client
 	github.com/vmware-tanzu/tanzu-framework/cli/core => ../../../../cli/core
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime => ../../../../cli/runtime
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common => ../../../../pinniped-components/common
 )
 
 require (

--- a/cmd/cli/plugin-admin/test/go.mod
+++ b/cmd/cli/plugin-admin/test/go.mod
@@ -8,6 +8,7 @@ replace (
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client => ../../../../capabilities/client
 	github.com/vmware-tanzu/tanzu-framework/cli/core => ../../../../cli/core
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime => ../../../../cli/runtime
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common => ../../../../pinniped-components/common
 )
 
 require (

--- a/cmd/cli/plugin/cluster/go.mod
+++ b/cmd/cli/plugin/cluster/go.mod
@@ -10,6 +10,7 @@ replace (
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client => ../../../../capabilities/client
 	github.com/vmware-tanzu/tanzu-framework/cli/core => ../../../../cli/core
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime => ../../../../cli/runtime
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common => ../../../../pinniped-components/common
 	github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr => ../../../../pkg/v1/tkr
 	github.com/vmware-tanzu/tanzu-framework/tkg => ../../../../tkg
 	github.com/vmware-tanzu/tanzu-framework/tkr => ../../../../tkr
@@ -201,6 +202,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/cli/core v0.0.0-20220914003300-5b2ed024556a // indirect
 	github.com/vmware-tanzu/tanzu-framework/packageclients v0.0.0-20220908202723-7a1ddb97efab // indirect
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/tkr v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/util v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware/govmomi v0.30.2 // indirect

--- a/cmd/cli/plugin/isolated-cluster/go.mod
+++ b/cmd/cli/plugin/isolated-cluster/go.mod
@@ -11,6 +11,7 @@ replace (
 	github.com/vmware-tanzu/tanzu-framework/cli/core => ../../../../cli/core
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime => ../../../../cli/runtime
 	github.com/vmware-tanzu/tanzu-framework/packageclients => ../../../../packageclients
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common => ../../../../pinniped-components/common
 	github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr => ../../../../pkg/v1/tkr
 	github.com/vmware-tanzu/tanzu-framework/tkg => ../../../../tkg
 	github.com/vmware-tanzu/tanzu-framework/tkr => ../../../../tkr
@@ -146,6 +147,7 @@ require (
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/vito/go-interact v1.0.1 // indirect
 	github.com/vmware-tanzu/tanzu-framework/apis/cli v0.0.0-00010101000000-000000000000 // indirect
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common v0.0.0-00010101000000-000000000000 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.23.0 // indirect

--- a/cmd/cli/plugin/login/go.mod
+++ b/cmd/cli/plugin/login/go.mod
@@ -8,6 +8,7 @@ replace (
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client => ../../../../capabilities/client
 	github.com/vmware-tanzu/tanzu-framework/cli/core => ../../../../cli/core
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime => ../../../../cli/runtime
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common => ../../../../pinniped-components/common
 )
 
 require (
@@ -110,6 +111,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/apis/cli v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-00010101000000-000000000000 // indirect
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common v0.0.0-00010101000000-000000000000 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect

--- a/cmd/cli/plugin/managementcluster/go.mod
+++ b/cmd/cli/plugin/managementcluster/go.mod
@@ -9,6 +9,7 @@ replace (
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client => ../../../../capabilities/client
 	github.com/vmware-tanzu/tanzu-framework/cli/core => ../../../../cli/core
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime => ../../../../cli/runtime
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common => ../../../../pinniped-components/common
 	github.com/vmware-tanzu/tanzu-framework/tkg => ../../../../tkg
 	github.com/vmware-tanzu/tanzu-framework/tkr => ../../../../tkr
 	github.com/vmware-tanzu/tanzu-framework/util => ../../../../util
@@ -202,6 +203,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/apis/config v0.0.0-20220824221239-af5a644ffef7 // indirect
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/packageclients v0.0.0-20220908202723-7a1ddb97efab // indirect
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/tkr v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/util v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware/govmomi v0.30.2 // indirect

--- a/cmd/cli/plugin/managementcluster/kubeconfig_get.go
+++ b/cmd/cli/plugin/managementcluster/kubeconfig_get.go
@@ -100,7 +100,7 @@ func getPinnipedKubeconfig(tkgctlClient tkgctl.TKGClient, mcClustername string) 
 	}
 
 	// for management cluster the audience would be set to IssuerURL
-	audience := clusterPinnipedInfo.PinnipedInfo.Data.Issuer
+	audience := clusterPinnipedInfo.PinnipedInfo.Issuer
 
 	kubeconfig, _ := tkgauth.GetPinnipedKubeconfig(clusterPinnipedInfo.ClusterInfo, clusterPinnipedInfo.PinnipedInfo,
 		clusterPinnipedInfo.ClusterName, audience)

--- a/cmd/cli/plugin/package/go.mod
+++ b/cmd/cli/plugin/package/go.mod
@@ -12,6 +12,7 @@ replace (
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime => ../../../../cli/runtime
 	github.com/vmware-tanzu/tanzu-framework/cmd/cli/plugin/secret => ../../../../cmd/cli/plugin/secret
 	github.com/vmware-tanzu/tanzu-framework/packageclients => ../../../../packageclients
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common => ../../../../pinniped-components/common
 	github.com/vmware-tanzu/tanzu-framework/tkg => ../../../../tkg
 	github.com/vmware-tanzu/tanzu-framework/tkr => ../../../../tkr
 	github.com/vmware-tanzu/tanzu-framework/util => ../../../../util
@@ -211,6 +212,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/apis/config v0.0.0-20220824221239-af5a644ffef7 // indirect
 	github.com/vmware-tanzu/tanzu-framework/apis/run v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/cli/core v0.0.0-20220914003300-5b2ed024556a // indirect
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/tkr v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/util v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware/govmomi v0.30.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ replace (
 	github.com/vmware-tanzu/tanzu-framework/cli/core => ./cli/core
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime => ./cli/runtime
 	github.com/vmware-tanzu/tanzu-framework/packageclients => ./packageclients
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common => ./pinniped-components/common
 	github.com/vmware-tanzu/tanzu-framework/pkg/v1/tkr => ./pkg/v1/tkr
 	github.com/vmware-tanzu/tanzu-framework/tkg => ./tkg
 	github.com/vmware-tanzu/tanzu-framework/tkr => ./tkr
@@ -216,6 +217,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/capabilities/client v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/cli/core v0.0.0-20220914003300-5b2ed024556a // indirect
 	github.com/vmware-tanzu/tanzu-framework/packageclients v0.0.0-00010101000000-000000000000 // indirect
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware-tanzu/tanzu-framework/util v0.0.0-00010101000000-000000000000 // indirect
 	github.com/vmware/govmomi v0.30.2 // indirect
 	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0 // indirect

--- a/pinniped-components/common/doc.go
+++ b/pinniped-components/common/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package common is intentionally empty at this time
+package common

--- a/pinniped-components/common/go.mod
+++ b/pinniped-components/common/go.mod
@@ -1,0 +1,5 @@
+module github.com/vmware-tanzu/tanzu-framework/pinniped-components/common
+
+go 1.18
+
+require github.com/pkg/errors v0.9.1

--- a/pinniped-components/common/go.sum
+++ b/pinniped-components/common/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pinniped-components/common/pkg/pinnipedinfo/doc.go
+++ b/pinniped-components/common/pkg/pinnipedinfo/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package pinnipedinfo contains common code related to the Pinniped Info config map
+package pinnipedinfo

--- a/pinniped-components/common/pkg/pinnipedinfo/pinnipedinfo.go
+++ b/pinniped-components/common/pkg/pinnipedinfo/pinnipedinfo.go
@@ -1,0 +1,35 @@
+// Copyright 2023 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package pinnipedinfo
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// PinnipedInfo contains settings for the supervisor.
+type PinnipedInfo struct {
+	ClusterName              string `json:"cluster_name"`
+	Issuer                   string `json:"issuer"`
+	IssuerCABundleData       string `json:"issuer_ca_bundle_data"`
+	ConciergeIsClusterScoped bool   `json:"concierge_is_cluster_scoped,string"`
+
+	// ConciergeEndpoint does not appear to be set anywhere in tanzu-framework.
+	// It appears that `pinniped kubeconfig get` will autodetect this endpoint from the current Kubeconfig context,
+	// when someone invokes `tanzu pinniped-auth login` via a Kubeconfig.
+	// See https://github.com/vmware-tanzu/pinniped/blob/77041760ccf3747972faa9b029fb85f0cb2b592c/cmd/pinniped/cmd/kubeconfig.go#L428-L436
+	ConciergeEndpoint string `json:"concierge_endpoint,omitempty"`
+}
+
+func ByteArrayToPinnipedInfo(responseBody []byte) (*PinnipedInfo, error) {
+	var pinnipedConfigMapInfo struct {
+		Data PinnipedInfo
+	}
+	if err := json.Unmarshal(responseBody, &pinnipedConfigMapInfo); err != nil {
+		return nil, errors.Wrap(err, "error parsing http response body")
+	}
+
+	return &pinnipedConfigMapInfo.Data, nil
+}

--- a/pinniped-components/post-deploy/go.mod
+++ b/pinniped-components/post-deploy/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-logr/logr v1.2.2
 	github.com/jetstack/cert-manager v1.1.0
 	github.com/stretchr/testify v1.8.0
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/pinniped-components/tanzu-auth-controller-manager v0.0.0-00010101000000-000000000000
 	go.pinniped.dev/generated/1.20/apis v0.0.0-00010101000000-000000000000
 	go.pinniped.dev/generated/1.20/client v0.0.0-20220209183828-4d6a2af89419 // Commit SHA 4d6a2af89419 is tag v0.12.1.
@@ -102,5 +103,7 @@ require (
 replace go.pinniped.dev/generated/1.20/apis => go.pinniped.dev/generated/1.19/apis v0.0.0-20220209183828-4d6a2af89419
 
 replace github.com/vmware-tanzu/tanzu-framework/pinniped-components/tanzu-auth-controller-manager => ../tanzu-auth-controller-manager
+
+replace github.com/vmware-tanzu/tanzu-framework/pinniped-components/common => ../common
 
 replace sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.8

--- a/pinniped-components/post-deploy/pkg/configure/configure.go
+++ b/pinniped-components/post-deploy/pkg/configure/configure.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/common/pkg/pinnipedinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/post-deploy/pkg/configure/concierge"
 	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/post-deploy/pkg/configure/dex"
 	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/post-deploy/pkg/configure/supervisor"
@@ -307,10 +308,10 @@ func Pinniped(ctx context.Context, c Clients, inspector inspect.Inspector, p *Pa
 		}
 
 		// create configmap for Pinniped info
-		if err := createOrUpdateManagementClusterPinnipedInfo(ctx, supervisor.PinnipedInfo{
-			MgmtClusterName:          &p.ClusterName,
-			Issuer:                   &supervisorSvcEndpoint,
-			IssuerCABundleData:       &caData,
+		if err := createOrUpdateManagementClusterPinnipedInfo(ctx, pinnipedinfo.PinnipedInfo{
+			ClusterName:              p.ClusterName,
+			Issuer:                   supervisorSvcEndpoint,
+			IssuerCABundleData:       caData,
 			ConciergeIsClusterScoped: p.ConciergeIsClusterScoped,
 		}, c.K8SClientset, p.SupervisorSvcNamespace); err != nil {
 			return err

--- a/pinniped-components/post-deploy/pkg/configure/helper.go
+++ b/pinniped-components/post-deploy/pkg/configure/helper.go
@@ -16,13 +16,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 
+	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/common/pkg/pinnipedinfo"
 	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/post-deploy/pkg/constants"
-
-	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/post-deploy/pkg/configure/supervisor"
 )
 
 // createOrUpdateManagementClusterPinnipedInfo creates Pinniped information or updates existing data for a management cluster.
-func createOrUpdateManagementClusterPinnipedInfo(ctx context.Context, pinnipedInfo supervisor.PinnipedInfo, k8sClientSet kubernetes.Interface, supervisorNamespaceName string) error {
+func createOrUpdateManagementClusterPinnipedInfo(ctx context.Context, pinnipedInfo pinnipedinfo.PinnipedInfo, k8sClientSet kubernetes.Interface, supervisorNamespaceName string) error {
 	var err error
 	zap.S().Info("Creating the ConfigMap for Pinniped info")
 

--- a/pinniped-components/post-deploy/pkg/configure/helper_test.go
+++ b/pinniped-components/post-deploy/pkg/configure/helper_test.go
@@ -18,7 +18,7 @@ import (
 	kubefake "k8s.io/client-go/kubernetes/fake"
 	kubetesting "k8s.io/client-go/testing"
 
-	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/post-deploy/pkg/configure/supervisor"
+	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/common/pkg/pinnipedinfo"
 )
 
 func TestCreateOrUpdateManagementClusterPinnipedInfo(t *testing.T) {
@@ -32,26 +32,16 @@ func TestCreateOrUpdateManagementClusterPinnipedInfo(t *testing.T) {
 		clusterName = "some-cluster-name"
 		issuer      = "some-issuer"
 		issuerCA    = "some-issuer-ca-bundle-data"
-		emptyString = ""
 	)
 
-	managementClusterPinnipedInfo := supervisor.PinnipedInfo{
-		MgmtClusterName:          &clusterName,
-		Issuer:                   &issuer,
-		IssuerCABundleData:       &issuerCA,
+	managementClusterPinnipedInfo := pinnipedinfo.PinnipedInfo{
+		ClusterName:              clusterName,
+		Issuer:                   issuer,
+		IssuerCABundleData:       issuerCA,
 		ConciergeIsClusterScoped: true,
 	}
 
-	workloadClusterPinnipedInfo := supervisor.PinnipedInfo{
-		ConciergeIsClusterScoped: true,
-	}
-
-	emptyFieldsPinnipedInfo := supervisor.PinnipedInfo{
-		MgmtClusterName:          &emptyString,
-		Issuer:                   &emptyString,
-		IssuerCABundleData:       &emptyString,
-		ConciergeIsClusterScoped: false,
-	}
+	emptyFieldsPinnipedInfo := pinnipedinfo.PinnipedInfo{}
 
 	configMapGVR := corev1.SchemeGroupVersion.WithResource("configmaps")
 	namespaceGVR := corev1.SchemeGroupVersion.WithResource("namespaces")
@@ -74,17 +64,6 @@ func TestCreateOrUpdateManagementClusterPinnipedInfo(t *testing.T) {
 			"issuer":                      issuer,
 			"issuer_ca_bundle_data":       issuerCA,
 			"concierge_is_cluster_scoped": fmt.Sprintf("%t", managementClusterPinnipedInfo.ConciergeIsClusterScoped),
-		},
-	}
-
-	workloadClusterPinnipedInfoConfigMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:       kubePublicNamespaceName,
-			Name:            pinnipedInfoConfigMapName,
-			OwnerReferences: []metav1.OwnerReference{supervisorNamespaceOwnerRef},
-		},
-		Data: map[string]string{
-			"concierge_is_cluster_scoped": fmt.Sprintf("%t", workloadClusterPinnipedInfo.ConciergeIsClusterScoped),
 		},
 	}
 
@@ -131,7 +110,7 @@ func TestCreateOrUpdateManagementClusterPinnipedInfo(t *testing.T) {
 	tests := []struct {
 		name          string
 		newKubeClient func() *kubefake.Clientset
-		pinnipedInfo  supervisor.PinnipedInfo
+		pinnipedInfo  pinnipedinfo.PinnipedInfo
 		wantError     string
 		wantActions   []kubetesting.Action
 	}{
@@ -217,19 +196,6 @@ func TestCreateOrUpdateManagementClusterPinnipedInfo(t *testing.T) {
 				kubetesting.NewGetAction(configMapGVR, kubePublicNamespaceName, pinnipedInfoConfigMapName),
 				kubetesting.NewGetAction(configMapGVR, kubePublicNamespaceName, pinnipedInfoConfigMapName),
 				kubetesting.NewUpdateAction(configMapGVR, kubePublicNamespaceName, managementClusterPinnipedInfoConfigMap),
-			},
-		},
-		{
-			name: "pinniped info exists and is up to date for workload cluster",
-			newKubeClient: func() *kubefake.Clientset {
-				return kubefake.NewSimpleClientset(workloadClusterPinnipedInfoConfigMap, supervisorNamespace)
-			},
-			pinnipedInfo: workloadClusterPinnipedInfo,
-			wantActions: []kubetesting.Action{
-				kubetesting.NewRootGetAction(namespaceGVR, supervisorNamespaceName),
-				kubetesting.NewGetAction(configMapGVR, kubePublicNamespaceName, pinnipedInfoConfigMapName),
-				kubetesting.NewGetAction(configMapGVR, kubePublicNamespaceName, pinnipedInfoConfigMapName),
-				kubetesting.NewUpdateAction(configMapGVR, kubePublicNamespaceName, workloadClusterPinnipedInfoConfigMap),
 			},
 		},
 		{

--- a/pinniped-components/post-deploy/pkg/configure/supervisor/supervisor.go
+++ b/pinniped-components/post-deploy/pkg/configure/supervisor/supervisor.go
@@ -31,14 +31,6 @@ type Configurator struct {
 	K8SClientset kubernetes.Interface
 }
 
-// PinnipedInfo contains settings for the supervisor.
-type PinnipedInfo struct {
-	MgmtClusterName          *string `json:"cluster_name,omitempty"`
-	Issuer                   *string `json:"issuer,omitempty"`
-	IssuerCABundleData       *string `json:"issuer_ca_bundle_data,omitempty"`
-	ConciergeIsClusterScoped bool    `json:"concierge_is_cluster_scoped,string"`
-}
-
 // CreateOrUpdateFederationDomain creates a new federation domain or updates an existing one.
 func (c Configurator) CreateOrUpdateFederationDomain(ctx context.Context, namespace, name, issuer string) error {
 	var err error

--- a/tkg/auth/kube_config_test.go
+++ b/tkg/auth/kube_config_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/common/pkg/pinnipedinfo"
 	tkgauth "github.com/vmware-tanzu/tanzu-framework/tkg/auth"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/fakes/helper"
 )
@@ -100,7 +101,7 @@ var _ = Describe("Unit tests for tkg auth", func() {
 				var clusterInfo, pinnipedInfo string
 				clusterInfo = GetFakeClusterInfo(endpoint, servCert)
 				pinnipedInfo = helper.GetFakePinnipedInfo(
-					helper.PinnipedInfo{
+					pinnipedinfo.PinnipedInfo{
 						ClusterName:        clustername,
 						Issuer:             issuer,
 						IssuerCABundleData: issuerCA,
@@ -143,7 +144,7 @@ var _ = Describe("Unit tests for tkg auth", func() {
 				var clusterInfo, pinnipedInfo string
 				clusterInfo = GetFakeClusterInfo(endpoint, servCert)
 				pinnipedInfo = helper.GetFakePinnipedInfo(
-					helper.PinnipedInfo{
+					pinnipedinfo.PinnipedInfo{
 						ClusterName:              clustername,
 						Issuer:                   issuer,
 						IssuerCABundleData:       issuerCA,
@@ -188,7 +189,7 @@ var _ = Describe("Unit tests for tkg auth", func() {
 				conciergeIsClusterScoped = false
 				clusterInfo = GetFakeClusterInfo(endpoint, servCert)
 				pinnipedInfo = helper.GetFakePinnipedInfo(
-					helper.PinnipedInfo{
+					pinnipedinfo.PinnipedInfo{
 						ClusterName:              clustername,
 						Issuer:                   issuer,
 						IssuerCABundleData:       issuerCA,

--- a/tkg/fakes/helper/fakeobjectcreater.go
+++ b/tkg/fakes/helper/fakeobjectcreater.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/vmware-tanzu/tanzu-framework/apis/cli/v1alpha1"
 	tkgsv1alpha2 "github.com/vmware-tanzu/tanzu-framework/apis/run/v1alpha2"
+	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/common/pkg/pinnipedinfo"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/clusterclient"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/constants"
 )
@@ -554,17 +555,8 @@ func GetFakeClusterInfo(server string, cert *x509.Certificate) string {
 	return clusterInfoJSON
 }
 
-// PinnipedInfo contains settings for the supervisor.
-type PinnipedInfo struct {
-	ClusterName              string `json:"cluster_name"`
-	ConciergeEndpoint        string `json:"concierge_endpoint"`
-	Issuer                   string `json:"issuer"`
-	IssuerCABundleData       string `json:"issuer_ca_bundle_data"`
-	ConciergeIsClusterScoped bool   `json:"concierge_is_cluster_scoped,string"`
-}
-
 // GetFakePinnipedInfo returns the pinniped-info configmap
-func GetFakePinnipedInfo(pinnipedInfo PinnipedInfo) string {
+func GetFakePinnipedInfo(pinnipedInfo pinnipedinfo.PinnipedInfo) string {
 	data, err := json.Marshal(pinnipedInfo)
 	if err != nil {
 		err = fmt.Errorf("could not marshal Pinniped info into JSON: %w", err)

--- a/tkg/go.mod
+++ b/tkg/go.mod
@@ -10,6 +10,7 @@ replace (
 	github.com/vmware-tanzu/tanzu-framework/cli/core => ../cli/core
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime => ../cli/runtime
 	github.com/vmware-tanzu/tanzu-framework/packageclients => ../packageclients
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common => ../pinniped-components/common
 	github.com/vmware-tanzu/tanzu-framework/tkr => ../tkr
 	github.com/vmware-tanzu/tanzu-framework/util => ../util
 	sigs.k8s.io/cluster-api => sigs.k8s.io/cluster-api v1.2.8
@@ -74,6 +75,7 @@ require (
 	github.com/vmware-tanzu/tanzu-framework/cli/core v0.0.0-20220914003300-5b2ed024556a
 	github.com/vmware-tanzu/tanzu-framework/cli/runtime v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/packageclients v0.0.0-00010101000000-000000000000
+	github.com/vmware-tanzu/tanzu-framework/pinniped-components/common v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/tkr v0.0.0-00010101000000-000000000000
 	github.com/vmware-tanzu/tanzu-framework/util v0.0.0-00010101000000-000000000000
 	github.com/vmware/govmomi v0.30.2

--- a/tkg/utils/kubeconfig.go
+++ b/tkg/utils/kubeconfig.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/common/pkg/pinnipedinfo"
 	netutil "github.com/vmware-tanzu/tanzu-framework/tkg/utils/net"
 )
 
@@ -25,19 +26,6 @@ const (
 	KubePublicNamespace       = "kube-public"
 	PinnipedInfoConfigMapName = "pinniped-info"
 )
-
-// PinnipedConfigMapInfo defines the fields of pinniped-info configMap
-type PinnipedConfigMapInfo struct {
-	Kind    string `json:"kind" yaml:"kind"`
-	Version string `json:"apiVersion" yaml:"apiVersion"`
-	Data    struct {
-		ClusterName              string `json:"cluster_name" yaml:"cluster_name"`
-		Issuer                   string `json:"issuer" yaml:"issuer"`
-		IssuerCABundle           string `json:"issuer_ca_bundle_data" yaml:"issuer_ca_bundle_data"`
-		ConciergeEndpoint        string `json:"concierge_endpoint" yaml:"concierge_endpoint"`
-		ConciergeIsClusterScoped bool   `json:"concierge_is_cluster_scoped,string" yaml:"concierge_is_cluster_scoped"`
-	}
-}
 
 type clusterInfoConfig struct {
 	Version string `json:"apiVersion"`
@@ -160,7 +148,7 @@ func GetClusterInfoFromCluster(clusterAPIServerURL, configmapName string) (*clie
 // 'discoveryPort' is used to optionally override the port used for discovery. This may be needed on setups that expose
 // discovery information to unauthenticated users on a different port (for instance, to avoid the need to anonymous auth
 // on the apiserver). By default, the endpoint from the cluster-info is used.
-func GetPinnipedInfoFromCluster(clusterInfo *clientcmdapi.Cluster, discoveryPort *int) (*PinnipedConfigMapInfo, error) {
+func GetPinnipedInfoFromCluster(clusterInfo *clientcmdapi.Cluster, discoveryPort *int) (*pinnipedinfo.PinnipedInfo, error) {
 	endpoint := strings.TrimRight(clusterInfo.Server, " /")
 	var err error
 	if discoveryPort != nil {
@@ -203,11 +191,5 @@ func GetPinnipedInfoFromCluster(clusterInfo *clientcmdapi.Cluster, discoveryPort
 		return nil, errors.Wrap(err, "failed to read the response body")
 	}
 
-	var pinnipedConfigMapInfo PinnipedConfigMapInfo
-	err = json.Unmarshal(responseBody, &pinnipedConfigMapInfo)
-	if err != nil {
-		return nil, errors.Wrap(err, "error parsing http response body")
-	}
-
-	return &pinnipedConfigMapInfo, nil
+	return pinnipedinfo.ByteArrayToPinnipedInfo(responseBody)
 }

--- a/tkg/utils/kubeconfig_test.go
+++ b/tkg/utils/kubeconfig_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/onsi/gomega/ghttp"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
+	"github.com/vmware-tanzu/tanzu-framework/pinniped-components/common/pkg/pinnipedinfo"
 	fakehelper "github.com/vmware-tanzu/tanzu-framework/tkg/fakes/helper"
 	"github.com/vmware-tanzu/tanzu-framework/tkg/utils"
 )
@@ -190,7 +191,7 @@ var _ = Describe("Kubeconfig Tests", func() {
 
 		Context("When the configMap 'pinniped-info' is not present in kube-public namespace", func() {
 			var cluster clientcmdapi.Cluster
-			var gotPinnipedInfo *utils.PinnipedConfigMapInfo
+			var gotPinnipedInfo *pinnipedinfo.PinnipedInfo
 			BeforeEach(func() {
 				tlsserver.AppendHandlers(
 					ghttp.CombineHandlers(
@@ -229,13 +230,13 @@ var _ = Describe("Kubeconfig Tests", func() {
 		})
 		Context("When the configMap 'pinniped-info' is present in kube-public namespace", func() {
 			var cluster clientcmdapi.Cluster
-			var gotPinnipedInfo *utils.PinnipedConfigMapInfo
+			var gotPinnipedInfo *pinnipedinfo.PinnipedInfo
 			BeforeEach(func() {
 				clustername = fakeCluster
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
 				conciergeIsClusterScoped = false
-				pinnipedInfo := fakehelper.GetFakePinnipedInfo(fakehelper.PinnipedInfo{
+				pinnipedInfo := fakehelper.GetFakePinnipedInfo(pinnipedinfo.PinnipedInfo{
 					ClusterName:              clustername,
 					Issuer:                   issuer,
 					IssuerCABundleData:       issuerCA,
@@ -253,15 +254,15 @@ var _ = Describe("Kubeconfig Tests", func() {
 			})
 			It("should return the pinniped-info successfully", func() {
 				Expect(err).ToNot(HaveOccurred())
-				Expect(gotPinnipedInfo.Data.ClusterName).Should(Equal(clustername))
-				Expect(gotPinnipedInfo.Data.Issuer).Should(Equal(issuer))
-				Expect(gotPinnipedInfo.Data.IssuerCABundle).Should(Equal(issuerCA))
-				Expect(gotPinnipedInfo.Data.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
+				Expect(gotPinnipedInfo.ClusterName).Should(Equal(clustername))
+				Expect(gotPinnipedInfo.Issuer).Should(Equal(issuer))
+				Expect(gotPinnipedInfo.IssuerCABundleData).Should(Equal(issuerCA))
+				Expect(gotPinnipedInfo.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
 			})
 		})
 		Context("When a different port is used for discovery of 'pinniped-info'", func() {
 			var cluster clientcmdapi.Cluster
-			var gotPinnipedInfo *utils.PinnipedConfigMapInfo
+			var gotPinnipedInfo *pinnipedinfo.PinnipedInfo
 			var discoveryTLSServer *ghttp.Server
 			BeforeEach(func() {
 				// The second TLS server mimics the different endpoints for
@@ -278,7 +279,7 @@ var _ = Describe("Kubeconfig Tests", func() {
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
 				conciergeIsClusterScoped = false
-				pinnipedInfo := fakehelper.GetFakePinnipedInfo(fakehelper.PinnipedInfo{
+				pinnipedInfo := fakehelper.GetFakePinnipedInfo(pinnipedinfo.PinnipedInfo{
 					ClusterName:              clustername,
 					Issuer:                   issuer,
 					IssuerCABundleData:       issuerCA,
@@ -296,15 +297,15 @@ var _ = Describe("Kubeconfig Tests", func() {
 			})
 			It("should return the pinniped-info successfully", func() {
 				Expect(err).ToNot(HaveOccurred())
-				Expect(gotPinnipedInfo.Data.ClusterName).Should(Equal(clustername))
-				Expect(gotPinnipedInfo.Data.Issuer).Should(Equal(issuer))
-				Expect(gotPinnipedInfo.Data.IssuerCABundle).Should(Equal(issuerCA))
-				Expect(gotPinnipedInfo.Data.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
+				Expect(gotPinnipedInfo.ClusterName).Should(Equal(clustername))
+				Expect(gotPinnipedInfo.Issuer).Should(Equal(issuer))
+				Expect(gotPinnipedInfo.IssuerCABundleData).Should(Equal(issuerCA))
+				Expect(gotPinnipedInfo.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
 			})
 		})
 		Context("When the concierge endpoint is distinct from the cluster endpoint", func() {
 			var cluster clientcmdapi.Cluster
-			var gotPinnipedInfo *utils.PinnipedConfigMapInfo
+			var gotPinnipedInfo *pinnipedinfo.PinnipedInfo
 			var conciergeEndpoint string
 			BeforeEach(func() {
 				clustername = fakeCluster
@@ -312,7 +313,7 @@ var _ = Describe("Kubeconfig Tests", func() {
 				issuerCA = fakeCAData
 				conciergeEndpoint = "my-favourite-concierge.com"
 				conciergeIsClusterScoped = false
-				pinnipedInfo := fakehelper.GetFakePinnipedInfo(fakehelper.PinnipedInfo{
+				pinnipedInfo := fakehelper.GetFakePinnipedInfo(pinnipedinfo.PinnipedInfo{
 					ClusterName:              clustername,
 					Issuer:                   issuer,
 					IssuerCABundleData:       issuerCA,
@@ -331,11 +332,11 @@ var _ = Describe("Kubeconfig Tests", func() {
 			})
 			It("should return the pinniped-info successfully", func() {
 				Expect(err).ToNot(HaveOccurred())
-				Expect(gotPinnipedInfo.Data.ClusterName).Should(Equal(clustername))
-				Expect(gotPinnipedInfo.Data.Issuer).Should(Equal(issuer))
-				Expect(gotPinnipedInfo.Data.IssuerCABundle).Should(Equal(issuerCA))
-				Expect(gotPinnipedInfo.Data.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
-				Expect(gotPinnipedInfo.Data.ConciergeEndpoint).Should(Equal(conciergeEndpoint))
+				Expect(gotPinnipedInfo.ClusterName).Should(Equal(clustername))
+				Expect(gotPinnipedInfo.Issuer).Should(Equal(issuer))
+				Expect(gotPinnipedInfo.IssuerCABundleData).Should(Equal(issuerCA))
+				Expect(gotPinnipedInfo.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
+				Expect(gotPinnipedInfo.ConciergeEndpoint).Should(Equal(conciergeEndpoint))
 			})
 		})
 	})

--- a/tkg/vsphere-template-resolver/Dockerfile
+++ b/tkg/vsphere-template-resolver/Dockerfile
@@ -23,6 +23,7 @@ COPY packageclients/ packageclients/
 COPY apis/run/ apis/run/
 COPY util/ util/
 COPY tkr/ tkr/
+COPY pinniped-components/common pinniped-components/common
 
 COPY tkg/go.mod tkg/go.mod
 COPY tkg/go.sum tkg/go.sum


### PR DESCRIPTION
### What this PR does / why we need it

Extract common PinnipedInfo struct so that it can be used everywhere

### Describe testing done for PR

Ran unit tests for changed modules. Not all unit tests can be run locally due to some configuration required.