### PR TITLE
update antreaConfig crd as some new members are added to CRD

### DIFF
--- a/addons/controllers/antrea/antreaconfig_util.go
+++ b/addons/controllers/antrea/antreaconfig_util.go
@@ -208,6 +208,11 @@ func (r *AntreaConfigReconciler) ClusterToAntreaConfig(o client.Object) []ctrl.R
 	return requests
 }
 
+// MapAntreaConfigSpec is a handy function to use outside the pkg.
+func MapAntreaConfigSpec(cluster *clusterv1beta1.Cluster, config *cniv1alpha2.AntreaConfig) (*AntreaConfigSpec, error) {
+	return mapAntreaConfigSpec(cluster, config, nil)
+}
+
 func mapAntreaConfigSpec(cluster *clusterv1beta1.Cluster, config *cniv1alpha2.AntreaConfig, client client.Client) (*AntreaConfigSpec, error) {
 
 	packageName := config.GetLabels()[addontypes.PackageNameLabel]

--- a/addons/controllers/antreaconfig_controller_test.go
+++ b/addons/controllers/antreaconfig_controller_test.go
@@ -128,11 +128,17 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 					return false
 				}
 
+				spec, err := antreatype.MapAntreaConfigSpec(cluster, config)
+				if err != nil {
+					return false
+				}
+
 				Expect(len(config.OwnerReferences)).Should(Equal(1))
 				Expect(config.OwnerReferences[0].Name).Should(Equal(clusterName))
 
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.TrafficEncapMode).Should(Equal("encap"))
-				Expect(config.Spec.Antrea.AntreaConfigDataValue.TunnelCsum).Should(Equal(true))
+				Expect(config.Spec.Antrea.AntreaConfigDataValue.TunnelCsum).Should(Equal(spec.Antrea.AntreaConfigDataValue.TunnelCsum))
+				Expect(config.Spec.Antrea.AntreaConfigDataValue.TunnelPort).Should(Equal(spec.Antrea.AntreaConfigDataValue.TunnelPort))
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.AntreaTraceflow).Should(Equal(false))
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.AntreaPolicy).Should(Equal(true))
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.FlowExporter).Should(Equal(false))
@@ -143,7 +149,7 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.SecondaryNetwork).Should(Equal(false))
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.TrafficControl).Should(Equal(false))
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.NodePortLocal).Should(Equal(true))
-				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.TopologyAwareHints).Should(Equal(true))
+				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.TopologyAwareHints).Should(Equal(*spec.Antrea.AntreaConfigDataValue.FeatureGates.TopologyAwareHints))
 
 				return true
 			}, waitTimeout, pollingInterval).Should(BeTrue())

--- a/addons/controllers/antreaconfig_controller_test.go
+++ b/addons/controllers/antreaconfig_controller_test.go
@@ -132,6 +132,7 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 				Expect(config.OwnerReferences[0].Name).Should(Equal(clusterName))
 
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.TrafficEncapMode).Should(Equal("encap"))
+				Expect(config.Spec.Antrea.AntreaConfigDataValue.TunnelCsum).Should(Equal(true))
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.AntreaTraceflow).Should(Equal(false))
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.AntreaPolicy).Should(Equal(true))
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.FlowExporter).Should(Equal(false))
@@ -142,6 +143,7 @@ var _ = Describe("AntreaConfig Reconciler and Webhooks", func() {
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.SecondaryNetwork).Should(Equal(false))
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.TrafficControl).Should(Equal(false))
 				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.NodePortLocal).Should(Equal(true))
+				Expect(config.Spec.Antrea.AntreaConfigDataValue.FeatureGates.TopologyAwareHints).Should(Equal(true))
 
 				return true
 			}, waitTimeout, pollingInterval).Should(BeTrue())

--- a/addons/controllers/testdata/antrea-custom-cb-2-resources.yaml
+++ b/addons/controllers/testdata/antrea-custom-cb-2-resources.yaml
@@ -37,6 +37,8 @@ kind: AntreaConfig
 metadata:
   name: antrea-config-template-2
   namespace: tkg-system
+  labels:
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:

--- a/addons/controllers/testdata/antrea-custom-tkg-system.yaml
+++ b/addons/controllers/testdata/antrea-custom-tkg-system.yaml
@@ -37,6 +37,8 @@ kind: AntreaConfig
 metadata:
   name: antrea-config-template
   namespace: tkg-system
+  labels:
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:

