### PR TITLE
fix providerServiceAccountRBACRules to remove ResourceNames

### DIFF
--- a/addons/controllers/antrea/antreaconfig_controller.go
+++ b/addons/controllers/antrea/antreaconfig_controller.go
@@ -279,21 +279,17 @@ func (r *AntreaConfigReconciler) ensureProviderServiceAccount(ctx context.Contex
 		return err
 	}
 	clusterName, _ := getClusterName(antreaConfig)
-	nsxSAName := clusterName + "-antrea"
-	nsxSecretName := clusterName + "-antrea-nsx-cert"
 	clusterName = vsphereCluster.Name
 	providerServiceAccountRBACRules := []rbacv1.PolicyRule{
 		{
-			APIGroups:     []string{nsxServiceAccountAPIGroup},
-			Resources:     []string{nsxServiceAccountKind},
-			ResourceNames: []string{nsxSAName},
-			Verbs:         []string{"get", "list", "watch"},
+			APIGroups: []string{nsxServiceAccountAPIGroup},
+			Resources: []string{nsxServiceAccountKind},
+			Verbs:     []string{"get", "list", "watch"},
 		},
 		{
-			APIGroups:     []string{""},
-			Resources:     []string{"secrets"},
-			ResourceNames: []string{fmt.Sprintf(nsxSecretName)},
-			Verbs:         []string{"get", "list", "watch"},
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"get", "list", "watch"},
 		},
 	}
 	_, err = controllerutil.CreateOrPatch(ctx, r.Client, vsphereAntreaConfigProviderServiceAccountAggregatedClusterRole, func() error {


### PR DESCRIPTION
### What this PR does / why we need it

### Which issue(s) this PR fixes

<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #
    The issue is that Antrea addon controller needs to create a ClusterRole to allow tkg controllers
    to read all NSXServiceAccount CRs, however, the Antrea addon controller wrongly adds the specific
    NSXServiceAccount name (instead of all) restriction to the permission. This only allows the
    tkg controllers to read a specific NSXServiceAccount instead all NSXServiceAccounts.
    
    So if the Cluster is created one by one, customer will not hit this bug. For each cluster, Antrea
    addon controller updates the ClusterRole with the current NSXServiceAccount name for the current Cluster.
    
    If the Clusters are created in batch, all controllers need to process Clusters in parallel, chances are
    Antrea addon controller specifies a specific NSXServiceAccount name for Cluster A, but tkg controllers are
    processing Cluster B, then tkg controllers will fail to read NSXServiceAccount.
### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
