### PR TITLE
Fix apigroups for volumesnapshots psa RBAC

### DIFF
--- a/addons/controllers/csi/vspherecsiconfig_controller.go
+++ b/addons/controllers/csi/vspherecsiconfig_controller.go
@@ -76,7 +76,7 @@ var providerServiceAccountRBACRules = []rbacv1.PolicyRule{
 		Verbs:     []string{"list"},
 	},
 	{
-		APIGroups: []string{""},
+		APIGroups: []string{"snapshot.storage.k8s.io"},
 		Resources: []string{"volumesnapshots"},
 		Verbs:     []string{"create", "delete", "get", "list", "patch"},
 	},

--- a/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
+++ b/packages/addons-manager/bundle/config/upstream/addons-manager.yaml
@@ -209,6 +209,16 @@ rules:
   - update
   - patch
 - apiGroups:
+  - "snapshot.storage.k8s.io"
+  resources:
+  - volumesnapshots
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+- apiGroups:
   - ""
   resources:
   - events


### PR DESCRIPTION
### What this PR does / why we need it
Add the missing apigroups in the RBAC definition.

### Which issue(s) this PR fixes


Fixes #TKG-19216

### Describe testing done for PR
Manually tested the change by replacing the add-on manager image:

Before fix:
Notice the missing `vsphere-pv-csi.tanzu.vmware.com` package
```
root@4213a29125606e28acbec1b86cbcf2dc [ ~ ]# k --kubeconfig guest-config get pkgi -A
NAMESPACE           NAME                                 PACKAGE NAME                                  PACKAGE VERSION                    DESCRIPTION           AGE
vmware-system-tkg   tkc-two-antrea                       antrea.tanzu.vmware.com                       1.5.3+tkg.2-zshippable             Reconcile succeeded   5h22m
vmware-system-tkg   tkc-two-capabilities                 capabilities.tanzu.vmware.com                 0.28.0-dev-19-g0e3cb04b+vmware.1   Reconcile succeeded   5h22m
vmware-system-tkg   tkc-two-guest-cluster-auth-service   guest-cluster-auth-service.tanzu.vmware.com   1.0.0+tkg.2-zshippable             Reconcile succeeded   5h22m
vmware-system-tkg   tkc-two-metrics-server               metrics-server.tanzu.vmware.com               0.6.1+vmware.1-tkg.3-zshippable    Reconcile succeeded   5h22m
vmware-system-tkg   tkc-two-pinniped                     pinniped.tanzu.vmware.com                     0.12.1+vmware.2-tkg.2-zshippable   Reconcile succeeded   5h22m
vmware-system-tkg   tkc-two-secretgen-controller         secretgen-controller.tanzu.vmware.com         0.11.0+vmware.2-tkg.1-zshippable   Reconcile succeeded   5h22m
vmware-system-tkg   tkc-two-vsphere-cpi                  vsphere-cpi.tanzu.vmware.com                  1.23.1+vmware.1-tkg.2-zshippable   Reconcile succeeded   5h22m
```

After fix:
```
root@4213a29125606e28acbec1b86cbcf2dc [ ~ ]# k --kubeconfig guest-config get pkgi -A
NAMESPACE           NAME                                 PACKAGE NAME                                  PACKAGE VERSION                    DESCRIPTION           AGE
vmware-system-tkg   tkc-two-antrea                       antrea.tanzu.vmware.com                       1.5.3+tkg.2-zshippable             Reconcile succeeded   5h40m
vmware-system-tkg   tkc-two-capabilities                 capabilities.tanzu.vmware.com                 0.28.0-dev-19-g0e3cb04b+vmware.1   Reconcile succeeded   5h40m
vmware-system-tkg   tkc-two-guest-cluster-auth-service   guest-cluster-auth-service.tanzu.vmware.com   1.0.0+tkg.2-zshippable             Reconcile succeeded   5h40m
vmware-system-tkg   tkc-two-metrics-server               metrics-server.tanzu.vmware.com               0.6.1+vmware.1-tkg.3-zshippable    Reconcile succeeded   5h40m
vmware-system-tkg   tkc-two-pinniped                     pinniped.tanzu.vmware.com                     0.12.1+vmware.2-tkg.2-zshippable   Reconcile succeeded   5h40m
vmware-system-tkg   tkc-two-secretgen-controller         secretgen-controller.tanzu.vmware.com         0.11.0+vmware.2-tkg.1-zshippable   Reconcile succeeded   5h40m
vmware-system-tkg   tkc-two-vsphere-cpi                  vsphere-cpi.tanzu.vmware.com                  1.23.1+vmware.1-tkg.2-zshippable   Reconcile succeeded   5h40m
vmware-system-tkg   tkc-two-vsphere-pv-csi               vsphere-pv-csi.tanzu.vmware.com               2.6.0+vmware.1-tkg.1-zshippable    Reconcile succeeded   101s
```

Correct provider service accounts are created, verified that they contain the permissions for volumesnapshot
```
root@4213a29125606e28acbec1b86cbcf2dc [ ~ ]# k get clusterrole|grep provider
addons-vsphere-csi-providerserviceaccount-aggregatedrole               2023-04-05T07:45:49Z
vmware-vsphere-csi-providerserviceaccount-aggregatedrole               2023-04-04T03:46:50Z
```




### Release note
```release-note
Fixed apigroups for volumesnapshot psa RBAC
```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