--- a/addons/controllers/testdata/antrea-test-1.yaml
+++ b/addons/controllers/testdata/antrea-test-1.yaml
@@ -63,7 +63,7 @@ spec:
       multicastInterfaces: []
       tunnelType: geneve
       tunnelPort: 0
-      tunnelCsum: false
+      tunnelCsum: true
       trafficEncryptionMode: none
       wireGuard:
         port: 51820
@@ -93,4 +93,4 @@ spec:
         Multicluster: false
         SecondaryNetwork: false
         TrafficControl: false
-        TopologyAwareHints: false
+        TopologyAwareHints: true

--- a/addons/controllers/testdata/antrea-test-1.yaml
+++ b/addons/controllers/testdata/antrea-test-1.yaml
@@ -26,7 +26,7 @@ metadata:
   name: test-cluster-4-antrea-package
   namespace: default
   labels:
-    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.9.0---tkg.1-advanced
   ownerReferences:
     - apiVersion: cluster.x-k8s.io/v1beta1
       blockOwnerDeletion: true

--- a/addons/controllers/testdata/antrea-test-template-config-1.yaml
+++ b/addons/controllers/testdata/antrea-test-template-config-1.yaml
@@ -4,6 +4,8 @@ kind: AntreaConfig
 metadata:
   name: test-cluster-4-antrea-package
   namespace: tkg-system
+  labels:
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:

--- a/addons/controllers/testdata/test-cluster-bootstrap-10.yaml
+++ b/addons/controllers/testdata/test-cluster-bootstrap-10.yaml
@@ -841,6 +841,8 @@ kind: AntreaConfig
 metadata:
   name: antrea-config-custom-1
   namespace: tkg-system
+  labels:
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
 spec:
   antrea:
     config:

--- a/addons/controllers/testdata/test-cluster-bootstrap-2.yaml
+++ b/addons/controllers/testdata/test-cluster-bootstrap-2.yaml
@@ -459,6 +459,8 @@ kind: AntreaConfig
 metadata:
   name: test-cluster-tcbt-2
   namespace: tkg-system
+  labels:
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
 spec:
   antrea:
     config:

--- a/addons/controllers/testdata/test-cluster-bootstrap-3.yaml
+++ b/addons/controllers/testdata/test-cluster-bootstrap-3.yaml
@@ -36,6 +36,8 @@ kind: AntreaConfig
 metadata:
   name: test-cluster-tcbt-3
   namespace: tkg-system
+  labels:
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
 spec:
   antrea:
     config:

--- a/addons/controllers/testdata/test-cluster-bootstrap-7.yaml
+++ b/addons/controllers/testdata/test-cluster-bootstrap-7.yaml
@@ -406,6 +406,8 @@ kind: AntreaConfig
 metadata:
   name: test-cluster-7
   namespace: tkg-system
+  labels:
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
 spec:
   antrea:
     config:
@@ -416,6 +418,8 @@ kind: AntreaConfig
 metadata:
   name: test-cluster-7
   namespace: cluster-namespace-7
+  labels:
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
 spec:
   antrea:
     config:

--- a/addons/controllers/testdata/test-cluster-bootstrap-8.yaml
+++ b/addons/controllers/testdata/test-cluster-bootstrap-8.yaml
@@ -405,6 +405,8 @@ kind: AntreaConfig
 metadata:
   name: test-cluster-8
   namespace: tkg-system
+  labels:
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
 spec:
   antrea:
     config:
@@ -415,6 +417,8 @@ kind: AntreaConfig
 metadata:
   name: test-cluster-8
   namespace: cluster-namespace-8
+  labels:
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
 spec:
   antrea:
     config:

--- a/addons/controllers/testdata/test-cluster-bootstrap-9.yaml
+++ b/addons/controllers/testdata/test-cluster-bootstrap-9.yaml
@@ -986,6 +986,8 @@ kind: AntreaConfig
 metadata:
   name: antrea-config-custom
   namespace: tkg-system
+  labels:
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
 spec:
   antrea:
     config:

--- a/addons/controllers/testdata/test-packageinstallstatus.yaml
+++ b/addons/controllers/testdata/test-packageinstallstatus.yaml
@@ -112,6 +112,8 @@ kind: AntreaConfig
 metadata:
   name: test-mng
   namespace: tkg-system
+  labels:
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
 spec:
   antrea:
     config:

