### PR TITLE
Pinniped | Remove embedded Pinniped 0.4.4 CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ PROVIDER_BUNDLE_ZIP = providers/client/manifest/providers.zip
 TKG_PROVIDER_BUNDLE_ZIP = tkg/tkgctl/client/manifest/providers.zip
 
 PINNIPED_GIT_REPOSITORY = https://github.com/vmware-tanzu/pinniped.git
-PINNIPED_VERSIONS = v0.4.4 v0.12.1
+PINNIPED_VERSIONS = v0.12.1
 
 ifndef IS_OFFICIAL_BUILD
 IS_OFFICIAL_BUILD = ""

--- a/cli/core/pkg/auth/tkg/cluster_pinniped_info_test.go
+++ b/cli/core/pkg/auth/tkg/cluster_pinniped_info_test.go
@@ -27,14 +27,13 @@ const (
 
 var _ = Describe("Kubeconfig Tests", func() {
 	var (
-		err                      error
-		endpoint                 string
-		tlsserver                *ghttp.Server
-		clustername              string
-		issuer                   string
-		issuerCA                 string
-		conciergeIsClusterScoped bool
-		servCert                 *x509.Certificate
+		err         error
+		endpoint    string
+		tlsserver   *ghttp.Server
+		clustername string
+		issuer      string
+		issuerCA    string
+		servCert    *x509.Certificate
 	)
 
 	Describe("Get cluster-info from the cluster", func() {
@@ -168,12 +167,11 @@ var _ = Describe("Kubeconfig Tests", func() {
 				clustername = fakeCluster
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
-				conciergeIsClusterScoped = false
 				pinnipedInfo := fakehelper.GetFakePinnipedInfo(pinnipedinfo.PinnipedInfo{
-					ClusterName:              clustername,
-					Issuer:                   issuer,
-					IssuerCABundleData:       issuerCA,
-					ConciergeIsClusterScoped: conciergeIsClusterScoped})
+					ClusterName:        clustername,
+					Issuer:             issuer,
+					IssuerCABundleData: issuerCA,
+				})
 				tlsserver.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
@@ -190,7 +188,6 @@ var _ = Describe("Kubeconfig Tests", func() {
 				Expect(gotPinnipedInfo.ClusterName).Should(Equal(clustername))
 				Expect(gotPinnipedInfo.Issuer).Should(Equal(issuer))
 				Expect(gotPinnipedInfo.IssuerCABundleData).Should(Equal(issuerCA))
-				Expect(gotPinnipedInfo.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
 			})
 		})
 		Context("When a different port is used for discovery of 'pinniped-info'", func() {
@@ -211,12 +208,11 @@ var _ = Describe("Kubeconfig Tests", func() {
 				clustername = fakeCluster
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
-				conciergeIsClusterScoped = false
 				pinnipedInfo := fakehelper.GetFakePinnipedInfo(pinnipedinfo.PinnipedInfo{
-					ClusterName:              clustername,
-					Issuer:                   issuer,
-					IssuerCABundleData:       issuerCA,
-					ConciergeIsClusterScoped: conciergeIsClusterScoped})
+					ClusterName:        clustername,
+					Issuer:             issuer,
+					IssuerCABundleData: issuerCA,
+				})
 				discoveryTLSServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
@@ -233,7 +229,6 @@ var _ = Describe("Kubeconfig Tests", func() {
 				Expect(gotPinnipedInfo.ClusterName).Should(Equal(clustername))
 				Expect(gotPinnipedInfo.Issuer).Should(Equal(issuer))
 				Expect(gotPinnipedInfo.IssuerCABundleData).Should(Equal(issuerCA))
-				Expect(gotPinnipedInfo.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
 			})
 		})
 		Context("When the concierge endpoint is distinct from the cluster endpoint", func() {
@@ -244,13 +239,12 @@ var _ = Describe("Kubeconfig Tests", func() {
 				clustername = fakeCluster
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
-				conciergeIsClusterScoped = false
 				pinnipedInfo := fakehelper.GetFakePinnipedInfo(pinnipedinfo.PinnipedInfo{
-					ClusterName:              clustername,
-					Issuer:                   issuer,
-					IssuerCABundleData:       issuerCA,
-					ConciergeEndpoint:        conciergeEndpoint,
-					ConciergeIsClusterScoped: conciergeIsClusterScoped})
+					ClusterName:        clustername,
+					Issuer:             issuer,
+					IssuerCABundleData: issuerCA,
+					ConciergeEndpoint:  conciergeEndpoint,
+				})
 				tlsserver.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
@@ -267,7 +261,6 @@ var _ = Describe("Kubeconfig Tests", func() {
 				Expect(gotPinnipedInfo.ClusterName).Should(Equal(clustername))
 				Expect(gotPinnipedInfo.Issuer).Should(Equal(issuer))
 				Expect(gotPinnipedInfo.IssuerCABundleData).Should(Equal(issuerCA))
-				Expect(gotPinnipedInfo.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
 				Expect(gotPinnipedInfo.ConciergeEndpoint).Should(Equal(conciergeEndpoint))
 			})
 		})

--- a/cli/core/pkg/auth/tkg/kube_config.go
+++ b/cli/core/pkg/auth/tkg/kube_config.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -23,9 +22,6 @@ import (
 )
 
 const (
-	// ConciergeNamespace is the namespace where pinniped concierge is deployed
-	ConciergeNamespace = "pinniped-concierge"
-
 	// ConciergeAuthenticatorType is the pinniped concierge authenticator type
 	ConciergeAuthenticatorType = "jwt"
 
@@ -173,7 +169,6 @@ func GetPinnipedKubeconfig(cluster *clientcmdapi.Cluster, pinnipedInfo *pinniped
 		"--enable-concierge",
 		"--concierge-authenticator-name="+ConciergeAuthenticatorName,
 		"--concierge-authenticator-type="+ConciergeAuthenticatorType,
-		"--concierge-is-cluster-scoped="+strconv.FormatBool(pinnipedInfo.ConciergeIsClusterScoped),
 		"--concierge-endpoint="+conciergeEndpoint,
 		"--concierge-ca-bundle-data="+base64.StdEncoding.EncodeToString(cluster.CertificateAuthorityData),
 		"--issuer="+pinnipedInfo.Issuer, // configure OIDC
@@ -181,10 +176,6 @@ func GetPinnipedKubeconfig(cluster *clientcmdapi.Cluster, pinnipedInfo *pinniped
 		"--ca-bundle-data="+pinnipedInfo.IssuerCABundleData,
 		"--request-audience="+audience,
 	)
-
-	if !pinnipedInfo.ConciergeIsClusterScoped {
-		execConfig.Args = append(execConfig.Args, "--concierge-namespace="+ConciergeNamespace)
-	}
 
 	if os.Getenv("TANZU_CLI_PINNIPED_AUTH_LOGIN_SKIP_BROWSER") != "" {
 		execConfig.Args = append(execConfig.Args, "--skip-browser")

--- a/cli/core/pkg/auth/tkg/kube_config_test.go
+++ b/cli/core/pkg/auth/tkg/kube_config_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -38,11 +37,10 @@ const kubeconfigPath = "../../fakes/config/kubeconfig_server_ver.yaml"
 
 var _ = Describe("Unit tests for tkg auth", func() {
 	var (
-		err                      error
-		endpoint                 string
-		tlsserver                *ghttp.Server
-		conciergeIsClusterScoped bool
-		servCert                 *x509.Certificate
+		err       error
+		endpoint  string
+		tlsserver *ghttp.Server
+		servCert  *x509.Certificate
 	)
 
 	const (
@@ -98,7 +96,7 @@ var _ = Describe("Unit tests for tkg auth", func() {
 				Expect(err.Error()).Should(ContainSubstring("failed to get pinniped-info"))
 			})
 		})
-		Context("When ConciergeIsClusterScoped is not set in 'pinniped-info' configMap", func() {
+		Context("When the configMap 'pinniped-info' is present in kube-public namespace", func() {
 			var kubeConfigPath, kubeContext, kubeconfigMergeFilePath string
 			BeforeEach(func() {
 				var clusterInfo, pinnipedInfo string
@@ -108,95 +106,6 @@ var _ = Describe("Unit tests for tkg auth", func() {
 						ClusterName:        clustername,
 						Issuer:             issuer,
 						IssuerCABundleData: issuerCA,
-					})
-				tlsserver.AppendHandlers(
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/cluster-info"),
-						ghttp.RespondWith(http.StatusOK, clusterInfo),
-					),
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
-						ghttp.RespondWith(http.StatusOK, pinnipedInfo),
-					),
-				)
-				kubeconfigMergeFilePath = testingDir + "/config"
-				options := &tkgauth.KubeConfigOptions{
-					MergeFilePath: kubeconfigMergeFilePath,
-				}
-				kubeConfigPath, kubeContext, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, options, tkgauth.DiscoveryStrategy{ClusterInfoConfigMap: tkgauth.DefaultClusterInfoConfigMap})
-			})
-			It("should set default values", func() {
-				Expect(err).ToNot(HaveOccurred())
-				Expect(kubeConfigPath).Should(Equal(kubeconfigMergeFilePath))
-				Expect(len(kubeContext)).Should(Not(Equal(0)))
-				config, err := clientcmd.LoadFromFile(kubeConfigPath)
-				Expect(err).ToNot(HaveOccurred())
-				gotClusterName := config.Contexts[kubeContext].Cluster
-				cluster := config.Clusters[config.Contexts[kubeContext].Cluster]
-				user := config.AuthInfos[config.Contexts[kubeContext].AuthInfo]
-				Expect(cluster.Server).To(Equal(endpoint))
-				Expect(gotClusterName).To(Equal(clustername))
-				expectedExecConf := getExpectedExecConfig(endpoint, issuer, issuerCA, false, servCert)
-				Expect(*user.Exec).To(Equal(*expectedExecConf))
-
-			})
-		})
-		Context("When ConciergeIsClusterScoped is true in 'pinniped-info' configMap", func() {
-			var kubeConfigPath, kubeContext, kubeconfigMergeFilePath string
-			BeforeEach(func() {
-				var clusterInfo, pinnipedInfo string
-				clusterInfo = GetFakeClusterInfo(endpoint, servCert)
-				pinnipedInfo = helper.GetFakePinnipedInfo(
-					pinnipedinfo.PinnipedInfo{
-						ClusterName:              clustername,
-						Issuer:                   issuer,
-						IssuerCABundleData:       issuerCA,
-						ConciergeIsClusterScoped: true,
-					})
-				tlsserver.AppendHandlers(
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/cluster-info"),
-						ghttp.RespondWith(http.StatusOK, clusterInfo),
-					),
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
-						ghttp.RespondWith(http.StatusOK, pinnipedInfo),
-					),
-				)
-				kubeconfigMergeFilePath = testingDir + "/config"
-				options := &tkgauth.KubeConfigOptions{
-					MergeFilePath: kubeconfigMergeFilePath,
-				}
-				kubeConfigPath, kubeContext, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, options, tkgauth.DiscoveryStrategy{ClusterInfoConfigMap: tkgauth.DefaultClusterInfoConfigMap})
-			})
-			It("should not include --concierge-namespace arg in kubeconfig", func() {
-				Expect(err).ToNot(HaveOccurred())
-				Expect(kubeConfigPath).Should(Equal(kubeconfigMergeFilePath))
-				Expect(len(kubeContext)).Should(Not(Equal(0)))
-				config, err := clientcmd.LoadFromFile(kubeConfigPath)
-				Expect(err).ToNot(HaveOccurred())
-				gotClusterName := config.Contexts[kubeContext].Cluster
-				cluster := config.Clusters[config.Contexts[kubeContext].Cluster]
-				user := config.AuthInfos[config.Contexts[kubeContext].AuthInfo]
-				Expect(cluster.Server).To(Equal(endpoint))
-				Expect(gotClusterName).To(Equal(clustername))
-				expectedExecConf := getExpectedExecConfig(endpoint, issuer, issuerCA, true, servCert)
-				Expect(*user.Exec).To(Equal(*expectedExecConf))
-
-			})
-		})
-		Context("When the configMap 'pinniped-info' is present in kube-public namespace", func() {
-			var kubeConfigPath, kubeContext, kubeconfigMergeFilePath string
-			BeforeEach(func() {
-				var clusterInfo, pinnipedInfo string
-				conciergeIsClusterScoped = false
-				clusterInfo = GetFakeClusterInfo(endpoint, servCert)
-				pinnipedInfo = helper.GetFakePinnipedInfo(
-					pinnipedinfo.PinnipedInfo{
-						ClusterName:              clustername,
-						Issuer:                   issuer,
-						IssuerCABundleData:       issuerCA,
-						ConciergeIsClusterScoped: conciergeIsClusterScoped,
 					})
 				tlsserver.AppendHandlers(
 					ghttp.CombineHandlers(
@@ -225,9 +134,8 @@ var _ = Describe("Unit tests for tkg auth", func() {
 				user := config.AuthInfos[config.Contexts[kubeContext].AuthInfo]
 				Expect(cluster.Server).To(Equal(endpoint))
 				Expect(gotClusterName).To(Equal(clustername))
-				expectedExecConf := getExpectedExecConfig(endpoint, issuer, issuerCA, conciergeIsClusterScoped, servCert)
+				expectedExecConf := getExpectedExecConfig(endpoint, issuer, issuerCA, servCert)
 				Expect(*user.Exec).To(Equal(*expectedExecConf))
-
 			})
 		})
 		Describe("Get Tanzu local Kubeconfig path", func() {
@@ -284,24 +192,19 @@ func GetFakeClusterInfo(server string, cert *x509.Certificate) string {
 	return clusterInfoJSON
 }
 
-func getExpectedExecConfig(endpoint string, issuer string, issuerCA string, conciergeIsClusterScoped bool, servCert *x509.Certificate) *clientcmdapi.ExecConfig {
+func getExpectedExecConfig(endpoint string, issuer string, issuerCA string, servCert *x509.Certificate) *clientcmdapi.ExecConfig {
 	certBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: servCert.Raw})
 	args := []string{
 		"pinniped-auth", "login",
 		"--enable-concierge",
 		"--concierge-authenticator-name=" + tkgauth.ConciergeAuthenticatorName,
 		"--concierge-authenticator-type=" + tkgauth.ConciergeAuthenticatorType,
-		"--concierge-is-cluster-scoped=" + strconv.FormatBool(conciergeIsClusterScoped),
 		"--concierge-endpoint=" + endpoint,
 		"--concierge-ca-bundle-data=" + base64.StdEncoding.EncodeToString(certBytes),
 		"--issuer=" + issuer,
 		"--scopes=" + tkgauth.PinnipedOIDCScopes,
 		"--ca-bundle-data=" + issuerCA,
 		"--request-audience=" + issuer,
-	}
-
-	if !conciergeIsClusterScoped {
-		args = append(args, "--concierge-namespace="+tkgauth.ConciergeNamespace)
 	}
 
 	execConfig := &clientcmdapi.ExecConfig{

--- a/docs/cli/commands/tanzu_pinniped-auth_login.md
+++ b/docs/cli/commands/tanzu_pinniped-auth_login.md
@@ -27,8 +27,6 @@ tanzu pinniped-auth login [flags]
       --concierge-authenticator-type string   Concierge authenticator type (e.g., 'webhook', 'jwt')
       --concierge-ca-bundle-data string       CA bundle to use when connecting to the concierge
       --concierge-endpoint string             API base for the Pinniped concierge endpoint
-      --concierge-is-cluster-scoped           Is concierge cluster scoped
-      --concierge-namespace string            Namespace in which the concierge was installed (default "pinniped-concierge")
       --credential-cache string               Path to cluster-specific credentials cache ("" disables the cache) (default "/Users/pkalle/.config/tanzu/pinniped/credentials.yaml")
       --enable-concierge                      Exchange the OIDC ID token with the Pinniped concierge during login
   -h, --help                                  help for login

--- a/pinniped-components/common/pkg/pinnipedinfo/pinnipedinfo.go
+++ b/pinniped-components/common/pkg/pinnipedinfo/pinnipedinfo.go
@@ -11,10 +11,9 @@ import (
 
 // PinnipedInfo contains settings for the supervisor.
 type PinnipedInfo struct {
-	ClusterName              string `json:"cluster_name"`
-	Issuer                   string `json:"issuer"`
-	IssuerCABundleData       string `json:"issuer_ca_bundle_data"`
-	ConciergeIsClusterScoped bool   `json:"concierge_is_cluster_scoped,string"`
+	ClusterName        string `json:"cluster_name"`
+	Issuer             string `json:"issuer"`
+	IssuerCABundleData string `json:"issuer_ca_bundle_data"`
 
 	// ConciergeEndpoint does not appear to be set anywhere in tanzu-framework.
 	// It appears that `pinniped kubeconfig get` will autodetect this endpoint from the current Kubeconfig context,

--- a/pinniped-components/post-deploy/cmd/job/main.go
+++ b/pinniped-components/post-deploy/cmd/job/main.go
@@ -22,9 +22,6 @@ import (
 
 func main() {
 	// optional
-	flag.BoolVar(&vars.ConciergeIsClusterScoped, "concierge-is-cluster-scoped", vars.ConciergeIsClusterScoped, "Whether the Pinniped Concierge APIs are cluster-scoped")
-
-	// optional
 	flag.StringVar(&vars.SupervisorNamespace, "supervisor-namespace", vars.SupervisorNamespace, "The namespace of Pinniped supervisor")
 
 	// required for management cluster: yes

--- a/pinniped-components/post-deploy/pkg/configure/configure.go
+++ b/pinniped-components/post-deploy/pkg/configure/configure.go
@@ -59,7 +59,6 @@ type Parameters struct {
 	DexSvcName               string
 	DexCertName              string
 	DexConfigMapName         string
-	ConciergeIsClusterScoped bool
 }
 
 func ensureDeploymentReady(ctx context.Context, c Clients, namespace, deploymentTypeName string) error {
@@ -207,7 +206,6 @@ func TKGAuthentication(c Clients) error {
 		DexSvcName:               vars.DexSvcName,
 		DexCertName:              vars.DexCertName,
 		DexConfigMapName:         vars.DexConfigMapName,
-		ConciergeIsClusterScoped: vars.ConciergeIsClusterScoped,
 	}); err != nil {
 		// logging has been done inside the function
 		return err
@@ -309,10 +307,9 @@ func Pinniped(ctx context.Context, c Clients, inspector inspect.Inspector, p *Pa
 
 		// create configmap for Pinniped info
 		if err := createOrUpdateManagementClusterPinnipedInfo(ctx, pinnipedinfo.PinnipedInfo{
-			ClusterName:              p.ClusterName,
-			Issuer:                   supervisorSvcEndpoint,
-			IssuerCABundleData:       caData,
-			ConciergeIsClusterScoped: p.ConciergeIsClusterScoped,
+			ClusterName:        p.ClusterName,
+			Issuer:             supervisorSvcEndpoint,
+			IssuerCABundleData: caData,
 		}, c.K8SClientset, p.SupervisorSvcNamespace); err != nil {
 			return err
 		}

--- a/pinniped-components/post-deploy/pkg/configure/configure_test.go
+++ b/pinniped-components/post-deploy/pkg/configure/configure_test.go
@@ -472,10 +472,9 @@ func TestPinniped(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{supervisorNamespaceOwnerRef},
 		},
 		Data: map[string]string{
-			"cluster_name":                "some-pinniped-info-management-cluster-name",
-			"issuer":                      serviceHTTPSEndpoint(supervisorService),
-			"issuer_ca_bundle_data":       base64.StdEncoding.EncodeToString(supervisorCertificateSecret.Data["ca.crt"]),
-			"concierge_is_cluster_scoped": "true",
+			"cluster_name":          "some-pinniped-info-management-cluster-name",
+			"issuer":                serviceHTTPSEndpoint(supervisorService),
+			"issuer_ca_bundle_data": base64.StdEncoding.EncodeToString(supervisorCertificateSecret.Data["ca.crt"]),
 		},
 	}
 
@@ -567,15 +566,14 @@ func TestPinniped(t *testing.T) {
 				return pinnipedconciergefake.NewSimpleClientset(defaultJWTAuthenticator)
 			},
 			parameters: Parameters{
-				ClusterType:              "management",
-				ClusterName:              pinnipedInfoConfigMap.Data["cluster_name"],
-				SupervisorSvcNamespace:   supervisorService.Namespace,
-				SupervisorSvcName:        supervisorService.Name,
-				FederationDomainName:     federationDomain.Name,
-				SupervisorCertNamespace:  supervisorCertificate.Namespace,
-				SupervisorCertName:       supervisorCertificate.Name,
-				JWTAuthenticatorName:     jwtAuthenticator.Name,
-				ConciergeIsClusterScoped: true,
+				ClusterType:             "management",
+				ClusterName:             pinnipedInfoConfigMap.Data["cluster_name"],
+				SupervisorSvcNamespace:  supervisorService.Namespace,
+				SupervisorSvcName:       supervisorService.Name,
+				FederationDomainName:    federationDomain.Name,
+				SupervisorCertNamespace: supervisorCertificate.Namespace,
+				SupervisorCertName:      supervisorCertificate.Name,
+				JWTAuthenticatorName:    jwtAuthenticator.Name,
 			},
 			wantKubeClientActions: []kubetesting.Action{
 				// 1. Get the supervisor service endpoint to create the correct issuer
@@ -652,7 +650,6 @@ func TestPinniped(t *testing.T) {
 				SupervisorCertName:       supervisorCertificate.Name,
 				JWTAuthenticatorName:     jwtAuthenticator.Name,
 				JWTAuthenticatorAudience: "I am a rebel and providing this even when I should not have done so.",
-				ConciergeIsClusterScoped: true,
 			},
 			wantKubeClientActions: []kubetesting.Action{
 				// 1. Get the supervisor service endpoint to create the correct issuer
@@ -709,13 +706,12 @@ func TestPinniped(t *testing.T) {
 				return pinnipedconciergefake.NewSimpleClientset(defaultJWTAuthenticator)
 			},
 			parameters: Parameters{
-				ClusterType:              "workload",
-				ClusterName:              jwtAuthenticator.Spec.Audience,
-				SupervisorSvcNamespace:   supervisorService.Namespace,
-				SupervisorSvcEndpoint:    jwtAuthenticator.Spec.Issuer,
-				SupervisorCABundleData:   jwtAuthenticator.Spec.TLS.CertificateAuthorityData,
-				JWTAuthenticatorName:     jwtAuthenticator.Name,
-				ConciergeIsClusterScoped: true,
+				ClusterType:            "workload",
+				ClusterName:            jwtAuthenticator.Spec.Audience,
+				SupervisorSvcNamespace: supervisorService.Namespace,
+				SupervisorSvcEndpoint:  jwtAuthenticator.Spec.Issuer,
+				SupervisorCABundleData: jwtAuthenticator.Spec.TLS.CertificateAuthorityData,
+				JWTAuthenticatorName:   jwtAuthenticator.Name,
 			},
 			wantKubeClientActions: []kubetesting.Action{
 				// 2. Look for any supervisor pods to recreate (we do this on both management and workload clusters)
@@ -756,7 +752,6 @@ func TestPinniped(t *testing.T) {
 				JWTAuthenticatorName:   jwtAuthenticatorWithUUIDAudience.Name,
 				// custom audience provided
 				JWTAuthenticatorAudience: jwtAuthenticatorWithUUIDAudience.Spec.Audience,
-				ConciergeIsClusterScoped: true,
 			},
 			wantKubeClientActions: []kubetesting.Action{
 				// 2. Look for any supervisor pods to recreate (we do this on both management and workload clusters)

--- a/pinniped-components/post-deploy/pkg/configure/helper_test.go
+++ b/pinniped-components/post-deploy/pkg/configure/helper_test.go
@@ -35,10 +35,9 @@ func TestCreateOrUpdateManagementClusterPinnipedInfo(t *testing.T) {
 	)
 
 	managementClusterPinnipedInfo := pinnipedinfo.PinnipedInfo{
-		ClusterName:              clusterName,
-		Issuer:                   issuer,
-		IssuerCABundleData:       issuerCA,
-		ConciergeIsClusterScoped: true,
+		ClusterName:        clusterName,
+		Issuer:             issuer,
+		IssuerCABundleData: issuerCA,
 	}
 
 	emptyFieldsPinnipedInfo := pinnipedinfo.PinnipedInfo{}
@@ -60,10 +59,9 @@ func TestCreateOrUpdateManagementClusterPinnipedInfo(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{supervisorNamespaceOwnerRef},
 		},
 		Data: map[string]string{
-			"cluster_name":                clusterName,
-			"issuer":                      issuer,
-			"issuer_ca_bundle_data":       issuerCA,
-			"concierge_is_cluster_scoped": fmt.Sprintf("%t", managementClusterPinnipedInfo.ConciergeIsClusterScoped),
+			"cluster_name":          clusterName,
+			"issuer":                issuer,
+			"issuer_ca_bundle_data": issuerCA,
 		},
 	}
 
@@ -74,10 +72,9 @@ func TestCreateOrUpdateManagementClusterPinnipedInfo(t *testing.T) {
 			OwnerReferences: []metav1.OwnerReference{supervisorNamespaceOwnerRef},
 		},
 		Data: map[string]string{
-			"cluster_name":                "",
-			"issuer":                      "",
-			"issuer_ca_bundle_data":       "",
-			"concierge_is_cluster_scoped": "false",
+			"cluster_name":          "",
+			"issuer":                "",
+			"issuer_ca_bundle_data": "",
 		},
 	}
 
@@ -87,10 +84,9 @@ func TestCreateOrUpdateManagementClusterPinnipedInfo(t *testing.T) {
 			Name:      pinnipedInfoConfigMapName,
 		},
 		Data: map[string]string{
-			"cluster_name":                clusterName,
-			"issuer":                      issuer,
-			"issuer_ca_bundle_data":       issuerCA,
-			"concierge_is_cluster_scoped": fmt.Sprintf("%t", managementClusterPinnipedInfo.ConciergeIsClusterScoped),
+			"cluster_name":          clusterName,
+			"issuer":                issuer,
+			"issuer_ca_bundle_data": issuerCA,
 		},
 	}
 
@@ -203,7 +199,7 @@ func TestCreateOrUpdateManagementClusterPinnipedInfo(t *testing.T) {
 			newKubeClient: func() *kubefake.Clientset {
 				existingPinnipedInfoConfigMap := managementClusterPinnipedInfoConfigMap.DeepCopy()
 				existingPinnipedInfoConfigMap.Data = map[string]string{
-					"concierge_is_cluster_scoped": "false",
+					"cluster_name": "invalid-cluster-name",
 				}
 				return kubefake.NewSimpleClientset(managementClusterPinnipedInfoConfigMap, supervisorNamespace)
 			},

--- a/pinniped-components/post-deploy/pkg/vars/vars.go
+++ b/pinniped-components/post-deploy/pkg/vars/vars.go
@@ -5,10 +5,6 @@
 package vars
 
 var (
-	// ConciergeIsClusterScoped indicates whether the Pinniped Concierge APIs are
-	// cluster-scoped (as opposed to namespace-scoped).
-	ConciergeIsClusterScoped = false
-
 	// SupervisorNamespace is the supervisor service namespace.
 	SupervisorNamespace = "pinniped-supervisor"
 

--- a/tkg/auth/kube_config.go
+++ b/tkg/auth/kube_config.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -24,9 +23,6 @@ import (
 )
 
 const (
-	// ConciergeNamespace is the namespace where pinniped concierge is deployed
-	ConciergeNamespace = "pinniped-concierge"
-
 	// ConciergeAuthenticatorType is the pinniped concierge authenticator type
 	ConciergeAuthenticatorType = "jwt"
 
@@ -174,7 +170,6 @@ func GetPinnipedKubeconfig(cluster *clientcmdapi.Cluster, pinnipedInfo *pinniped
 		"--enable-concierge",
 		"--concierge-authenticator-name="+ConciergeAuthenticatorName,
 		"--concierge-authenticator-type="+ConciergeAuthenticatorType,
-		"--concierge-is-cluster-scoped="+strconv.FormatBool(pinnipedInfo.ConciergeIsClusterScoped),
 		"--concierge-endpoint="+conciergeEndpoint,
 		"--concierge-ca-bundle-data="+base64.StdEncoding.EncodeToString(cluster.CertificateAuthorityData),
 		"--issuer="+pinnipedInfo.Issuer, // configure OIDC
@@ -182,10 +177,6 @@ func GetPinnipedKubeconfig(cluster *clientcmdapi.Cluster, pinnipedInfo *pinniped
 		"--ca-bundle-data="+pinnipedInfo.IssuerCABundleData,
 		"--request-audience="+audience,
 	)
-
-	if !pinnipedInfo.ConciergeIsClusterScoped {
-		execConfig.Args = append(execConfig.Args, "--concierge-namespace="+ConciergeNamespace)
-	}
 
 	if os.Getenv("TANZU_CLI_PINNIPED_AUTH_LOGIN_SKIP_BROWSER") != "" {
 		execConfig.Args = append(execConfig.Args, "--skip-browser")

--- a/tkg/auth/kube_config_test.go
+++ b/tkg/auth/kube_config_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -35,11 +34,10 @@ func TestTkgAuth(t *testing.T) {
 
 var _ = Describe("Unit tests for tkg auth", func() {
 	var (
-		err                      error
-		endpoint                 string
-		tlsserver                *ghttp.Server
-		conciergeIsClusterScoped bool
-		servCert                 *x509.Certificate
+		err       error
+		endpoint  string
+		tlsserver *ghttp.Server
+		servCert  *x509.Certificate
 	)
 
 	const (
@@ -95,7 +93,7 @@ var _ = Describe("Unit tests for tkg auth", func() {
 				Expect(err.Error()).Should(ContainSubstring("failed to get pinniped-info"))
 			})
 		})
-		Context("When ConciergeIsClusterScoped is not set in 'pinniped-info' configMap", func() {
+		Context("When the configMap 'pinniped-info' is present in kube-public namespace", func() {
 			var kubeConfigPath, kubeContext, kubeconfigMergeFilePath string
 			BeforeEach(func() {
 				var clusterInfo, pinnipedInfo string
@@ -105,95 +103,6 @@ var _ = Describe("Unit tests for tkg auth", func() {
 						ClusterName:        clustername,
 						Issuer:             issuer,
 						IssuerCABundleData: issuerCA,
-					})
-				tlsserver.AppendHandlers(
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/cluster-info"),
-						ghttp.RespondWith(http.StatusOK, clusterInfo),
-					),
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
-						ghttp.RespondWith(http.StatusOK, pinnipedInfo),
-					),
-				)
-				kubeconfigMergeFilePath = testingDir + "/config"
-				options := &tkgauth.KubeConfigOptions{
-					MergeFilePath: kubeconfigMergeFilePath,
-				}
-				kubeConfigPath, kubeContext, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, options, tkgauth.DiscoveryStrategy{ClusterInfoConfigMap: tkgauth.DefaultClusterInfoConfigMap})
-			})
-			It("should set default values", func() {
-				Expect(err).ToNot(HaveOccurred())
-				Expect(kubeConfigPath).Should(Equal(kubeconfigMergeFilePath))
-				Expect(len(kubeContext)).Should(Not(Equal(0)))
-				config, err := clientcmd.LoadFromFile(kubeConfigPath)
-				Expect(err).ToNot(HaveOccurred())
-				gotClusterName := config.Contexts[kubeContext].Cluster
-				cluster := config.Clusters[config.Contexts[kubeContext].Cluster]
-				user := config.AuthInfos[config.Contexts[kubeContext].AuthInfo]
-				Expect(cluster.Server).To(Equal(endpoint))
-				Expect(gotClusterName).To(Equal(clustername))
-				expectedExecConf := getExpectedExecConfig(endpoint, issuer, issuerCA, false, servCert)
-				Expect(*user.Exec).To(Equal(*expectedExecConf))
-
-			})
-		})
-		Context("When ConciergeIsClusterScoped is true in 'pinniped-info' configMap", func() {
-			var kubeConfigPath, kubeContext, kubeconfigMergeFilePath string
-			BeforeEach(func() {
-				var clusterInfo, pinnipedInfo string
-				clusterInfo = GetFakeClusterInfo(endpoint, servCert)
-				pinnipedInfo = helper.GetFakePinnipedInfo(
-					pinnipedinfo.PinnipedInfo{
-						ClusterName:              clustername,
-						Issuer:                   issuer,
-						IssuerCABundleData:       issuerCA,
-						ConciergeIsClusterScoped: true,
-					})
-				tlsserver.AppendHandlers(
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/cluster-info"),
-						ghttp.RespondWith(http.StatusOK, clusterInfo),
-					),
-					ghttp.CombineHandlers(
-						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
-						ghttp.RespondWith(http.StatusOK, pinnipedInfo),
-					),
-				)
-				kubeconfigMergeFilePath = testingDir + "/config"
-				options := &tkgauth.KubeConfigOptions{
-					MergeFilePath: kubeconfigMergeFilePath,
-				}
-				kubeConfigPath, kubeContext, err = tkgauth.KubeconfigWithPinnipedAuthLoginPlugin(endpoint, options, tkgauth.DiscoveryStrategy{ClusterInfoConfigMap: tkgauth.DefaultClusterInfoConfigMap})
-			})
-			It("should not include --concierge-namespace arg in kubeconfig", func() {
-				Expect(err).ToNot(HaveOccurred())
-				Expect(kubeConfigPath).Should(Equal(kubeconfigMergeFilePath))
-				Expect(len(kubeContext)).Should(Not(Equal(0)))
-				config, err := clientcmd.LoadFromFile(kubeConfigPath)
-				Expect(err).ToNot(HaveOccurred())
-				gotClusterName := config.Contexts[kubeContext].Cluster
-				cluster := config.Clusters[config.Contexts[kubeContext].Cluster]
-				user := config.AuthInfos[config.Contexts[kubeContext].AuthInfo]
-				Expect(cluster.Server).To(Equal(endpoint))
-				Expect(gotClusterName).To(Equal(clustername))
-				expectedExecConf := getExpectedExecConfig(endpoint, issuer, issuerCA, true, servCert)
-				Expect(*user.Exec).To(Equal(*expectedExecConf))
-
-			})
-		})
-		Context("When the configMap 'pinniped-info' is present in kube-public namespace", func() {
-			var kubeConfigPath, kubeContext, kubeconfigMergeFilePath string
-			BeforeEach(func() {
-				var clusterInfo, pinnipedInfo string
-				conciergeIsClusterScoped = false
-				clusterInfo = GetFakeClusterInfo(endpoint, servCert)
-				pinnipedInfo = helper.GetFakePinnipedInfo(
-					pinnipedinfo.PinnipedInfo{
-						ClusterName:              clustername,
-						Issuer:                   issuer,
-						IssuerCABundleData:       issuerCA,
-						ConciergeIsClusterScoped: conciergeIsClusterScoped,
 					})
 				tlsserver.AppendHandlers(
 					ghttp.CombineHandlers(
@@ -222,9 +131,8 @@ var _ = Describe("Unit tests for tkg auth", func() {
 				user := config.AuthInfos[config.Contexts[kubeContext].AuthInfo]
 				Expect(cluster.Server).To(Equal(endpoint))
 				Expect(gotClusterName).To(Equal(clustername))
-				expectedExecConf := getExpectedExecConfig(endpoint, issuer, issuerCA, conciergeIsClusterScoped, servCert)
+				expectedExecConf := getExpectedExecConfig(endpoint, issuer, issuerCA, servCert)
 				Expect(*user.Exec).To(Equal(*expectedExecConf))
-
 			})
 		})
 		Describe("Get Tanzu local Kubeconfig path", func() {
@@ -264,24 +172,19 @@ func GetFakeClusterInfo(server string, cert *x509.Certificate) string {
 	return clusterInfoJSON
 }
 
-func getExpectedExecConfig(endpoint string, issuer string, issuerCA string, conciergeIsClusterScoped bool, servCert *x509.Certificate) *clientcmdapi.ExecConfig {
+func getExpectedExecConfig(endpoint string, issuer string, issuerCA string, servCert *x509.Certificate) *clientcmdapi.ExecConfig {
 	certBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: servCert.Raw})
 	args := []string{
 		"pinniped-auth", "login",
 		"--enable-concierge",
 		"--concierge-authenticator-name=" + tkgauth.ConciergeAuthenticatorName,
 		"--concierge-authenticator-type=" + tkgauth.ConciergeAuthenticatorType,
-		"--concierge-is-cluster-scoped=" + strconv.FormatBool(conciergeIsClusterScoped),
 		"--concierge-endpoint=" + endpoint,
 		"--concierge-ca-bundle-data=" + base64.StdEncoding.EncodeToString(certBytes),
 		"--issuer=" + issuer,
 		"--scopes=" + tkgauth.PinnipedOIDCScopes,
 		"--ca-bundle-data=" + issuerCA,
 		"--request-audience=" + issuer,
-	}
-
-	if !conciergeIsClusterScoped {
-		args = append(args, "--concierge-namespace="+tkgauth.ConciergeNamespace)
 	}
 
 	execConfig := &clientcmdapi.ExecConfig{

--- a/tkg/client/get_cluster_pinniped_info.go
+++ b/tkg/client/get_cluster_pinniped_info.go
@@ -116,20 +116,6 @@ func (c *TkgClient) GetWCClusterPinnipedInfo(
 
 	log.Debugf("Management cluster pinniped info: %+v", managementClusterPinnipedInfo)
 
-	workloadClusterPinnipedInfo, err := utils.GetPinnipedInfoFromCluster(wcClusterInfo, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get pinniped-info from workload cluster")
-	}
-
-	pinnipedInfo := managementClusterPinnipedInfo
-	if workloadClusterPinnipedInfo != nil {
-		// Get ConciergeIsClusterScoped from workload cluster in case it is different from the management cluster
-		pinnipedInfo.ConciergeIsClusterScoped = workloadClusterPinnipedInfo.ConciergeIsClusterScoped
-	} else {
-		// If workloadClusterPinnipedInfo is nil, assume it is an older TKG cluster and set ConciergeIsClusterScoped to defaults
-		pinnipedInfo.ConciergeIsClusterScoped = false
-	}
-
 	// For clusters that use a TKr API version newer than v1alpha1, we use the cluster name + UID as the audience.
 	// Do this on pacific clusters and TKG "classy" clusters, but not on TKG legacy (non-classy) clusters.
 	var audience *string
@@ -153,14 +139,14 @@ func (c *TkgClient) GetWCClusterPinnipedInfo(
 		// Pacific uses a different Concierge endpoint. Ignore it when fetching
 		// a kubeconfig for a workload cluster since we use the workload
 		// cluster APIserver as the concierge endpoint.
-		pinnipedInfo.ConciergeEndpoint = ""
+		managementClusterPinnipedInfo.ConciergeEndpoint = ""
 	}
 
 	return &ClusterPinnipedInfo{
 		ClusterName:     options.ClusterName,
 		ClusterAudience: audience,
 		ClusterInfo:     wcClusterInfo,
-		PinnipedInfo:    pinnipedInfo,
+		PinnipedInfo:    managementClusterPinnipedInfo,
 	}, nil
 }
 

--- a/tkg/utils/kubeconfig_test.go
+++ b/tkg/utils/kubeconfig_test.go
@@ -28,14 +28,13 @@ const (
 
 var _ = Describe("Kubeconfig Tests", func() {
 	var (
-		err                      error
-		endpoint                 string
-		tlsserver                *ghttp.Server
-		clustername              string
-		issuer                   string
-		issuerCA                 string
-		conciergeIsClusterScoped bool
-		servCert                 *x509.Certificate
+		err         error
+		endpoint    string
+		tlsserver   *ghttp.Server
+		clustername string
+		issuer      string
+		issuerCA    string
+		servCert    *x509.Certificate
 	)
 
 	const kubeconfig1Path = "../fakes/config/kubeconfig/config1.yaml"
@@ -235,12 +234,11 @@ var _ = Describe("Kubeconfig Tests", func() {
 				clustername = fakeCluster
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
-				conciergeIsClusterScoped = false
 				pinnipedInfo := fakehelper.GetFakePinnipedInfo(pinnipedinfo.PinnipedInfo{
-					ClusterName:              clustername,
-					Issuer:                   issuer,
-					IssuerCABundleData:       issuerCA,
-					ConciergeIsClusterScoped: conciergeIsClusterScoped})
+					ClusterName:        clustername,
+					Issuer:             issuer,
+					IssuerCABundleData: issuerCA,
+				})
 				tlsserver.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
@@ -257,7 +255,6 @@ var _ = Describe("Kubeconfig Tests", func() {
 				Expect(gotPinnipedInfo.ClusterName).Should(Equal(clustername))
 				Expect(gotPinnipedInfo.Issuer).Should(Equal(issuer))
 				Expect(gotPinnipedInfo.IssuerCABundleData).Should(Equal(issuerCA))
-				Expect(gotPinnipedInfo.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
 			})
 		})
 		Context("When a different port is used for discovery of 'pinniped-info'", func() {
@@ -278,12 +275,11 @@ var _ = Describe("Kubeconfig Tests", func() {
 				clustername = fakeCluster
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
-				conciergeIsClusterScoped = false
 				pinnipedInfo := fakehelper.GetFakePinnipedInfo(pinnipedinfo.PinnipedInfo{
-					ClusterName:              clustername,
-					Issuer:                   issuer,
-					IssuerCABundleData:       issuerCA,
-					ConciergeIsClusterScoped: conciergeIsClusterScoped})
+					ClusterName:        clustername,
+					Issuer:             issuer,
+					IssuerCABundleData: issuerCA,
+				})
 				discoveryTLSServer.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
@@ -300,7 +296,6 @@ var _ = Describe("Kubeconfig Tests", func() {
 				Expect(gotPinnipedInfo.ClusterName).Should(Equal(clustername))
 				Expect(gotPinnipedInfo.Issuer).Should(Equal(issuer))
 				Expect(gotPinnipedInfo.IssuerCABundleData).Should(Equal(issuerCA))
-				Expect(gotPinnipedInfo.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
 			})
 		})
 		Context("When the concierge endpoint is distinct from the cluster endpoint", func() {
@@ -312,13 +307,12 @@ var _ = Describe("Kubeconfig Tests", func() {
 				issuer = fakeIssuer
 				issuerCA = fakeCAData
 				conciergeEndpoint = "my-favourite-concierge.com"
-				conciergeIsClusterScoped = false
 				pinnipedInfo := fakehelper.GetFakePinnipedInfo(pinnipedinfo.PinnipedInfo{
-					ClusterName:              clustername,
-					Issuer:                   issuer,
-					IssuerCABundleData:       issuerCA,
-					ConciergeEndpoint:        conciergeEndpoint,
-					ConciergeIsClusterScoped: conciergeIsClusterScoped})
+					ClusterName:        clustername,
+					Issuer:             issuer,
+					IssuerCABundleData: issuerCA,
+					ConciergeEndpoint:  conciergeEndpoint,
+				})
 				tlsserver.AppendHandlers(
 					ghttp.CombineHandlers(
 						ghttp.VerifyRequest("GET", "/api/v1/namespaces/kube-public/configmaps/pinniped-info"),
@@ -335,7 +329,6 @@ var _ = Describe("Kubeconfig Tests", func() {
 				Expect(gotPinnipedInfo.ClusterName).Should(Equal(clustername))
 				Expect(gotPinnipedInfo.Issuer).Should(Equal(issuer))
 				Expect(gotPinnipedInfo.IssuerCABundleData).Should(Equal(issuerCA))
-				Expect(gotPinnipedInfo.ConciergeIsClusterScoped).Should(Equal(conciergeIsClusterScoped))
 				Expect(gotPinnipedInfo.ConciergeEndpoint).Should(Equal(conciergeEndpoint))
 			})
 		})


### PR DESCRIPTION
Pinniped | Remove embedded Pinniped 0.4.4 CLI

NOTE: I have reworked this PR to simply remove the old 0.4.4 CLI. This PR does not introduce a newer version of the CLI, since Pinniped 0.22.0 requires go1.19+ to compile. (This means the branch name is stale).

This PR also removes the `--concierge-namespace`/`--concierge-is-cluster-scoped` args which were only used for the Pinniped 0.4.4 CLI.

Depends on:
- [x] #4514 