### PR TITLE
Zero out the AWS credential for CC upgrade

### DIFF
--- a/tkg/client/upgrade_cluster_clusterclass.go
+++ b/tkg/client/upgrade_cluster_clusterclass.go
@@ -16,15 +16,20 @@ import (
 func (c *TkgClient) DoClassyClusterUpgrade(regionalClusterClient clusterclient.Client,
 	currentClusterClient clusterclient.Client, options *UpgradeClusterOptions) error {
 
+	if err := currentClusterClient.PatchClusterAPIAWSControllersToUseEC2Credentials(); err != nil {
+		return errors.Wrap(err, "unable to zero out the cluster-api-aws credentials")
+	}
+
 	kubernetesVersion := options.KubernetesVersion
 	tkrVersion := options.TkrVersion
 
 	log.Infof("Upgrading kubernetes cluster to `%v` version, tkr version: `%s`", kubernetesVersion, tkrVersion)
 	patchJSONString := fmt.Sprintf(`{"spec": {"topology": {"version": "%v"}}}`, tkrVersion)
 
-	// Timeout set to 15 minutes because the continuousTKRDiscoverFreq for tkr-source-controller's fetcher is 10 minutes.
-	// Wait time should be longer than the fetcher's frequency of pulling tkrs.
-	pollOptions := &clusterclient.PollOptions{Interval: upgradePatchInterval, Timeout: 15 * time.Minute}
+	// Timeout set to 30 minutes because the continuousTKRDiscoverFreq for tkr-source-controller's fetcher is 10 minutes.
+	// And kapp package reconcile frequency is 10 minutes.
+	// Wait time should be longer than the fetcher's frequency of pulling tkrs plus the frequency of kapp package reconciliation.
+	pollOptions := &clusterclient.PollOptions{Interval: upgradePatchInterval, Timeout: 30 * time.Minute}
 	err := regionalClusterClient.PatchClusterObjectWithPollOptions(options.ClusterName, options.Namespace, patchJSONString, pollOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to patch kubernetes version to cluster")

--- a/tkg/client/upgrade_cluster_test.go
+++ b/tkg/client/upgrade_cluster_test.go
@@ -980,8 +980,18 @@ var _ = Describe("Unit tests for clusterclass-based upgrade", func() {
 	JustBeforeEach(func() {
 		err = tkgClient.DoClassyClusterUpgrade(regionalClusterClient, currentClusterClient, &upgradeClusterOptions)
 	})
+	Context("When patch ClusterAPI AWSControllers to use EC2 credentials fails", func() {
+		BeforeEach(func() {
+			currentClusterClient.PatchClusterAPIAWSControllersToUseEC2CredentialsReturns(errors.New("fake-patch-CAPA-cred-error"))
+		})
+		It("should return an error", func() {
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unable to zero out the cluster-api-aws credentials: fake-patch-CAPA-cred-error"))
+		})
+	})
 	Context("When cluster patch fails", func() {
 		BeforeEach(func() {
+			currentClusterClient.PatchClusterAPIAWSControllersToUseEC2CredentialsReturns(nil)
 			regionalClusterClient.PatchClusterObjectWithPollOptionsReturns(errors.New("fake-patch-error"))
 		})
 		It("should return an error", func() {
@@ -991,6 +1001,7 @@ var _ = Describe("Unit tests for clusterclass-based upgrade", func() {
 	})
 	Context("When failure happens while waiting for control-plane node upgrade", func() {
 		BeforeEach(func() {
+			currentClusterClient.PatchClusterAPIAWSControllersToUseEC2CredentialsReturns(nil)
 			regionalClusterClient.PatchClusterObjectWithPollOptionsReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForCPNodesReturns(errors.New("fake-error-kcp-upgrade"))
 		})
@@ -1001,6 +1012,7 @@ var _ = Describe("Unit tests for clusterclass-based upgrade", func() {
 	})
 	Context("When failure happens while waiting for worker node upgrade", func() {
 		BeforeEach(func() {
+			currentClusterClient.PatchClusterAPIAWSControllersToUseEC2CredentialsReturns(nil)
 			regionalClusterClient.PatchClusterObjectWithPollOptionsReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForCPNodesReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForWorkerNodesReturns(errors.New("fake-error-worker-upgrade"))
@@ -1012,6 +1024,7 @@ var _ = Describe("Unit tests for clusterclass-based upgrade", func() {
 	})
 	Context("When failure happens while applyPatch for autoscaler upgrade", func() {
 		BeforeEach(func() {
+			currentClusterClient.PatchClusterAPIAWSControllersToUseEC2CredentialsReturns(nil)
 			regionalClusterClient.PatchClusterObjectWithPollOptionsReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForCPNodesReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForWorkerNodesReturns(nil)
@@ -1024,6 +1037,7 @@ var _ = Describe("Unit tests for clusterclass-based upgrade", func() {
 	})
 	Context("When cluster patch is successful and cluster get's upgraded successfully", func() {
 		BeforeEach(func() {
+			currentClusterClient.PatchClusterAPIAWSControllersToUseEC2CredentialsReturns(nil)
 			regionalClusterClient.PatchClusterObjectWithPollOptionsReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForCPNodesReturns(nil)
 			regionalClusterClient.WaitK8sVersionUpdateForWorkerNodesReturns(nil)


### PR DESCRIPTION
### What this PR does / why we need it
This is to ensures that the Cluster API Provider AWS controller is pinned to control plane nodes and is running without static credentials such that Cluster API AWS runs using the EC2 instance profile attached to the control plane node. 

This is done by zeroing out the credentials secret for CAPA, causing the AWS SDK to fall back to the default credential provider chain. 

This was implemented for mgmt cluster creation and legacy mgmt cluster upgrade, but missing in classy mgmt cluster upgrade.

Additionally extend the k8s versionpatch waiting time to allow corner cases.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