--- a/addons/controllers/testdata/test-tkg-system-ns-resources.yaml
+++ b/addons/controllers/testdata/test-tkg-system-ns-resources.yaml
@@ -166,6 +166,8 @@ kind: AntreaConfig
 metadata:
   name: test-cluster-tcbt
   namespace: tkg-system
+  labels:
+    tkg.tanzu.vmware.com/package-name: antrea.tanzu.vmware.com.1.7.2---tkg.1-advanced
   annotations:
     tkg.tanzu.vmware.com/template-config: "true"
 spec:

--- a/apis/addonconfigs/config/crd/bases/cni.tanzu.vmware.com_antreaconfigs.yaml
+++ b/apis/addonconfigs/config/crd/bases/cni.tanzu.vmware.com_antreaconfigs.yaml
@@ -458,6 +458,12 @@ spec:
                             default: false
                             description: Flag to enable/disable service external IP
                             type: boolean
+                          TopologyAwareHints:
+                            default: false
+                            description: Enable TopologyAwareHints in AntreaProxy.
+                              This requires AntreaProxy and EndpointSlice to be enabled,
+                              otherwise this flag will not take effect.
+                            type: boolean
                           TrafficControl:
                             default: false
                             description: Enable mirroring or redirecting the traffic
@@ -545,6 +551,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      tunnelCsum:
+                        default: false
+                        description: TunnelCsum determines whether to compute UDP
+                          encapsulation header (Geneve or VXLAN) checksums on outgoing
+                          packets
+                        type: boolean
+                      tunnelPort:
+                        default: 0
+                        description: TunnelPort is the destination port for UDP and
+                          TCP based tunnel protocols (Geneve, VXLAN, and STT).If zero,
+                          it will use the assigned IANA port for the protocol.
+                        type: integer
                       tunnelType:
                         description: Tunnel protocols used for encapsulating traffic
                           across Nodes. One of the following options =:> geneve, vxlan,

--- a/packages/addons-manager/bundle/config/upstream/addonconfigscrds/cni.tanzu.vmware.com_antreaconfigs.yaml
+++ b/packages/addons-manager/bundle/config/upstream/addonconfigscrds/cni.tanzu.vmware.com_antreaconfigs.yaml
@@ -458,6 +458,12 @@ spec:
                             default: false
                             description: Flag to enable/disable service external IP
                             type: boolean
+                          TopologyAwareHints:
+                            default: false
+                            description: Enable TopologyAwareHints in AntreaProxy.
+                              This requires AntreaProxy and EndpointSlice to be enabled,
+                              otherwise this flag will not take effect.
+                            type: boolean
                           TrafficControl:
                             default: false
                             description: Enable mirroring or redirecting the traffic
@@ -545,6 +551,18 @@ spec:
                         items:
                           type: string
                         type: array
+                      tunnelCsum:
+                        default: false
+                        description: TunnelCsum determines whether to compute UDP
+                          encapsulation header (Geneve or VXLAN) checksums on outgoing
+                          packets
+                        type: boolean
+                      tunnelPort:
+                        default: 0
+                        description: TunnelPort is the destination port for UDP and
+                          TCP based tunnel protocols (Geneve, VXLAN, and STT).If zero,
+                          it will use the assigned IANA port for the protocol.
+                        type: integer
                       tunnelType:
                         description: Tunnel protocols used for encapsulating traffic
                           across Nodes. One of the following options =:> geneve, vxlan,


### PR DESCRIPTION
since antrea 1.9 has options for TunnelPort,TunnelCsum and TopologyAwareHints. But it seems antreaconfig does not include the properties in crd defination in pr https://github.com/vmware-tanzu/tanzu-framework/pull/4481

### What this PR does / why we need it

### Which issue(s) this PR fixes
with [https://github.com/vmware-tanzu/tanzu-framework/pull/4481 ,](https://github.com/vmware-tanzu/tanzu-framework/pull/4481) antreaConfig should support TunnelPort,TunnelCsum and TopologyAwareHints

define antreaConfig like:
```
apiVersion: cni.tanzu.vmware.com/v1alpha2
kind: AntreaConfig
metadata:
name: xxx
namespace: default
spec:
antrea:
config:
tunnelPort: 9999
```
got the following error:

`Error from server (BadRequest): error when creating "an.yaml": AntreaConfig in version "v1alpha2" cannot be handled as a AntreaConfig: strict decoding error: unknown field "spec.antrea.config.tunnelPort"`

Fixes #TKG-19288

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

manually tested on a Living TKG env

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
