### PR TITLE
use latest tkgConfigReaderWriter to validate vsphere contol plane end point 

### DIFF
--- a/tkg/client/validate.go
+++ b/tkg/client/validate.go
@@ -651,6 +651,11 @@ func (c *TkgClient) ConfigureAndValidateManagementClusterConfiguration(options *
 
 // ValidateVsphereControlPlaneEndpointIP validates if the control plane endpoint has been used by another cluster in the same network
 func (c *TkgClient) ValidateVsphereControlPlaneEndpointIP(endpointIP string) *ValidationError {
+	//should read from TKGConfigReaderWriter if endpointIP not set
+	if endpointIP == "" {
+		endpointIP, _ = c.TKGConfigReaderWriter().Get(constants.ConfigVariableVsphereControlPlaneEndpoint)
+	}
+
 	log.V(6).Infof("Checking if VSPHERE_CONTROL_PLANE_ENDPOINT %s is already in use", endpointIP)
 	currentNetwork, err := c.TKGConfigReaderWriter().Get(constants.ConfigVariableVsphereNetwork)
 	if err != nil {
@@ -838,6 +843,12 @@ func (c *TkgClient) ValidateVsphereVipWorkloadCluster(clusterClient clusterclien
 	if err != nil {
 		return errors.Wrapf(err, "failed to get clusters")
 	}
+
+	//should read from TKGConfigReaderWriter if vip not set
+	if vip == "" {
+		vip, _ = c.TKGConfigReaderWriter().Get(constants.ConfigVariableVsphereControlPlaneEndpoint)
+	}
+
 	for i := range clusterList {
 		if clusterList[i].Spec.ControlPlaneEndpoint.Host == vip {
 			return errors.Errorf("control plane endpoint '%s' already in use by cluster '%s' and cannot be reused", vip, clusterList[i].ObjectMeta.Name)


### PR DESCRIPTION
### What this PR does / why we need it
tanzu cli should use vip from tkg config reader writer for validation. The configs are written to tkg config readerwriter [here](https://github.com/vmware-tanzu/tanzu-framework/blob/main/tkg/client/validate.go#L798). If vip is set by `_VSPHERE_CONTROL_PLANE_ENDPOINT`, the validation did not catch this config and always pass the validation.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
