### PR TITLE
pinniped-components: fix make target and Dockerfile

### DIFF
--- a/pinniped-components/post-deploy/Dockerfile
+++ b/pinniped-components/post-deploy/Dockerfile
@@ -15,6 +15,8 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 # We depend on tanzu-auth-controller-manager, so copy it in
 COPY tanzu-auth-controller-manager tanzu-auth-controller-manager
+# We depend on common, so copy it in
+COPY common common
 COPY post-deploy/go.mod post-deploy/go.mod
 COPY post-deploy/go.sum post-deploy/go.sum
 

--- a/pinniped-components/post-deploy/Makefile
+++ b/pinniped-components/post-deploy/Makefile
@@ -34,7 +34,7 @@ native: ## Build binary
 
 .PHONY: build-images
 build-images: ## Build tkg-pinniped-post-deploy docker images
-	VERSION=$(VERSION) DISTROLESS_BASE_IMAGE=$(DISTROLESS_BASE_IMAGE) ./hack/scripts/build-images.sh
+	GOPROXY=$(GOPROXY) GOSUMDB=$(GOSUMDB) VERSION=$(VERSION) DISTROLESS_BASE_IMAGE=$(DISTROLESS_BASE_IMAGE) ./hack/scripts/build-images.sh
 
 run:
 	go run ./cmd/job \


### PR DESCRIPTION
### What this PR does / why we need it

Small fix to make `make build-images` work in the `pinniped-components` directory.

### Describe testing done for PR

Run `make build-images` in the `pinniped-components` directory. See that it now compiles without error.

### Release note
```release-note
NONE
```
