### PR TITLE
Combine the zeroes-out AWS credential action for both legacy and cc

### DIFF
--- a/tkg/client/upgrade_cluster.go
+++ b/tkg/client/upgrade_cluster.go
@@ -384,11 +384,6 @@ func (c *TkgClient) applyPatchAndWait(regionalClusterClient, currentClusterClien
 	var err error
 	kubernetesVersion := upgradeClusterConfig.UpgradeComponentInfo.KubernetesVersion
 
-	// Ensure Cluster API Provider AWS is running on the control plane before continuing with EC2 instance profile
-	if err := currentClusterClient.PatchClusterAPIAWSControllersToUseEC2Credentials(); err != nil {
-		return err
-	}
-
 	// Clusters deployed with TKG CLI version prior to v1.2 uses `beta.kubernetes.io/os: linux` nodeSelector
 	// for `calico-node` daemonset and `calico-kube-controller` deployment.
 	// As k8s v1.19.x removed the support for `beta.kubernetes.io/os: linux` node label and it requires nodes

--- a/tkg/client/upgrade_cluster_clusterclass.go
+++ b/tkg/client/upgrade_cluster_clusterclass.go
@@ -22,9 +22,10 @@ func (c *TkgClient) DoClassyClusterUpgrade(regionalClusterClient clusterclient.C
 	log.Infof("Upgrading kubernetes cluster to `%v` version, tkr version: `%s`", kubernetesVersion, tkrVersion)
 	patchJSONString := fmt.Sprintf(`{"spec": {"topology": {"version": "%v"}}}`, tkrVersion)
 
-	// Timeout set to 15 minutes because the continuousTKRDiscoverFreq for tkr-source-controller's fetcher is 10 minutes.
-	// Wait time should be longer than the fetcher's frequency of pulling tkrs.
-	pollOptions := &clusterclient.PollOptions{Interval: upgradePatchInterval, Timeout: 15 * time.Minute}
+	// Timeout set to 30 minutes because the continuousTKRDiscoverFreq for tkr-source-controller's fetcher is 10 minutes.
+	// And kapp package reconcile frequency is 10 minutes.
+	// Wait time should be longer than the fetcher's frequency of pulling tkrs plus the frequency of kapp package reconciliation.
+	pollOptions := &clusterclient.PollOptions{Interval: upgradePatchInterval, Timeout: 30 * time.Minute}
 	err := regionalClusterClient.PatchClusterObjectWithPollOptions(options.ClusterName, options.Namespace, patchJSONString, pollOptions)
 	if err != nil {
 		return errors.Wrap(err, "unable to patch kubernetes version to cluster")

--- a/tkg/client/upgrade_region.go
+++ b/tkg/client/upgrade_region.go
@@ -136,6 +136,11 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 		return errors.Wrap(err, "failed to upgrade management cluster providers")
 	}
 
+	// Ensure Cluster API Provider AWS is running on the control plane before continuing with EC2 instance profile
+	if err := regionalClusterClient.PatchClusterAPIAWSControllersToUseEC2Credentials(); err != nil {
+		return errors.Wrap(err, "unable to patch the Cluster API Provider AWS controller to use EC2 instance profile")
+	}
+
 	// Wait for installed providers to get up and running
 	// TODO: Currently tkg doesn't support TargetNamespace and WatchingNamespace as it's not supporting multi-tenency of providers
 	// If we support it in future we need to make these namespaces as command line options and use here
@@ -147,6 +152,7 @@ func (c *TkgClient) UpgradeManagementCluster(options *UpgradeClusterOptions) err
 	if err != nil {
 		return errors.Wrap(err, "error waiting for provider components to be up and running after upgrading them")
 	}
+
 	log.Info("Management cluster providers upgraded successfully...")
 
 	// Patch management cluster with the TKG version


### PR DESCRIPTION
### What this PR does / why we need it

This is to ensures that the Cluster API Provider AWS controller is pinned to control plane nodes and is running without static credentials such that Cluster API AWS runs using the EC2 instance profile attached to the control plane node.

This is done by zeroing out the credentials secret for CAPA, causing the AWS SDK to fall back to the default credential provider chain.

This was implemented for mgmt cluster creation and legacy mgmt cluster upgrade, but missing in classy mgmt cluster upgrade. Moving this patch right after provider upgrade will cover both legacy and classy mgmt cluster upgrades.

Additionally extend the k8s versionpatch waiting time to allow corner cases.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
