### PR TITLE
Fix local certificate manager startup issue in featuregates controller

### DIFF
--- a/featuregates/controller/main.go
+++ b/featuregates/controller/main.go
@@ -15,6 +15,7 @@ import (
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	cliflag "k8s.io/component-base/cli/flag"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -139,10 +140,16 @@ func main() {
 
 	signalHandler := ctrl.SetupSignalHandler()
 
+	ctrlClient, err := client.New(ctrl.GetConfigOrDie(), client.Options{})
+	if err != nil {
+		setupLog.Error(err, "unable to create ctrl client")
+		os.Exit(1)
+	}
+
 	// Start certificate manager
 	setupLog.Info("Starting certificate manager")
 	certManagerOpts := &certs.Options{
-		Client:                        mgr.GetClient(),
+		Client:                        ctrlClient,
 		Logger:                        ctrl.Log.WithName("featuregates-webhook-cert-manager"),
 		CertDir:                       webhookSecretVolumeMountPath,
 		WebhookConfigLabel:            webhookConfigLabel,


### PR DESCRIPTION
### What this PR does / why we need it
The attempt to fetch the secrets using the client fails in the cert manager. The failure is due to improper initialisation of the client object. The client object gets initialised only after the controller manager starts; but, the cert manager attempts to use the client object before the manager start.

The solution is to create an independent client object that gets initialised independent of the manager.

### Which issue(s) this PR fixes
<!--
     Usage: Fixes #<issue number>.

     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first
     (and reference it here) so that the problem the PR addresses can be discussed independently of
     the solutions proposed by this PR.
-->

Fixes #4630 

### Describe testing done for PR
Tested by manually deploying the package in Kind cluster
Tested by starting the featuregates controller locally
<!-- Example: Created vSphere workload cluster to verify change. -->

### Release note
<!--
     Please add a short text (limit to 1 to 2 sentences if possible) in the release-note block below if
     there is anything in this PR that is worthy of mention in the next release.

     See https://github.com/vmware-tanzu/tanzu-framework/blob/main/docs/release/release-notes.md#does-my-pull-request-need-a-release-note
     for more details.
-->
```release-note

```

<!--
     ## PR Checklist

     Please ensure the following:

     - Use good commit [messages](https://github.com/vmware-tanzu/tanzu-framework/blob/main/CONTRIBUTING.md)
     - Ensure PR contains terms all contributors can understand and links all contributors can access
     - Squash the commits into one or a small number of logical commits

       | This repository adopts a linear git history model where no merge commits are necessary. To
       | keep the commit history tidy, it is recommended that authors be responsible for the decision
       | whether to squash the PR's changes into a single commit (and tidy up the commit message in the
       | process) or organizing them into a small number of self-contained and meaningful ones.
-->

### Additional information

#### Special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
     If this pull request is just an idea or POC, or is not ready for review, instead of "Create pull request", please select
     "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
-->
