### PR TITLE
Add missing labels for antreaconfig from clusterbootstrap

### DIFF
--- a/addons/controllers/calicoconfig_controller_test.go
+++ b/addons/controllers/calicoconfig_controller_test.go
@@ -478,6 +478,7 @@ var _ = Describe("CalicoConfig Reconciler and Webhooks", func() {
 				Expect(k8sClient.Get(ctx, configKey, calicoConfig)).To(Succeed())
 
 				Expect(calicoConfig.Spec.Calico.Config.VethMTU).Should(Equal(int64(1420)))
+				Expect(calicoConfig.ObjectMeta.Labels["tkg.tanzu.vmware.com/package-name"]).Should(Equal("calico.tanzu.vmware.com.1.2.5--vmware.12-tkg.1"))
 				//  why  int64??  that would make it architecture specific, as oposed to why not just int?
 				// (defined in apis/addonconfigs/cni/v1alpha1/calicoconfig_types.go)
 				// seems to also have forced part of this fix: https://github.com/vmware-tanzu/tanzu-framework/pull/2164

--- a/addons/controllers/clusterbootstrap_controller.go
+++ b/addons/controllers/clusterbootstrap_controller.go
@@ -481,6 +481,11 @@ func (r *ClusterBootstrapReconciler) patchClusterBootstrapFromTemplate(
 		return nil, err
 	}
 
+	if err := clusterBootstrapHelper.AddPackageLabelForCNIProvider(cluster.Name, updatedClusterBootstrap); err != nil {
+		r.Log.Error(err, fmt.Sprintf("unable to add labels to cni provider"))
+		return nil, err
+	}
+
 	r.Log.Info("updated clusterBootstrap", "clusterBootstrap", updatedClusterBootstrap)
 	return updatedClusterBootstrap, nil
 }

--- a/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
+++ b/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
@@ -444,7 +444,7 @@ func (h *Helper) HandleExistingClusterBootstrap(clusterBootstrap *runtanzuv1alph
 		h.Logger.Error(err, fmt.Sprintf("unable to add cluster %s/%s as owner reference to providers", cluster.Namespace, cluster.Name))
 	}
 
-	if err := h.addPackageLabelForCNIProvider(cluster.Name, clusterBootstrap); err != nil {
+	if err := h.AddPackageLabelForCNIProvider(cluster.Name, clusterBootstrap); err != nil {
 		h.Logger.Error(err, fmt.Sprintf("unable to add labels to cni provider"))
 		return nil, err
 	}
@@ -970,9 +970,9 @@ func (h *Helper) AddClusterOwnerRefToExistingProviders(cluster *clusterapiv1beta
 	return nil
 }
 
-// AddPackageLabelForCNIConfig patch the missing labels for AntreaConfig(cni config) when it's related to
+// AddPackageLabelForCNIProvider patch the missing labels for AntreaConfig(cni config) when it's related to
 // an existing clusterboostrap. To make antreaconfig works with old versions, it relies on the package label now.
-func (h *Helper) addPackageLabelForCNIProvider(clusterName string, clusterBootstrap *runtanzuv1alpha3.ClusterBootstrap) error {
+func (h *Helper) AddPackageLabelForCNIProvider(clusterName string, clusterBootstrap *runtanzuv1alpha3.ClusterBootstrap) error {
 	cni := clusterBootstrap.Spec.CNI
 	if cni != nil {
 		providers, err := h.getListOfExistingProviders(clusterBootstrap)

--- a/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
+++ b/addons/pkg/util/clusterbootstrapclone/clusterbootstrapclone.go
@@ -1042,7 +1042,7 @@ func (h *Helper) setLabels(labels map[string]string, child *unstructured.Unstruc
 	}
 	_, err = h.DynamicClient.Resource(*gvr).Namespace(child.GetNamespace()).Patch(h.Ctx, child.GetName(), types.MergePatchType, patchData, metav1.PatchOptions{})
 	if err != nil {
-		h.Logger.Error(fmt.Sprintf("unable to patch provider %s/%s", child.GetNamespace(), child.GetName()), "gvr", gvr)
+		h.Logger.Error(err, fmt.Sprintf("unable to patch provider %s/%s", child.GetNamespace(), child.GetName()), "gvr", gvr)
 	}
 	return err
 


### PR DESCRIPTION
### What this PR does / why we need it

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

In the last version bump, antrea controller relies on a package label to working normally. But in cert cases(cb and antreaconfig created from kubectl, the label is missing). This patch added the missing label from clusterboostrap clone

Fixes # TKG-18782

This is also an alternative solution compared to https://github.com/vmware-tanzu/tanzu-framework/pull/4544

### Describe testing done for PR

Test done in a Live tanzu env

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
