### PR TITLE
[WIP]Skip vip validation when vip is empty

### DIFF
--- a/tkg/client/client_suite_test.go
+++ b/tkg/client/client_suite_test.go
@@ -382,6 +382,16 @@ var _ = Describe("ValidateVSphereControlPlaneEndpointIP", func() {
 					},
 				},
 			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-in-creation",
+				},
+				Spec: capi.ClusterSpec{
+					ControlPlaneEndpoint: capi.APIEndpoint{
+						Host: "",
+					},
+				},
+			},
 		}, nil)
 		err = tkgClient.ValidateVsphereVipWorkloadCluster(clusterclient, vip, false)
 	})
@@ -399,6 +409,15 @@ var _ = Describe("ValidateVSphereControlPlaneEndpointIP", func() {
 	Context("When vsphere --vsphere-controlplane-endpoint is provided with valid IP", func() {
 		BeforeEach(func() {
 			vip = "10.0.0.1"
+		})
+		It("should not error", func() {
+			Expect(err).To(Not(HaveOccurred()))
+		})
+	})
+
+	Context("When vsphere --vsphere-controlplane-endpoint empty, but there is in-creation cluster whose cp endpoint is also empty", func() {
+		BeforeEach(func() {
+			vip = ""
 		})
 		It("should not error", func() {
 			Expect(err).To(Not(HaveOccurred()))

--- a/tkg/client/validate.go
+++ b/tkg/client/validate.go
@@ -831,7 +831,9 @@ func (c *TkgClient) configureAndValidateVIPForVsphereCluster(vip string) error {
 
 // ValidateVsphereVipWorkloadCluster validates that the control plane endpoint is unique
 func (c *TkgClient) ValidateVsphereVipWorkloadCluster(clusterClient clusterclient.Client, vip string, skipValidation bool) error {
-	if skipValidation {
+	// Skip vip validation when we enable avi ha provider and set empty vip
+	// Since when we create many workload clusters at same time, it's expected to have many clusters whose control plane endpoint are empty at some time
+	if vip == "" || skipValidation {
 		return nil
 	}
 	clusterList, err := clusterClient.ListClusters("")


### PR DESCRIPTION
### What this PR does / why we need it

Skip vip validation when we enable avi ha provider and set empty vip
Since when we create many workload clusters at same time, it's expected to have many clusters whose control plane endpoint are empty at some time

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
