### PR TITLE
Pinniped | Support additional configuration options

### DIFF
--- a/providers/yttcb/clusterbootstraphelpers.star
+++ b/providers/yttcb/clusterbootstraphelpers.star
@@ -36,3 +36,23 @@ def get_no_proxy():
   end
   return ""
 end
+
+#! Takes in something that looks like "prompt=consent,something-else=other-value"
+#! and returns something that looks like [{name: prompt, value: consent},{name: something-else, value: other-value}]
+#! This is purposely intended to be forgiving of additional whitespace.
+def get_additional_authorize_params():
+  result = []
+
+  if data.values.OIDC_IDENTITY_PROVIDER_ADDITIONAL_AUTHORIZE_PARAMS:
+    for pair in data.values.OIDC_IDENTITY_PROVIDER_ADDITIONAL_AUTHORIZE_PARAMS.split(","):
+      pair = pair.lstrip().rstrip()
+      elements = pair.split("=")
+
+      if len(elements) == 2:
+        result.append(dict(name=elements[0].lstrip().rstrip(), value=elements[1].lstrip().rstrip()))
+      end
+    end
+  end
+
+  return result
+end

--- a/providers/yttcb/pinniped_addon_secret.lib.yaml
+++ b/providers/yttcb/pinniped_addon_secret.lib.yaml
@@ -1,5 +1,5 @@
 #@ load("@ytt:data", "data")
-#@ load("clusterbootstraphelpers.star", "get_no_proxy")
+#@ load("clusterbootstraphelpers.star", "get_no_proxy", "get_additional_authorize_params")
 
 #! These default names have been around since 1.3.0, and we want to keep them the same for backwards stability.
 #@ supervisor_service_name = "pinniped-supervisor"
@@ -14,6 +14,9 @@ type: LoadBalancer
 #@ else:
 type: NodePort
 #@ end
+#@ if/end data.values.AWS_LOAD_BALANCER_SCHEME_INTERNAL in (True, “TRUE”, “True”, “true”):
+annotations:
+  service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
 #@ end
 
 #@ def getDefaultValuesForMC():
@@ -41,16 +44,18 @@ pinniped:
   supervisor_svc_endpoint: "https://0.0.0.0:31234" #! Do not change. Will be updated by post-deployment job. This is used to configure jwtAuthenticator
   supervisor_ca_bundle_data: "ca_bundle_data_of_supervisor_svc" #! Do not change. Will be updated by post-deployment job. This is used to configure jwtAuthenticator to communicate with supervisor svc
   supervisor_svc_external_ip: "0.0.0.0" #! provide if the node IP or LB IP of Pinniped supervisor service is known, otherwise leave it as is. e.g. 10.165.123.84
-  supervisor_svc_external_dns: null #! provide if the LB DNS of Pinniped supervisor service is known, otherwise leave it as is. e.g pinniped-svc.us-west-2a.com
+  #! provide supervisor_svc_external_dns only the LB DNS of Pinniped supervisor service is known (e.g. pinniped-svc.us-west-2a.com)
+  supervisor_svc_external_dns: #@ data.values.PINNIPED_EXTERNAL_DNS_HOSTNAME
   upstream_oidc_client_id: #@ data.values.OIDC_IDENTITY_PROVIDER_CLIENT_ID
   upstream_oidc_client_secret: #@ data.values.OIDC_IDENTITY_PROVIDER_CLIENT_SECRET
   upstream_oidc_issuer_url: #@ data.values.OIDC_IDENTITY_PROVIDER_ISSUER_URL
-  upstream_oidc_tls_ca_data: "" #! This tls ca data is used to communicate with upstream_oidc_issuer_url
+  upstream_oidc_tls_ca_data: #@ data.values.OIDC_IDENTITY_PROVIDER_CA_BUNDLE_DATA_B64
   upstream_oidc_additional_scopes:
   #@ for val in data.values.OIDC_IDENTITY_PROVIDER_SCOPES.split(","):
     #@overlay/append
     - #@ val
   #@ end
+  upstream_oidc_additional_authorize_parameters: #@ get_additional_authorize_params()
   upstream_oidc_claims: #! required. If no claims, put {}
     username: #@ data.values.OIDC_IDENTITY_PROVIDER_USERNAME_CLAIM
     groups: #@ data.values.OIDC_IDENTITY_PROVIDER_GROUPS_CLAIM
@@ -74,7 +79,8 @@ pinniped:
   supervisor_svc_endpoint: "https://0.0.0.0:31234" #! Do not change. Will be updated by post-deployment job. This is used to configure jwtAuthenticator
   supervisor_ca_bundle_data: "ca_bundle_data_of_supervisor_svc" #! Do not change. Will be updated by post-deployment job. This is used to configure jwtAuthenticator to communicate with supervisor svc
   supervisor_svc_external_ip: "0.0.0.0" #! provide if the node IP or LB IP of Pinniped supervisor service is known, otherwise leave it as is. e.g. 10.165.123.84
-  supervisor_svc_external_dns: null #! provide if the LB DNS of Pinniped supervisor service is known, otherwise leave it as is. e.g pinniped-svc.us-west-2a.com
+  #! provide supervisor_svc_external_dns only the LB DNS of Pinniped supervisor service is known (e.g. pinniped-svc.us-west-2a.com)
+  supervisor_svc_external_dns: #@ data.values.PINNIPED_EXTERNAL_DNS_HOSTNAME
   upstream_oidc_client_id: "" #! Do not change. Will be updated by post-deployment job. The client secret used to talk to Dex
   upstream_oidc_client_secret: "" #! Do not change. Will be updated by post-deployment job. This is the client secret used to talk to Dex
   upstream_oidc_issuer_url: "https://0.0.0.0:30167" #! Do not change. Will be updated by post-deployment job. This is the upstream oidc issuer url. It should be pointed to Dex service, since Dex is deployed as the upstream of Pinniped. e.g https://endpoint-points-to-dex:5443 !!!


### PR DESCRIPTION
### What this PR does / why we need it

### Which issue(s) this PR fixes
Pinniped | Support additional configuration options

- PINNIPED_EXTERNAL_DNS_HOSTNAME
- OIDC_IDENTITY_PROVIDER_ADDITIONAL_AUTHORIZE_PARAMS
- OIDC_IDENTITY_PROVIDER_CA_BUNDLE_DATA_B64
- AWS_LOAD_BALANCER_SCHEME_INTERNAL

Fixes #

### Describe testing done for PR

Unknown how to test

### Release note
```release-note

```

### Additional information

#### Special notes for your reviewer

How do I test this outside of the pipelines?